### PR TITLE
Implement InstanceStorage optionally as sync for #18

### DIFF
--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -171,7 +171,8 @@ jobs:
 
           - name: linux-threads
             os: ubuntu-20.04
-            godot-binary: godot.linuxbsd.editor.dev.double.x86_64
+            artifact-name: linux
+            godot-binary: godot.linuxbsd.editor.dev.x86_64
             rust-extra-args: --features threads
 
           - name: linux-nightly

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -169,6 +169,11 @@ jobs:
             godot-binary: godot.linuxbsd.editor.dev.double.x86_64
             rust-extra-args: --features double-precision
 
+          - name: linux-threads
+            os: ubuntu-20.04
+            godot-binary: godot.linuxbsd.editor.dev.double.x86_64
+            rust-extra-args: --features threads
+
           - name: linux-nightly
             os: ubuntu-20.04
             artifact-name: linux

--- a/godot-core/Cargo.toml
+++ b/godot-core/Cargo.toml
@@ -14,6 +14,7 @@ codegen-fmt = ["godot-ffi/codegen-fmt", "godot-codegen/codegen-fmt"]
 codegen-full = ["godot-codegen/codegen-full"]
 double-precision = ["godot-codegen/double-precision"]
 custom-godot = ["godot-ffi/custom-godot", "godot-codegen/custom-godot"]
+threads = []
 
 [dependencies]
 godot-ffi = { path = "../godot-ffi" }

--- a/godot-core/src/obj/guards.rs
+++ b/godot-core/src/obj/guards.rs
@@ -4,20 +4,33 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+#[cfg(not(feature = "threads"))]
 use std::cell;
 use std::fmt::Debug;
 use std::ops::{Deref, DerefMut};
+#[cfg(feature = "threads")]
+use std::sync;
 
 /// Immutably/shared bound reference guard for a [`Gd`][crate::obj::Gd] smart pointer.
 ///
 /// See [`Gd::bind`][crate::obj::Gd::bind] for usage.
 #[derive(Debug)]
 pub struct GdRef<'a, T> {
+    #[cfg(not(feature = "threads"))]
     cell_ref: cell::Ref<'a, T>,
+
+    #[cfg(feature = "threads")]
+    cell_ref: sync::RwLockReadGuard<'a, T>,
 }
 
 impl<'a, T> GdRef<'a, T> {
+    #[cfg(not(feature = "threads"))]
     pub(crate) fn from_cell(cell_ref: cell::Ref<'a, T>) -> Self {
+        Self { cell_ref }
+    }
+
+    #[cfg(feature = "threads")]
+    pub(crate) fn from_cell(cell_ref: sync::RwLockReadGuard<'a, T>) -> Self {
         Self { cell_ref }
     }
 }
@@ -39,11 +52,21 @@ impl<T> Deref for GdRef<'_, T> {
 /// See [`Gd::bind_mut`][crate::obj::Gd::bind_mut] for usage.
 #[derive(Debug)]
 pub struct GdMut<'a, T> {
+    #[cfg(not(feature = "threads"))]
     cell_ref: cell::RefMut<'a, T>,
+
+    #[cfg(feature = "threads")]
+    cell_ref: sync::RwLockWriteGuard<'a, T>,
 }
 
 impl<'a, T> GdMut<'a, T> {
+    #[cfg(not(feature = "threads"))]
     pub(crate) fn from_cell(cell_ref: cell::RefMut<'a, T>) -> Self {
+        Self { cell_ref }
+    }
+
+    #[cfg(feature = "threads")]
+    pub(crate) fn from_cell(cell_ref: sync::RwLockWriteGuard<'a, T>) -> Self {
         Self { cell_ref }
     }
 }

--- a/godot/Cargo.toml
+++ b/godot/Cargo.toml
@@ -12,6 +12,7 @@ default = ["codegen-full"]
 formatted = ["godot-core/codegen-fmt"]
 double-precision = ["godot-core/double-precision"]
 custom-godot = ["godot-core/custom-godot"]
+threads = ["godot-core/threads"]
 
 # Private features, they are under no stability guarantee
 codegen-full = ["godot-core/codegen-full"]

--- a/itest/rust/Cargo.toml
+++ b/itest/rust/Cargo.toml
@@ -12,6 +12,7 @@ crate-type = ["cdylib"]
 default = []
 trace = ["godot/trace"]
 double-precision = ["godot/double-precision"]
+threads = ["godot/threads"]
 
 [dependencies]
 godot = { path = "../../godot", default-features = false, features = ["formatted"] }


### PR DESCRIPTION
This is a second implementation of `InstanceStorage` that is `Sync` and `Send` and should make it suitable for usage with rust threads.

I hope it fits with the general plans for multithreading in #18. Feedback is more than welcome.