### PR TITLE
Improve `cargo check` times for incremental changes to `godot-core`

### DIFF
--- a/godot-codegen/src/class_generator.rs
+++ b/godot-codegen/src/class_generator.rs
@@ -294,7 +294,6 @@ fn make_class(class: &Class, class_name: &TyName, ctx: &mut Context) -> Generate
         #![doc = #module_doc]
 
         use godot_ffi as sys;
-        use crate::engine::*;
         use crate::engine::notify::*;
         use crate::builtin::*;
         use crate::obj::{AsArg, Gd};

--- a/godot-codegen/src/util.rs
+++ b/godot-codegen/src/util.rs
@@ -283,7 +283,7 @@ fn to_rust_type_uncached(ty: &str, ctx: &mut Context) -> RustTy {
             let enum_ty = make_enum_name(enum_);
 
             RustTy::EngineEnum {
-                tokens: quote! { #module::#enum_ty },
+                tokens: quote! { crate::engine::#module::#enum_ty },
                 surrounding_class: Some(class.to_string()),
             }
         } else {
@@ -291,7 +291,7 @@ fn to_rust_type_uncached(ty: &str, ctx: &mut Context) -> RustTy {
             let enum_ty = make_enum_name(qualified_enum);
 
             RustTy::EngineEnum {
-                tokens: quote! { global::#enum_ty },
+                tokens: quote! { crate::engine::global::#enum_ty },
                 surrounding_class: None,
             }
         };
@@ -323,7 +323,7 @@ fn to_rust_type_uncached(ty: &str, ctx: &mut Context) -> RustTy {
     } else {
         let ty = rustify_ty(ty);
         RustTy::EngineClass {
-            tokens: quote! { Gd<#ty> },
+            tokens: quote! { Gd<crate::engine::#ty> },
             class: ty.to_string(),
         }
     }

--- a/godot-core/build.rs
+++ b/godot-core/build.rs
@@ -16,4 +16,5 @@ fn main() {
     }
 
     godot_codegen::generate_core_files(gen_path);
+    println!("cargo:rerun-if-changed=build.rs");
 }

--- a/godot-ffi/build.rs
+++ b/godot-ffi/build.rs
@@ -26,4 +26,5 @@ fn main() {
     godot_codegen::generate_sys_files(gen_path, &mut watch);
 
     watch.write_stats_to(&gen_path.join("ffi-stats.txt"));
+    println!("cargo:rerun-if-changed=build.rs");
 }


### PR DESCRIPTION
On my machine, this change makes the time `cargo check` takes to run go from 48 seconds to 11 seconds when making an incremental change to `godot-core`. in this case tested by adding/removing a single method to/from `Basis`.

I've seen it be as low as 2 seconds sometimes but im not entirely sure why that happens.