### PR TITLE
fix callable crashing when from_sys_init_default is used

### DIFF
--- a/godot-core/src/builtin/callable.rs
+++ b/godot-core/src/builtin/callable.rs
@@ -180,6 +180,12 @@ impl_builtin_traits! {
 // beyond what is done in `from_opaque` and `drop`. So using `*mut Opaque` is safe.
 unsafe impl GodotFfi for Callable {
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Opaque; .. }
+
+    unsafe fn from_sys_init_default(init_fn: impl FnOnce(sys::GDExtensionTypePtr)) -> Self {
+        let mut result = Self::default();
+        init_fn(result.sys_mut());
+        result
+    }
 }
 
 impl std::fmt::Debug for Callable {

--- a/itest/rust/build.rs
+++ b/itest/rust/build.rs
@@ -62,6 +62,7 @@ fn collect_inputs() -> Vec<Input> {
     push!(inputs; Vector4, Vector4, Vector4(-18.5, 24.75, -1.25, 777.875), Vector4::new(-18.5, 24.75, -1.25, 777.875));
     push!(inputs; Vector2i, Vector2i, Vector2i(-2147483648, 2147483647), Vector2i::new(-2147483648, 2147483647));
     push!(inputs; Vector3i, Vector3i, Vector3i(-1, -2147483648, 2147483647), Vector3i::new(-1, -2147483648, 2147483647));
+    push!(inputs; Callable, Callable, Callable(), Callable::default());
 
     // Data structures
     // TODO enable below, when GDScript has typed array literals, or find a hack with eval/lambdas


### PR DESCRIPTION
callable needed to override `from_sys_init_default` in the usual way.

closes #248