### PR TITLE
godot-core: bug: fix UB in GodotString::chars_(un)checked

### DIFF
--- a/godot-core/src/builtin/string.rs
+++ b/godot-core/src/builtin/string.rs
@@ -55,6 +55,11 @@ impl GodotString {
             let len = interface_fn!(string_to_utf32_chars)(s, std::ptr::null_mut(), 0);
             let ptr = interface_fn!(string_operator_index_const)(s, 0);
 
+            // Even when len == 0, from_raw_parts requires ptr != 0
+            if ptr.is_null() {
+                return &[];
+            }
+
             validate_unicode_scalar_sequence(std::slice::from_raw_parts(ptr, len as usize))
                 .expect("GodotString::chars_checked: string contains invalid unicode scalar values")
         }
@@ -71,6 +76,11 @@ impl GodotString {
         let s = self.string_sys();
         let len = interface_fn!(string_to_utf32_chars)(s, std::ptr::null_mut(), 0);
         let ptr = interface_fn!(string_operator_index_const)(s, 0);
+
+        // Even when len == 0, from_raw_parts requires ptr != 0
+        if ptr.is_null() {
+            return &[];
+        }
         std::slice::from_raw_parts(ptr as *const char, len as usize)
     }
 }

--- a/itest/rust/src/string_test.rs
+++ b/itest/rust/src/string_test.rs
@@ -56,6 +56,14 @@ fn string_clone() {
     assert_eq!(first, cloned);
 }
 
+#[itest]
+fn empty_string_chars() {
+    // Tests regression from #228: Null pointer passed to slice::from_raw_parts
+    let s = GodotString::new();
+    assert_eq!(s.chars_checked(), &[]);
+    assert_eq!(unsafe { s.chars_unchecked() }, &[]);
+}
+
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 
 #[itest]


### PR DESCRIPTION
`slice::from_raw_parts` requires its first argument to be non-null, even when `len == 0` [1], resulting in a crash on the expect in `chars_checked` when Godot returns an empty GodotString as a null pointer and a length of 0.

I only checked these two usages, but might be worth checking other usages, too.

[1] https://doc.rust-lang.org/std/slice/fn.from_raw_parts.html