### PR TITLE
Update the ptrcall convention to work with 4.0 and 4.1

### DIFF
--- a/.github/composite/godot-install/action.yml
+++ b/.github/composite/godot-install/action.yml
@@ -44,9 +44,9 @@ runs:
       # curl https://nightly.link/Bromeon/godot4-nightly/actions/runs/4910907653/${{ inputs.artifact-name }}.zip \
       run: |
         if [[ $ARTIFACT_NAME == *"stable"* ]]; then
-          url="https://nightly.link/Bromeon/godot4-nightly/workflows/compile-godot-stable/master/$ARTIFACT_NAME.zip"
+          url="https://nightly.link/Bromeon/godot4-nightly/workflows/compile-godot-stable/godot-object-ptr/$ARTIFACT_NAME.zip"
         else
-          url="https://nightly.link/Bromeon/godot4-nightly/workflows/compile-godot-nightly/master/$ARTIFACT_NAME.zip"
+          url="https://nightly.link/Bromeon/godot4-nightly/workflows/compile-godot-nightly/godot-object-ptr/$ARTIFACT_NAME.zip"
         fi
         
         curl "$url" -Lo artifact.zip --retry 3

--- a/.github/composite/godot-install/action.yml
+++ b/.github/composite/godot-install/action.yml
@@ -44,9 +44,9 @@ runs:
       # curl https://nightly.link/Bromeon/godot4-nightly/actions/runs/4910907653/${{ inputs.artifact-name }}.zip \
       run: |
         if [[ $ARTIFACT_NAME == *"stable"* ]]; then
-          url="https://nightly.link/Bromeon/godot4-nightly/workflows/compile-godot-stable/godot-object-ptr/$ARTIFACT_NAME.zip"
+          url="https://nightly.link/Bromeon/godot4-nightly/workflows/compile-godot-stable/master/$ARTIFACT_NAME.zip"
         else
-          url="https://nightly.link/Bromeon/godot4-nightly/workflows/compile-godot-nightly/godot-object-ptr/$ARTIFACT_NAME.zip"
+          url="https://nightly.link/Bromeon/godot4-nightly/workflows/compile-godot-nightly/master/$ARTIFACT_NAME.zip"
         fi
         
         curl "$url" -Lo artifact.zip --retry 3

--- a/.github/composite/godot-itest/action.yml
+++ b/.github/composite/godot-itest/action.yml
@@ -19,6 +19,7 @@ inputs:
     default: ''
     description: "Command-line arguments passed to Godot"
 
+  # Currently unused; could be removed entirely.
   godot-check-header:
     required: false
     default: 'false'

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -12,7 +12,6 @@ on:
     branches:
       - staging
       - trying
-
 env:
   GDEXT_FEATURES: ''
 

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -125,141 +125,85 @@ jobs:
         # Naming: {os}[-{runtimeVersion}]-{apiVersion}
         # runtimeVersion = version of Godot binary; apiVersion = version of GDExtension API against which gdext is compiled.
 
+        # --disallow-focus: fail if #[itest(focus)] is encountered, to prevent running only a few tests for full CI
+
         # Order this way because macOS typically has the longest duration, followed by Windows, so it benefits total workflow execution time.
         # Additionally, the 'linux (msrv *)' special case will then be listed next to the other 'linux' jobs.
         # Note: Windows uses '--target x86_64-pc-windows-msvc' by default as Cargo argument.
         include:
           # macOS
 
-          - name: macos-stableRt-4.0.3
-            os: macos-12
-            artifact-name: macos-stable
-            godot-binary: godot.macos.editor.dev.x86_64
-            godot-prebuilt-patch: '4.0.3'
-
-          - name: macos-4.0.3
+          - name: macos
             os: macos-12
             artifact-name: macos-nightly
             godot-binary: godot.macos.editor.dev.x86_64
-            godot-prebuilt-patch: '4.0.3'
+            rust-extra-args: --features godot/custom-godot
+            godot-prebuilt-patch: '4.1'
 
           - name: macos-double
             os: macos-12
             artifact-name: macos-double-nightly
             godot-binary: godot.macos.editor.dev.double.x86_64
-            rust-extra-args: --features godot/double-precision
-
-          - name: macos-nightly
-            os: macos-12
-            artifact-name: macos-nightly
-            godot-binary: godot.macos.editor.dev.x86_64
-            rust-extra-args: --features godot/custom-godot
-            with-llvm: true
+            rust-extra-args: --features godot/custom-godot,godot/double-precision
             godot-prebuilt-patch: '4.1'
+
+          - name: macos-4.0.3
+            os: macos-12
+            artifact-name: macos-stable
+            godot-binary: godot.macos.editor.dev.x86_64
+            godot-prebuilt-patch: '4.0.3'
 
           # Windows
 
-          - name: windows-stableRt-4.0.3
-            os: windows-latest
-            artifact-name: windows-stable
-            godot-binary: godot.windows.editor.dev.x86_64.exe
-            godot-prebuilt-patch: '4.0.3'
-
-          - name: windows-4.0.3
+          - name: windows
             os: windows-latest
             artifact-name: windows-nightly
             godot-binary: godot.windows.editor.dev.x86_64.exe
-            godot-prebuilt-patch: '4.0.3'
+            rust-extra-args: --features godot/custom-godot
+            godot-prebuilt-patch: '4.1'
 
           - name: windows-double
             os: windows-latest
             artifact-name: windows-double-nightly
             godot-binary: godot.windows.editor.dev.double.x86_64.exe
-            rust-extra-args: --features godot/double-precision
-
-          - name: windows-nightly
-            os: windows-latest
-            artifact-name: windows-nightly
-            godot-binary: godot.windows.editor.dev.x86_64.exe
-            rust-extra-args: --features godot/custom-godot
+            rust-extra-args: --features godot/custom-godot,godot/double-precision
             godot-prebuilt-patch: '4.1'
+
+          - name: windows-4.0.3
+            os: windows-latest
+            artifact-name: windows-stable
+            godot-binary: godot.windows.editor.dev.x86_64.exe
+            godot-prebuilt-patch: '4.0.3'
 
           # Linux
 
           # Don't use latest Ubuntu (22.04) as it breaks lots of ecosystem compatibility.
           # If ever moving to ubuntu-latest, need to manually install libtinfo5 for LLVM.
-          - name: linux-stableRt-4.0.3
-            os: ubuntu-20.04
-            artifact-name: linux-stable
-            godot-binary: godot.linuxbsd.editor.dev.x86_64
-
-          - name: linux-4.0.3
+          - name: linux
             os: ubuntu-20.04
             artifact-name: linux-nightly
             godot-binary: godot.linuxbsd.editor.dev.x86_64
-            godot-check-header: false # disabled for now
-
-          - name: linux-4.0.2
-            os: ubuntu-20.04
-            artifact-name: linux-nightly
-            godot-binary: godot.linuxbsd.editor.dev.x86_64
-            godot-prebuilt-patch: '4.0.2'
-
-          - name: linux-4.0.1
-            os: ubuntu-20.04
-            artifact-name: linux-nightly
-            godot-binary: godot.linuxbsd.editor.dev.x86_64
-            godot-prebuilt-patch: '4.0.1'
-
-          - name: linux-4.0
-            os: ubuntu-20.04
-            artifact-name: linux-nightly
-            godot-binary: godot.linuxbsd.editor.dev.x86_64
-            godot-prebuilt-patch: '4.0'
+            rust-extra-args: --features godot/custom-godot,godot/custom-godot
+            godot-prebuilt-patch: '4.1'
 
           - name: linux-double
             os: ubuntu-20.04
             artifact-name: linux-double-nightly
             godot-binary: godot.linuxbsd.editor.dev.double.x86_64
-            rust-extra-args: --features godot/double-precision
+            rust-extra-args: --features godot/custom-godot,godot/double-precision
+            godot-prebuilt-patch: '4.1'
 
           - name: linux-features
             os: ubuntu-20.04
             artifact-name: linux-nightly
             godot-binary: godot.linuxbsd.editor.dev.x86_64
-            rust-extra-args: --features godot/threads,godot/serde
-
-          - name: linux-nightly
-            os: ubuntu-20.04
-            artifact-name: linux-nightly
-            godot-binary: godot.linuxbsd.editor.dev.x86_64
-            rust-extra-args: --features godot/custom-godot
+            rust-extra-args: --features godot/custom-godot,godot/threads,godot/serde
             godot-prebuilt-patch: '4.1'
 
           # Special Godot binaries compiled with AddressSanitizer/LeakSanitizer to detect UB/leaks.
           # Additionally, the Godot source is patched to make dlclose() a no-op, as unloading dynamic libraries loses stacktrace and
           # cause false positives like println!. See https://github.com/google/sanitizers/issues/89.
           # The gcc version can possibly be removed later, as it is slower and needs a larger artifact than the clang one.
-
-          # --disallow-focus: fail if #[itest(focus)] is encountered, to prevent running only a few tests for full CI
-
-          - name: linux-memcheck-stableRt-4.0.3
-            os: ubuntu-20.04
-            artifact-name: linux-memcheck-clang-stable
-            godot-binary: godot.linuxbsd.editor.dev.x86_64.llvm.san
-            godot-args: -- --disallow-focus
-            rust-toolchain: nightly
-            rust-env-rustflags: -Zrandomize-layout
-
-          # FIXME(#298): memory leaks detected when running 4.0.3 API with 4.1+ binary
-#          - name: linux-memcheck-4.0.3
-#            os: ubuntu-20.04
-#            artifact-name: linux-memcheck-clang-nightly
-#            godot-binary: godot.linuxbsd.editor.dev.x86_64.llvm.san
-#            godot-args: -- --disallow-focus
-#            rust-toolchain: nightly
-#            rust-env-rustflags: -Zrandomize-layout
-
           - name: linux-memcheck-nightly
             os: ubuntu-20.04
             artifact-name: linux-memcheck-clang-nightly
@@ -269,6 +213,39 @@ jobs:
             rust-env-rustflags: -Zrandomize-layout
             rust-extra-args: --features godot/custom-godot
             godot-prebuilt-patch: '4.1'
+
+          # Linux under Godot 4.0.x
+
+          - name: linux-4.0.3
+            os: ubuntu-20.04
+            artifact-name: linux-stable
+            godot-binary: godot.linuxbsd.editor.dev.x86_64
+
+          - name: linux-4.0.2
+            os: ubuntu-20.04
+            artifact-name: linux-stable
+            godot-binary: godot.linuxbsd.editor.dev.x86_64
+            godot-prebuilt-patch: '4.0.2'
+
+          - name: linux-4.0.1
+            os: ubuntu-20.04
+            artifact-name: linux-stable
+            godot-binary: godot.linuxbsd.editor.dev.x86_64
+            godot-prebuilt-patch: '4.0.1'
+
+          - name: linux-4.0
+            os: ubuntu-20.04
+            artifact-name: linux-stable
+            godot-binary: godot.linuxbsd.editor.dev.x86_64
+            godot-prebuilt-patch: '4.0'
+
+          - name: linux-memcheck-4.0.3
+            os: ubuntu-20.04
+            artifact-name: linux-memcheck-clang-stable
+            godot-binary: godot.linuxbsd.editor.dev.x86_64.llvm.san
+            godot-args: -- --disallow-focus
+            rust-toolchain: nightly
+            rust-env-rustflags: -Zrandomize-layout
 
 
     steps:
@@ -284,7 +261,7 @@ jobs:
           rust-extra-args: ${{ matrix.rust-extra-args }}
           rust-toolchain: ${{ matrix.rust-toolchain || 'stable' }}
           rust-env-rustflags: ${{ matrix.rust-env-rustflags }}
-          with-llvm: ${{ matrix.with-llvm }}
+          with-llvm: ${{ contains(matrix.name, 'macos') && contains(matrix.rust-extra-args, 'custom-godot') }}
           godot-check-header: ${{ matrix.godot-check-header }}
 
 

--- a/.github/workflows/minimal-ci.yml
+++ b/.github/workflows/minimal-ci.yml
@@ -88,7 +88,8 @@ jobs:
         with:
           artifact-name: godot-linux-nightly
           godot-binary: godot.linuxbsd.editor.dev.x86_64
-
+          rust-extra-args: --features godot/custom-godot,godot/custom-godot
+          godot-prebuilt-patch: '4.1'
 
   license-guard:
     runs-on: ubuntu-20.04

--- a/godot-core/src/builtin/callable.rs
+++ b/godot-core/src/builtin/callable.rs
@@ -9,7 +9,7 @@ use godot_ffi as sys;
 use crate::builtin::{inner, ToVariant, Variant};
 use crate::engine::Object;
 use crate::obj::mem::Memory;
-use crate::obj::{Gd, GodotClass, InstanceId};
+use crate::obj::{AsArg, Gd, GodotClass, InstanceId};
 use std::fmt;
 use sys::{ffi_methods, GodotFfi};
 
@@ -47,7 +47,7 @@ impl Callable {
         unsafe {
             sys::from_sys_init_or_init_default::<Self>(|self_ptr| {
                 let ctor = sys::builtin_fn!(callable_from_object_method);
-                let args = [object.sys_const(), method.sys_const()];
+                let args = [object.as_arg_ptr(), method.sys_const()];
                 ctor(self_ptr, args.as_ptr());
             })
         }

--- a/godot-core/src/obj/as_arg.rs
+++ b/godot-core/src/obj/as_arg.rs
@@ -27,7 +27,16 @@ impl<T: GodotClass> AsArg for Gd<T> {
         //
         // In Rust terms, if `T` is refcounted then we are effectively passing a `&Arc<T>`, and the callee
         // would need to call `.clone()` if desired.
-        self.sys_const()
+
+        // In 4.0, argument pointers are passed to godot as `T*`, except for in virtual method calls. We
+        // can't perform virtual method calls currently, so they are always `T*`.
+        //
+        // In 4.1 argument pointers were standardized to always be `T**`.
+        if cfg!(gdextension_api = "4.0") {
+            self.sys_const()
+        } else {
+            std::ptr::addr_of!(self.opaque) as sys::GDExtensionConstTypePtr
+        }
     }
 }
 

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -556,7 +556,7 @@ where
             // ptr is `Ref<T>*`
             // See the docs for `PtrcallType::Virtual` for more info on `Ref<T>`.
             interface_fn!(ref_get_object)(ptr as sys::GDExtensionRefPtr)
-        } else if matches!(call_type, PtrcallType::Virtual) {
+        } else if !cfg!(gdextension_api = "4.0") || matches!(call_type, PtrcallType::Virtual) {
             // ptr is `T**`
             *(ptr as *mut sys::GDExtensionObjectPtr)
         } else {

--- a/godot-ffi/src/compat/compat_4_1.rs
+++ b/godot-ffi/src/compat/compat_4_1.rs
@@ -77,6 +77,8 @@ impl BindingCompat for sys::GDExtensionInterfaceGetProcAddress {
         // Version 4.0.999 is used to signal that we're running Godot 4.1+ but loading extensions in legacy mode.
         if patch == 999 {
             // Godot 4.1+ loading the extension in legacy mode.
+            // Note: this can not happen as of June 2023 anymore, because Godot disallows loading 4.0 extensions now.
+            // TODO(bromeon): a while after 4.1 release, remove this branch.
             //
             // Instead of panicking, we could *theoretically* fall back to the legacy API at runtime, but then gdext would need to
             // always ship two versions of gdextension_interface.h (+ generated code) and would encourage use of the legacy API.
@@ -90,9 +92,10 @@ impl BindingCompat for sys::GDExtensionInterfaceGetProcAddress {
                 "gdext was compiled against a newer Godot version ({static_version}),\n\
                 but loaded by a legacy Godot binary ({runtime_version}).\n\
                 \n\
-                You have multiple options:\n\
-                1) Run the newer Godot version.\n\
-                2) Compile gdext against the older Godot binary (see `custom-godot` feature).\n\
+                Update your Godot engine version.\n\
+                \n\
+                (If you _really_ need an older Godot version, recompile your Rust extension against that one\
+                (see `custom-godot` feature). However, that setup will not be supported for a long time.\n\
                 \n"
             );
         }


### PR DESCRIPTION
This doesn't currently work when running a 4.1 binary against a 4.0 gdextension library. The godot devs are intentionally breaking backwards compatibility here too though.