### PR TITLE
Extensive `#[func]` testing (GDScript -> Rust calls)

### DIFF
--- a/godot-core/src/builtin/array.rs
+++ b/godot-core/src/builtin/array.rs
@@ -855,7 +855,7 @@ macro_rules! varray {
 /// [`set_typed`](https://docs.godotengine.org/en/latest/classes/class_array.html#class-array-method-set-typed).
 ///
 /// We ignore the `script` parameter because it has no impact on typing in Godot.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(PartialEq, Eq)]
 struct TypeInfo {
     variant_type: VariantType,
     class_name: StringName,
@@ -878,5 +878,18 @@ impl TypeInfo {
 
     fn is_typed(&self) -> bool {
         self.variant_type != VariantType::Nil
+    }
+}
+
+impl fmt::Debug for TypeInfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let class = self.class_name.to_string();
+        let class_str = if class.is_empty() {
+            String::new()
+        } else {
+            format!(" (class={class})")
+        };
+
+        write!(f, "{:?}{}", self.variant_type, class_str)
     }
 }

--- a/godot-core/src/builtin/meta/mod.rs
+++ b/godot-core/src/builtin/meta/mod.rs
@@ -27,13 +27,14 @@ pub trait VariantMetadata {
     }
 
     fn property_info(property_name: &str) -> PropertyInfo {
-        PropertyInfo::new(
-            Self::variant_type(),
-            Self::class_name(),
-            StringName::from(property_name),
-            global::PropertyHint::PROPERTY_HINT_NONE,
-            GodotString::new(),
-        )
+        PropertyInfo {
+            variant_type: Self::variant_type(),
+            class_name: Self::class_name(),
+            property_name: StringName::from(property_name),
+            hint: global::PropertyHint::PROPERTY_HINT_NONE,
+            hint_string: GodotString::new(),
+            usage: global::PropertyUsageFlags::PROPERTY_USAGE_DEFAULT,
+        }
     }
 
     fn param_metadata() -> sys::GDExtensionClassMethodArgumentMetadata {
@@ -52,33 +53,17 @@ impl<T: VariantMetadata> VariantMetadata for Option<T> {
 /// Rusty abstraction of sys::GDExtensionPropertyInfo
 /// Keeps the actual allocated values (the sys equivalent only keeps pointers, which fall out of scope)
 #[derive(Debug)]
+// Note: is not #[non_exhaustive], so adding fields is a breaking change. Mostly used internally at the moment though.
 pub struct PropertyInfo {
-    variant_type: VariantType,
-    class_name: ClassName,
-    property_name: StringName,
-    hint: global::PropertyHint,
-    hint_string: GodotString,
-    usage: global::PropertyUsageFlags,
+    pub variant_type: VariantType,
+    pub class_name: ClassName,
+    pub property_name: StringName,
+    pub hint: global::PropertyHint,
+    pub hint_string: GodotString,
+    pub usage: global::PropertyUsageFlags,
 }
 
 impl PropertyInfo {
-    pub fn new(
-        variant_type: VariantType,
-        class_name: ClassName,
-        property_name: StringName,
-        hint: global::PropertyHint,
-        hint_string: GodotString,
-    ) -> Self {
-        Self {
-            variant_type,
-            class_name,
-            property_name,
-            hint,
-            hint_string,
-            usage: global::PropertyUsageFlags::PROPERTY_USAGE_DEFAULT,
-        }
-    }
-
     /// Converts to the FFI type. Keep this object allocated while using that!
     pub fn property_sys(&self) -> sys::GDExtensionPropertyInfo {
         use crate::obj::EngineEnum as _;

--- a/godot-core/src/builtin/meta/signature.rs
+++ b/godot-core/src/builtin/meta/signature.rs
@@ -162,8 +162,9 @@ macro_rules! impl_signature_for_tuple {
 				unsafe { <$R as sys::GodotFuncMarshal>::try_write_sys(&ret_val, ret) }
                     .unwrap_or_else(|e| return_error::<$R>(method_name, &e));
 
-                // FIXME is inc_ref needed here?
-				// std::mem::forget(ret_val);
+               //Note: we want to prevent the destructor from being run, since we pass ownership to the caller.
+               //https://github.com/godot-rust/gdext/pull/165
+				std::mem::forget(ret_val);
             }
         }
     };

--- a/godot-core/src/builtin/node_path.rs
+++ b/godot-core/src/builtin/node_path.rs
@@ -90,5 +90,7 @@ impl_builtin_traits! {
         Default => node_path_construct_default;
         Clone => node_path_construct_copy;
         Drop => node_path_destroy;
+        Eq => node_path_operator_equal;
+        // Ord => node_path_operator_less;
     }
 }

--- a/godot-core/src/builtin/variant/impls.rs
+++ b/godot-core/src/builtin/variant/impls.rs
@@ -5,8 +5,9 @@
  */
 
 use super::*;
-use crate::builtin::meta::VariantMetadata;
+use crate::builtin::meta::{PropertyInfo, VariantMetadata};
 use crate::builtin::*;
+use crate::engine::global;
 use crate::obj::EngineEnum;
 use godot_ffi as sys;
 use sys::GodotFfi;
@@ -223,6 +224,21 @@ impl VariantMetadata for Variant {
     fn variant_type() -> VariantType {
         // Arrays use the `NIL` type to indicate that they are untyped.
         VariantType::Nil
+    }
+
+    fn property_info(property_name: &str) -> PropertyInfo {
+        PropertyInfo {
+            variant_type: Self::variant_type(),
+            class_name: Self::class_name(),
+            property_name: StringName::from(property_name),
+            hint: global::PropertyHint::PROPERTY_HINT_NONE,
+            hint_string: GodotString::new(),
+            usage: global::PropertyUsageFlags::PROPERTY_USAGE_NIL_IS_VARIANT,
+        }
+    }
+
+    fn param_metadata() -> sys::GDExtensionClassMethodArgumentMetadata {
+        sys::GDEXTENSION_METHOD_ARGUMENT_METADATA_INT_IS_INT8
     }
 }
 

--- a/godot-core/src/lib.rs
+++ b/godot-core/src/lib.rs
@@ -69,11 +69,20 @@ pub mod private {
         match std::panic::catch_unwind(code) {
             Ok(result) => Some(result),
             Err(err) => {
+                // Flush, to make sure previous Rust output (e.g. test announcement, or debug prints during app) have been printed
+                // TODO write custom panic handler and move this there, before panic backtrace printing
+                flush_stdout();
+
                 log::godot_error!("Rust function panicked. Context: {}", error_context());
                 print_panic(err);
                 None
             }
         }
+    }
+
+    pub fn flush_stdout() {
+        use std::io::Write;
+        std::io::stdout().flush().expect("flush stdout");
     }
 }
 

--- a/godot-macros/src/derive_godot_class.rs
+++ b/godot-macros/src/derive_godot_class.rs
@@ -377,14 +377,14 @@ fn make_exports_impl(class_name: &Ident, fields: &Fields) -> TokenStream {
             use ::godot::builtin::meta::VariantMetadata;
 
             let class_name = ::godot::builtin::StringName::from(#class_name::CLASS_NAME);
-
-            let property_info = ::godot::builtin::meta::PropertyInfo::new(
-                <#field_type>::variant_type(),
-                ::godot::builtin::meta::ClassName::of::<#class_name>(),
-                ::godot::builtin::StringName::from(#field_name),
-                ::godot::engine::global::PropertyHint::#hint_type,
-                ::godot::builtin::GodotString::from(#description),
-            );
+            let property_info = ::godot::builtin::meta::PropertyInfo {
+                variant_type:  <#field_type>::variant_type(),
+                class_name:    ::godot::builtin::meta::ClassName::of::<#class_name>(),
+                property_name: ::godot::builtin::StringName::from(#field_name),
+                hint:          ::godot::engine::global::PropertyHint::#hint_type,
+                hint_string:   ::godot::builtin::GodotString::from(#description),
+                usage:         ::godot::engine::global::PropertyUsageFlags::PROPERTY_USAGE_DEFAULT,
+            };
             let property_info_sys = property_info.property_sys();
 
             let getter_name = ::godot::builtin::StringName::from(#getter_name);

--- a/itest/godot/InheritTests.gd
+++ b/itest/godot/InheritTests.gd
@@ -1,0 +1,27 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+extends ArrayTest
+
+var test_suite: TestSuite = TestSuite.new()
+
+# In order to reproduce the behavior discovered in https://github.com/godot-rust/gdext/issues/138
+# we must inherit a Godot Node. Because of this we can't just inherit TesSuite like the rest of the tests.
+func assert_that(what: bool, message: String = "") -> bool:
+	return test_suite.assert_that(what, message)
+
+func assert_eq(left, right, message: String = "") -> bool:
+	return test_suite.assert_eq(left, right, message)
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	pass
+
+func test_vector_array_return_from_user_func():
+	var array: Array = return_typed_array(2)
+	assert_eq(array, [1,2])
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta):
+	pass

--- a/itest/godot/TestRunner.gd
+++ b/itest/godot/TestRunner.gd
@@ -24,6 +24,7 @@ func _ready():
 	var gdscript_suites: Array = [
 		preload("res://ManualFfiTests.gd").new(),
 		preload("res://gen/GenFfiTests.gd").new(),
+		preload("res://InheritTests.gd").new()
 	]
 	
 	var gdscript_tests: Array = []

--- a/itest/godot/TestSuite.gd
+++ b/itest/godot/TestSuite.gd
@@ -14,10 +14,12 @@ func assert_that(what: bool, message: String = "") -> bool:
 		return true
 
 	_assertion_failed = true
+
+	printerr() # previous line not yet broken
 	if message:
-		print("assertion failed: %s" % message)
+		push_error("GDScript assertion failed:  %s" % message)
 	else:
-		print("assertion failed")
+		push_error("GDScript assertion failed.")
 	return false
 
 func assert_eq(left, right, message: String = "") -> bool:
@@ -25,8 +27,10 @@ func assert_eq(left, right, message: String = "") -> bool:
 		return true
 
 	_assertion_failed = true
+
+	printerr() # previous line not yet broken
 	if message:
-		print("assertion failed: %s\n  left: %s\n right: %s" % [message, left, right])
+		push_error("GDScript assertion failed:  %s\n  left: %s\n right: %s" % [message, left, right])
 	else:
-		print("assertion failed: `(left == right)`\n  left: %s\n right: %s" % [left, right])
+		push_error("GDScript assertion failed:  `(left == right)`\n  left: %s\n right: %s" % [left, right])
 	return false

--- a/itest/godot/input/GenFfiTests.template.gd
+++ b/itest/godot/input/GenFfiTests.template.gd
@@ -4,14 +4,31 @@
 
 extends TestSuite
 
+# Note: GDScript only uses ptrcalls if it has the full type information available at "compile" (parse) time.
+# That includes all arguments (including receiver) as well as function signature (parameters + return type).
+# Otherwise, GDScript will use varcall. Both are tested below.
+# It is thus important that `ffi` is initialized using = for varcalls, and using := for ptrcalls.
+
 #(
 func test_varcall_IDENT():
 	var ffi = GenFfi.new()
 
-	var from_rust = ffi.return_IDENT()
-	assert_that(ffi.accept_IDENT(from_rust))
+	var from_rust: Variant = ffi.return_IDENT()
+	assert_that(ffi.accept_IDENT(from_rust), "ffi.accept_IDENT(from_rust)")
 
-	var from_gdscript = VAL
-	var mirrored = ffi.mirror_IDENT(from_gdscript)
-	assert_eq(mirrored, from_gdscript)
+	var from_gdscript: Variant = VAL
+	var mirrored: Variant = ffi.mirror_IDENT(from_gdscript)
+	assert_eq(mirrored, from_gdscript, "mirrored == from_gdscript")
+#)
+
+#(
+func test_ptrcall_IDENT():
+	var ffi := GenFfi.new()
+
+	var from_rust: TYPE = ffi.return_IDENT()
+	assert_that(ffi.accept_IDENT(from_rust), "ffi.accept_IDENT(from_rust)")
+
+	var from_gdscript: TYPE = VAL
+	var mirrored: TYPE = ffi.mirror_IDENT(from_gdscript)
+	assert_eq(mirrored, from_gdscript, "mirrored == from_gdscript")
 #)


### PR DESCRIPTION
Generates both ptrcall and varcall tests now.
Adds several values to the test input.

Currently fails in some ptrcall cases; possibly related to #138 and #195.