### PR TITLE
Improve compile times, unbreak CI temporarily

### DIFF
--- a/.github/composite/godot-install/action.yml
+++ b/.github/composite/godot-install/action.yml
@@ -38,8 +38,10 @@ runs:
 
     - name: "Download Godot artifact"
 #      if: steps.cache-godot.outputs.cache-hit != 'true'
+      # FIXME(#270): Use again latest workflow, instead of last-known good one 4921814392
       run: |
-        curl https://nightly.link/Bromeon/godot4-nightly/workflows/compile-godot/master/${{ inputs.artifact-name }}.zip \
+        #curl https://nightly.link/Bromeon/godot4-nightly/workflows/compile-godot/master/${{ inputs.artifact-name }}.zip \
+        curl https://nightly.link/Bromeon/godot4-nightly/actions/runs/4910907653/${{ inputs.artifact-name }}.zip \
           -Lo artifact.zip \
           --retry 3
         unzip artifact.zip -d $RUNNER_DIR/godot_bin

--- a/.github/composite/godot-install/action.yml
+++ b/.github/composite/godot-install/action.yml
@@ -18,7 +18,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v3
+    # Do not check out here, as this would overwrite (clean) the current directory and is already done by the parent workflow.
 
     # Replaces also backspaces on Windows, since they cause problems in Bash
     - name: "Store variable to Godot binary"

--- a/.github/composite/godot-itest/action.yml
+++ b/.github/composite/godot-itest/action.yml
@@ -48,7 +48,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v3
+    # Do not check out here, as this would overwrite (clean) the current directory and is already done by the parent workflow.
 
     - name: "Install Godot"
       uses: ./.github/composite/godot-install

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -134,7 +134,7 @@ jobs:
           - name: macos-double
             os: macos-12
             godot-binary: godot.macos.editor.dev.double.x86_64
-            rust-extra-args: --features double-precision
+            rust-extra-args: --features godot/double-precision
 
           - name: macos-nightly
             os: macos-12
@@ -150,7 +150,7 @@ jobs:
           - name: windows-double
             os: windows-latest
             godot-binary: godot.windows.editor.dev.double.x86_64.exe
-            rust-extra-args: --features double-precision
+            rust-extra-args: --features godot/double-precision
 
           - name: windows-nightly
             os: windows-latest
@@ -167,13 +167,13 @@ jobs:
           - name: linux-double
             os: ubuntu-20.04
             godot-binary: godot.linuxbsd.editor.dev.double.x86_64
-            rust-extra-args: --features double-precision
+            rust-extra-args: --features godot/double-precision
 
           - name: linux-features
             os: ubuntu-20.04
             artifact-name: linux
             godot-binary: godot.linuxbsd.editor.dev.x86_64
-            rust-extra-args: --features threads,serde
+            rust-extra-args: --features godot/threads,godot/serde
 
           - name: linux-nightly
             os: ubuntu-20.04

--- a/.github/workflows/minimal-ci.yml
+++ b/.github/workflows/minimal-ci.yml
@@ -103,14 +103,14 @@ jobs:
           # token: # optional: the token that license eye uses when it needs to comment on the pull request.
           # Set to empty ("") to disable commenting on pull request. The default value is ${{ github.token }}
           # mode: # optional: Which mode License-Eye should be run in. Choices are `check` or `fix`. The default value is `check`.
-          mode: fix
+          mode: check
 
-      - name: "Commit changes"
-        uses: EndBug/add-and-commit@v9
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          author_name: 'Godot-Rust Automation'
-          author_email: 'actions@github.com'
-          message: 'Auto-apply license headers'
+#      - name: "Commit changes"
+#        uses: EndBug/add-and-commit@v9
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#        with:
+#          author_name: 'Godot-Rust Automation'
+#          author_email: 'actions@github.com'
+#          message: 'Auto-apply license headers'
 

--- a/check.sh
+++ b/check.sh
@@ -165,7 +165,7 @@ for arg in "$@"; do
             exit 0
             ;;
         --double)
-            extraCargoArgs+=("--features" "double-precision")
+            extraCargoArgs+=("--features" "godot/double-precision")
             ;;
         fmt | clippy | test | itest | doc | dok)
             cmds+=("$arg")

--- a/check.sh
+++ b/check.sh
@@ -155,8 +155,10 @@ function cmd_dok() {
 # Argument parsing
 ################################################################################
 
+# By default, disable `codegen-full` to reduce compile times and prevent flip-flopping
+# between `itest` compilations and `check.sh` runs.
+extraCargoArgs=("--no-default-features")
 cmds=()
-extraCargoArgs=()
 
 for arg in "$@"; do
     case "$arg" in
@@ -183,18 +185,39 @@ if [[ ${#cmds[@]} -eq 0 ]]; then
 fi
 
 ################################################################################
-# Execution
+# Execution and summary
 ################################################################################
+
+function compute_elapsed() {
+    local total=$SECONDS
+    local min=$(("$total" / 60))
+    if [[ "$min" -gt 0 ]]; then
+        min="${min}min "
+    else
+        min=""
+    fi
+    local sec=$(("$total" % 60))
+
+    # Don't use echo and call it with $(compute_elapsed), it messes with stdout
+    elapsed="${min}${sec}s"
+}
 
 for cmd in "${cmds[@]}"; do
     "cmd_${cmd}" || {
+        compute_elapsed
         log -ne "$RED\n====================="
         log -ne "\ngdext: checks FAILED."
         log -ne "\n=====================\n$END"
+        log -ne "\nTotal duration: $elapsed.\n"
         exit 1
     }
 done
 
+compute_elapsed
 log -ne "$CYAN\n========================="
 log -ne "\ngdext: checks SUCCESSFUL."
 log -ne "\n=========================\n$END"
+log -ne "\nTotal duration: $elapsed.\n"
+
+# If invoked with sh instead of bash, pressing Up arrow after executing `sh check.sh` may cause a `[A` to appear.
+# See https://unix.stackexchange.com/q/103608.

--- a/examples/dodge-the-creeps/rust/Cargo.toml
+++ b/examples/dodge-the-creeps/rust/Cargo.toml
@@ -2,11 +2,12 @@
 name = "dodge-the-creeps"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.66"
 publish = false
 
 [lib]
 crate-type = ["cdylib"]
 
 [dependencies]
-godot = { path = "../../../godot", default-features = false, features = ["formatted"] }
+godot = { path = "../../../godot", default-features = false }
 rand = "0.8"

--- a/godot-codegen/src/lib.rs
+++ b/godot-codegen/src/lib.rs
@@ -86,7 +86,7 @@ pub fn generate_core_files(core_gen_path: &Path) {
     watch.write_stats_to(&core_gen_path.join("codegen-stats.txt"));
 }
 
-// #[cfg(feature = "codegen-fmt")]
+#[cfg(feature = "codegen-fmt")]
 fn rustfmt_if_needed(out_files: Vec<PathBuf>) {
     println!("Format {} generated files...", out_files.len());
 
@@ -106,9 +106,9 @@ fn rustfmt_if_needed(out_files: Vec<PathBuf>) {
 
     println!("Rustfmt completed.");
 }
-//
-// #[cfg(not(feature = "codegen-fmt"))]
-// fn rustfmt_if_needed(_out_files: Vec<PathBuf>) {}
+
+#[cfg(not(feature = "codegen-fmt"))]
+fn rustfmt_if_needed(_out_files: Vec<PathBuf>) {}
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Shared utility types

--- a/godot-core/src/builtin/mod.rs
+++ b/godot-core/src/builtin/mod.rs
@@ -140,36 +140,36 @@ pub(crate) fn u8_to_bool(u: u8) -> bool {
 /// Clippy often complains if you do `f as f64` when `f` is already an `f64`. This trait exists to make it easy to
 /// convert between the different reals and floats without a lot of allowing clippy lints for your code.
 pub trait RealConv {
-    /// Cast this [`real`] to an [`f32`] using `as`.
+    /// Cast this [`real`][type@real] to an [`f32`] using `as`.
     // Clippy complains that this is an `as_*` function but it takes a `self`
     // however, since this uses `as` internally it makes much more sense for
     // it to be named `as_f32` rather than `to_f32`.
     #[allow(clippy::wrong_self_convention)]
     fn as_f32(self) -> f32;
 
-    /// Cast this [`real`] to an [`f64`] using `as`.
+    /// Cast this [`real`][type@real] to an [`f64`] using `as`.
     // Clippy complains that this is an `as_*` function but it takes a `self`
     // however, since this uses `as` internally it makes much more sense for
     // it to be named `as_f64` rather than `to_f64`.
     #[allow(clippy::wrong_self_convention)]
     fn as_f64(self) -> f64;
 
-    /// Cast an [`f32`] to a [`real`] using `as`.
+    /// Cast an [`f32`] to a [`real`][type@real] using `as`.
     fn from_f32(f: f32) -> Self;
 
-    /// Cast an [`f64`] to a [`real`] using `as`.
+    /// Cast an [`f64`] to a [`real`][type@real] using `as`.
     fn from_f64(f: f64) -> Self;
 }
 
 #[cfg(not(feature = "double-precision"))]
 mod real_mod {
-    //! Definitions for single-precision `real`.
-
     /// Floating point type used for many structs and functions in Godot.
     ///
+    /// This type is `f32` by default, and `f64` when the Cargo feature `double-precision` is enabled.
+    ///
     /// This is not the `float` type in GDScript; that type is always 64-bits. Rather, many structs in Godot may use
-    /// either 32-bit or 64-bit floats such as [`Vector2`](super::Vector2). To convert between [`real`] and [`f32`] or
-    /// [`f64`] see [`RealConv`](super::RealConv).
+    /// either 32-bit or 64-bit floats, for example [`Vector2`](super::Vector2). To convert between [`real`] and [`f32`] or
+    /// [`f64`], see [`RealConv`](super::RealConv).
     ///
     /// See also the [Godot docs on float](https://docs.godotengine.org/en/stable/classes/class_float.html).
     ///
@@ -230,13 +230,13 @@ mod real_mod {
 
 #[cfg(feature = "double-precision")]
 mod real_mod {
-    //! Definitions for double-precision `real`.
-
     /// Floating point type used for many structs and functions in Godot.
     ///
+    /// This type is `f32` by default, and `f64` when the Cargo feature `double-precision` is enabled.
+    ///
     /// This is not the `float` type in GDScript; that type is always 64-bits. Rather, many structs in Godot may use
-    /// either 32-bit or 64-bit floats such as [`Vector2`](super::Vector2). To convert between [`real`] and [`f32`] or
-    /// [`f64`] see [`RealConv`](super::RealConv).
+    /// either 32-bit or 64-bit floats, for example [`Vector2`](super::Vector2). To convert between [`real`] and [`f32`] or
+    /// [`f64`], see [`RealConv`](super::RealConv).
     ///
     /// See also the [Godot docs on float](https://docs.godotengine.org/en/stable/classes/class_float.html).
     ///

--- a/godot/Cargo.toml
+++ b/godot/Cargo.toml
@@ -9,11 +9,11 @@ categories = ["game-engines", "graphics"]
 
 [features]
 default = ["codegen-full"]
-formatted = ["godot-core/codegen-fmt"]
-double-precision = ["godot-core/double-precision"]
 custom-godot = ["godot-core/custom-godot"]
-threads = ["godot-core/threads"]
+double-precision = ["godot-core/double-precision"]
+formatted = ["godot-core/codegen-fmt"]
 serde = ["godot-core/serde"]
+threads = ["godot-core/threads"]
 
 # Private features, they are under no stability guarantee
 codegen-full = ["godot-core/codegen-full"]

--- a/godot/src/lib.rs
+++ b/godot/src/lib.rs
@@ -4,15 +4,15 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-//! Rust bindings for GDExtension, the extension API of [Godot](https://godotengine.org/) 4.
+//! The **gdext** library implements Rust bindings for GDExtension, the C API of [Godot 4](https://godotengine.org).
 //!
 //! This documentation is a work in progress.
 //!
-//! # Kinds of types
+//! # Type categories
 //!
 //! Godot is written in C++, which doesn't have the same strict guarantees about safety and
 //! mutability that Rust does. As a result, not everything in this crate will look and feel
-//! entirely "Rusty". We distinguish four different kinds of types:
+//! entirely "rusty". We distinguish four different kinds of types:
 //!
 //! 1. **Value types**: `i64`, `f64`, and mathematical types like
 //!    [`Vector2`][crate::builtin::Vector2] and [`Color`][crate::builtin::Color].
@@ -59,10 +59,9 @@
 //!
 //! # Ergonomics and panics
 //!
-//! The GDExtension Rust bindings are designed with usage ergonomics in mind, making them viable
-//! for fast prototyping. Part of this design means that users should not constantly be forced
-//! to write code such as `obj.cast::<T>().unwrap()`. Instead, they can just write `obj.cast::<T>()`,
-//! which may panic at runtime.
+//! gdext is designed with usage ergonomics in mind, making it viable for fast prototyping.
+//! Part of this design means that users should not constantly be forced to write code such as
+//! `obj.cast::<T>().unwrap()`. Instead, they can just write `obj.cast::<T>()`, which may panic at runtime.
 //!
 //! This approach has several advantages:
 //! * The code is more concise and less cluttered.
@@ -93,8 +92,50 @@
 //! appropriate, but the Rust compiler cannot check what happens to an object through C++ or
 //! GDScript.
 //!
-//! As a rule of thumb, if you must use threading, prefer to use Rust threads instead of Godot
-//! threads.
+//! As a rule of thumb, if you must use threading, prefer to use [Rust threads](https://doc.rust-lang.org/std/thread)
+//! over Godot threads.
+//!
+//! The Cargo feature `threads` provides experimental support for multithreading. The underlying safety
+//! rules are still being worked out, as such you may encounter unsoundness and an unstable API.
+//!
+//! # Cargo features
+//!
+//! The following features can be enabled for this crate. All off them are off by default.
+//!
+//! * **`formatted`**
+//!
+//!   Format the generated bindings with `rustfmt`. This significantly increases initial compile times and is
+//!   mostly useful when you actively contribute to the library and/or want to inspect generated files.<br><br>
+//!
+//! * **`double-precision`**
+//!
+//!   Use `f64` instead of `f32` for the floating-point type [`real`][type@builtin::real]. Requires Godot to be compiled with the
+//!   scons flag `precision=double`.<br><br>
+//!
+//! * **`custom-godot`**
+//!
+//!   Use a custom Godot build instead of the latest official release. This is useful when you like to use a
+//!   version compiled yourself, with custom flags.
+//!
+//!   If you simply want to use a different official release, use this pattern instead (here e.g. for version `4.0`):
+//!   ```toml
+//!   # Trick Cargo into seeing a different URL; https://github.com/rust-lang/cargo/issues/5478
+//!   [patch."https://github.com/godot-rust/godot4-prebuilt"]
+//!   godot4-prebuilt = { git = "https://github.com//godot-rust/godot4-prebuilt", branch = "4.0"}
+//!   ```
+//!   <br>
+//!
+//! * **`serde`**
+//!
+//!   Implement the [serde](https://docs.rs/serde) traits `Serialize` and `Deserialize` traits for certain built-in types.
+//!   The serialized representation underlies **no stability guarantees** and may change at any time, even without a SemVer-breaking change.
+//!   <br><br>
+//!
+//! * **`threads`**
+//!
+//!   Experimental threading support. This enables `Send`/`Sync` traits for `Gd<T>` and makes the guard types `Gd`/`GdMut` aware of
+//!   multi-threaded references. The safety aspects of this are not ironed out yet; use at your own risk. The API may also change
+//!   at any time.
 
 #[doc(inline)]
 pub use godot_core::{builtin, engine, log, obj, sys};
@@ -109,8 +150,6 @@ pub mod init {
 
 /// Export user-defined classes and methods to be called by the engine.
 pub mod bind {
-
-    // Re-exports
     pub use godot_macros::{godot_api, GodotClass};
 }
 

--- a/itest/rust/Cargo.toml
+++ b/itest/rust/Cargo.toml
@@ -14,7 +14,7 @@ default = []
 # Instead, compile itest with `--features godot/my-feature`.
 
 [dependencies]
-godot = { path = "../../godot", default-features = false, features = ["formatted"] }
+godot = { path = "../../godot", default-features = false }
 
 [build-dependencies]
 quote = "1"

--- a/itest/rust/Cargo.toml
+++ b/itest/rust/Cargo.toml
@@ -10,10 +10,8 @@ crate-type = ["cdylib"]
 
 [features]
 default = []
-trace = ["godot/trace"]
-double-precision = ["godot/double-precision"]
-threads = ["godot/threads"]
-serde = ["godot/serde"]
+# Do not add features here that are 1:1 forwarded to the `godot` crate.
+# Instead, compile itest with `--features godot/my-feature`.
 
 [dependencies]
 godot = { path = "../../godot", default-features = false, features = ["formatted"] }


### PR DESCRIPTION
Until #270 is resolved, this freezes the nightly version of Godot being used for integration tests.

Resolves two few low-hanging fruits regarding compile time:
* Disable rustfmt by default, allowing to still use the `formatted` feature.
* Disable features for `check.sh` runs, avoiding switching between `codegen-full` on and off.

Smaller improvements:
* Document Cargo features for `godot` crate.
* `check.sh` prints its execution duration.
* Avoid some needless calls to `checkout@v3` in GitHub actions.
* `itest` no longer duplicates all the features from `godot`; those are directly specified via `--features godot/xy`.
* The CI job `license-guard` in `minimal-ci` now uses 'check' instead of 'fix' mode.