### PR TITLE
Catch failed calls to `classdb_get_method_bind()`

### DIFF
--- a/godot-codegen/src/class_generator.rs
+++ b/godot-codegen/src/class_generator.rs
@@ -575,6 +575,12 @@ fn make_method_definition(
             __method_name.string_sys(),
             #hash
         );
+        assert!(
+            !__method_bind.is_null(),
+            "failed to load method {}::{} -- possible Godot and gdext version mismatch",
+            #class_name_str,
+            #method_name_str
+        );
         let __call_fn = sys::interface_fn!(#function_provider);
     };
     let varcall_invocation = quote! {


### PR DESCRIPTION
When Godot fails to provide a method (e.g. invalid hash), this FFI method returns a null pointer. Instead of UB from dereferencing that pointer, a panic is now caused.

Found as a result of https://github.com/godotengine/godot/issues/75779.