### PR TITLE
Added instantiate_as for PackedScene

### DIFF
--- a/examples/dodge-the-creeps/rust/src/main_scene.rs
+++ b/examples/dodge-the-creeps/rust/src/main_scene.rs
@@ -2,7 +2,6 @@ use crate::hud::Hud;
 use crate::mob;
 use crate::player;
 use godot::engine::node::InternalMode;
-use godot::engine::packed_scene::GenEditState;
 use godot::engine::{Marker2D, PathFollow2D, RigidBody2D, Timer};
 use godot::prelude::*;
 use rand::Rng as _;
@@ -78,7 +77,7 @@ impl Main {
             .base
             .get_node_as::<PathFollow2D>("MobPath/MobSpawnLocation");
 
-        let mut mob_scene: Gd<RigidBody2D> = instantiate_scene(&self.mob_scene);
+        let mut mob_scene = self.mob_scene.instantiate_as::<RigidBody2D>();
 
         let mut rng = rand::thread_rng();
         let progress = rng.gen_range(u32::MIN..u32::MAX);
@@ -145,17 +144,4 @@ impl NodeVirtual for Main {
         self.music = Some(self.base.get_node_as("Music"));
         self.death_sound = Some(self.base.get_node_as("DeathSound"));
     }
-}
-
-/// Root here is needs to be the same type (or a parent type) of the node that you put in the child
-///   scene as the root. For instance Spatial is used for this example.
-fn instantiate_scene<Root>(scene: &PackedScene) -> Gd<Root>
-where
-    Root: GodotClass + Inherits<Node>,
-{
-    let s = scene
-        .instantiate(GenEditState::GEN_EDIT_STATE_DISABLED)
-        .expect("scene instantiated");
-
-    s.cast::<Root>()
 }

--- a/godot-core/src/engine.rs
+++ b/godot-core/src/engine.rs
@@ -16,6 +16,40 @@ pub use crate::gen::central::global;
 pub use crate::gen::classes::*;
 pub use crate::gen::utilities;
 
+use self::packed_scene::GenEditState;
+
+/// Extension trait for convenience functions on `PackedScene`
+pub trait PackedSceneExt {
+    /// ⚠️ Instantiates the scene as type `T`, panicking if not found or bad type.
+    ///
+    /// # Panics
+    /// If the scene is not type `T` or inherited.
+    fn instantiate_as<T>(&self) -> Gd<T>
+    where
+        T: Inherits<Node>,
+    {
+        self.try_instantiate_as::<T>()
+            .unwrap_or_else(|| panic!("Failed to instantiate {to}", to = T::CLASS_NAME))
+    }
+
+    /// Instantiates the scene as type `T` (fallible).
+    ///
+    /// If the scene is not type `T` or inherited.
+    fn try_instantiate_as<T>(&self) -> Option<Gd<T>>
+    where
+        T: Inherits<Node>;
+}
+
+impl PackedSceneExt for PackedScene {
+    fn try_instantiate_as<T>(&self) -> Option<Gd<T>>
+    where
+        T: Inherits<Node>,
+    {
+        self.instantiate(GenEditState::GEN_EDIT_STATE_DISABLED)
+            .and_then(|gd| gd.try_cast::<T>())
+    }
+}
+
 /// Extension trait with convenience functions for the node tree.
 pub trait NodeExt {
     /// Retrieves the node at path `path`, panicking if not found or bad type.

--- a/godot/src/lib.rs
+++ b/godot/src/lib.rs
@@ -171,8 +171,9 @@ pub mod prelude {
     pub use super::engine::{
         load, try_load, utilities, AudioStreamPlayer, AudioStreamPlayerVirtual, Camera2D,
         Camera2DVirtual, Camera3D, Camera3DVirtual, Input, Node, Node2D, Node2DVirtual, Node3D,
-        Node3DVirtual, NodeVirtual, Object, ObjectVirtual, PackedScene, PackedSceneVirtual,
-        RefCounted, RefCountedVirtual, Resource, ResourceVirtual, SceneTree, SceneTreeVirtual,
+        Node3DVirtual, NodeVirtual, Object, ObjectVirtual, PackedScene, PackedSceneExt,
+        PackedSceneVirtual, RefCounted, RefCountedVirtual, Resource, ResourceVirtual, SceneTree,
+        SceneTreeVirtual,
     };
     pub use super::init::{gdextension, ExtensionLayer, ExtensionLibrary, InitHandle, InitLevel};
     pub use super::log::*;


### PR DESCRIPTION
I added PackedSceneExt as a trait for the PackedScene to impl, made the impl and added usage of instantiate_as to the example dodge the creeps.

I commented out areas in the dodge-the-creeps file.