### PR TITLE
`ApproxEq` trait + refactorings

### DIFF
--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -12,6 +12,7 @@ on:
     branches:
       - staging
       - trying
+
 env:
   GDEXT_FEATURES: ''
 

--- a/godot-codegen/src/class_generator.rs
+++ b/godot-codegen/src/class_generator.rs
@@ -333,7 +333,7 @@ fn make_class(class: &Class, class_name: &TyName, ctx: &mut Context) -> Generate
         use godot_ffi as sys;
         use crate::engine::notify::*;
         use crate::builtin::*;
-        use crate::native_structure::*;
+        use crate::engine::native::*;
         use crate::obj::{AsArg, Gd};
         use sys::GodotFfi as _;
         use std::ffi::c_void;
@@ -564,7 +564,7 @@ fn make_builtin_class(
     let tokens = quote! {
         use godot_ffi as sys;
         use crate::builtin::*;
-        use crate::native_structure::*;
+        use crate::engine::native::*;
         use crate::obj::{AsArg, Gd};
         use crate::sys::GodotFfi as _;
         use crate::engine::Object;
@@ -605,7 +605,7 @@ fn make_native_structure(
     let tokens = quote! {
         use godot_ffi as sys;
         use crate::builtin::*;
-        use crate::native_structure::*;
+        use crate::engine::native::*;
         use crate::obj::{AsArg, Gd};
         use crate::sys::GodotFfi as _;
         use crate::engine::Object;

--- a/godot-core/src/builtin/aabb.rs
+++ b/godot-core/src/builtin/aabb.rs
@@ -7,7 +7,8 @@
 use godot_ffi as sys;
 use sys::{ffi_methods, GodotFfi};
 
-use super::{real, Plane, Vector3, Vector3Axis};
+use crate::builtin::math::ApproxEq;
+use crate::builtin::{real, Plane, Vector3, Vector3Axis};
 
 /// Axis-aligned bounding box in 3D space.
 ///
@@ -183,13 +184,6 @@ impl Aabb {
     #[inline]
     pub fn set_end(&mut self, end: Vector3) {
         self.size = end - self.position
-    }
-
-    /// Returns `true` if the two `Aabb`s are approximately equal, by calling `is_equal_approx` on
-    /// `position` and `size`.
-    #[inline]
-    pub fn is_equal_approx(&self, other: &Self) -> bool {
-        self.position.is_equal_approx(other.position) && self.size.is_equal_approx(other.size)
     }
 
     /// Returns the normalized longest axis of the AABB.
@@ -386,6 +380,16 @@ impl std::fmt::Display for Aabb {
 // This type is represented as `Self` in Godot, so `*mut Self` is sound.
 unsafe impl GodotFfi for Aabb {
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Self; .. }
+}
+
+impl ApproxEq for Aabb {
+    /// Returns `true` if the two `Aabb`s are approximately equal, by calling `is_equal_approx` on
+    /// `position` and `size`.
+    #[inline]
+    fn approx_eq(&self, other: &Self) -> bool {
+        Vector3::approx_eq(&self.position, &other.position)
+            && Vector3::approx_eq(&self.size, &other.size)
+    }
 }
 
 #[cfg(test)]

--- a/godot-core/src/builtin/color.rs
+++ b/godot-core/src/builtin/color.rs
@@ -5,10 +5,13 @@
  */
 
 use crate::builtin::inner::InnerColor;
+use crate::builtin::math::ApproxEq;
 use crate::builtin::GodotString;
+
 use godot_ffi as sys;
-use std::ops;
 use sys::{ffi_methods, GodotFfi};
+
+use std::ops;
 
 /// Color built-in type, in floating-point RGBA format.
 ///
@@ -287,12 +290,6 @@ impl Color {
         self.as_inner().to_html(false)
     }
 
-    /// Returns true if `self` and `to` are approximately equal, within the tolerance used by
-    /// the global `is_equal_approx` function in GDScript.
-    pub fn is_equal_approx(self, to: Color) -> bool {
-        self.as_inner().is_equal_approx(to)
-    }
-
     /// Returns the color converted to a 32-bit integer (each component is 8 bits) with the given
     /// `order` of channels (from most to least significant byte).
     pub fn to_u32(self, order: ColorChannelOrder) -> u32 {
@@ -319,6 +316,13 @@ impl Color {
 // This type is represented as `Self` in Godot, so `*mut Self` is sound.
 unsafe impl GodotFfi for Color {
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Self; .. }
+}
+
+impl ApproxEq for Color {
+    fn approx_eq(&self, other: &Self) -> bool {
+        // TODO(bromeon): re-implement in Rust
+        self.as_inner().is_equal_approx(*other)
+    }
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]

--- a/godot-core/src/builtin/math/approx_eq.rs
+++ b/godot-core/src/builtin/math/approx_eq.rs
@@ -1,0 +1,74 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use crate::builtin::real;
+
+// TODO(bromeon): test this against Godot's own is_equal_approx() implementation for equality-comparable built-in types (excl Callable/Rid/...)
+
+/// Approximate equality-comparison of geometric types.
+///
+/// The implementation is specific to the type. It's mostly used for gdext-internal tests, but you may use it for your own code.
+/// Note that we give no guarantees about precision, and implementation can change at any time.
+///
+/// We currently also do not guarantee that this gives the same results as Godot's own `is_equal_approx()` function; although this may
+/// be the goal in the future.
+pub trait ApproxEq: PartialEq {
+    fn approx_eq(&self, other: &Self) -> bool;
+}
+
+impl ApproxEq for real {
+    fn approx_eq(&self, other: &Self) -> bool {
+        crate::builtin::math::is_equal_approx(*self, *other)
+    }
+}
+
+/// Asserts that two values are approximately equal
+///
+/// For comparison, this uses `ApproxEq::approx_eq` by default, or the provided `fn = ...` function.
+#[macro_export]
+macro_rules! assert_eq_approx {
+    ($actual:expr, $expected:expr, fn = $func:expr $(,)?) => {
+        match ($actual, $expected) {
+            (a, b) => assert!(($func)(&a, &b), "\n  left: {:?},\n right: {:?}", $actual, $expected)
+        }
+    };
+    ($actual:expr, $expected:expr, fn = $func:expr, $($t:tt)+) => {
+        match ($actual, $expected) {
+            (a, b) => assert!(($func)(&a, &b), "\n  left: {:?},\n right: {:?}{}", $actual, $expected, format_args!($($t)+) )
+        }
+    };
+    ($actual:expr, $expected:expr $(,)?) => {
+        match ($actual, $expected) {
+             (a, b) => assert!($crate::builtin::math::ApproxEq::approx_eq(&a, &b), "\n  left: {:?},\n right: {:?}", $actual, $expected),
+            // (a, b) => $crate::assert_eq_approx!($actual, $expected, fn = $crate::builtin::ApproxEq::approx_eq),
+        }
+    };
+    ($actual:expr, $expected:expr, $($t:tt)+) => {
+        match ($actual, $expected) {
+            (a, b) => assert!($crate::builtin::math::ApproxEq::approx_eq(&a, &b), "\n  left: {:?},\n right: {:?},\n{}", $actual, $expected, format_args!($($t)+)),
+            // (a, b) => $crate::assert_eq_approx!($actual, $expected, fn = $crate::builtin::ApproxEq::approx_eq, $($t)+),
+        }
+    };
+}
+
+/// Asserts that two values are not approximately equal, using the provided
+/// `func` for equality checking.
+#[macro_export]
+macro_rules! assert_ne_approx {
+    ($actual:expr, $expected:expr, fn = $func:expr $(, $($t:tt)* )?) => {
+        #[allow(clippy::redundant_closure_call)]
+        {
+            $crate::assert_eq_approx!($actual, $expected, fn = |a,b| !($func)(a, b) $(, $($t)* )?)
+        }
+    };
+
+    ($actual:expr, $expected:expr $(, $($t:tt)* )?) => {
+        #[allow(clippy::redundant_closure_call)]
+        {
+            $crate::assert_eq_approx!($actual, $expected, fn = |a, b| !$crate::builtin::math::ApproxEq::approx_eq(a, b) $(, $($t)* )?)
+        }
+    };
+}

--- a/godot-core/src/builtin/math/glam_helpers.rs
+++ b/godot-core/src/builtin/math/glam_helpers.rs
@@ -15,7 +15,7 @@
 //   self.glam().dot(b.glam())
 //   GlamType::dot(self.glam(), b.glam())
 
-use super::real;
+use crate::builtin::real;
 
 pub(crate) trait GlamConv {
     type Glam: GlamType<Mapped = Self>;

--- a/godot-core/src/builtin/mod.rs
+++ b/godot-core/src/builtin/mod.rs
@@ -41,7 +41,6 @@ pub use basis::*;
 pub use callable::*;
 pub use color::*;
 pub use dictionary_inner::Dictionary;
-pub use math::*;
 pub use others::*;
 pub use packed_array::*;
 pub use plane::*;
@@ -59,6 +58,9 @@ pub use vectors::*;
 
 /// Meta-information about variant types, properties and class names.
 pub mod meta;
+
+/// Math-related functions and traits like [`ApproxEq`][math::ApproxEq].
+pub mod math;
 
 /// Specialized types related to arrays.
 pub mod array {
@@ -81,8 +83,6 @@ mod aabb;
 mod basis;
 mod callable;
 mod color;
-mod glam_helpers;
-mod math;
 mod others;
 mod packed_array;
 mod plane;
@@ -104,9 +104,6 @@ mod array_inner;
 mod dictionary_inner;
 #[path = "real.rs"]
 mod real_inner;
-
-// Glam re-exports
-pub(crate) use glam::{IVec2, IVec3, IVec4};
 
 #[doc(hidden)]
 pub mod inner {

--- a/godot-core/src/builtin/mod.rs
+++ b/godot-core/src/builtin/mod.rs
@@ -33,7 +33,7 @@
 //!   overloading would become impossible](https://github.com/kvark/mint/issues/75).
 
 // Re-export macros.
-pub use crate::{array, dict, varray};
+pub use crate::{array, dict, real, reals, varray};
 
 pub use aabb::*;
 pub use array_inner::{Array, VariantArray};
@@ -47,6 +47,7 @@ pub use packed_array::*;
 pub use plane::*;
 pub use projection::*;
 pub use quaternion::*;
+pub use real_inner::*;
 pub use rect2::*;
 pub use rect2i::*;
 pub use rid::*;
@@ -75,12 +76,7 @@ pub mod dictionary {
 // Modules exporting declarative macros must appear first.
 mod macros;
 
-// Rename imports because we re-export a subset of types under same module names.
-#[path = "array.rs"]
-mod array_inner;
-#[path = "dictionary.rs"]
-mod dictionary_inner;
-
+// Other modules
 mod aabb;
 mod basis;
 mod callable;
@@ -100,6 +96,17 @@ mod transform2d;
 mod transform3d;
 mod variant;
 mod vectors;
+
+// Rename imports because we re-export a subset of types under same module names.
+#[path = "array.rs"]
+mod array_inner;
+#[path = "dictionary.rs"]
+mod dictionary_inner;
+#[path = "real.rs"]
+mod real_inner;
+
+// Glam re-exports
+pub(crate) use glam::{IVec2, IVec3, IVec4};
 
 #[doc(hidden)]
 pub mod inner {
@@ -124,202 +131,6 @@ pub(crate) fn u8_to_bool(u: u8) -> bool {
         1 => true,
         _ => panic!("Invalid boolean value {u}"),
     }
-}
-
-/// Clippy often complains if you do `f as f64` when `f` is already an `f64`. This trait exists to make it easy to
-/// convert between the different reals and floats without a lot of allowing clippy lints for your code.
-pub trait RealConv {
-    /// Cast this [`real`][type@real] to an [`f32`] using `as`.
-    // Clippy complains that this is an `as_*` function but it takes a `self`
-    // however, since this uses `as` internally it makes much more sense for
-    // it to be named `as_f32` rather than `to_f32`.
-    #[allow(clippy::wrong_self_convention)]
-    fn as_f32(self) -> f32;
-
-    /// Cast this [`real`][type@real] to an [`f64`] using `as`.
-    // Clippy complains that this is an `as_*` function but it takes a `self`
-    // however, since this uses `as` internally it makes much more sense for
-    // it to be named `as_f64` rather than `to_f64`.
-    #[allow(clippy::wrong_self_convention)]
-    fn as_f64(self) -> f64;
-
-    /// Cast an [`f32`] to a [`real`][type@real] using `as`.
-    fn from_f32(f: f32) -> Self;
-
-    /// Cast an [`f64`] to a [`real`][type@real] using `as`.
-    fn from_f64(f: f64) -> Self;
-}
-
-#[cfg(not(feature = "double-precision"))]
-mod real_mod {
-    /// Floating point type used for many structs and functions in Godot.
-    ///
-    /// This type is `f32` by default, and `f64` when the Cargo feature `double-precision` is enabled.
-    ///
-    /// This is not the `float` type in GDScript; that type is always 64-bits. Rather, many structs in Godot may use
-    /// either 32-bit or 64-bit floats, for example [`Vector2`](super::Vector2). To convert between [`real`] and [`f32`] or
-    /// [`f64`], see [`RealConv`](super::RealConv).
-    ///
-    /// See also the [Godot docs on float](https://docs.godotengine.org/en/stable/classes/class_float.html).
-    // As this is a scalar value, we will use a non-standard type name.
-    #[allow(non_camel_case_types)]
-    pub type real = f32;
-
-    impl super::RealConv for real {
-        #[inline]
-        fn as_f32(self) -> f32 {
-            self
-        }
-
-        #[inline]
-        fn as_f64(self) -> f64 {
-            self as f64
-        }
-
-        #[inline]
-        fn from_f32(f: f32) -> Self {
-            f
-        }
-
-        #[inline]
-        fn from_f64(f: f64) -> Self {
-            f as f32
-        }
-    }
-
-    /// Re-export of [`std::f32::consts`] or [`std::f64::consts`], depending on precision config.
-    pub mod real_consts {
-        pub use std::f32::consts::*;
-    }
-
-    /// A 2-dimensional vector from [`glam`]. Using a floating-point format compatible with [`real`].
-    pub type RVec2 = glam::Vec2;
-    /// A 3-dimensional vector from [`glam`]. Using a floating-point format compatible with [`real`].
-    pub type RVec3 = glam::Vec3;
-    /// A 4-dimensional vector from [`glam`]. Using a floating-point format compatible with [`real`].
-    pub type RVec4 = glam::Vec4;
-
-    /// A 2x2 column-major matrix from [`glam`]. Using a floating-point format compatible with [`real`].
-    pub type RMat2 = glam::Mat2;
-    /// A 3x3 column-major matrix from [`glam`]. Using a floating-point format compatible with [`real`].
-    pub type RMat3 = glam::Mat3;
-    /// A 4x4 column-major matrix from [`glam`]. Using a floating-point format compatible with [`real`].
-    pub type RMat4 = glam::Mat4;
-
-    /// A matrix from [`glam`] quaternion representing an orientation. Using a floating-point format compatible
-    /// with [`real`].
-    pub type RQuat = glam::Quat;
-
-    /// A 2D affine transform from [`glam`], which can represent translation, rotation, scaling and
-    /// shear. Using a floating-point format compatible with [`real`].
-    pub type RAffine2 = glam::Affine2;
-    /// A 3D affine transform from [`glam`], which can represent translation, rotation, scaling and
-    /// shear. Using a floating-point format compatible with [`real`].
-    pub type RAffine3 = glam::Affine3A;
-}
-
-#[cfg(feature = "double-precision")]
-mod real_mod {
-    /// Floating point type used for many structs and functions in Godot.
-    ///
-    /// This type is `f32` by default, and `f64` when the Cargo feature `double-precision` is enabled.
-    ///
-    /// This is not the `float` type in GDScript; that type is always 64-bits. Rather, many structs in Godot may use
-    /// either 32-bit or 64-bit floats, for example [`Vector2`](super::Vector2). To convert between [`real`] and [`f32`] or
-    /// [`f64`], see [`RealConv`](super::RealConv).
-    ///
-    /// See also the [Godot docs on float](https://docs.godotengine.org/en/stable/classes/class_float.html).
-    ///
-    /// _Godot equivalent: `real_t`_
-    // As this is a scalar value, we will use a non-standard type name.
-    #[allow(non_camel_case_types)]
-    pub type real = f64;
-
-    impl super::RealConv for real {
-        #[inline]
-        fn as_f32(self) -> f32 {
-            self as f32
-        }
-
-        #[inline]
-        fn as_f64(self) -> f64 {
-            self
-        }
-
-        #[inline]
-        fn from_f32(f: f32) -> Self {
-            f as f64
-        }
-
-        #[inline]
-        fn from_f64(f: f64) -> Self {
-            f
-        }
-    }
-
-    /// Re-export of [`std::f32::consts`] or [`std::f64::consts`], depending on precision config.
-    pub mod real_consts {
-        pub use std::f64::consts::*;
-    }
-
-    /// A 2-dimensional vector from [`glam`]. Using a floating-point format compatible with [`real`].
-    pub type RVec2 = glam::DVec2;
-    /// A 3-dimensional vector from [`glam`]. Using a floating-point format compatible with [`real`].
-    pub type RVec3 = glam::DVec3;
-    /// A 4-dimensional vector from [`glam`]. Using a floating-point format compatible with [`real`].
-    pub type RVec4 = glam::DVec4;
-
-    /// A 2x2 column-major matrix from [`glam`]. Using a floating-point format compatible with [`real`].
-    pub type RMat2 = glam::DMat2;
-    /// A 3x3 column-major matrix from [`glam`]. Using a floating-point format compatible with [`real`].
-    pub type RMat3 = glam::DMat3;
-    /// A 4x4 column-major matrix from [`glam`]. Using a floating-point format compatible with [`real`].
-    pub type RMat4 = glam::DMat4;
-
-    /// A matrix from [`glam`] quaternion representing an orientation. Using a floating-point format
-    /// compatible with [`real`].
-    pub type RQuat = glam::DQuat;
-
-    /// A 2D affine transform from [`glam`], which can represent translation, rotation, scaling and
-    /// shear. Using a floating-point format compatible with [`real`].
-    pub type RAffine2 = glam::DAffine2;
-    /// A 3D affine transform from [`glam`], which can represent translation, rotation, scaling and
-    /// shear. Using a floating-point format compatible with [`real`].
-    pub type RAffine3 = glam::DAffine3;
-}
-
-pub use crate::real;
-pub(crate) use real_mod::*;
-
-pub use real_mod::{real, real_consts};
-
-pub(crate) use glam::{IVec2, IVec3, IVec4};
-
-/// A macro to coerce float-literals into the [`real`] type.
-///
-/// Mainly used where you'd normally use a suffix to specify the type, such as `115.0f32`.
-///
-/// # Examples
-///
-/// Rust is not able to infer the `self` type of this call to `to_radians`:
-/// ```compile_fail
-/// use godot::builtin::real;
-///
-/// let radians: real = 115.0.to_radians();
-/// ```
-/// But we cannot add a suffix to the literal, since it may be either `f32` or
-/// `f64` depending on the context. So instead we use our macro:
-/// ```
-/// use godot::builtin::real;
-///
-/// let radians: real = real!(115.0).to_radians();
-/// ```
-#[macro_export]
-macro_rules! real {
-    ($f:literal) => {{
-        let f: $crate::builtin::real = $f;
-        f
-    }};
 }
 
 /// The side of a [`Rect2`] or [`Rect2i`].

--- a/godot-core/src/builtin/quaternion.rs
+++ b/godot-core/src/builtin/quaternion.rs
@@ -3,16 +3,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
-use std::ops::*;
-
 use godot_ffi as sys;
 use sys::{ffi_methods, GodotFfi};
 
-use crate::builtin::glam_helpers::{GlamConv, GlamType};
-use crate::builtin::{inner, math::*, Vector3};
+use crate::builtin::math::{is_equal_approx, ApproxEq, GlamConv, GlamType, CMP_EPSILON};
+use crate::builtin::{inner, real, Basis, EulerOrder, RQuat, Vector3};
 
-use super::{real, RQuat};
-use super::{Basis, EulerOrder};
+use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 #[derive(Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -106,13 +103,6 @@ impl Quaternion {
 
     pub fn inverse(self) -> Self {
         Self::new(-self.x, -self.y, -self.z, self.w)
-    }
-
-    pub fn is_equal_approx(self, to: Self) -> bool {
-        is_equal_approx(self.x, to.x)
-            && is_equal_approx(self.y, to.y)
-            && is_equal_approx(self.z, to.z)
-            && is_equal_approx(self.w, to.w)
     }
 
     pub fn is_finite(self) -> bool {
@@ -270,6 +260,15 @@ impl std::fmt::Display for Quaternion {
 impl Default for Quaternion {
     fn default() -> Self {
         Self::new(0.0, 0.0, 0.0, 1.0)
+    }
+}
+
+impl ApproxEq for Quaternion {
+    fn approx_eq(&self, other: &Self) -> bool {
+        is_equal_approx(self.x, other.x)
+            && is_equal_approx(self.y, other.y)
+            && is_equal_approx(self.z, other.z)
+            && is_equal_approx(self.w, other.w)
     }
 }
 

--- a/godot-core/src/builtin/real.rs
+++ b/godot-core/src/builtin/real.rs
@@ -1,0 +1,215 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+/// Clippy often complains if you do `f as f64` when `f` is already an `f64`. This trait exists to make it easy to
+/// convert between the different reals and floats without a lot of allowing clippy lints for your code.
+pub trait RealConv {
+    /// Cast this [`real`][type@real] to an [`f32`] using `as`.
+    // Clippy complains that this is an `as_*` function but it takes a `self`
+    // however, since this uses `as` internally it makes much more sense for
+    // it to be named `as_f32` rather than `to_f32`.
+    #[allow(clippy::wrong_self_convention)]
+    fn as_f32(self) -> f32;
+
+    /// Cast this [`real`][type@real] to an [`f64`] using `as`.
+    // Clippy complains that this is an `as_*` function but it takes a `self`
+    // however, since this uses `as` internally it makes much more sense for
+    // it to be named `as_f64` rather than `to_f64`.
+    #[allow(clippy::wrong_self_convention)]
+    fn as_f64(self) -> f64;
+
+    /// Cast an [`f32`] to a [`real`][type@real] using `as`.
+    fn from_f32(f: f32) -> Self;
+
+    /// Cast an [`f64`] to a [`real`][type@real] using `as`.
+    fn from_f64(f: f64) -> Self;
+}
+
+#[cfg(not(feature = "double-precision"))]
+mod real_mod {
+    /// Floating point type used for many structs and functions in Godot.
+    ///
+    /// This type is `f32` by default, and `f64` when the Cargo feature `double-precision` is enabled.
+    ///
+    /// This is not the `float` type in GDScript; that type is always 64-bits. Rather, many structs in Godot may use
+    /// either 32-bit or 64-bit floats, for example [`Vector2`](super::Vector2). To convert between [`real`] and [`f32`] or
+    /// [`f64`], see [`RealConv`](super::RealConv).
+    ///
+    /// See also the [Godot docs on float](https://docs.godotengine.org/en/stable/classes/class_float.html).
+    // As this is a scalar value, we will use a non-standard type name.
+    #[allow(non_camel_case_types)]
+    pub type real = f32;
+
+    impl super::RealConv for real {
+        #[inline]
+        fn as_f32(self) -> f32 {
+            self
+        }
+
+        #[inline]
+        fn as_f64(self) -> f64 {
+            self as f64
+        }
+
+        #[inline]
+        fn from_f32(f: f32) -> Self {
+            f
+        }
+
+        #[inline]
+        fn from_f64(f: f64) -> Self {
+            f as f32
+        }
+    }
+
+    /// Re-export of [`std::f32::consts`] or [`std::f64::consts`], depending on precision config.
+    pub mod real_consts {
+        pub use std::f32::consts::*;
+    }
+
+    /// A 2-dimensional vector from [`glam`]. Using a floating-point format compatible with [`real`].
+    pub type RVec2 = glam::Vec2;
+    /// A 3-dimensional vector from [`glam`]. Using a floating-point format compatible with [`real`].
+    pub type RVec3 = glam::Vec3;
+    /// A 4-dimensional vector from [`glam`]. Using a floating-point format compatible with [`real`].
+    pub type RVec4 = glam::Vec4;
+
+    /// A 2x2 column-major matrix from [`glam`]. Using a floating-point format compatible with [`real`].
+    pub type RMat2 = glam::Mat2;
+    /// A 3x3 column-major matrix from [`glam`]. Using a floating-point format compatible with [`real`].
+    pub type RMat3 = glam::Mat3;
+    /// A 4x4 column-major matrix from [`glam`]. Using a floating-point format compatible with [`real`].
+    pub type RMat4 = glam::Mat4;
+
+    /// A matrix from [`glam`] quaternion representing an orientation. Using a floating-point format compatible
+    /// with [`real`].
+    pub type RQuat = glam::Quat;
+
+    /// A 2D affine transform from [`glam`], which can represent translation, rotation, scaling and
+    /// shear. Using a floating-point format compatible with [`real`].
+    pub type RAffine2 = glam::Affine2;
+    /// A 3D affine transform from [`glam`], which can represent translation, rotation, scaling and
+    /// shear. Using a floating-point format compatible with [`real`].
+    pub type RAffine3 = glam::Affine3A;
+}
+
+#[cfg(feature = "double-precision")]
+mod real_mod {
+    /// Floating point type used for many structs and functions in Godot.
+    ///
+    /// This type is `f32` by default, and `f64` when the Cargo feature `double-precision` is enabled.
+    ///
+    /// This is not the `float` type in GDScript; that type is always 64-bits. Rather, many structs in Godot may use
+    /// either 32-bit or 64-bit floats, for example [`Vector2`](super::Vector2). To convert between [`real`] and [`f32`] or
+    /// [`f64`], see [`RealConv`](super::RealConv).
+    ///
+    /// See also the [Godot docs on float](https://docs.godotengine.org/en/stable/classes/class_float.html).
+    // As this is a scalar value, we will use a non-standard type name.
+    #[allow(non_camel_case_types)]
+    pub type real = f64;
+
+    impl super::RealConv for real {
+        #[inline]
+        fn as_f32(self) -> f32 {
+            self as f32
+        }
+
+        #[inline]
+        fn as_f64(self) -> f64 {
+            self
+        }
+
+        #[inline]
+        fn from_f32(f: f32) -> Self {
+            f as f64
+        }
+
+        #[inline]
+        fn from_f64(f: f64) -> Self {
+            f
+        }
+    }
+
+    /// Re-export of [`std::f32::consts`] or [`std::f64::consts`], depending on precision config.
+    pub mod real_consts {
+        pub use std::f64::consts::*;
+    }
+
+    /// A 2-dimensional vector from [`glam`]. Using a floating-point format compatible with [`real`].
+    pub type RVec2 = glam::DVec2;
+    /// A 3-dimensional vector from [`glam`]. Using a floating-point format compatible with [`real`].
+    pub type RVec3 = glam::DVec3;
+    /// A 4-dimensional vector from [`glam`]. Using a floating-point format compatible with [`real`].
+    pub type RVec4 = glam::DVec4;
+
+    /// A 2x2 column-major matrix from [`glam`]. Using a floating-point format compatible with [`real`].
+    pub type RMat2 = glam::DMat2;
+    /// A 3x3 column-major matrix from [`glam`]. Using a floating-point format compatible with [`real`].
+    pub type RMat3 = glam::DMat3;
+    /// A 4x4 column-major matrix from [`glam`]. Using a floating-point format compatible with [`real`].
+    pub type RMat4 = glam::DMat4;
+
+    /// A matrix from [`glam`] quaternion representing an orientation. Using a floating-point format
+    /// compatible with [`real`].
+    pub type RQuat = glam::DQuat;
+
+    /// A 2D affine transform from [`glam`], which can represent translation, rotation, scaling and
+    /// shear. Using a floating-point format compatible with [`real`].
+    pub type RAffine2 = glam::DAffine2;
+    /// A 3D affine transform from [`glam`], which can represent translation, rotation, scaling and
+    /// shear. Using a floating-point format compatible with [`real`].
+    pub type RAffine3 = glam::DAffine3;
+}
+
+// Public symbols (note that macro `real!` is re-exported in `lib.rs`)
+pub use real_mod::{real, real_consts};
+
+// Internal re-exports
+pub(crate) use real_mod::*;
+
+/// A macro to coerce float-literals into the [`real`] type.
+///
+/// Mainly used where you'd normally use a suffix to specify the type, such as `115.0f32`.
+///
+/// # Examples
+///
+/// Rust is not able to infer the `self` type of this call to `to_radians`:
+/// ```compile_fail
+/// use godot::builtin::real;
+///
+/// let radians: real = 115.0.to_radians();
+/// ```
+/// But we cannot add a suffix to the literal, since it may be either `f32` or
+/// `f64` depending on the context. So instead we use our macro:
+/// ```
+/// use godot::builtin::real;
+///
+/// let radians: real = real!(115.0).to_radians();
+/// ```
+#[macro_export]
+macro_rules! real {
+    ($f:literal) => {{
+        let f: $crate::builtin::real = $f;
+        f
+    }};
+}
+
+/// Array of reals.
+///
+/// ### Examples
+/// ```
+/// use godot_core::builtin::{real, reals};
+///
+/// let arr = reals![1.0, 2.0, 3.0];
+/// assert_eq!(arr[1], real!(2.0));
+/// ```
+#[macro_export]
+macro_rules! reals {
+    ($($f:literal),* $(,)?) => {{
+        let arr = [$($crate::real!($f)),*];
+        arr
+    }};
+}

--- a/godot-core/src/builtin/rect2.rs
+++ b/godot-core/src/builtin/rect2.rs
@@ -7,7 +7,8 @@
 use godot_ffi as sys;
 use sys::{ffi_methods, GodotFfi};
 
-use super::{real, Rect2i, Vector2};
+use crate::builtin::math::ApproxEq;
+use crate::builtin::{real, Rect2i, Vector2};
 
 /// 2D axis-aligned bounding box.
 ///
@@ -82,15 +83,6 @@ impl Rect2 {
         self.size = end - self.position
     }
 
-    /// Returns `true` if the two `Rect2`s are approximately equal, by calling `is_equal_approx` on
-    /// `position` and `size`.
-    ///
-    /// _Godot equivalent: `Rect2.is_equal_approx()`_
-    #[inline]
-    pub fn is_equal_approx(&self, other: &Self) -> bool {
-        self.position.is_equal_approx(other.position) && self.size.is_equal_approx(other.size)
-    }
-
     /* Add in when `Rect2::abs()` is implemented.
     /// Assert that the size of the `Rect2` is not negative.
     ///
@@ -110,6 +102,15 @@ impl Rect2 {
 // This type is represented as `Self` in Godot, so `*mut Self` is sound.
 unsafe impl GodotFfi for Rect2 {
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Self; .. }
+}
+
+impl ApproxEq for Rect2 {
+    /// Returns if the two `Rect2`s are approximately equal, by comparing `position` and `size` separately.
+    #[inline]
+    fn approx_eq(&self, other: &Self) -> bool {
+        Vector2::approx_eq(&self.position, &other.position)
+            && Vector2::approx_eq(&self.size, &other.size)
+    }
 }
 
 impl std::fmt::Display for Rect2 {

--- a/godot-core/src/builtin/vectors/vector2.rs
+++ b/godot-core/src/builtin/vectors/vector2.rs
@@ -3,19 +3,20 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
-use std::fmt;
-use std::ops::*;
 
 use godot_ffi as sys;
 use sys::{ffi_methods, GodotFfi};
 
-use crate::builtin::math::*;
-use crate::builtin::{inner, Vector2i};
+use crate::builtin::inner;
+use crate::builtin::math::{
+    bezier_derivative, bezier_interpolate, cubic_interpolate, cubic_interpolate_in_time, fposmod,
+    is_equal_approx, is_zero_approx, lerp, sign, snapped, ApproxEq, GlamConv, GlamType,
+    CMP_EPSILON,
+};
+use crate::builtin::vectors::Vector2Axis;
+use crate::builtin::{real, RAffine2, RVec2, Vector2i};
 
-use super::super::glam_helpers::GlamConv;
-use super::super::glam_helpers::GlamType;
-use super::super::{real, RAffine2, RVec2};
-use super::vector_axis::*;
+use std::fmt;
 
 /// Vector used for 2D math using floating point coordinates.
 ///
@@ -190,10 +191,6 @@ impl Vector2 {
         Self::from_glam(RVec2::from_angle(angle))
     }
 
-    pub fn is_equal_approx(self, to: Self) -> bool {
-        is_equal_approx(self.x, to.x) && is_equal_approx(self.y, to.y)
-    }
-
     pub fn is_finite(self) -> bool {
         self.to_glam().is_finite()
     }
@@ -323,6 +320,13 @@ unsafe impl GodotFfi for Vector2 {
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Self; .. }
 }
 
+impl ApproxEq for Vector2 {
+    #[inline]
+    fn approx_eq(&self, other: &Self) -> bool {
+        is_equal_approx(self.x, other.x) && is_equal_approx(self.y, other.y)
+    }
+}
+
 impl GlamConv for Vector2 {
     type Glam = RVec2;
 }
@@ -349,16 +353,9 @@ mod test {
     fn coord_min_max() {
         let a = Vector2::new(1.2, 3.4);
         let b = Vector2::new(0.1, 5.6);
-        assert_eq_approx!(
-            a.coord_min(b),
-            Vector2::new(0.1, 3.4),
-            Vector2::is_equal_approx
-        );
-        assert_eq_approx!(
-            a.coord_max(b),
-            Vector2::new(1.2, 5.6),
-            Vector2::is_equal_approx
-        );
+
+        assert_eq_approx!(a.coord_min(b), Vector2::new(0.1, 3.4));
+        assert_eq_approx!(a.coord_max(b), Vector2::new(1.2, 5.6));
     }
 
     #[cfg(feature = "serde")]

--- a/godot-core/src/builtin/vectors/vector2i.rs
+++ b/godot-core/src/builtin/vectors/vector2i.rs
@@ -4,14 +4,13 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::fmt;
-
 use godot_ffi as sys;
 use sys::{ffi_methods, GodotFfi};
 
-use crate::builtin::glam_helpers::{GlamConv, GlamType};
-use crate::builtin::IVec2;
+use crate::builtin::math::{GlamConv, GlamType, IVec2};
 use crate::builtin::Vector2;
+
+use std::fmt;
 
 /// Vector used for 2D math using integer coordinates.
 ///

--- a/godot-core/src/builtin/vectors/vector3i.rs
+++ b/godot-core/src/builtin/vectors/vector3i.rs
@@ -9,10 +9,8 @@ use std::fmt;
 use godot_ffi as sys;
 use sys::{ffi_methods, GodotFfi};
 
+use crate::builtin::math::{GlamConv, GlamType, IVec3};
 use crate::builtin::Vector3;
-
-use super::super::glam_helpers::{GlamConv, GlamType};
-use super::super::IVec3;
 
 /// Vector used for 3D math using integer coordinates.
 ///

--- a/godot-core/src/builtin/vectors/vector4.rs
+++ b/godot-core/src/builtin/vectors/vector4.rs
@@ -4,15 +4,13 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::fmt;
-
 use godot_ffi as sys;
 use sys::{ffi_methods, GodotFfi};
 
-use super::super::glam_helpers::{GlamConv, GlamType};
-use super::super::{real, RVec4};
-use crate::builtin::math::*;
-use crate::builtin::Vector4i;
+use crate::builtin::math::{is_equal_approx, ApproxEq, GlamConv, GlamType};
+use crate::builtin::{real, RVec4, Vector4i};
+
+use std::fmt;
 
 /// Vector used for 4D math using floating point coordinates.
 ///
@@ -85,13 +83,6 @@ impl Vector4 {
         RVec4::new(self.x, self.y, self.z, self.w)
     }
 
-    pub fn is_equal_approx(self, to: Self) -> bool {
-        is_equal_approx(self.x, to.x)
-            && is_equal_approx(self.y, to.y)
-            && is_equal_approx(self.z, to.z)
-            && is_equal_approx(self.w, to.w)
-    }
-
     pub fn coords(&self) -> (real, real, real, real) {
         (self.x, self.y, self.z, self.w)
     }
@@ -108,6 +99,16 @@ impl fmt::Display for Vector4 {
 // This type is represented as `Self` in Godot, so `*mut Self` is sound.
 unsafe impl GodotFfi for Vector4 {
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Self; .. }
+}
+
+impl ApproxEq for Vector4 {
+    #[inline]
+    fn approx_eq(&self, other: &Self) -> bool {
+        is_equal_approx(self.x, other.x)
+            && is_equal_approx(self.y, other.y)
+            && is_equal_approx(self.z, other.z)
+            && is_equal_approx(self.w, other.w)
+    }
 }
 
 impl GlamType for RVec4 {
@@ -136,16 +137,8 @@ mod test {
     fn coord_min_max() {
         let a = Vector4::new(1.2, 3.4, 5.6, 0.1);
         let b = Vector4::new(0.1, 5.6, 2.3, 1.2);
-        assert_eq_approx!(
-            a.coord_min(b),
-            Vector4::new(0.1, 3.4, 2.3, 0.1),
-            Vector4::is_equal_approx
-        );
-        assert_eq_approx!(
-            a.coord_max(b),
-            Vector4::new(1.2, 5.6, 5.6, 1.2),
-            Vector4::is_equal_approx
-        );
+        assert_eq_approx!(a.coord_min(b), Vector4::new(0.1, 3.4, 2.3, 0.1),);
+        assert_eq_approx!(a.coord_max(b), Vector4::new(1.2, 5.6, 5.6, 1.2),);
     }
 
     #[cfg(feature = "serde")]

--- a/godot-core/src/builtin/vectors/vector4i.rs
+++ b/godot-core/src/builtin/vectors/vector4i.rs
@@ -4,14 +4,14 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::fmt;
-
 use godot_ffi as sys;
 use sys::{ffi_methods, GodotFfi};
 
-use super::super::glam_helpers::{GlamConv, GlamType};
-use super::super::IVec4;
+use crate::builtin::math::{GlamConv, GlamType, IVec4};
 use crate::builtin::Vector4;
+
+use std::fmt;
+
 /// Vector used for 4D math using integer coordinates.
 ///
 /// 4-element structure that can be used to represent 4D grid coordinates or sets of integers.

--- a/godot-core/src/builtin/vectors/vector_axis.rs
+++ b/godot-core/src/builtin/vectors/vector_axis.rs
@@ -158,49 +158,25 @@ mod test {
         let vec2swiz2: Vector2 = swizzle!(vector2 => y, x);
         let vec3swiz2: Vector2 = swizzle!(vector3 => y, x);
         let vec4swiz2: Vector2 = swizzle!(vector4 => y, x);
-        assert_eq_approx!(vec2swiz2, Vector2::new(2.0, 1.0), Vector2::is_equal_approx);
-        assert_eq_approx!(vec3swiz2, Vector2::new(2.0, 1.0), Vector2::is_equal_approx);
-        assert_eq_approx!(vec4swiz2, Vector2::new(2.0, 1.0), Vector2::is_equal_approx);
+        assert_eq_approx!(vec2swiz2, Vector2::new(2.0, 1.0));
+        assert_eq_approx!(vec3swiz2, Vector2::new(2.0, 1.0));
+        assert_eq_approx!(vec4swiz2, Vector2::new(2.0, 1.0));
 
         // VectorN to Vector3
         let vec2swiz3: Vector3 = swizzle!(vector2 => y, x, x);
         let vec3swiz3: Vector3 = swizzle!(vector3 => y, x, z);
         let vec4swiz3: Vector3 = swizzle!(vector4 => y, x, z);
-        assert_eq_approx!(
-            vec2swiz3,
-            Vector3::new(2.0, 1.0, 1.0),
-            Vector3::is_equal_approx
-        );
-        assert_eq_approx!(
-            vec3swiz3,
-            Vector3::new(2.0, 1.0, 3.0),
-            Vector3::is_equal_approx
-        );
-        assert_eq_approx!(
-            vec4swiz3,
-            Vector3::new(2.0, 1.0, 3.0),
-            Vector3::is_equal_approx
-        );
+        assert_eq_approx!(vec2swiz3, Vector3::new(2.0, 1.0, 1.0),);
+        assert_eq_approx!(vec3swiz3, Vector3::new(2.0, 1.0, 3.0),);
+        assert_eq_approx!(vec4swiz3, Vector3::new(2.0, 1.0, 3.0),);
 
         // VectorN to Vector4
         let vec2swiz4: Vector4 = swizzle!(vector2 => y, x, x, y);
         let vec3swiz4: Vector4 = swizzle!(vector3 => y, x, z, y);
         let vec4swiz4: Vector4 = swizzle!(vector4 => y, x, z, w);
-        assert_eq_approx!(
-            vec2swiz4,
-            Vector4::new(2.0, 1.0, 1.0, 2.0),
-            Vector4::is_equal_approx
-        );
-        assert_eq_approx!(
-            vec3swiz4,
-            Vector4::new(2.0, 1.0, 3.0, 2.0),
-            Vector4::is_equal_approx
-        );
-        assert_eq_approx!(
-            vec4swiz4,
-            Vector4::new(2.0, 1.0, 3.0, 4.0),
-            Vector4::is_equal_approx
-        );
+        assert_eq_approx!(vec2swiz4, Vector4::new(2.0, 1.0, 1.0, 2.0),);
+        assert_eq_approx!(vec3swiz4, Vector4::new(2.0, 1.0, 3.0, 2.0),);
+        assert_eq_approx!(vec4swiz4, Vector4::new(2.0, 1.0, 3.0, 4.0),);
 
         // * VectorNi swizzle
         let vector2i = Vector2i::new(1, 2);

--- a/godot-core/src/engine.rs
+++ b/godot-core/src/engine.rs
@@ -16,6 +16,17 @@ pub use crate::gen::central::global;
 pub use crate::gen::classes::*;
 pub use crate::gen::utilities;
 
+/// Support for Godot _native structures_.
+///
+/// Native structures are a niche API in Godot. These are low-level data types that are passed as pointers to/from the engine.
+/// In Rust, they are represented as `#[repr(C)]` structs.
+///
+/// There is unfortunately not much official documentation available; you may need to look at Godot source code.
+/// Most users will not need native structures, as they are very specialized.
+pub mod native {
+    pub use crate::gen::native::*;
+}
+
 use self::packed_scene::GenEditState;
 
 /// Extension trait for convenience functions on `PackedScene`

--- a/godot-core/src/lib.rs
+++ b/godot-core/src/lib.rs
@@ -13,7 +13,6 @@ pub mod export;
 pub mod init;
 pub mod log;
 pub mod macros;
-pub mod native_structure;
 pub mod obj;
 
 pub use godot_ffi as sys;

--- a/godot-core/src/native_structure.rs
+++ b/godot-core/src/native_structure.rs
@@ -1,7 +1,0 @@
-/*
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at https://mozilla.org/MPL/2.0/.
- */
-
-pub use crate::gen::native::*;

--- a/godot/src/lib.rs
+++ b/godot/src/lib.rs
@@ -138,7 +138,7 @@
 //!   at any time.
 
 #[doc(inline)]
-pub use godot_core::{builtin, engine, export, log, native_structure, obj, sys};
+pub use godot_core::{builtin, engine, export, log, obj, sys};
 
 /// Facilities for initializing and terminating the GDExtension library.
 pub mod init {

--- a/itest/rust/src/native_structures_test.rs
+++ b/itest/rust/src/native_structures_test.rs
@@ -5,9 +5,9 @@
  */
 
 use crate::itest;
+use godot::engine::native::{AudioFrame, CaretInfo, Glyph};
 use godot::engine::text_server::Direction;
 use godot::engine::{TextServer, TextServerExtension, TextServerExtensionVirtual};
-use godot::native_structure::{AudioFrame, CaretInfo, Glyph};
 use godot::prelude::{godot_api, Base, Gd, GodotClass, Rect2, Rid, Share, Variant};
 
 use std::cell::Cell;

--- a/itest/rust/src/plane_test.rs
+++ b/itest/rust/src/plane_test.rs
@@ -4,12 +4,13 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::fmt::Debug;
-
 use crate::itest;
+
 use godot::builtin::inner::InnerPlane;
+use godot::builtin::math::{assert_eq_approx, ApproxEq};
 use godot::builtin::{real, Plane, RealConv, ToVariant, Vector3};
-use godot::private::class_macros::assert_eq_approx;
+
+use std::fmt::Debug;
 
 fn check_mapping_eq<T>(context: &str, outer: T, inner: T)
 where
@@ -22,12 +23,7 @@ where
 }
 
 fn check_mapping_eq_approx_plane(context: &str, outer: Plane, inner: Plane) {
-    assert_eq_approx!(
-        outer,
-        inner,
-        |a: Plane, b: Plane| a.is_equal_approx(&b),
-        "{context}: outer != inner ({outer:?} != {inner:?})"
-    );
+    assert_eq_approx!(outer, inner, "{context}");
 }
 
 #[itest]
@@ -195,7 +191,7 @@ fn plane_is_equal_approx() {
     let b = Plane::new(Vector3::new(1.5, 6.3, 2.2).normalized(), 5.2000001);
     check_mapping_eq(
         "is_equal_approx",
-        a.is_equal_approx(&b),
+        a.approx_eq(&b),
         inner_a.is_equal_approx(b),
     );
 
@@ -204,7 +200,7 @@ fn plane_is_equal_approx() {
     let b = Plane::new(Vector3::new(0.0, 6.2, 2.5).normalized(), 0.4);
     check_mapping_eq(
         "is_equal_approx",
-        a.is_equal_approx(&b),
+        a.approx_eq(&b),
         inner_a.is_equal_approx(b),
     );
 }

--- a/itest/rust/src/transform2d_test.rs
+++ b/itest/rust/src/transform2d_test.rs
@@ -33,30 +33,22 @@ fn transform2d_equiv() {
         ("interpolate_with", inner.interpolate_with(Transform2D::IDENTITY, 0.5), outer.interpolate_with(Transform2D::IDENTITY, 0.5))
     ];
     for (name, inner, outer) in mappings_transform {
-        assert_eq_approx!(
-            &inner,
-            &outer,
-            Transform2D::is_equal_approx,
-            "function: {name}\n"
-        );
+        assert_eq_approx!(inner, outer, "function: {name}\n");
     }
 
     assert_eq_approx!(
-        inner.get_rotation(),
+        real::from_f64(inner.get_rotation()),
         outer.rotation(),
-        |a, b| is_equal_approx(real::from_f64(a), b),
         "function: get_rotation\n"
     );
     assert_eq_approx!(
-        inner.get_rotation(),
+        real::from_f64(inner.get_rotation()),
         outer.rotation(),
-        |a, b| is_equal_approx(real::from_f64(a), b),
         "function: get_rotation\n"
     );
     assert_eq_approx!(
-        inner.get_skew(),
+        real::from_f64(inner.get_skew()),
         outer.skew(),
-        |a, b| is_equal_approx(real::from_f64(a), b),
         "function: get_scale\n"
     );
 }
@@ -72,7 +64,6 @@ fn transform2d_xform_equiv() {
             .evaluate(&vec.to_variant(), VariantOperator::Multiply)
             .unwrap()
             .to::<Vector2>(),
-        Vector2::is_equal_approx,
         "operator: Transform2D * Vector2"
     );
 
@@ -85,7 +76,6 @@ fn transform2d_xform_equiv() {
             .evaluate(&rect_2.to_variant(), VariantOperator::Multiply)
             .unwrap()
             .to::<Rect2>(),
-        |a, b| Rect2::is_equal_approx(&a, &b),
         "operator: Transform2D * Rect2 (1)"
     );
 
@@ -97,7 +87,6 @@ fn transform2d_xform_equiv() {
             .evaluate(&rect_2.to_variant(), VariantOperator::Multiply)
             .unwrap()
             .to::<Rect2>(),
-        |a, b| Rect2::is_equal_approx(&a, &b),
         "operator: Transform2D * Rect2 (2)"
     );
 }

--- a/itest/rust/src/transform3d_test.rs
+++ b/itest/rust/src/transform3d_test.rs
@@ -36,12 +36,7 @@ fn transform3d_equiv() {
         ("interpolate_with", inner.interpolate_with(Transform3D::IDENTITY, 0.5), outer.interpolate_with(Transform3D::IDENTITY, 0.5))
     ];
     for (name, inner, outer) in mappings_transform {
-        assert_eq_approx!(
-            &inner,
-            &outer,
-            Transform3D::is_equal_approx,
-            "function: {name}\n"
-        );
+        assert_eq_approx!(inner, outer, "function: {name}\n");
     }
 }
 
@@ -56,7 +51,6 @@ fn transform3d_xform_equiv() {
             .evaluate(&vec.to_variant(), VariantOperator::Multiply)
             .unwrap()
             .to::<Vector3>(),
-        Vector3::is_equal_approx,
         "operator: Transform3D * Vector3"
     );
 
@@ -69,7 +63,6 @@ fn transform3d_xform_equiv() {
             .evaluate(&aabb.to_variant(), VariantOperator::Multiply)
             .unwrap()
             .to::<Aabb>(),
-        |a, b| Aabb::is_equal_approx(&a, &b),
         "operator: Transform3D * Aabb"
     );
 
@@ -82,7 +75,6 @@ fn transform3d_xform_equiv() {
             .evaluate(&plane.to_variant(), VariantOperator::Multiply)
             .unwrap()
             .to::<Plane>(),
-        |a, b| Plane::is_equal_approx(&a, &b),
         "operator: Transform3D * Plane"
     );
 }

--- a/itest/rust/src/virtual_methods_test.rs
+++ b/itest/rust/src/virtual_methods_test.rs
@@ -6,12 +6,13 @@
 
 #![allow(dead_code)]
 
-use crate::TestContext;
+use crate::{itest, TestContext};
+
 use godot::bind::{godot_api, GodotClass};
 use godot::builtin::{
-    is_equal_approx, real, varray, Color, GodotString, PackedByteArray, PackedColorArray,
-    PackedFloat32Array, PackedInt32Array, PackedStringArray, PackedVector2Array,
-    PackedVector3Array, RealConv, StringName, ToVariant, Variant, VariantArray, Vector2, Vector3,
+    real, varray, Color, GodotString, PackedByteArray, PackedColorArray, PackedFloat32Array,
+    PackedInt32Array, PackedStringArray, PackedVector2Array, PackedVector3Array, RealConv,
+    StringName, ToVariant, Variant, VariantArray, Vector2, Vector3,
 };
 use godot::engine::node::InternalMode;
 use godot::engine::notify::NodeNotification;
@@ -23,7 +24,6 @@ use godot::engine::{
 };
 use godot::obj::{Base, Gd, Share};
 use godot::private::class_macros::assert_eq_approx;
-use godot::test::itest;
 
 /// Simple class, that deliberately has no constructor accessible from GDScript
 #[derive(GodotClass, Debug)]
@@ -362,22 +362,18 @@ fn test_virtual_method_with_return() {
     assert_eq_approx!(
         arr.get(0).to::<PackedVector3Array>().get(0),
         arr_rust.get(0).to::<PackedVector3Array>().get(0),
-        Vector3::is_equal_approx
     );
     assert_eq_approx!(
-        arr.get(2).to::<PackedFloat32Array>().get(3),
-        arr_rust.get(2).to::<PackedFloat32Array>().get(3),
-        |a, b| is_equal_approx(real::from_f32(a), real::from_f32(b))
+        real::from_f32(arr.get(2).to::<PackedFloat32Array>().get(3)),
+        real::from_f32(arr_rust.get(2).to::<PackedFloat32Array>().get(3)),
     );
     assert_eq_approx!(
         arr.get(3).to::<PackedColorArray>().get(0),
         arr_rust.get(3).to::<PackedColorArray>().get(0),
-        Color::is_equal_approx
     );
     assert_eq_approx!(
         arr.get(4).to::<PackedVector2Array>().get(0),
         arr_rust.get(4).to::<PackedVector2Array>().get(0),
-        Vector2::is_equal_approx
     );
     assert_eq!(
         arr.get(6).to::<PackedByteArray>(),


### PR DESCRIPTION
Changes:

### Add `ApproxEq` trait and implement it for many builtin types.
  * This standardizes checking for approximate equality across types.
  * Gets rid of the boilerplate 3rd argument `assert_eq_approx!(a, b, is_equal_approx)`.
    * That argument can still be specified if desired, using `assert_eq_approx!(a, b, fn = is_equal_approx)`. 
    * In 95% of cases, it's not needed though.

### Refactor modules
  * `godot::builtin::math` is now a public module, which contains:
    * Godot ported functions such as `lerp`, `sign`
    * `ApproxEq` trait + `assert_eq_approx!`, `assert_ne_approx!` macros
    * glam utilities: `IVec4`, `GlamConv`, etc (internal)
  * The above symbols are no longer in `godot::builtin`. If this turns out to be an issue, we can also revert this in the future; but it might help some discoverability. Some symbols could also be considered to be part of the prelude.
  * Move `godot::native_structure` -> `godot::engine::native`
    * Added in #272
    * Native structures are now less prominent because rarely used.
  * Move `real`-related symbols into their own `real.rs` file (internal; API unaffected).

### Refactor import statements (just around geometric types, not whole codebase)
  * Remove wildcard imports
  * Remove nested import statements
  * Consistent order