### PR TITLE
godot-core: delegate TypeStringHint on Option<T> to T

### DIFF
--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -691,6 +691,12 @@ impl<T: GodotClass> TypeStringHint for Gd<T> {
     }
 }
 
+impl<T: TypeStringHint> TypeStringHint for Option<T> {
+    fn type_string() -> String {
+        <T>::type_string()
+    }
+}
+
 impl<T: GodotClass> Export for Gd<T> {
     fn export(&self) -> Self {
         self.share()


### PR DESCRIPTION
So when trying to export an array of resources property from my Rust struct I encountered the problem of crashes when the user adds null to the array (i.e. adding an element, not initializing it, then reopening the scene). I will open a separate issue for this.

However, in investigating this, I saw that TypeStringHint is not implemented for Option<Gd<T>>, only for Gd<T>. I feel that it should be implemented for that type as well, but I'm not sure delegating to Gd<T> is the right call here, that's why this is a draft.

Currently I just want to get this topic on the radar and spark discussion. However, should it turn out that delegating to Gd<T> here is the right thing to do, I believe the change can be applied as-is. From what I've seen from #241 there are no tests for TypeStringHint yet, so I haven't added any here, either.