### PR TITLE
check.sh: find Godot 4 executable when available as `godot`

### DIFF
--- a/check.sh
+++ b/check.sh
@@ -76,6 +76,18 @@ function findGodot() {
         echo "Found 'godot4.bat' script"
         godotBin="godot4.bat"
 
+    # This should come last: only use this as a last resort as usually `godot`
+    # refers to a Godot 3.x installation.
+    elif command -v godot &>/dev/null; then
+        # Check if `godot` actually is Godot 4.x
+        if godot --version | grep -qE "^4\\."; then
+            echo "Found 'godot' executable with version $(godot --version)"
+            godotBin="godot"
+        else
+            echo "Found 'godot' executable, but it has the incompatible version $(godot --version)"
+            exit 2
+        fi
+
     # Error case
     else
         echo "Godot executable not found"
@@ -99,7 +111,7 @@ for arg in "${args[@]}"; do
         ;;
     itest)
         findGodot
-        
+
         cmds+=("cargo $toolchain build -p itest $extraArgs")
         cmds+=("$godotBin --path itest/godot --headless")
         ;;


### PR DESCRIPTION
# The Issue

Some package managers (Arch Linux) install Godot 4.x as `godot` in the PATH. This is currently not correctly dealt with by check.sh, requiring the user to set GODOT4_BIN manually.

# The Solution

If `godot` is available, `check.sh` now inspects the version of that Godot installation, and if 4.x, accepts it gladly, removing the need to manually set GODOT4_BIN.

# Detail

The version check applies the regex `^4\.` to the version returned by `godot --version`. An example version (the one available in Arch Linux's community repo) is `4.0.1.stable.arch_linux`.