### PR TITLE
Refactor small parts of `class_generator.rs`

### DIFF
--- a/godot-codegen/src/class_generator.rs
+++ b/godot-codegen/src/class_generator.rs
@@ -13,13 +13,54 @@ use std::path::{Path, PathBuf};
 use crate::api_parser::*;
 use crate::central_generator::{collect_builtin_types, BuiltinTypeInfo};
 use crate::util::{
-    function_uses_pointers, ident, option_as_slice, parse_native_structures_format, safe_ident,
-    to_pascal_case, to_rust_type, to_rust_type_abi, to_snake_case, NativeStructuresField,
+    ident, option_as_slice, parse_native_structures_format, safe_ident, to_pascal_case,
+    to_rust_type, to_rust_type_abi, to_snake_case, NativeStructuresField,
 };
 use crate::{
     special_cases, util, Context, GeneratedBuiltin, GeneratedBuiltinModule, GeneratedClass,
     GeneratedClassModule, ModName, RustTy, TyName,
 };
+
+struct FnReceiver {
+    /// `&self`, `&mut self`, (none)
+    param: TokenStream,
+
+    /// `ptr::null_mut()`, `self.object_ptr`, `self.sys_ptr`, (none)
+    ffi_arg: TokenStream,
+
+    /// `Self::`, `self.`
+    #[allow(dead_code)] // TODO remove as soon as used
+    self_prefix: TokenStream,
+}
+
+impl FnReceiver {
+    /// No receiver, not even static `Self`
+    fn global_function() -> FnReceiver {
+        FnReceiver {
+            param: TokenStream::new(),
+            ffi_arg: TokenStream::new(),
+            self_prefix: TokenStream::new(),
+        }
+    }
+}
+
+struct FnSignature<'a> {
+    function_name: &'a str,
+    is_private: bool,
+    is_virtual: bool,
+    method_args: &'a [MethodArg],
+    return_value: Option<&'a MethodReturn>,
+}
+
+struct FnCode {
+    receiver: FnReceiver,
+    variant_ffi: Option<VariantFfi>,
+    init_code: TokenStream,
+    varcall_invocation: TokenStream,
+    ptrcall_invocation: TokenStream,
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
 
 pub(crate) fn generate_class_files(
     api: &ExtensionApi,
@@ -891,7 +932,7 @@ fn make_method_definition(
 
     let method_name_str = special_cases::maybe_renamed(class_name, &method.name);
 
-    let (receiver, receiver_arg) = make_receiver(
+    let receiver = make_receiver(
         method.is_static,
         method.is_const,
         quote! { self.object_ptr },
@@ -925,25 +966,30 @@ fn make_method_definition(
         );
         let __call_fn = sys::interface_fn!(#function_provider);
     };
+
+    let receiver_ffi_arg = &receiver.ffi_arg;
     let varcall_invocation = quote! {
-        __call_fn(__method_bind, #receiver_arg, __args_ptr, __args.len() as i64, return_ptr, std::ptr::addr_of_mut!(__err));
+        __call_fn(__method_bind, #receiver_ffi_arg, __args_ptr, __args.len() as i64, return_ptr, std::ptr::addr_of_mut!(__err));
     };
     let ptrcall_invocation = quote! {
-        __call_fn(__method_bind, #receiver_arg, __args_ptr, return_ptr);
+        __call_fn(__method_bind, #receiver_ffi_arg, __args_ptr, return_ptr);
     };
 
-    let is_virtual = false;
     make_function_definition(
-        method_name_str,
-        special_cases::is_private(class_name, &method.name),
-        receiver,
-        option_as_slice(&method.arguments),
-        method.return_value.as_ref(),
-        variant_ffi,
-        init_code,
-        &varcall_invocation,
-        &ptrcall_invocation,
-        is_virtual,
+        &FnSignature {
+            function_name: method_name_str,
+            is_private: special_cases::is_private(class_name, &method.name),
+            is_virtual: false,
+            method_args: option_as_slice(&method.arguments),
+            return_value: method.return_value.as_ref(),
+        },
+        &FnCode {
+            receiver,
+            variant_ffi,
+            init_code,
+            varcall_invocation,
+            ptrcall_invocation,
+        },
         ctx,
     )
 }
@@ -956,11 +1002,8 @@ fn make_builtin_method_definition(
 ) -> TokenStream {
     let method_name_str = &method.name;
 
-    let (receiver, receiver_arg) =
-        make_receiver(method.is_static, method.is_const, quote! { self.sys_ptr });
-
     let return_value = method.return_type.as_deref().map(MethodReturn::from_type);
-    let hash = method.hash;
+    let hash = method.hash.expect("missing hash for builtin method");
     let is_varcall = method.is_vararg;
     let variant_ffi = is_varcall.then(VariantFfi::type_ptr);
 
@@ -975,22 +1018,28 @@ fn make_builtin_method_definition(
         );
         let __call_fn = __call_fn.unwrap_unchecked();
     };
+
+    let receiver = make_receiver(method.is_static, method.is_const, quote! { self.sys_ptr });
+    let receiver_ffi_arg = &receiver.ffi_arg;
     let ptrcall_invocation = quote! {
-        __call_fn(#receiver_arg, __args_ptr, return_ptr, __args.len() as i32);
+        __call_fn(#receiver_ffi_arg, __args_ptr, return_ptr, __args.len() as i32);
     };
 
-    let is_virtual = false;
     make_function_definition(
-        method_name_str,
-        special_cases::is_private(class_name, &method.name),
-        receiver,
-        option_as_slice(&method.arguments),
-        return_value.as_ref(),
-        variant_ffi,
-        init_code,
-        &ptrcall_invocation,
-        &ptrcall_invocation,
-        is_virtual,
+        &FnSignature {
+            function_name: method_name_str,
+            is_private: special_cases::is_private(class_name, &method.name),
+            is_virtual: false,
+            method_args: option_as_slice(&method.arguments),
+            return_value: return_value.as_ref(),
+        },
+        &FnCode {
+            receiver,
+            variant_ffi,
+            init_code,
+            varcall_invocation: ptrcall_invocation.clone(),
+            ptrcall_invocation,
+        },
         ctx,
     )
 }
@@ -1016,18 +1065,21 @@ pub(crate) fn make_utility_function_definition(
         __call_fn(return_ptr, __args_ptr, __args.len() as i32);
     };
 
-    let is_virtual = false;
     make_function_definition(
-        function_name_str,
-        false,
-        TokenStream::new(),
-        option_as_slice(&function.arguments),
-        return_value.as_ref(),
-        variant_ffi,
-        init_code,
-        &invocation,
-        &invocation,
-        is_virtual,
+        &FnSignature {
+            function_name: function_name_str,
+            is_private: false,
+            is_virtual: false,
+            method_args: option_as_slice(&function.arguments),
+            return_value: return_value.as_ref(),
+        },
+        &FnCode {
+            receiver: FnReceiver::global_function(),
+            variant_ffi,
+            init_code,
+            varcall_invocation: invocation.clone(),
+            ptrcall_invocation: invocation,
+        },
         ctx,
     )
 }
@@ -1052,26 +1104,13 @@ impl VariantFfi {
     }
 }
 
-#[allow(clippy::too_many_arguments)] // adding a struct/trait that's used only here, one time, reduces complexity by precisely 0%
-fn make_function_definition(
-    function_name: &str,
-    is_private: bool,
-    receiver: TokenStream,
-    method_args: &[MethodArg],
-    return_value: Option<&MethodReturn>,
-    variant_ffi: Option<VariantFfi>,
-    init_code: TokenStream,
-    varcall_invocation: &TokenStream,
-    ptrcall_invocation: &TokenStream,
-    is_virtual: bool,
-    ctx: &mut Context,
-) -> TokenStream {
-    let vis = if is_private {
+fn make_function_definition(sig: &FnSignature, code: &FnCode, ctx: &mut Context) -> TokenStream {
+    let vis = if sig.is_private {
         quote! { pub(crate) }
     } else {
         quote! { pub }
     };
-    let (maybe_unsafe, safety_doc) = if function_uses_pointers(method_args, return_value.clone()) {
+    let (maybe_unsafe, safety_doc) = if function_uses_pointers(sig) {
         (
             quote! { unsafe },
             quote! {
@@ -1084,12 +1123,13 @@ fn make_function_definition(
         (TokenStream::new(), TokenStream::new())
     };
 
-    let is_varcall = variant_ffi.is_some();
-    let fn_name = safe_ident(function_name);
-    let [params, variant_types, arg_exprs, arg_names] = make_params(method_args, is_varcall, ctx);
+    let is_varcall = code.variant_ffi.is_some();
+    let [params, variant_types, arg_exprs, arg_names] =
+        make_params(sig.method_args, is_varcall, ctx);
 
+    let fn_name = safe_ident(sig.function_name);
     let (prepare_arg_types, error_fn_context);
-    if variant_ffi.is_some() {
+    if code.variant_ffi.is_some() {
         // varcall (using varargs)
         prepare_arg_types = quote! {
             let mut __arg_types = Vec::with_capacity(__explicit_args.len() + varargs.len());
@@ -1104,7 +1144,7 @@ fn make_function_definition(
             .collect::<Vec<_>>()
             .join(", ");
 
-        let fmt = format!("{function_name}({joined}; {{__vararg_str}})");
+        let fmt = format!("{f}({joined}; {{__vararg_str}})", f = sig.function_name);
         error_fn_context = quote! { &format!(#fmt) };
     } else {
         // ptrcall
@@ -1113,33 +1153,40 @@ fn make_function_definition(
                 #( #variant_types ),*
             ];
         };
-        error_fn_context = function_name.to_token_stream();
+        error_fn_context = sig.function_name.to_token_stream();
     };
 
     let (return_decl, call_code) = make_return(
-        return_value,
-        variant_ffi.as_ref(),
-        varcall_invocation,
-        ptrcall_invocation,
+        sig.return_value,
+        code,
         prepare_arg_types,
         error_fn_context,
-        is_virtual,
+        sig.is_virtual,
         ctx,
     );
 
-    if is_virtual {
+    let receiver_param = &code.receiver.param;
+    if sig.is_virtual {
         quote! {
             #safety_doc
-            #maybe_unsafe fn #fn_name( #receiver #( #params, )* ) #return_decl {
+            #maybe_unsafe fn #fn_name(
+                #receiver_param
+                #( #params, )*
+            ) #return_decl {
                 #call_code
             }
         }
-    } else if let Some(variant_ffi) = variant_ffi.as_ref() {
+    } else if let Some(variant_ffi) = code.variant_ffi.as_ref() {
         // varcall (using varargs)
         let sys_method = &variant_ffi.sys_method;
+        let init_code = &code.init_code;
         quote! {
             #safety_doc
-            #vis #maybe_unsafe fn #fn_name( #receiver #( #params, )* varargs: &[Variant]) #return_decl {
+            #vis #maybe_unsafe fn #fn_name(
+                #receiver_param
+                #( #params, )*
+                varargs: &[Variant]
+            ) #return_decl {
                 unsafe {
                     #init_code
 
@@ -1159,9 +1206,13 @@ fn make_function_definition(
         }
     } else {
         // ptrcall
+        let init_code = &code.init_code;
         quote! {
             #safety_doc
-            #vis #maybe_unsafe fn #fn_name( #receiver #( #params, )* ) #return_decl {
+            #vis #maybe_unsafe fn #fn_name(
+                #receiver_param
+                #( #params, )*
+            ) #return_decl {
                 unsafe {
                     #init_code
 
@@ -1178,29 +1229,31 @@ fn make_function_definition(
     }
 }
 
-fn make_receiver(
-    is_static: bool,
-    is_const: bool,
-    receiver_arg: TokenStream,
-) -> (TokenStream, TokenStream) {
-    let receiver = make_receiver_self_param(is_static, is_const);
-
-    let receiver_arg = if is_static {
-        quote! { std::ptr::null_mut() }
-    } else {
-        receiver_arg
-    };
-
-    (receiver, receiver_arg)
-}
-
-fn make_receiver_self_param(is_static: bool, is_const: bool) -> TokenStream {
-    if is_static {
+fn make_receiver(is_static: bool, is_const: bool, ffi_arg: TokenStream) -> FnReceiver {
+    let param = if is_static {
         quote! {}
     } else if is_const {
         quote! { &self, }
     } else {
         quote! { &mut self, }
+    };
+
+    let ffi_arg = if is_static {
+        quote! { std::ptr::null_mut() }
+    } else {
+        ffi_arg
+    };
+
+    let self_prefix = if is_static {
+        quote! { Self:: }
+    } else {
+        quote! { self. }
+    };
+
+    FnReceiver {
+        param,
+        ffi_arg,
+        self_prefix,
     }
 }
 
@@ -1236,9 +1289,7 @@ fn make_params(
 #[allow(clippy::too_many_arguments)]
 fn make_return(
     return_value: Option<&MethodReturn>,
-    variant_ffi: Option<&VariantFfi>,
-    varcall_invocation: &TokenStream,
-    ptrcall_invocation: &TokenStream,
+    code: &FnCode,
     prepare_arg_types: TokenStream,
     error_fn_context: TokenStream, // only for panic message
     is_virtual: bool,
@@ -1255,6 +1306,13 @@ fn make_return(
         return_decl = TokenStream::new();
         return_ty = None;
     }
+
+    let FnCode {
+        varcall_invocation,
+        ptrcall_invocation,
+        variant_ffi,
+        ..
+    } = code;
 
     let call = match (is_virtual, variant_ffi, return_ty) {
         (true, _, _) => {
@@ -1398,28 +1456,22 @@ fn make_virtual_method(class_method: &ClassMethod, ctx: &mut Context) -> TokenSt
     // Virtual methods are never static.
     assert!(!class_method.is_static);
 
-    let receiver = make_receiver_self_param(false, class_method.is_const);
-
-    // make_return requests these token streams, but they won't be used for
-    // virtual methods. We can provide empty streams.
-    let varcall_invocation = TokenStream::new();
-    let ptrcall_invocation = TokenStream::new();
-    let init_code = TokenStream::new();
-    let variant_ffi = None;
-
-    let is_virtual = true;
-    let is_private = false;
     make_function_definition(
-        method_name,
-        is_private,
-        receiver,
-        option_as_slice(&class_method.arguments),
-        class_method.return_value.as_ref(),
-        variant_ffi,
-        init_code,
-        &varcall_invocation,
-        &ptrcall_invocation,
-        is_virtual,
+        &FnSignature {
+            function_name: method_name,
+            is_private: false,
+            is_virtual: true,
+            method_args: option_as_slice(&class_method.arguments),
+            return_value: class_method.return_value.as_ref(),
+        },
+        &FnCode {
+            receiver: make_receiver(false, class_method.is_const, TokenStream::new()),
+            // make_return() requests following args, but they are not used for virtual methods. We can provide empty streams.
+            variant_ffi: None,
+            init_code: TokenStream::new(),
+            varcall_invocation: TokenStream::new(),
+            ptrcall_invocation: TokenStream::new(),
+        },
         ctx,
     )
 }
@@ -1481,4 +1533,18 @@ fn virtual_method_name(class_method: &ClassMethod) -> &str {
     } else {
         method_name
     }
+}
+
+fn function_uses_pointers(sig: &FnSignature) -> bool {
+    if sig.method_args.iter().any(|x| x.type_.contains('*')) {
+        return true;
+    }
+
+    if let Some(return_value) = sig.return_value {
+        if return_value.type_.contains('*') {
+            return true;
+        }
+    }
+
+    false
 }

--- a/godot-codegen/src/tests.rs
+++ b/godot-codegen/src/tests.rs
@@ -188,18 +188,19 @@ fn test_parse_native_structures_format() {
         vec![native("int", "x"),],
     );
 
-    assert_eq!(
-    parse_native_structures_format("Vector3 position;Vector3 normal;Vector3 collider_velocity;Vector3 collider_angular_velocity;real_t depth;int local_shape;ObjectID collider_id;RID collider;int collider_shape").unwrap(),
-    vec![
-      native("Vector3", "position"),
-      native("Vector3", "normal"),
-      native("Vector3", "collider_velocity"),
-      native("Vector3", "collider_angular_velocity"),
-      native("real_t", "depth"),
-      native("int", "local_shape"),
-      native("ObjectID", "collider_id"),
-      native("RID", "collider"),
-      native("int", "collider_shape"),
-    ],
-  );
+    let actual = parse_native_structures_format(
+        "Vector3 position;Vector3 normal;Vector3 collider_velocity;Vector3 collider_angular_velocity;real_t depth;int local_shape;ObjectID collider_id;RID collider;int collider_shape"
+    );
+    let expected = vec![
+        native("Vector3", "position"),
+        native("Vector3", "normal"),
+        native("Vector3", "collider_velocity"),
+        native("Vector3", "collider_angular_velocity"),
+        native("real_t", "depth"),
+        native("int", "local_shape"),
+        native("ObjectID", "collider_id"),
+        native("RID", "collider"),
+        native("int", "collider_shape"),
+    ];
+    assert_eq!(actual.unwrap(), expected);
 }

--- a/godot-codegen/src/util.rs
+++ b/godot-codegen/src/util.rs
@@ -4,7 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use crate::api_parser::{ClassConstant, Enum, MethodArg, MethodReturn};
+use crate::api_parser::{ClassConstant, Enum};
 use crate::special_cases::is_builtin_scalar;
 use crate::{Context, ModName, RustTy, TyName};
 use proc_macro2::{Ident, Literal, TokenStream};
@@ -414,21 +414,4 @@ pub fn parse_native_structures_format(input: &str) -> Option<Vec<NativeStructure
             })
         })
         .collect()
-}
-
-pub fn function_uses_pointers(
-    method_args: &[MethodArg],
-    return_value: Option<&MethodReturn>,
-) -> bool {
-    if method_args.iter().any(|x| x.type_.contains('*')) {
-        return true;
-    }
-
-    if let Some(return_value) = return_value {
-        if return_value.type_.contains('*') {
-            return true;
-        }
-    }
-
-    false
 }

--- a/godot-codegen/src/util.rs
+++ b/godot-codegen/src/util.rs
@@ -16,6 +16,11 @@ pub struct NativeStructuresField {
     pub field_name: String,
 }
 
+/// Small utility that turns an optional vector (often encountered as JSON deserialization type) into a slice.
+pub fn option_as_slice<T>(option: &Option<Vec<T>>) -> &[T] {
+    option.as_ref().map_or(&[], Vec::as_slice)
+}
+
 pub fn make_enum_definition(enum_: &Enum) -> TokenStream {
     // TODO enums which have unique ords could be represented as Rust enums
     // This would allow exhaustive matches (or at least auto-completed matches + #[non_exhaustive]). But even without #[non_exhaustive],
@@ -412,18 +417,18 @@ pub fn parse_native_structures_format(input: &str) -> Option<Vec<NativeStructure
 }
 
 pub fn function_uses_pointers(
-    method_args: &Option<Vec<MethodArg>>,
-    return_value: &Option<&MethodReturn>,
+    method_args: &[MethodArg],
+    return_value: Option<&MethodReturn>,
 ) -> bool {
-    if let Some(method_args) = method_args {
-        if method_args.iter().any(|x| x.type_.contains('*')) {
-            return true;
-        }
+    if method_args.iter().any(|x| x.type_.contains('*')) {
+        return true;
     }
+
     if let Some(return_value) = return_value {
         if return_value.type_.contains('*') {
             return true;
         }
     }
+
     false
 }


### PR DESCRIPTION
Makes a few things more readable.

No functional changes, except:

1. Added `expect()` call around hash retrieval, failing at codegen rather than `godot-core` compilation.
   ```rs
   let hash = method.hash.expect("missing hash for builtin method");
   ```
2. `{varcall/ptrcall}_invocation` variables are now two fields, cloned when needed.

3. New `FnReceiver` struct has a new `self_prefix` field to be used in the future.