### PR TITLE
Make exporting without a `#[godot_api]` a compile error

### DIFF
--- a/godot-core/src/export.rs
+++ b/godot-core/src/export.rs
@@ -86,6 +86,23 @@ pub trait TypeStringHint {
     fn type_string() -> String;
 }
 
+/// To export properties to godot, you must have an impl-block with the `#[godot_api]` attribute, even if
+/// it is empty.
+///
+/// This trait is automatically implemented when such an impl-block is present. If rust complains that it is
+/// not implemented, then you can usually fix this by adding:
+///
+/// ```ignore
+/// #[godot_api]
+/// impl MyClass {}
+/// ```
+///
+/// Where you replace `MyClass` with the name of your class.
+#[allow(non_camel_case_types)]
+pub trait Cannot_export_without_godot_api_impl {
+    const EXISTS: () = ();
+}
+
 mod export_impls {
     use super::*;
     use crate::builtin::meta::VariantMetadata;

--- a/godot-core/src/lib.rs
+++ b/godot-core/src/lib.rs
@@ -46,6 +46,7 @@ pub mod private {
     // If someone forgets #[godot_api], this causes a compile error, rather than virtual functions not being called at runtime.
     #[allow(non_camel_case_types)]
     pub trait You_forgot_the_attribute__godot_api {}
+    pub use crate::export::Cannot_export_without_godot_api_impl;
 
     use std::sync::{Arc, Mutex};
 

--- a/godot-macros/src/derive_godot_class.rs
+++ b/godot-macros/src/derive_godot_class.rs
@@ -409,8 +409,18 @@ fn make_exports_impl(class_name: &Ident, fields: &Fields) -> TokenStream {
         });
     }
 
+    let enforce_godot_api_impl = if !export_tokens.is_empty() {
+        quote! {
+            const MUST_HAVE_GODOT_API_IMPL: () = <#class_name as ::godot::private::Cannot_export_without_godot_api_impl>::EXISTS;
+        }
+    } else {
+        TokenStream::new()
+    };
+
     quote! {
         impl #class_name {
+            #enforce_godot_api_impl
+
             #(#getter_setter_impls)*
         }
 

--- a/godot-macros/src/godot_api.rs
+++ b/godot-macros/src/godot_api.rs
@@ -122,6 +122,8 @@ fn transform_inherent_impl(mut decl: Impl) -> Result<TokenStream, Error> {
             }
         }
 
+        impl ::godot::private::Cannot_export_without_godot_api_impl for #class_name {}
+
         ::godot::sys::plugin_add!(__GODOT_PLUGIN_REGISTRY in #prv; #prv::ClassPlugin {
             class_name: #class_name_str,
             component: #prv::PluginComponent::UserMethodBinds {

--- a/godot-macros/src/lib.rs
+++ b/godot-macros/src/lib.rs
@@ -197,11 +197,17 @@ mod util;
 ///     #[export]
 ///     my_field: i64,
 /// }
+///
+/// #[godot_api]
+/// impl MyStruct {}
 /// ```
 ///
 /// This makes the field accessible in GDScript using `my_struct.my_field` syntax. Additionally, it
 /// generates a trivial getter and setter named `get_my_field` and `set_my_field`, respectively.
 /// These are `pub` in Rust, since they're exposed from GDScript anyway.
+///
+/// For technical reasons, an impl-block with the `#[godot_api]` attribute is required for exports to work.
+/// Failing to include one will cause a compile error if you try to export any properties.
 ///
 /// If you want to implement your own getter and/or setter, write those as a function on your Rust
 /// type, expose it using `#[func]`, and annotate the field with


### PR DESCRIPTION
Adds a new trait `Cannot_export_without_godot_api_impl`, similar to `You_forgot_the_attribute__godot_api`, that will be a required trait impl when the user tries to export a field.

closes #187