### PR TITLE
Fix early destruction of objects returned from Rust (#138)

### DIFF
--- a/godot-core/src/builtin/meta/signature.rs
+++ b/godot-core/src/builtin/meta/signature.rs
@@ -162,8 +162,9 @@ macro_rules! impl_signature_for_tuple {
 				unsafe { <$R as sys::GodotFuncMarshal>::try_write_sys(&ret_val, ret) }
                     .unwrap_or_else(|e| return_error::<$R>(method_name, &e));
 
-                // FIXME is inc_ref needed here?
-				// std::mem::forget(ret_val);
+               //Note: we want to prevent the destructor from being run, since we pass ownership to the caller.
+               //https://github.com/godot-rust/gdext/pull/165
+				std::mem::forget(ret_val);
             }
         }
     };

--- a/itest/godot/InheritTests.gd
+++ b/itest/godot/InheritTests.gd
@@ -1,0 +1,27 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+extends ArrayTest
+
+var test_suite: TestSuite = TestSuite.new()
+
+# In order to reproduce the behavior discovered in https://github.com/godot-rust/gdext/issues/138
+# we must inherit a Godot Node. Because of this we can't just inherit TesSuite like the rest of the tests.
+func assert_that(what: bool, message: String = "") -> bool:
+	return test_suite.assert_that(what, message)
+
+func assert_eq(left, right, message: String = "") -> bool:
+	return test_suite.assert_eq(left, right, message)
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	pass
+
+func test_vector_array_return_from_user_func():
+	var array: Array = return_typed_array(2)
+	assert_eq(array, [1,2])
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta):
+	pass

--- a/itest/godot/TestRunner.gd
+++ b/itest/godot/TestRunner.gd
@@ -10,6 +10,7 @@ func _ready():
 	var gdscript_suites: Array = [
 		preload("res://ManualFfiTests.gd").new(),
 		preload("res://gen/GenFfiTests.gd").new(),
+		preload("res://InheritTests.gd").new()
 	]
 	
 	var gdscript_tests: Array = []


### PR DESCRIPTION
Hi there,

I probably need to test this more thoroughly. Just opening a pull request for collaboration and such.

Basically it came down to for some reason(I'm still learning about this rust port of godot) ac02be1a4692445a980f646e97e4c0f020bdbfa4 triggers this behavior.  And this PR reverts that commit(except for the tests).


This patch fixes my use case, but I'll try to write unit tests and test in general to make sure we don't miss any other edge cases.


Hope this PR is clear enough.

Thanks
Lorenzo