### PR TITLE
adds --filtering option to check.sh

### DIFF
--- a/check.sh
+++ b/check.sh
@@ -32,8 +32,8 @@ Commands:
     dok           generate docs and open in browser
 
 Options:
-    -h, --help    print this help text
-    --double      run check with double-precision
+    -h, --help          print this help text
+    --double            run check with double-precision
     -f, --filter <arg>  only run integration tests which contain any of the
                         args (comma-separated). requires itest.
 
@@ -177,8 +177,13 @@ for arg in "$@"; do
         fmt | clippy | test | itest | doc | dok)
             cmds+=("$arg")
             ;;
-        -f | --filtering)
-            nextArgIsFilter=true
+        -f | --filter)
+            if [[ "${cmds[*]}" =~ itest ]]; then
+                nextArgIsFilter=true
+            else
+                log "-f/--filter requires 'itest' to be specified as a command."
+                exit 2
+            fi
             ;;
         *)
             if $nextArgIsFilter; then

--- a/itest/godot/TestRunner.gd
+++ b/itest/godot/TestRunner.gd
@@ -10,13 +10,18 @@ func _ready():
 	await get_tree().physics_frame
 
 	var allow_focus := true
+	var filters: Array = []
 	var unrecognized_args: Array = []
 	for arg in OS.get_cmdline_user_args():
 		match arg:
 			"--disallow-focus":
 				allow_focus = false
 			_:
-				unrecognized_args.push_back(arg)
+				if not arg.begins_with("[") or not arg.ends_with("]"):
+					unrecognized_args.push_back(arg)
+
+				var args = arg.lstrip("[").rstrip("]").split(",")
+				filters.append_array(args)
 
 	if unrecognized_args:
 		push_error("Unrecognized arguments: ", unrecognized_args)
@@ -53,6 +58,7 @@ func _ready():
 		gdscript_suites.size(),
 		allow_focus,
 		self,
+		filters
 	)
 
 	var exit_code: int = 0 if success else 1

--- a/itest/godot/project.godot
+++ b/itest/godot/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="IntegrationTests"
 run/main_scene="res://TestRunner.tscn"
-config/features=PackedStringArray("4.0")
+config/features=PackedStringArray("4.1")
 run/flush_stdout_on_print=true
 
 [debug]

--- a/itest/rust/src/lib.rs
+++ b/itest/rust/src/lib.rs
@@ -85,7 +85,7 @@ unsafe impl ExtensionLibrary for runner::IntegrationTests {}
 sys::plugin_registry!(__GODOT_ITEST: RustTestCase);
 
 /// Finds all `#[itest]` tests.
-fn collect_rust_tests() -> (Vec<RustTestCase>, usize, bool) {
+fn collect_rust_tests(filters: &[String]) -> (Vec<RustTestCase>, usize, bool) {
     let mut all_files = std::collections::HashSet::new();
     let mut tests: Vec<RustTestCase> = vec![];
     let mut is_focus_run = false;
@@ -99,7 +99,7 @@ fn collect_rust_tests() -> (Vec<RustTestCase>, usize, bool) {
         }
 
         // Only collect tests if normal mode, or focus mode and test is focused.
-        if !is_focus_run || test.focused {
+        if (!is_focus_run || test.focused) && passes_filter(filters, test.name) {
             all_files.insert(test.file);
             tests.push(*test);
         }
@@ -125,4 +125,8 @@ struct RustTestCase {
     #[allow(dead_code)]
     line: u32,
     function: fn(&TestContext),
+}
+
+pub(crate) fn passes_filter(filters: &[String], test_name: &str) -> bool {
+    filters.is_empty() || filters.iter().any(|x| test_name.contains(x))
 }


### PR DESCRIPTION
note that `check.sh itest --filtering clippy` wont parse clippy as a filter but as an arg

it shouldn't pose problems except maybe for fmt, I don't feel extremely confident improving the parsing in the sh language but if it's required i could rewrite it as a little rust script and pico-arg or something else.

this filters all tests.