### PR TITLE
Update MSRV to 1.66; fix detection in CI

### DIFF
--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -86,8 +86,14 @@ jobs:
 
           - name: linux
             os: ubuntu-20.04
-            rust-toolchain: '1.63.0'
+            rust-toolchain: nightly
             rust-special: -minimal-deps
+            rust-cache-key: minimal-deps
+
+          - name: linux
+            os: ubuntu-20.04
+            rust-toolchain: '1.66.0'
+            rust-special: -msrv
 
     steps:
       - uses: actions/checkout@v3
@@ -96,14 +102,7 @@ jobs:
         uses: ./.github/composite/rust
         with:
           rust: ${{ matrix.rust-toolchain || 'stable' }}
-          cache-key: ${{ matrix.rust-special }} # '-minimal-deps' or empty/not defined
-
-      - name: "Install Rust nightly (minimal deps)"
-        if: matrix.rust-special == '-minimal-deps'
-        uses: ./.github/composite/rust
-        with:
-          rust: nightly
-          cache-key: minimal-deps-nightly
+          cache-key: ${{ matrix.rust-cache-key }} # only needed when rustc version is possibly the same
 
       - name: "Install minimal dependency versions from Cargo"
         if: matrix.rust-special == '-minimal-deps'
@@ -195,6 +194,7 @@ jobs:
             godot-args: -- --disallow-focus
             rust-toolchain: nightly
             rust-env-rustflags: -Zrandomize-layout
+
 
     steps:
       - uses: actions/checkout@v3

--- a/godot-bindings/Cargo.toml
+++ b/godot-bindings/Cargo.toml
@@ -2,7 +2,7 @@
 name = "godot-bindings"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.66"
 license = "MPL-2.0"
 keywords = ["gamedev", "godot", "engine", "ffi", "sys"]
 categories = ["game-engines", "graphics"]

--- a/godot-codegen/Cargo.toml
+++ b/godot-codegen/Cargo.toml
@@ -2,7 +2,7 @@
 name = "godot-codegen"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.66"
 license = "MPL-2.0"
 keywords = ["gamedev", "godot", "engine", "codegen"]
 categories = ["game-engines", "graphics"]

--- a/godot-core/Cargo.toml
+++ b/godot-core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "godot-core"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.66"
 license = "MPL-2.0"
 keywords = ["gamedev", "godot", "engine", "2d", "3d"] # possibly: "ffi"
 categories = ["game-engines", "graphics"]

--- a/godot-ffi/Cargo.toml
+++ b/godot-ffi/Cargo.toml
@@ -2,7 +2,7 @@
 name = "godot-ffi"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.66"
 license = "MPL-2.0"
 keywords = ["gamedev", "godot", "engine", "ffi"]
 categories = ["game-engines", "graphics"]

--- a/godot-macros/Cargo.toml
+++ b/godot-macros/Cargo.toml
@@ -2,7 +2,7 @@
 name = "godot-macros"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.66"
 license = "MPL-2.0"
 keywords = ["gamedev", "godot", "engine", "derive", "macro"]
 categories = ["game-engines", "graphics"]

--- a/godot/Cargo.toml
+++ b/godot/Cargo.toml
@@ -2,7 +2,7 @@
 name = "godot"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.66"
 license = "MPL-2.0"
 keywords = ["gamedev", "godot", "engine", "2d", "3d"] # possibly: "ffi"
 categories = ["game-engines", "graphics"]

--- a/itest/rust/Cargo.toml
+++ b/itest/rust/Cargo.toml
@@ -2,7 +2,7 @@
 name = "itest"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.66"
 publish = false
 
 [lib]


### PR DESCRIPTION
The unit-test job accidentally used the nightly compiler in MSRV check. Now, `minimal-deps` and `msrv` are two separate jobs.

MSRV 1.63 was incorrect -- two features require newer Rust versions:

1. discriminants on enums with fields (for `*Notification` types)
    https://blog.rust-lang.org/2022/12/15/Rust-1.66.0.html#explicit-discriminants-on-enums-with-fields

2. let-else
    https://blog.rust-lang.org/2022/11/03/Rust-1.65.0.html#let-else-statements