### PR TITLE
Allow `GodotExt` syntax to be used for virtuals

### DIFF
--- a/examples/dodge-the-creeps/rust/src/hud.rs
+++ b/examples/dodge-the-creeps/rust/src/hud.rs
@@ -61,7 +61,7 @@ impl Hud {
 }
 
 #[godot_api]
-impl CanvasLayerVirtual for Hud {
+impl GodotExt for Hud {
     fn init(base: Base<Self::Base>) -> Self {
         Self { base }
     }

--- a/examples/dodge-the-creeps/rust/src/main_scene.rs
+++ b/examples/dodge-the-creeps/rust/src/main_scene.rs
@@ -126,7 +126,7 @@ impl Main {
 }
 
 #[godot_api]
-impl NodeVirtual for Main {
+impl GodotExt for Main {
     fn init(base: Base<Node>) -> Self {
         Main {
             mob_scene: PackedScene::new(),

--- a/examples/dodge-the-creeps/rust/src/mob.rs
+++ b/examples/dodge-the-creeps/rust/src/mob.rs
@@ -47,7 +47,7 @@ impl Mob {
 }
 
 #[godot_api]
-impl RigidBody2DVirtual for Mob {
+impl GodotExt for Mob {
     fn init(base: Base<RigidBody2D>) -> Self {
         Mob {
             min_speed: 150.0,

--- a/examples/dodge-the-creeps/rust/src/player.rs
+++ b/examples/dodge-the-creeps/rust/src/player.rs
@@ -42,7 +42,7 @@ impl Player {
 }
 
 #[godot_api]
-impl Area2DVirtual for Player {
+impl GodotExt for Player {
     fn init(base: Base<Area2D>) -> Self {
         Player {
             speed: 400.0,

--- a/godot-core/src/obj/traits.rs
+++ b/godot-core/src/obj/traits.rs
@@ -50,6 +50,9 @@ pub trait Share {
     fn share(&self) -> Self;
 }
 
+// Marker trait that exists only for documentation purposes.
+// pub trait GodotExt : private::Sealed {}
+
 /// Non-strict inheritance relationship in the Godot class hierarchy.
 ///
 /// `Derived: Inherits<Base>` means that either `Derived` is a subclass of `Base`, or the class `Base` itself (hence "non-strict").
@@ -164,7 +167,7 @@ pub mod cap {
         fn __register_exports();
     }
 
-    /// Auto-implemented for `#[godot_api] impl ***Virtual for MyClass` blocks
+    /// Auto-implemented for `#[godot_api] impl GodotExt for MyClass` blocks
     pub trait ImplementsGodotVirtual: GodotClass {
         #[doc(hidden)]
         fn __virtual_call(_name: &str) -> sys::GDExtensionClassCallVirtual;

--- a/godot-macros/src/lib.rs
+++ b/godot-macros/src/lib.rs
@@ -21,6 +21,8 @@ pub fn derive_native_class(input: TokenStream) -> TokenStream {
     translate(input, derive_godot_class::transform)
 }
 
+/// Attribute to annotate `impl` blocks.
+#[doc(alias = "GodotExt")]
 #[proc_macro_attribute]
 pub fn godot_api(_meta: TokenStream, input: TokenStream) -> TokenStream {
     translate(input, godot_api::transform)

--- a/godot-macros/src/util.rs
+++ b/godot-macros/src/util.rs
@@ -380,8 +380,9 @@ pub(crate) fn validate_impl(
     validate_self(original_impl, attr)
 }
 
-/// Validates that the declaration is the of the form `impl Trait for
-/// SomeType`, where the name of `Trait` ends in `Virtual`.
+/// Validates that the declaration is the of the form `impl Trait for SomeType`, where the name of `Trait` ends in `Virtual`.
+///
+/// Returns (class_name, trait_name).
 pub(crate) fn validate_trait_impl_virtual(
     original_impl: &Impl,
     attr: &str,
@@ -390,10 +391,9 @@ pub(crate) fn validate_trait_impl_virtual(
     let typename = extract_typename(trait_name);
 
     // Validate trait
-    if !typename
-        .as_ref()
-        .map_or(false, |seg| seg.ident.to_string().ends_with("Virtual"))
-    {
+    if !typename.as_ref().map_or(false, |seg| {
+        seg.ident == "GodotExt" || seg.ident.to_string().ends_with("Virtual")
+    }) {
         return bail(
             format!("#[{attr}] for trait impls requires a virtual method trait (trait name should end in 'Virtual')"),
             original_impl,
@@ -407,6 +407,9 @@ pub(crate) fn validate_trait_impl_virtual(
     })
 }
 
+/// Check the `MyType` (self) part of `impl Trait for MyType`.
+///
+/// Returns the type name of `Self`, or error.
 fn validate_self(original_impl: &Impl, attr: &str) -> ParseResult<Ident> {
     if let Some(segment) = extract_typename(&original_impl.self_ty) {
         if segment.generic_args.is_none() {

--- a/itest/rust/src/codegen_test.rs
+++ b/itest/rust/src/codegen_test.rs
@@ -60,7 +60,7 @@ pub struct TestBaseRenamed {
 }
 
 #[godot_api]
-impl HttpRequestVirtual for TestBaseRenamed {
+impl GodotExt for TestBaseRenamed {
     fn init(base: Base<HttpRequest>) -> Self {
         TestBaseRenamed { base }
     }

--- a/itest/rust/src/export_test.rs
+++ b/itest/rust/src/export_test.rs
@@ -75,7 +75,7 @@ impl HasProperty {
 }
 
 #[godot_api]
-impl NodeVirtual for HasProperty {
+impl GodotExt for HasProperty {
     fn init(base: Base<Node>) -> Self {
         HasProperty {
             int_val: 0,

--- a/itest/rust/src/object_test.rs
+++ b/itest/rust/src/object_test.rs
@@ -637,7 +637,7 @@ pub struct ObjPayload {
 }
 
 #[godot_api]
-impl RefCountedVirtual for ObjPayload {
+impl GodotExt for ObjPayload {
     fn init(_base: Base<Self::Base>) -> Self {
         Self { value: 111 }
     }

--- a/itest/rust/src/virtual_methods_test.rs
+++ b/itest/rust/src/virtual_methods_test.rs
@@ -35,7 +35,7 @@ struct VirtualMethodTest {
 impl VirtualMethodTest {}
 
 #[godot_api]
-impl RefCountedVirtual for VirtualMethodTest {
+impl GodotExt for VirtualMethodTest {
     fn to_string(&self) -> GodotString {
         format!("VirtualMethodTest[integer={}]", self.integer).into()
     }
@@ -50,7 +50,7 @@ struct ReadyVirtualTest {
 }
 
 #[godot_api]
-impl Node2DVirtual for ReadyVirtualTest {
+impl GodotExt for ReadyVirtualTest {
     fn init(base: Base<Node2D>) -> Self {
         ReadyVirtualTest {
             some_base: base,
@@ -73,7 +73,7 @@ struct TreeVirtualTest {
 }
 
 #[godot_api]
-impl Node2DVirtual for TreeVirtualTest {
+impl GodotExt for TreeVirtualTest {
     fn init(base: Base<Node2D>) -> Self {
         TreeVirtualTest {
             some_base: base,


### PR DESCRIPTION
#136 introduced virtual function dispatch, and with it a new syntax for `init`, `ready` etc:
```rs
#[derive(GodotClass)]
#[class(base=Area2D)]   // <- 1
pub struct Player {
    ...

    #[base]
    base: Base<Area2D>,   // <- 2
}

#[godot_api]
impl Area2DVirtual for Player {   // <- 3
    fn init(base: Base<Area2D>) -> Self { ... }
    fn ready(&mut self) { ... }
    fn process(&mut self, delta: f64) { ... }
}
```

As you can see, there is now quite a bit of repetition, although (2) could use `Base<Self::Base>`.

---

I took it as a challenge to see if it's possible to still use `GodotExt` in place of the `*Virtual` name:
```rs
#[godot_api]
impl GodotExt for Player {
    ...
}
```

This turned out to be not straightforward, because `#[godot_api]` does not know the base class of `Player` at that point. But trick 77, which I had already used in a variation for the `Inherits` declarations, came in handy: I'd define a _declarative_ macro during the `#[derive(GodotClass)]`, which would help resolve `Player` to its base name `Area2D`. So the proc-macro could eventually replace `GodotExt` with the true trait.

This works as demonstrated by this PR. But there are a few trade-offs to keep in mind:
1. It's now not necessary to repeat the base class' name anywhere, just mention it once in `#[class]`.
2. The declarative macros add a bit of implementation complexity (and possibly compile-time overhead?). It's also a bit brittle if someone declares impls in a different module, or chooses qualified identifiers like `engine::NodeVirtual`.
3. It may be confusing to users that `GodotExt` is not a real trait, but a magic placeholder substituted by the proc-macro. I added a doc-alias so one would find `GodotExt` in the docs (under `#[godot_api]`), but still.
4. There are now two ways to implement virtuals: `GodotExt` and `*Virtual`. While identical in semantics, it's not clear to the user which one they should choose or if there's a difference. I'm also not sure if the repetition is a problem in the first place, or rather makes code clearer by expressing which functionality is inherited.

Thoughts? This is a draft, and we may end up not merging it.