### PR TITLE
DTC example - Don't `_process` on player in editor

### DIFF
--- a/examples/dodge-the-creeps/rust/src/player.rs
+++ b/examples/dodge-the-creeps/rust/src/player.rs
@@ -1,4 +1,6 @@
-use godot::engine::{AnimatedSprite2D, Area2D, Area2DVirtual, CollisionShape2D, PhysicsBody2D};
+use godot::engine::{
+    AnimatedSprite2D, Area2D, Area2DVirtual, CollisionShape2D, Engine, PhysicsBody2D,
+};
 use godot::prelude::*;
 
 #[derive(GodotClass)]
@@ -58,6 +60,12 @@ impl Area2DVirtual for Player {
     }
 
     fn process(&mut self, delta: f64) {
+        // Don't process if running in editor. This part should be removed when
+        // issue is resolved: https://github.com/godot-rust/gdext/issues/70
+        if Engine::singleton().is_editor_hint() {
+            return;
+        }
+
         let mut animated_sprite = self
             .base
             .get_node_as::<AnimatedSprite2D>("AnimatedSprite2D");


### PR DESCRIPTION
Same bug we went over on the Discord channel.

Prevents this stuff from happening in the editor:
![image](https://user-images.githubusercontent.com/35111165/235373942-9da696f3-9c9e-430e-bc71-327010524058.png)

...at least, until #70 is resolved. Then, this can be removed, since it's not necessary.