### PR TITLE
Added doc aliases for godot-core/builtin

### DIFF
--- a/godot-core/src/builtin/aabb.rs
+++ b/godot-core/src/builtin/aabb.rs
@@ -52,8 +52,6 @@ impl Aabb {
     }
 
     /// Set size based on desired end-point.
-    ///
-    /// _Godot equivalent: `Aabb.size` property_
     #[inline]
     pub fn set_end(&mut self, end: Vector3) {
         self.size = end - self.position
@@ -61,8 +59,6 @@ impl Aabb {
 
     /// Returns `true` if the two `Aabb`s are approximately equal, by calling `is_equal_approx` on
     /// `position` and `size`.
-    ///
-    /// _Godot equivalent: `Aabb.is_equal_approx()`_
     #[inline]
     pub fn is_equal_approx(&self, other: &Self) -> bool {
         self.position.is_equal_approx(other.position) && self.size.is_equal_approx(other.size)

--- a/godot-core/src/builtin/array.rs
+++ b/godot-core/src/builtin/array.rs
@@ -42,7 +42,9 @@ use sys::{ffi_methods, interface_fn, GodotFfi};
 /// Usage is safe if the `Array` is used on a single thread only. Concurrent reads on
 /// different threads are also safe, but any writes must be externally synchronized. The Rust
 /// compiler will enforce this as long as you use only Rust threads, but it cannot protect against
+
 /// concurrent modification on other threads (e.g. created through GDScript).
+
 // `T` must be restricted to `VariantMetadata` in the type, because `Drop` can only be implemented
 // for `T: VariantMetadata` because `drop()` requires `sys_mut()`, which is on the `GodotFfi`
 // trait, whose `from_sys_init()` requires `Default`, which is only implemented for `T:
@@ -82,6 +84,7 @@ impl<T: VariantMetadata> Array<T> {
     ///
     /// Retrieving the size incurs an FFI call. If you know the size hasn't changed, you may consider storing
     /// it in a variable. For loops, prefer iterators.
+    #[doc(alias = "size")]
     pub fn len(&self) -> usize {
         to_usize(self.as_inner().size())
     }

--- a/godot-core/src/builtin/basis.rs
+++ b/godot-core/src/builtin/basis.rs
@@ -144,6 +144,7 @@ impl Basis {
     /// cannot be parallel to each other.
     ///
     /// _Godot equivalent: `Basis.looking_at()`_
+    #[doc(alias = "looking_at")]
     pub fn new_looking_at(target: Vector3, up: Vector3) -> Self {
         super::inner::InnerBasis::looking_at(target, up)
     }
@@ -155,7 +156,8 @@ impl Basis {
 
     /// Creates a [`Quaternion`] representing the same rotation as this basis.
     ///
-    /// _Godot equivalent: `Basis()`_
+    /// _Godot equivalent: `Basis.get_rotation_quaternion()`_
+    #[doc(alias = "get_rotation_quaternion")]
     pub fn to_quat(self) -> Quaternion {
         RQuat::from_mat3(&self.orthonormalized().to_glam()).to_front()
     }
@@ -449,6 +451,7 @@ impl Basis {
     /// Returns the first column of the matrix,
     ///
     /// _Godot equivalent: `Basis.x`_
+    #[doc(alias = "x")]
     #[must_use]
     pub fn col_a(&self) -> Vector3 {
         Vector3::new(self.rows[0].x, self.rows[1].x, self.rows[2].x)
@@ -464,6 +467,7 @@ impl Basis {
     /// Returns the second column of the matrix,
     ///
     /// _Godot equivalent: `Basis.y`_
+    #[doc(alias = "y")]
     #[must_use]
     pub fn col_b(&self) -> Vector3 {
         Vector3::new(self.rows[0].y, self.rows[1].y, self.rows[2].y)
@@ -479,6 +483,7 @@ impl Basis {
     /// Returns the third column of the matrix,
     ///
     /// _Godot equivalent: `Basis.z`_
+    #[doc(alias = "z")]
     #[must_use]
     pub fn col_c(&self) -> Vector3 {
         Vector3::new(self.rows[0].z, self.rows[1].z, self.rows[2].z)

--- a/godot-core/src/builtin/dictionary.rs
+++ b/godot-core/src/builtin/dictionary.rs
@@ -74,6 +74,7 @@ impl Dictionary {
     /// the key if the key was in the dictionary.
     ///
     /// _Godot equivalent: `erase`_
+    #[doc(alias = "erase")]
     pub fn remove<K: ToVariant>(&mut self, key: K) -> Option<Variant> {
         let key = key.to_variant();
         let old_value = self.get(key.clone());
@@ -89,6 +90,7 @@ impl Dictionary {
     /// using a `HashMap` or `Dictionary` with the inverse mapping (`V` -> `K`).
     ///
     /// _Godot equivalent: `find_key`_
+    #[doc(alias = "find_key")]
     pub fn find_key_by_value<V: ToVariant>(&self, value: V) -> Option<Variant> {
         let key = self.as_inner().find_key(value.to_variant());
 
@@ -118,6 +120,7 @@ impl Dictionary {
     /// If you need that, use [`Self::get`].
     ///
     /// _Godot equivalent: `dict.get(key, null)`_
+    #[doc(alias = "get")]
     pub fn get_or_nil<K: ToVariant>(&self, key: K) -> Variant {
         self.as_inner().get(key.to_variant(), Variant::nil())
     }
@@ -125,6 +128,7 @@ impl Dictionary {
     /// Returns `true` if the dictionary contains the given key.
     ///
     /// _Godot equivalent: `has`_
+    #[doc(alias = "has")]
     pub fn contains_key<K: ToVariant>(&self, key: K) -> bool {
         let key = key.to_variant();
         self.as_inner().has(key)
@@ -133,6 +137,7 @@ impl Dictionary {
     /// Returns `true` if the dictionary contains all the given keys.
     ///
     /// _Godot equivalent: `has_all`_
+    #[doc(alias = "has_all")]
     pub fn contains_all_keys(&self, keys: VariantArray) -> bool {
         self.as_inner().has_all(keys)
     }
@@ -145,6 +150,7 @@ impl Dictionary {
     /// Creates a new `Array` containing all the keys currently in the dictionary.
     ///
     /// _Godot equivalent: `keys`_
+    #[doc(alias = "keys")]
     pub fn keys_array(&self) -> VariantArray {
         self.as_inner().keys()
     }
@@ -152,6 +158,7 @@ impl Dictionary {
     /// Creates a new `Array` containing all the values currently in the dictionary.
     ///
     /// _Godot equivalent: `values`_
+    #[doc(alias = "values")]
     pub fn values_array(&self) -> VariantArray {
         self.as_inner().values()
     }
@@ -166,6 +173,7 @@ impl Dictionary {
     /// If `overwrite` is true, it will overwrite pre-existing keys.
     ///
     /// _Godot equivalent: `merge`_
+    #[doc(alias = "merge")]
     pub fn extend_dictionary(&mut self, other: Self, overwrite: bool) {
         self.as_inner().merge(other, overwrite)
     }
@@ -173,6 +181,7 @@ impl Dictionary {
     /// Returns the number of entries in the dictionary.
     ///
     /// This is equivalent to `size` in Godot.
+    #[doc(alias = "size")]
     pub fn len(&self) -> usize {
         self.as_inner().size().try_into().unwrap()
     }

--- a/godot-core/src/builtin/mod.rs
+++ b/godot-core/src/builtin/mod.rs
@@ -172,8 +172,6 @@ mod real_mod {
     /// [`f64`], see [`RealConv`](super::RealConv).
     ///
     /// See also the [Godot docs on float](https://docs.godotengine.org/en/stable/classes/class_float.html).
-    ///
-    /// _Godot equivalent: `real_t`_
     // As this is a scalar value, we will use a non-standard type name.
     #[allow(non_camel_case_types)]
     pub type real = f32;
@@ -329,6 +327,7 @@ macro_rules! real {
 /// The side of a [`Rect2`] or [`Rect2i`].
 ///
 /// _Godot equivalent: `@GlobalScope.Side`_
+#[doc(alias = "Side")]
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub enum RectSide {

--- a/godot-core/src/builtin/packed_array.rs
+++ b/godot-core/src/builtin/packed_array.rs
@@ -201,6 +201,8 @@ macro_rules! impl_packed_array {
 
             /// Appends an element to the end of the array. Equivalent of `append` and `push_back`
             /// in GDScript.
+            #[doc(alias = "append")]
+            #[doc(alias = "push_back")]
             pub fn push(&mut self, value: $Element) {
                 self.as_inner().push_back(Self::into_arg(value));
             }
@@ -231,6 +233,7 @@ macro_rules! impl_packed_array {
             // Design note: This returns the removed value instead of `()` for consistency with
             // `Array` and with `Vec::remove`. Compared to shifting all the subsequent array
             // elements to their new position, the overhead of retrieving this element is trivial.
+            #[doc(alias = "remove_at")]
             pub fn remove(&mut self, index: usize) -> $Element {
                 self.check_bounds(index);
                 let element = self.get(index);

--- a/godot-core/src/builtin/rect2.rs
+++ b/godot-core/src/builtin/rect2.rs
@@ -68,6 +68,7 @@ impl Rect2 {
     /// The end of the `Rect2` calculated as `position + size`.
     ///
     /// _Godot equivalent: `Rect2.size` property_
+    #[doc(alias = "size")]
     #[inline]
     pub fn end(&self) -> Vector2 {
         self.position + self.size

--- a/godot-core/src/builtin/rect2i.rs
+++ b/godot-core/src/builtin/rect2i.rs
@@ -68,6 +68,7 @@ impl Rect2i {
     /// The end of the `Rect2i` calculated as `position + size`.
     ///
     /// _Godot equivalent: `Rect2i.size` property_
+    #[doc(alias = "size")]
     #[inline]
     pub const fn end(&self) -> Vector2i {
         Vector2i::new(self.position.x + self.size.x, self.position.y + self.size.y)
@@ -120,7 +121,6 @@ impl Rect2i {
     /// Returns the area of the `Rect2i`.
     ///
     /// _Godot equivalent: `Rect2i.get_area` function_
-    #[doc(alias = "get_area")]
     #[inline]
     pub const fn area(&self) -> i32 {
         self.size.x * self.size.y
@@ -131,7 +131,6 @@ impl Rect2i {
     /// If `size` is an odd number, the returned center value will be rounded towards `position`.
     ///
     /// _Godot equivalent: `Rect2i.get_center` function_
-    #[doc(alias = "get_center")]
     #[inline]
     pub fn center(&self) -> Vector2i {
         self.position + (self.size / 2)

--- a/godot-core/src/builtin/rid.rs
+++ b/godot-core/src/builtin/rid.rs
@@ -52,6 +52,7 @@ impl Rid {
     /// Convert this RID into a [`u64`]. Returns 0 if it is invalid.
     ///
     /// _Godot equivalent: `Rid.get_id()`_
+    #[doc(alias = "get_id")]
     #[inline]
     pub const fn to_u64(self) -> u64 {
         match self {


### PR DESCRIPTION
Solved Issue #232 by adding doc-aliases to methods that differ from [Godot's Docs](https://docs.godotengine.org/en/stable/classes/index.html#variant-types) in folder `godot-core/src/builtin`.

I might have forgotten some in the Vectors section, whose code needs to be better documented.