### PR TITLE
Revert CI to use again latest nightly

### DIFF
--- a/.github/composite/godot-install/action.yml
+++ b/.github/composite/godot-install/action.yml
@@ -38,10 +38,10 @@ runs:
 
     - name: "Download Godot artifact"
 #      if: steps.cache-godot.outputs.cache-hit != 'true'
-      # FIXME(#270): Use again latest workflow, instead of last-known good one 4921814392
+      # If a specific Godot revision should be used, rather than latest, use this:
+      # curl https://nightly.link/Bromeon/godot4-nightly/actions/runs/4910907653/${{ inputs.artifact-name }}.zip \
       run: |
-        #curl https://nightly.link/Bromeon/godot4-nightly/workflows/compile-godot/master/${{ inputs.artifact-name }}.zip \
-        curl https://nightly.link/Bromeon/godot4-nightly/actions/runs/4910907653/${{ inputs.artifact-name }}.zip \
+        curl https://nightly.link/Bromeon/godot4-nightly/workflows/compile-godot/master/${{ inputs.artifact-name }}.zip \
           -Lo artifact.zip \
           --retry 3
         unzip artifact.zip -d $RUNNER_DIR/godot_bin


### PR DESCRIPTION
Moves CI to use latest nightly Godot binaries again, after #271 froze them.

Closes #270.

bors r+