### PR TITLE
Implement `#[func]` for static functions

### DIFF
--- a/godot-core/src/builtin/meta/signature.rs
+++ b/godot-core/src/builtin/meta/signature.rs
@@ -22,15 +22,6 @@ pub trait SignatureTuple {
         args_ptr: *const sys::GDExtensionConstVariantPtr,
         ret: sys::GDExtensionVariantPtr,
         err: *mut sys::GDExtensionCallError,
-        func: fn(&C, Self::Params) -> Self::Ret,
-        method_name: &str,
-    );
-
-    unsafe fn varcall_mut<C: GodotClass>(
-        instance_ptr: sys::GDExtensionClassInstancePtr,
-        args_ptr: *const sys::GDExtensionConstVariantPtr,
-        ret: sys::GDExtensionVariantPtr,
-        err: *mut sys::GDExtensionCallError,
         func: fn(sys::GDExtensionClassInstancePtr, Self::Params) -> Self::Ret,
         method_name: &str,
     );
@@ -41,18 +32,8 @@ pub trait SignatureTuple {
         instance_ptr: sys::GDExtensionClassInstancePtr,
         args_ptr: *const sys::GDExtensionConstTypePtr,
         ret: sys::GDExtensionTypePtr,
-        func: fn(&C, Self::Params) -> Self::Ret,
-        method_name: &str,
-        call_type: sys::PtrcallType,
-    );
-
-    // Note: this method imposes extra bounds on GodotFfi, which may not be implemented for user types.
-    // We could fall back to varcalls in such cases, and not require GodotFfi categorically.
-    unsafe fn ptrcall_mut<C: GodotClass>(
-        instance_ptr: sys::GDExtensionClassInstancePtr,
-        args_ptr: *const sys::GDExtensionConstTypePtr,
-        ret: sys::GDExtensionTypePtr,
         func: fn(sys::GDExtensionClassInstancePtr, Self::Params) -> Self::Ret,
+        method_name: &str,
         call_type: sys::PtrcallType,
     );
 }
@@ -130,59 +111,16 @@ macro_rules! impl_signature_for_tuple {
                 args_ptr: *const sys::GDExtensionConstVariantPtr,
                 ret: sys::GDExtensionVariantPtr,
                 err: *mut sys::GDExtensionCallError,
-                func: fn(&C, Self::Params) -> Self::Ret,
-                method_name: &str,
-            ) {
-    	        $crate::out!("varcall: {}", method_name);
-
-                let storage = unsafe { crate::private::as_storage::<C>(instance_ptr) };
-                let instance = storage.get();
-
-                let args = ( $(
-                    {
-                        let variant = unsafe { &*(*args_ptr.offset($n) as *mut Variant) }; // TODO from_var_sys
-                        let arg = <$Pn as FromVariant>::try_from_variant(variant)
-                            .unwrap_or_else(|e| param_error::<$Pn>(method_name, $n, variant));
-
-                        arg
-                    },
-                )* );
-
-				let ret_val = func(&*instance, args);
-                let ret_variant = <$R as ToVariant>::to_variant(&ret_val); // TODO write_sys
-				unsafe {
-                    *(ret as *mut Variant) = ret_variant;
-                    (*err).error = sys::GDEXTENSION_CALL_OK;
-                }
-            }
-
-            #[inline]
-            unsafe fn varcall_mut<C : GodotClass>(
-				instance_ptr: sys::GDExtensionClassInstancePtr,
-                args_ptr: *const sys::GDExtensionConstVariantPtr,
-                ret: sys::GDExtensionVariantPtr,
-                err: *mut sys::GDExtensionCallError,
                 func: fn(sys::GDExtensionClassInstancePtr, Self::Params) -> Self::Ret,
                 method_name: &str,
             ) {
                 $crate::out!("varcall: {}", method_name);
 
-                let args = ( $(
-                    {
-                        let variant = unsafe { &*(*args_ptr.offset($n) as *mut Variant) }; // TODO from_var_sys
-                        let arg = <$Pn as FromVariant>::try_from_variant(variant)
-                            .unwrap_or_else(|e| param_error::<$Pn>(method_name, $n, variant));
+                let args = ($(
+                    unsafe { varcall_arg::<$Pn, $n>(args_ptr, method_name) },
+                )*) ;
 
-                        arg
-                    },
-                )* );
-
-                let ret_val = func(instance_ptr, args);
-                let ret_variant = <$R as ToVariant>::to_variant(&ret_val); // TODO write_sys
-                unsafe {
-                    *(ret as *mut Variant) = ret_variant;
-                    (*err).error = sys::GDEXTENSION_CALL_OK;
-                }
+                varcall_return::<$R>(func(instance_ptr, args), ret, err)
             }
 
             #[inline]
@@ -190,62 +128,83 @@ macro_rules! impl_signature_for_tuple {
                 instance_ptr: sys::GDExtensionClassInstancePtr,
                 args_ptr: *const sys::GDExtensionConstTypePtr,
                 ret: sys::GDExtensionTypePtr,
-                func: fn(&C, Self::Params) -> Self::Ret,
+                func: fn(sys::GDExtensionClassInstancePtr, Self::Params) -> Self::Ret,
                 method_name: &str,
                 call_type: sys::PtrcallType,
             ) {
                 $crate::out!("ptrcall: {}", method_name);
 
-                let storage = unsafe { crate::private::as_storage::<C>(instance_ptr) };
-                let instance = storage.get();
+                let args = ($(
+                    unsafe { ptrcall_arg::<$Pn, $n>(args_ptr, method_name, call_type) },
+                )*) ;
 
-				let args = ( $(
-                    unsafe {
-                        <$Pn as sys::GodotFuncMarshal>::try_from_arg(
-                            sys::force_mut_ptr(*args_ptr.offset($n)),
-                            call_type
-                        )
-                    }
-                        .unwrap_or_else(|e| param_error::<$Pn>(method_name, $n, &e)),
-                )* );
-
-                let ret_val = func(&*instance, args);
                 // SAFETY:
                 // `ret` is always a pointer to an initialized value of type $R
                 // TODO: double-check the above
-				<$R as sys::GodotFuncMarshal>::try_return(ret_val, ret, call_type)
-                    .unwrap_or_else(|ret_val| return_error::<$R>(method_name, &ret_val));
-            }
-
-            #[inline]
-            unsafe fn ptrcall_mut<C : GodotClass>(
-				instance_ptr: sys::GDExtensionClassInstancePtr,
-                args_ptr: *const sys::GDExtensionConstTypePtr,
-                ret: sys::GDExtensionTypePtr,
-                func: fn(sys::GDExtensionClassInstancePtr, Self::Params) -> Self::Ret,
-                call_type: sys::PtrcallType,
-            ) {
-                $crate::out!("ptrcall: {}", method_name);
-
-                let args = ( $(
-                    unsafe {
-                        <$Pn as sys::GodotFuncMarshal>::try_from_arg(
-                            sys::force_mut_ptr(*args_ptr.offset($n)),
-                            call_type
-                        )
-                    }
-                        .unwrap_or_else(|e| param_error::<$Pn>(method_name, $n, &e)),
-                )* );
-
-                let ret_val = func(instance_ptr, args);
-                // SAFETY:
-                // `ret` is always a pointer to an initialized value of type $R
-                // TODO: double-check the above
-				<$R as sys::GodotFuncMarshal>::try_return(ret_val, ret, call_type)
-                    .unwrap_or_else(|ret_val| return_error::<$R>(method_name, &ret_val));
+                ptrcall_return::<$R>(func(instance_ptr, args), ret, method_name, call_type)
             }
         }
     };
+}
+
+/// Convert the `N`th argument of `args_ptr` into a value of type `P`.
+///
+/// # Safety
+/// - It must be safe to dereference the pointer at `args_ptr.offset(N)` .
+unsafe fn varcall_arg<P: FromVariant, const N: isize>(
+    args_ptr: *const sys::GDExtensionConstVariantPtr,
+    method_name: &str,
+) -> P {
+    let variant = &*(*args_ptr.offset(N) as *mut Variant); // TODO from_var_sys
+    P::try_from_variant(variant)
+        .unwrap_or_else(|_| param_error::<P>(method_name, N as i32, variant))
+}
+
+/// Moves `ret_val` into `ret`.
+///
+/// # Safety
+/// - `ret` must be a pointer to an initialized `Variant`.
+/// - It must be safe to write a `Variant` once to `ret`.
+/// - It must be safe to write a `sys::GDExtensionCallError` once to `err`.
+unsafe fn varcall_return<R: ToVariant>(
+    ret_val: R,
+    ret: sys::GDExtensionConstVariantPtr,
+    err: *mut sys::GDExtensionCallError,
+) {
+    let ret_variant = ret_val.to_variant(); // TODO write_sys
+    *(ret as *mut Variant) = ret_variant;
+    (*err).error = sys::GDEXTENSION_CALL_OK;
+}
+
+/// Convert the `N`th argument of `args_ptr` into a value of type `P`.
+///
+/// # Safety
+/// - It must be safe to dereference the address at `args_ptr.offset(N)` .
+/// - The pointer at `args_ptr.offset(N)` must follow the safety requirements as laid out in
+///   [`GodotFuncMarshal::try_from_arg`][sys::GodotFuncMarshal::try_from_arg].
+unsafe fn ptrcall_arg<P: sys::GodotFuncMarshal, const N: isize>(
+    args_ptr: *const sys::GDExtensionConstTypePtr,
+    method_name: &str,
+    call_type: sys::PtrcallType,
+) -> P {
+    P::try_from_arg(sys::force_mut_ptr(*args_ptr.offset(N)), call_type)
+        .unwrap_or_else(|e| param_error::<P>(method_name, N as i32, &e))
+}
+
+/// Moves `ret_val` into `ret`.
+///
+/// # Safety
+/// `ret_val`, `ret`, and `call_type` must follow the safety requirements as laid out in
+/// [`GodotFuncMarshal::try_return`](sys::GodotFuncMarshal::try_return).
+unsafe fn ptrcall_return<R: sys::GodotFuncMarshal + std::fmt::Debug>(
+    ret_val: R,
+    ret: sys::GDExtensionTypePtr,
+    method_name: &str,
+    call_type: sys::PtrcallType,
+) {
+    ret_val
+        .try_return(ret, call_type)
+        .unwrap_or_else(|ret_val| return_error::<R>(method_name, &ret_val))
 }
 
 fn param_error<P>(method_name: &str, index: i32, arg: &impl Debug) -> ! {

--- a/godot-core/src/macros.rs
+++ b/godot-core/src/macros.rs
@@ -39,12 +39,52 @@ macro_rules! gdext_is_not_unit {
 
 #[doc(hidden)]
 #[macro_export]
+macro_rules! gdext_method_flags {
+    (INSTANCE) => {
+        $crate::sys::GDEXTENSION_METHOD_FLAGS_DEFAULT
+    };
+    (STATIC) => {
+        $crate::sys::GDEXTENSION_METHOD_FLAG_STATIC
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! gdext_wrap_with_unpacked_params {
+    (
+        INSTANCE,
+        $Class:ty,
+        $method_name:ident,
+        $( $param:ident, )*
+    ) => {
+        |instance_ptr, params| {
+            let storage = unsafe { $crate::private::as_storage::<$Class>(instance_ptr) };
+            let mut instance = storage.get_mut();
+            let ( $($param,)* ) = params;
+            instance.$method_name( $( $param, )* )
+        }
+    };
+    (
+        STATIC,
+        $Class:ty,
+        $method_name:ident,
+        $( $param:ident, )*
+    ) => {
+        |instance_ptr, params| {
+            let ( $($param,)* ) = params;
+            <$Class>::$method_name( $( $param, )* )
+        }
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
 macro_rules! gdext_register_method_inner {
     (
         $ptrcall:ident,
         $varcall:ident,
+        $instance_or_static:ident, // "INSTANCE" or "STATIC"
         $Class:ty,
-        $map_method:ident,
         fn $method_name:ident(
             $( $param:ident : $ParamTy:ty, )*
             $( #[opt] $opt_param:ident : $OptParamTy:ty, )*
@@ -76,10 +116,8 @@ macro_rules! gdext_register_method_inner {
                                 args,
                                 ret,
                                 err,
-                                |inst, params| {
-                                    let ( $($param,)* ) = params;
-                                    inst.$method_name( $( $param, )* )
-                                },
+                                $crate::gdext_wrap_with_unpacked_params!(
+                                    $instance_or_static, $Class, $method_name, $($param,)*),
                                 stringify!($method_name),
                             );
                         }
@@ -109,10 +147,8 @@ macro_rules! gdext_register_method_inner {
                                 instance_ptr,
                                 args,
                                 ret,
-                                |inst, params| {
-                                    let ( $($param,)* ) = params;
-                                    inst.$method_name( $( $param, )* )
-                                },
+                                $crate::gdext_wrap_with_unpacked_params!(
+                                    $instance_or_static, $Class, $method_name, $($param,)*),
                                 stringify!($method_name),
                                 sys::PtrcallType::Standard
                             );
@@ -163,7 +199,7 @@ macro_rules! gdext_register_method_inner {
                 method_userdata: std::ptr::null_mut(),
                 call_func: Some(varcall_func),
                 ptrcall_func: Some(ptrcall_func),
-                method_flags: sys::GDEXTENSION_METHOD_FLAGS_DEFAULT as u32,
+                method_flags: $crate::gdext_method_flags!($instance_or_static) as u32,
                 has_return_value: has_return_value as u8,
                 return_value_info: std::ptr::addr_of_mut!(return_value_info_sys),
                 return_value_metadata,
@@ -207,8 +243,8 @@ macro_rules! gdext_register_method {
         $crate::gdext_register_method_inner!(
             ptrcall_mut,
             varcall_mut,
+            INSTANCE,
             $Class,
-            map_mut,
             fn $method_name(
                 $( $param : $ParamTy, )*
                 $( #[opt] $opt_param : $OptParamTy, )*
@@ -229,8 +265,29 @@ macro_rules! gdext_register_method {
         $crate::gdext_register_method_inner!(
             ptrcall,
             varcall,
+            INSTANCE,
             $Class,
-            map,
+            fn $method_name(
+                $( $arg : $Param, )*
+                $( #[opt] $opt_arg : $OptParam, )*
+            ) -> $RetTy
+        )
+    };
+
+    // static
+    (
+        $Class:ty,
+        fn $method_name:ident(
+            $( $arg:ident : $Param:ty),*
+            $(, #[opt] $opt_arg:ident : $OptParam:ty)*
+            $(,)?
+        ) -> $RetTy:ty
+    ) => {
+        $crate::gdext_register_method_inner!(
+            ptrcall_mut,
+            varcall_mut,
+            STATIC,
+            $Class,
             fn $method_name(
                 $( $arg : $Param, )*
                 $( #[opt] $opt_arg : $OptParam, )*
@@ -274,6 +331,25 @@ macro_rules! gdext_register_method {
             $Class,
             fn $method_name(
                 &self,
+                $( $param : $ParamTy, )*
+                $( #[opt] $opt_param : $OptParamTy, )*
+            ) -> ()
+        )
+    };
+
+    // static without return type
+    (
+        $Class:ty,
+        fn $method_name:ident(
+            $( $param:ident : $ParamTy:ty ),*
+            $(, #[opt] $opt_param:ident : $OptParamTy:ty )*
+            $(,)?
+        )
+    ) => {
+        // recurse this macro
+        $crate::gdext_register_method!(
+            $Class,
+            fn $method_name(
                 $( $param : $ParamTy, )*
                 $( #[opt] $opt_param : $OptParamTy, )*
             ) -> ()

--- a/itest/godot/ManualFfiTests.gd
+++ b/itest/godot/ManualFfiTests.gd
@@ -25,6 +25,10 @@ func test_init_defaults():
 	assert_eq(obj.literal_int, 42)
 	assert_eq(obj.expr_int, -42)
 
+func test_static():
+	assert_eq(StaticMethods.return_int(), 42)
+	assert_eq(StaticMethods.add(2, 2), 4)
+
 func test_to_string():
 	var ffi = VirtualMethodTest.new()
 	

--- a/itest/godot/ManualFfiTests.gd
+++ b/itest/godot/ManualFfiTests.gd
@@ -25,10 +25,6 @@ func test_init_defaults():
 	assert_eq(obj.literal_int, 42)
 	assert_eq(obj.expr_int, -42)
 
-func test_static():
-	assert_eq(StaticMethods.return_int(), 42)
-	assert_eq(StaticMethods.add(2, 2), 4)
-
 func test_to_string():
 	var ffi = VirtualMethodTest.new()
 	
@@ -149,3 +145,8 @@ func test_refcounted_as_object_return_from_user_func_ptrcall():
 	var obj_test: ObjectTest = ObjectTest.new()
 	var obj: MockRefCountedRust = obj_test.return_refcounted_as_object() 
 	assert_eq(obj.i, 42)
+
+func test_custom_constructor():
+	var obj = CustomConstructor.construct_object(42)
+	assert_eq(obj.val, 42)
+	obj.free()

--- a/itest/godot/input/GenFfiTests.template.gd
+++ b/itest/godot/input/GenFfiTests.template.gd
@@ -22,6 +22,16 @@ func test_varcall_IDENT():
 #)
 
 #(
+func test_varcall_static_IDENT():
+	var from_rust: Variant = GenFfi.return_static_IDENT()
+	assert_that(GenFfi.accept_static_IDENT(from_rust), "ffi.accept_static_IDENT(from_rust)")
+
+	var from_gdscript: Variant = VAL
+	var mirrored: Variant = GenFfi.mirror_static_IDENT(from_gdscript)
+	assert_eq(mirrored, from_gdscript, "mirrored_static == from_gdscript")
+#)
+
+#(
 func test_ptrcall_IDENT():
 	var ffi := GenFfi.new()
 
@@ -32,3 +42,14 @@ func test_ptrcall_IDENT():
 	var mirrored: TYPE = ffi.mirror_IDENT(from_gdscript)
 	assert_eq(mirrored, from_gdscript, "mirrored == from_gdscript")
 #)
+
+#(
+func test_ptrcall_static_IDENT():
+	var from_rust: TYPE = GenFfi.return_static_IDENT()
+	assert_that(GenFfi.accept_static_IDENT(from_rust), "ffi.accept_static_IDENT(from_rust)")
+
+	var from_gdscript: TYPE = VAL
+	var mirrored: TYPE = GenFfi.mirror_static_IDENT(from_gdscript)
+	assert_eq(mirrored, from_gdscript, "mirrored_static == from_gdscript")
+#)
+	

--- a/itest/rust/build.rs
+++ b/itest/rust/build.rs
@@ -172,6 +172,9 @@ fn generate_rust_methods(inputs: &[Input]) -> Vec<TokenStream> {
             let return_method = format_ident!("return_{}", ident);
             let accept_method = format_ident!("accept_{}", ident);
             let mirror_method = format_ident!("mirror_{}", ident);
+            let return_static_method = format_ident!("return_static_{}", ident);
+            let accept_static_method = format_ident!("accept_static_{}", ident);
+            let mirror_static_method = format_ident!("mirror_static_{}", ident);
 
             quote! {
                 #[func]
@@ -186,6 +189,21 @@ fn generate_rust_methods(inputs: &[Input]) -> Vec<TokenStream> {
 
                 #[func]
                 fn #mirror_method(&self, i: #rust_ty) -> #rust_ty {
+                    i
+                }
+
+                #[func]
+                fn #return_static_method() -> #rust_ty {
+                    #rust_val
+                }
+
+                #[func]
+                fn #accept_static_method(i: #rust_ty) -> bool {
+                    i == #rust_val
+                }
+
+                #[func]
+                fn #mirror_static_method(i: #rust_ty) -> #rust_ty {
                     i
                 }
             }

--- a/itest/rust/src/object_test.rs
+++ b/itest/rust/src/object_test.rs
@@ -761,6 +761,33 @@ pub mod object_test_gd {
             Gd::new(MockRefCountedRust { i: 42 }).upcast()
         }
     }
+
+    // ----------------------------------------------------------------------------------------------------------------------------------------------
+
+    #[derive(GodotClass)]
+    #[class(base=Object)]
+    pub struct CustomConstructor {
+        #[base]
+        base: Base<Object>,
+
+        #[export]
+        pub val: i64,
+    }
+
+    #[godot_api]
+    impl CustomConstructor {
+        #[func]
+        pub fn construct_object(val: i64) -> Gd<CustomConstructor> {
+            Gd::with_base(|base| Self { base, val })
+        }
+    }
+}
+
+#[itest]
+fn custom_constructor_works() {
+    let obj = object_test_gd::CustomConstructor::construct_object(42);
+    assert_eq!(obj.bind().val, 42);
+    obj.free();
 }
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
@@ -825,18 +852,4 @@ fn double_use_reference() {
 
     double_use.free();
     emitter.free();
-}
-struct StaticMethods {}
-
-#[godot_api]
-impl StaticMethods {
-    #[func]
-    fn return_int() -> i64 {
-        42
-    }
-
-    #[func]
-    fn add(a: i64, b: i64) -> i64 {
-        a + b
-    }
 }

--- a/itest/rust/src/object_test.rs
+++ b/itest/rust/src/object_test.rs
@@ -826,3 +826,17 @@ fn double_use_reference() {
     double_use.free();
     emitter.free();
 }
+struct StaticMethods {}
+
+#[godot_api]
+impl StaticMethods {
+    #[func]
+    fn return_int() -> i64 {
+        42
+    }
+
+    #[func]
+    fn add(a: i64, b: i64) -> i64 {
+        a + b
+    }
+}


### PR DESCRIPTION
Takes over from #210 

Adds support for static methods in classes.

also replaces tabs with spaces in `signature.rs`.

thanks a lot to @ttencate! it was very straightforward to make this work based on what they'd already done.

from what i can tell, there are no static virtual methods. so we dont need to implement support for that. im not sure if there ever will be but it doesn't seem likely to me at least.

it might be worth it to move more of this logic into procedural macros eventually.

closes #175 