### PR TITLE
Fix cast always succeeding due to Godot bug.

### DIFF
--- a/itest/rust/src/object_test.rs
+++ b/itest/rust/src/object_test.rs
@@ -426,6 +426,36 @@ fn object_engine_downcast() {
     node3d.free();
 }
 
+#[derive(GodotClass)]
+struct CustomClassA {}
+
+#[derive(GodotClass)]
+struct CustomClassB {}
+
+#[itest]
+fn object_reject_invalid_downcast() {
+    let a_instance = Gd::new(CustomClassA {});
+    let b_instance = Gd::new(CustomClassB {});
+
+    let a_obj = a_instance.upcast::<Object>();
+    let b_obj = b_instance.upcast::<Object>();
+
+    assert!(a_obj.try_cast::<CustomClassB>().is_none());
+    assert!(b_obj.try_cast::<CustomClassA>().is_none());
+}
+
+#[itest]
+fn variant_reject_invalid_downcast() {
+    let a_instance = Gd::new(CustomClassA {}).to_variant();
+    let b_instance = Gd::new(CustomClassB {}).to_variant();
+
+    assert!(a_instance.try_to::<Gd<CustomClassB>>().is_err());
+    assert!(b_instance.try_to::<Gd<CustomClassA>>().is_err());
+
+    assert!(a_instance.try_to::<Gd<CustomClassA>>().is_ok());
+    assert!(b_instance.try_to::<Gd<CustomClassB>>().is_ok());
+}
+
 #[itest]
 fn object_engine_downcast_reflexive() {
     let node3d: Gd<Node3D> = Node3D::new_alloc();


### PR DESCRIPTION
See #158 . 

Currently, casting always succeeds due to a bug in Godot. This PR adds an explicit (slow) check to make sure that the cast is valid before performing it. This should mirror the behavior that Godot will have when the bug is fixed upstream. This is better than the fix mentioned in #158 as that fix only works when the object you are casting is *exactly* the class you are casting to, you could not cast a derived class to a parent class. This PR has no such limitation.

I tested it with the following code:

```rust
#[derive(GodotClass)]
#[class(init)]
pub struct TestClass {}

#[godot_api]
impl TestClass {}

#[derive(GodotClass)]
#[class(init)]
pub struct OtherRefCountedClass {}

#[godot_api]
impl OtherRefCountedClass {}

#[derive(GodotClass)]
#[class(init)]
pub struct TestClassRunner {
    #[export]
    #[init(default = Gd::new(TestClass {}))]
    pub tc: Gd<TestClass>,
}

#[godot_api]
impl TestClassRunner {
    #[func]
    pub fn tests(&self) {
        godot_print!("{:?}", self.tc.share().upcast::<Object>());
        godot_print!("{:?}", self.tc.share().upcast::<RefCounted>());
        godot_print!(
            "{:?}",
            self.tc.share().upcast::<Object>().cast::<TestClass>()
        );
        godot_print!(
            "{:?}",
            self.tc.share().upcast::<Object>().try_cast::<Node>()
        );
        godot_print!(
            "{:?}",
            self.tc
                .share()
                .upcast::<Object>()
                .try_cast::<OtherRefCountedClass>()
        );
    }
}
```

And constructing the runner and running the function in Godot produced the following output:
```
Gd { id: -9223372008501280223, class: TestClass }
Gd { id: -9223372008501280223, class: TestClass }
Gd { id: -9223372008501280223, class: TestClass }
None
None
```