### PR TITLE
Fix `(no base)` showing up in all the docs

### DIFF
--- a/godot-core/src/builtin/array.rs
+++ b/godot-core/src/builtin/array.rs
@@ -883,12 +883,7 @@ struct TypeInfo {
 impl TypeInfo {
     fn new<T: VariantMetadata>() -> Self {
         let variant_type = T::variant_type();
-        let class_name = match variant_type {
-            VariantType::Object => StringName::from(T::class_name()),
-            // TODO for variant types other than Object, class_name() returns "(no base)"; just
-            // make it return "" instead?
-            _ => StringName::default(),
-        };
+        let class_name: StringName = T::class_name().into();
         Self {
             variant_type,
             class_name,

--- a/godot-core/src/builtin/meta/class_name.rs
+++ b/godot-core/src/builtin/meta/class_name.rs
@@ -19,6 +19,13 @@ pub struct ClassName {
 }
 
 impl ClassName {
+    /// In Godot, an empty `StringName` in a place that expects a class name, means that there is no class.
+    pub fn none() -> Self {
+        Self {
+            backing: StringName::default(),
+        }
+    }
+
     pub fn of<T: GodotClass>() -> Self {
         Self {
             backing: StringName::from(T::CLASS_NAME),

--- a/godot-core/src/builtin/meta/mod.rs
+++ b/godot-core/src/builtin/meta/mod.rs
@@ -23,7 +23,8 @@ pub trait VariantMetadata {
     fn variant_type() -> VariantType;
 
     fn class_name() -> ClassName {
-        ClassName::of::<()>() // FIXME Option or so
+        // If we use `ClassName::of::<()>()` then this type shows up as `(no base)` in documentation.
+        ClassName::none()
     }
 
     fn property_info(property_name: &str) -> PropertyInfo {


### PR DESCRIPTION
We were setting `class_name` to be `(no base)` in the `PropertyInfo` for all types by default. However that makes godot show the `class_name` in return values and arguments.

I dont know if there's a good way to test this? It would involve us checking what documentation is generated by godot which doesn't seem like something we can easily do.

closes #159 