### PR TITLE
Fix library paths in example project's .gdextension file

### DIFF
--- a/examples/dodge-the-creeps/godot/DodgeTheCreeps.gdextension
+++ b/examples/dodge-the-creeps/godot/DodgeTheCreeps.gdextension
@@ -2,6 +2,9 @@
 entry_symbol = "gdext_rust_init"
 
 [libraries]
-linux.64 = "res://../../../target/debug/libdodge_the_creeps.so"
-macos.64 = "res://../../../target/debug/libdodge_the_creeps.dylib"
-windows.64 = "res://../../../target/debug/dodge_the_creeps.dll"
+linux.debug.x86_64 = "res://../../../target/debug/libdodge_the_creeps.so"
+linux.release.x86_64 = "res://../../../target/release/libdodge_the_creeps.so"
+macos.debug = "res://../../../target/debug/libdodge_the_creeps.dylib"
+macos.release = "res://../../../target/release/libdodge_the_creeps.dylib"
+windows.debug.x86_64 = "res://../../../target/debug/dodge_the_creeps.dll"
+windows.release.x86_64 = "res://../../../target/release/dodge_the_creeps.dll"


### PR DESCRIPTION
The example `dodge-the-creeps` appears to use still an old format for its `.gdextension` file. This has caused numerous people, myself included, to hit issues when attempting to set up their own projects. This PR updates the file to the most recent format 