### PR TITLE
Add support for conditional compilation depending on godot api version

### DIFF
--- a/godot-bindings/src/godot_exe.rs
+++ b/godot-bindings/src/godot_exe.rs
@@ -6,10 +6,10 @@
 
 //! Commands related to Godot executable
 
-use crate::custom::godot_version::GodotVersion;
 use crate::godot_version::parse_godot_version;
 use crate::header_gen::generate_rust_binding;
 use crate::watch::StopWatch;
+use crate::GodotVersion;
 
 use regex::Regex;
 use std::fs;
@@ -99,7 +99,7 @@ fn update_version_file(version: &str) {
 }
 */
 
-fn read_godot_version(godot_bin: &Path) -> GodotVersion {
+pub(crate) fn read_godot_version(godot_bin: &Path) -> GodotVersion {
     let output = Command::new(godot_bin)
         .arg("--version")
         .output()
@@ -259,7 +259,7 @@ fn polyfill_legacy_header(c: &mut String) {
     );
 }
 
-fn locate_godot_binary() -> PathBuf {
+pub(crate) fn locate_godot_binary() -> PathBuf {
     if let Ok(string) = std::env::var("GODOT4_BIN") {
         println!("Found GODOT4_BIN with path to executable: '{string}'");
         println!("cargo:rerun-if-env-changed=GODOT4_BIN");

--- a/godot-bindings/src/godot_version.rs
+++ b/godot-bindings/src/godot_version.rs
@@ -6,27 +6,10 @@
 
 //#![allow(unused_variables, dead_code)]
 
+use crate::GodotVersion;
 use regex::{Captures, Regex};
 use std::error::Error;
 use std::str::FromStr;
-
-#[derive(Debug, Eq, PartialEq)]
-pub struct GodotVersion {
-    /// the original string (trimmed, stripped of text around)
-    pub full_string: String,
-
-    pub major: u8,
-    pub minor: u8,
-
-    /// 0 if none
-    pub patch: u8,
-
-    /// alpha|beta|dev|stable
-    pub status: String,
-
-    /// Git revision 'custom_build.{rev}' or '{official}.rev', if available
-    pub custom_rev: Option<String>,
-}
 
 pub fn parse_godot_version(version_str: &str) -> Result<GodotVersion, Box<dyn Error>> {
     // Format of the string emitted by `godot --version`:

--- a/godot-bindings/src/lib.rs
+++ b/godot-bindings/src/lib.rs
@@ -103,7 +103,10 @@ mod prebuilt {
             full_string: godot4_prebuilt::GODOT_VERSION.into(),
             major: version[0].parse().unwrap(),
             minor: version[1].parse().unwrap(),
-            patch: version[2].parse().unwrap(),
+            patch: version
+                .get(2)
+                .and_then(|patch| patch.parse().ok())
+                .unwrap_or(0),
             status: "stable".into(),
             custom_rev: None,
         }
@@ -132,12 +135,12 @@ pub fn emit_godot_version_cfg() {
         ..
     } = get_godot_version();
 
-    println!(r#"cargo:rustc-cfg=gdextension_api_version="{major}.{minor}""#);
+    println!(r#"cargo:rustc-cfg=gdextension_api="{major}.{minor}""#);
 
     // Godot drops the patch version if it is 0.
     if patch != 0 {
-        println!(r#"cargo:rustc-cfg=gdextension_api_version_full="{major}.{minor}.{patch}""#);
+        println!(r#"cargo:rustc-cfg=gdextension_exact_api="{major}.{minor}.{patch}""#);
     } else {
-        println!(r#"cargo:rustc-cfg=gdextension_api_version_full="{major}.{minor}""#);
+        println!(r#"cargo:rustc-cfg=gdextension_exact_api="{major}.{minor}""#);
     }
 }

--- a/godot-codegen/src/central_generator.rs
+++ b/godot-codegen/src/central_generator.rs
@@ -272,6 +272,15 @@ fn make_build_config(header: &Header) -> TokenStream {
                     String::from_utf8_lossy(c_str.to_bytes()).to_string()
                 }
             }
+
+            /// Version of the Godot engine which loaded gdext via GDExtension binding, as
+            /// `(major, minor, patch)` triple.
+            pub fn godot_runtime_version_triple() -> (u8, u8, u8) {
+                let version = unsafe {
+                    crate::runtime_metadata().godot_version
+                };
+                (version.major as u8, version.minor as u8, version.patch as u8)
+            }
         }
     }
 }

--- a/godot-core/Cargo.toml
+++ b/godot-core/Cargo.toml
@@ -29,4 +29,5 @@ godot = { path = "../godot" }
 serde_json = "1.0"
 
 [build-dependencies]
+godot-bindings = { path = "../godot-bindings" }
 godot-codegen = { path = "../godot-codegen" }

--- a/godot-core/build.rs
+++ b/godot-core/build.rs
@@ -17,4 +17,6 @@ fn main() {
 
     godot_codegen::generate_core_files(gen_path);
     println!("cargo:rerun-if-changed=build.rs");
+
+    godot_bindings::emit_godot_version_cfg();
 }

--- a/godot-core/src/builtin/basis.rs
+++ b/godot-core/src/builtin/basis.rs
@@ -143,12 +143,12 @@ impl Basis {
     /// orthonormalized. The `target` and `up` vectors cannot be zero, and
     /// cannot be parallel to each other.
     ///
-    #[cfg(gdextension_api_version = "4.0")]
+    #[cfg(gdextension_api = "4.0")]
     /// _Godot equivalent: `Basis.looking_at()`_
     pub fn new_looking_at(target: Vector3, up: Vector3) -> Self {
         super::inner::InnerBasis::looking_at(target, up)
     }
-    #[cfg(not(gdextension_api_version = "4.0"))]
+    #[cfg(not(gdextension_api = "4.0"))]
     /// If `use_model_front` is true, the +Z axis (asset front) is treated as forward (implies +X is left)
     /// and points toward the target position. By default, the -Z axis (camera forward) is treated as forward
     /// (implies +X is right).

--- a/godot-core/src/builtin/basis.rs
+++ b/godot-core/src/builtin/basis.rs
@@ -143,9 +143,19 @@ impl Basis {
     /// orthonormalized. The `target` and `up` vectors cannot be zero, and
     /// cannot be parallel to each other.
     ///
+    #[cfg(gdextension_api_version = "4.0")]
     /// _Godot equivalent: `Basis.looking_at()`_
     pub fn new_looking_at(target: Vector3, up: Vector3) -> Self {
         super::inner::InnerBasis::looking_at(target, up)
+    }
+    #[cfg(not(gdextension_api_version = "4.0"))]
+    /// If `use_model_front` is true, the +Z axis (asset front) is treated as forward (implies +X is left)
+    /// and points toward the target position. By default, the -Z axis (camera forward) is treated as forward
+    /// (implies +X is right).
+    ///
+    /// _Godot equivalent: `Basis.looking_at()`_
+    pub fn new_looking_at(target: Vector3, up: Vector3, use_model_front: bool) -> Self {
+        super::inner::InnerBasis::looking_at(target, up, use_model_front)
     }
 
     /// Creates a `[Vector3; 3]` with the columns of the `Basis`.

--- a/godot-core/src/builtin/transform3d.rs
+++ b/godot-core/src/builtin/transform3d.rs
@@ -145,10 +145,19 @@ impl Transform3D {
     /// See [`Basis::new_looking_at()`] for more information.
     ///
     /// _Godot equivalent: Transform3D.looking_at()_
+    #[cfg(gdextension_api_version = "4.0")]
     #[must_use]
     pub fn looking_at(self, target: Vector3, up: Vector3) -> Self {
         Self {
             basis: Basis::new_looking_at(target - self.origin, up),
+            origin: self.origin,
+        }
+    }
+    #[cfg(not(gdextension_api_version = "4.0"))]
+    #[must_use]
+    pub fn looking_at(self, target: Vector3, up: Vector3, use_model_front: bool) -> Self {
+        Self {
+            basis: Basis::new_looking_at(target - self.origin, up, use_model_front),
             origin: self.origin,
         }
     }

--- a/godot-core/src/builtin/transform3d.rs
+++ b/godot-core/src/builtin/transform3d.rs
@@ -145,7 +145,7 @@ impl Transform3D {
     /// See [`Basis::new_looking_at()`] for more information.
     ///
     /// _Godot equivalent: Transform3D.looking_at()_
-    #[cfg(gdextension_api_version = "4.0")]
+    #[cfg(gdextension_api = "4.0")]
     #[must_use]
     pub fn looking_at(self, target: Vector3, up: Vector3) -> Self {
         Self {
@@ -153,7 +153,7 @@ impl Transform3D {
             origin: self.origin,
         }
     }
-    #[cfg(not(gdextension_api_version = "4.0"))]
+    #[cfg(not(gdextension_api = "4.0"))]
     #[must_use]
     pub fn looking_at(self, target: Vector3, up: Vector3, use_model_front: bool) -> Self {
         Self {

--- a/godot-core/src/builtin/variant/mod.rs
+++ b/godot-core/src/builtin/variant/mod.rs
@@ -132,6 +132,22 @@ impl Variant {
         let op_sys = op.sys();
         let mut is_valid = false as u8;
 
+        #[cfg(gdextension_api = "4.0")]
+        let result = {
+            #[allow(unused_mut)]
+            let mut result = Variant::nil();
+            unsafe {
+                interface_fn!(variant_evaluate)(
+                    op_sys,
+                    self.var_sys(),
+                    rhs.var_sys(),
+                    result.var_sys(),
+                    ptr::addr_of_mut!(is_valid),
+                )
+            };
+            result
+        };
+        #[cfg(not(gdextension_api = "4.0"))]
         let result = unsafe {
             Variant::from_var_sys_init(|variant_ptr| {
                 interface_fn!(variant_evaluate)(

--- a/godot-core/src/lib.rs
+++ b/godot-core/src/lib.rs
@@ -172,14 +172,14 @@ macro_rules! generate_gdextension_api_version {
 //
 // This includes all versions we're developing for, including unreleased future versions.
 generate_gdextension_api_version!(
-    (GDEXTENSION_API_VERSION_FULL, gdextension_exact_api) => {
+    (GDEXTENSION_EXACT_API, gdextension_exact_api) => {
         "4.0",
         "4.0.1",
         "4.0.2",
         "4.0.3",
         "4.1",
     },
-    (GDEXTENSION_API_VERSION, gdextension_api) => {
+    (GDEXTENSION_API, gdextension_api) => {
         "4.0",
         "4.1",
     },

--- a/godot-core/src/lib.rs
+++ b/godot-core/src/lib.rs
@@ -148,3 +148,39 @@ pub mod private {
         std::io::stdout().flush().expect("flush stdout");
     }
 }
+
+macro_rules! generate_gdextension_api_version {
+    (
+        $(
+            $name:ident => {
+                $($version:literal, )*
+            }
+        ),* $(,)?
+    ) => {
+        $(
+            $(
+                #[cfg(gdextension_api_version = $version)]
+                #[allow(dead_code)]
+                const $name: &str = $version;
+            )*
+        )*
+    };
+}
+
+// If multiple gdextension_api_version's are found then this will generate several structs with the same
+// name, causing a compile error.
+//
+// This includes all versions we're developing for, including unreleased future versions.
+generate_gdextension_api_version!(
+    GDEXTENSION_API_VERSION_FULL => {
+        "4.0",
+        "4.0.1",
+        "4.0.2",
+        "4.0.3",
+        "4.1",
+    },
+    GDEXTENSION_API_VERSION => {
+        "4.0",
+        "4.1",
+    },
+);

--- a/godot-core/src/lib.rs
+++ b/godot-core/src/lib.rs
@@ -152,14 +152,14 @@ pub mod private {
 macro_rules! generate_gdextension_api_version {
     (
         $(
-            $name:ident => {
+            ($name:ident, $gdextension_api:ident) => {
                 $($version:literal, )*
             }
         ),* $(,)?
     ) => {
         $(
             $(
-                #[cfg(gdextension_api_version = $version)]
+                #[cfg($gdextension_api = $version)]
                 #[allow(dead_code)]
                 const $name: &str = $version;
             )*
@@ -172,14 +172,14 @@ macro_rules! generate_gdextension_api_version {
 //
 // This includes all versions we're developing for, including unreleased future versions.
 generate_gdextension_api_version!(
-    GDEXTENSION_API_VERSION_FULL => {
+    (GDEXTENSION_API_VERSION_FULL, gdextension_exact_api) => {
         "4.0",
         "4.0.1",
         "4.0.2",
         "4.0.3",
         "4.1",
     },
-    GDEXTENSION_API_VERSION => {
+    (GDEXTENSION_API_VERSION, gdextension_api) => {
         "4.0",
         "4.1",
     },

--- a/godot-ffi/build.rs
+++ b/godot-ffi/build.rs
@@ -27,4 +27,6 @@ fn main() {
 
     watch.write_stats_to(&gen_path.join("ffi-stats.txt"));
     println!("cargo:rerun-if-changed=build.rs");
+
+    godot_bindings::emit_godot_version_cfg();
 }


### PR DESCRIPTION
Adds the ability to conditionally compile code based on what version of godot we're compiling against, either on a major, minor, or patch level.

As an example, i have here fixed `Basis` and `Transform3D`'s `looking_at` functions so that they include the `use_model_front` argument in 4.1 (and any other version different from 4.0).

We can specify the major, minor, and patch version. I'm not sure if we'll get use out of specifying the major version only (like check if we're running godot 4 or 5). But it's a very simple addition for completeness, and who knows maybe we in 10 years still have gdextension when/if godot 5 comes out.

We also get a compile error if we have multiple conflicting `gdextension_api_version = "version"` settings (for instance, 4.0.1 and 4.1.0), as this will generate multiple constants with the same name. The compiler message isn't the best for this, but it does point to a piece of source code that has a comment explaining why it fails. 

Ensuring that our conditional compilation actually exhaustively covers all options, even ones that aren't valid states to be in, is probably ideal here. Like i could've made the `looking_at` impl just check `4.0` and `4.1`, and even ignoring the issue with forward compatability there, that could also trip up some IDEs that don't properly emit *any* of the cfgs even when they should do.

closes #287