### PR TITLE
impl `GodotFfi` for `Option<T>` when `T` is pointer sized and nullable #240

### DIFF
--- a/godot-ffi/src/lib.rs
+++ b/godot-ffi/src/lib.rs
@@ -32,7 +32,7 @@ use std::ffi::CStr;
 #[doc(hidden)]
 pub use paste;
 
-pub use crate::godot_ffi::{GodotFfi, GodotFuncMarshal, PtrcallType};
+pub use crate::godot_ffi::{GodotFfi, GodotFuncMarshal, GodotNullablePtr, PtrcallType};
 pub use gen::central::*;
 pub use gen::gdextension_interface::*;
 pub use gen::interface::*;

--- a/itest/godot/ManualFfiTests.gd
+++ b/itest/godot/ManualFfiTests.gd
@@ -150,3 +150,87 @@ func test_custom_constructor():
 	var obj = CustomConstructor.construct_object(42)
 	assert_eq(obj.val, 42)
 	obj.free()
+
+func test_option_refcounted_none_varcall():
+	var ffi := OptionFfiTest.new()
+
+	var from_rust: Variant = ffi.return_option_refcounted_none()
+	assert_that(ffi.accept_option_refcounted_none(from_rust), "ffi.accept_option_refcounted_none(from_rust)")
+
+	var from_gdscript: Variant = null
+	var mirrored: Variant = ffi.mirror_option_refcounted(from_gdscript)
+	assert_eq(mirrored, from_gdscript, "mirrored == from_gdscript")
+
+func test_option_refcounted_none_ptrcall():
+	var ffi := OptionFfiTest.new()
+
+	var from_rust: Object = ffi.return_option_refcounted_none()
+	assert_that(ffi.accept_option_refcounted_none(from_rust), "ffi.accept_option_refcounted_none(from_rust)")
+
+	var from_gdscript: Object = null
+	var mirrored: Object = ffi.mirror_option_refcounted(from_gdscript)
+	assert_eq(mirrored, from_gdscript, "mirrored == from_gdscript")
+
+func test_option_refcounted_some_varcall():
+	var ffi := OptionFfiTest.new()
+
+	var from_rust: Variant = ffi.return_option_refcounted_some()
+	assert_that(ffi.accept_option_refcounted_some(from_rust), "ffi.accept_option_refcounted_some(from_rust)")
+
+	var from_gdscript: Variant = RefCounted.new()
+	var mirrored: Variant = ffi.mirror_option_refcounted(from_gdscript)
+	assert_eq(mirrored, from_gdscript, "mirrored == from_gdscript")
+
+func test_option_refcounted_some_ptrcall():
+	var ffi := OptionFfiTest.new()
+
+	var from_rust: Object = ffi.return_option_refcounted_some()
+	assert_that(ffi.accept_option_refcounted_some(from_rust), "ffi.accept_option_refcounted_some(from_rust)")
+
+	var from_gdscript: Object = RefCounted.new()
+	var mirrored: Object = ffi.mirror_option_refcounted(from_gdscript)
+	assert_eq(mirrored, from_gdscript, "mirrored == from_gdscript")
+
+func test_option_node_none_varcall():
+	var ffi := OptionFfiTest.new()
+
+	var from_rust: Variant = ffi.return_option_node_none()
+	assert_that(ffi.accept_option_node_none(from_rust), "ffi.accept_option_node_none(from_rust)")
+
+	var from_gdscript: Variant = null
+	var mirrored: Variant = ffi.mirror_option_node(from_gdscript)
+	assert_eq(mirrored, from_gdscript, "mirrored == from_gdscript")
+
+func test_option_node_none_ptrcall():
+	var ffi := OptionFfiTest.new()
+
+	var from_rust: Node = ffi.return_option_node_none()
+	assert_that(ffi.accept_option_node_none(from_rust), "ffi.accept_option_node_none(from_rust)")
+
+	var from_gdscript: Node = null
+	var mirrored: Node = ffi.mirror_option_node(from_gdscript)
+	assert_eq(mirrored, from_gdscript, "mirrored == from_gdscript")
+
+func test_option_node_some_varcall():
+	var ffi := OptionFfiTest.new()
+
+	var from_rust: Variant = ffi.return_option_node_some()
+	assert_that(ffi.accept_option_node_some(from_rust), "ffi.accept_option_node_some(from_rust)")
+
+	var from_gdscript: Variant = Node.new()
+	var mirrored: Variant = ffi.mirror_option_node(from_gdscript)
+	assert_eq(mirrored, from_gdscript, "mirrored == from_gdscript")
+	from_gdscript.free()
+	from_rust.free()
+
+func test_option_node_some_ptrcall():
+	var ffi := OptionFfiTest.new()
+
+	var from_rust: Node = ffi.return_option_node_some()
+	assert_that(ffi.accept_option_node_some(from_rust), "ffi.accept_option_node_some(from_rust)")
+
+	var from_gdscript: Node = Node.new()
+	var mirrored: Node = ffi.mirror_option_node(from_gdscript)
+	assert_eq(mirrored, from_gdscript, "mirrored == from_gdscript")
+	from_gdscript.free()
+	from_rust.free()

--- a/itest/rust/src/lib.rs
+++ b/itest/rust/src/lib.rs
@@ -25,6 +25,7 @@ mod init_test;
 mod native_structures_test;
 mod node_test;
 mod object_test;
+mod option_ffi_test;
 mod packed_array_test;
 mod projection_test;
 mod quaternion_test;

--- a/itest/rust/src/option_ffi_test.rs
+++ b/itest/rust/src/option_ffi_test.rs
@@ -1,0 +1,87 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use godot::prelude::{godot_api, Gd, GodotClass, Node, Object, RefCounted};
+use godot::sys::GodotFfi;
+
+use crate::itest;
+
+#[itest]
+fn option_some_sys_conversion() {
+    let v = Some(Object::new_alloc());
+    let ptr = v.sys();
+
+    let v2 = unsafe { Option::<Gd<Object>>::from_sys(ptr) };
+    assert_eq!(v2, v);
+
+    v.unwrap().free();
+}
+
+#[itest]
+fn option_none_sys_conversion() {
+    let v = None;
+    let ptr = v.sys();
+
+    let v2 = unsafe { Option::<Gd<Object>>::from_sys(ptr) };
+    assert_eq!(v2, v);
+}
+
+#[derive(GodotClass, Debug)]
+#[class(base = RefCounted, init)]
+struct OptionFfiTest;
+
+#[godot_api]
+impl OptionFfiTest {
+    #[func]
+    fn return_option_refcounted_none(&self) -> Option<Gd<RefCounted>> {
+        None
+    }
+
+    #[func]
+    fn accept_option_refcounted_none(&self, value: Option<Gd<RefCounted>>) -> bool {
+        value.is_none()
+    }
+
+    #[func]
+    fn return_option_refcounted_some(&self) -> Option<Gd<RefCounted>> {
+        Some(RefCounted::new())
+    }
+
+    #[func]
+    fn accept_option_refcounted_some(&self, value: Option<Gd<RefCounted>>) -> bool {
+        value.is_some()
+    }
+
+    #[func]
+    fn mirror_option_refcounted(&self, value: Option<Gd<RefCounted>>) -> Option<Gd<RefCounted>> {
+        value
+    }
+
+    #[func]
+    fn return_option_node_none(&self) -> Option<Gd<Node>> {
+        None
+    }
+
+    #[func]
+    fn accept_option_node_none(&self, value: Option<Gd<Node>>) -> bool {
+        value.is_none()
+    }
+
+    #[func]
+    fn return_option_node_some(&self) -> Option<Gd<Node>> {
+        Some(Node::new_alloc())
+    }
+
+    #[func]
+    fn accept_option_node_some(&self, value: Option<Gd<Node>>) -> bool {
+        value.is_some()
+    }
+
+    #[func]
+    fn mirror_option_node(&self, value: Option<Gd<Node>>) -> Option<Gd<Node>> {
+        value
+    }
+}


### PR DESCRIPTION
`ToVariant` and `FromVariant` are implemented for `Option<Gd<T>>` as well as they are a requirement of `#[godot_api]`.

Closes #240.