### PR TITLE
Add `#[export_group]` Attribute for Creating Property Groups

### DIFF
--- a/godot-macros/src/lib.rs
+++ b/godot-macros/src/lib.rs
@@ -255,7 +255,10 @@ mod util;
 ///
 /// The `#[signal]` attribute is accepted, but not yet implemented. See [issue
 /// #8](https://github.com/godot-rust/gdext/issues/8).
-#[proc_macro_derive(GodotClass, attributes(class, base, export, init, signal))]
+#[proc_macro_derive(
+    GodotClass,
+    attributes(class, base, export, export_group, init, signal)
+)]
 pub fn derive_native_class(input: TokenStream) -> TokenStream {
     translate(input, derive_godot_class::transform)
 }

--- a/itest/rust/src/export_test.rs
+++ b/itest/rust/src/export_test.rs
@@ -35,6 +35,12 @@ struct HasProperty {
     texture_val: Gd<Texture>,
     #[export(get = get_texture_val, set = set_texture_val, hint = PROPERTY_HINT_RESOURCE_TYPE, hint_desc = "Texture")]
     texture_val_rw: Option<Gd<Texture>>,
+
+    #[export_group(name = "foo group", prefix = "grouped_")]
+    #[export]
+    grouped_foo: i32,
+    #[export]
+    grouped_bar: i32,
 }
 
 #[godot_api]
@@ -128,6 +134,8 @@ impl NodeVirtual for HasProperty {
             string_val: GodotString::new(),
             texture_val: Texture::new(),
             texture_val_rw: None,
+            grouped_foo: 0,
+            grouped_bar: 0,
             base,
         }
     }


### PR DESCRIPTION
This makes Godot's property groups available to exported properties in Rust.

On the itest side there may be possibilities to further test the success of creating the property, right now itest only uses the attribute, i.e. checks that code using it compiles. However, I am unsure how to properly query this in a way like `HasProperty` is tested.

Feedback is more than welcome!

# Without this PR

![Screenshot_2023-04-05_14-49-00](https://user-images.githubusercontent.com/76439353/230085224-05a21e0e-ac1a-40ad-a868-5795cbafb2e8.png)

![Screenshot_2023-04-05_14-49-54](https://user-images.githubusercontent.com/76439353/230085354-7be7e6ba-8029-4024-b3cc-ccb8e0c2ba6d.png)

# With this PR

![Screenshot_2023-04-05_14-43-06](https://user-images.githubusercontent.com/76439353/230083839-761879e6-6529-43ed-aa37-9e99c3d87e05.png)

![Screenshot_2023-04-05_14-44-01](https://user-images.githubusercontent.com/76439353/230083953-239c6c03-7b5d-4b23-b003-81d62a0831bc.png)
