### PR TITLE
Add an abstraction for `GDExtensionClassMethodInfo`

### DIFF
--- a/godot-core/src/builtin/meta/mod.rs
+++ b/godot-core/src/builtin/meta/mod.rs
@@ -9,9 +9,10 @@ mod signature;
 
 pub use class_name::*;
 pub use signature::*;
+use sys::interface_fn;
 
 use crate::builtin::*;
-use crate::engine::global;
+use crate::engine::global::{self, MethodFlags};
 
 use godot_ffi as sys;
 
@@ -40,6 +41,20 @@ pub trait VariantMetadata {
 
     fn param_metadata() -> sys::GDExtensionClassMethodArgumentMetadata {
         sys::GDEXTENSION_METHOD_ARGUMENT_METADATA_NONE
+    }
+
+    fn argument_info(property_name: &str) -> MethodParamOrReturnInfo {
+        MethodParamOrReturnInfo {
+            info: Self::property_info(property_name),
+            metadata: Self::param_metadata(),
+        }
+    }
+
+    fn return_info() -> Option<MethodParamOrReturnInfo> {
+        Some(MethodParamOrReturnInfo {
+            info: Self::property_info(""),
+            metadata: Self::param_metadata(),
+        })
     }
 }
 
@@ -80,6 +95,148 @@ impl PropertyInfo {
             hint: u32::try_from(self.hint.ord()).expect("hint.ord()"),
             hint_string: self.hint_string.string_sys(),
             usage: u32::try_from(self.usage.ord()).expect("usage.ord()"),
+        }
+    }
+
+    pub fn empty_sys() -> sys::GDExtensionPropertyInfo {
+        use crate::obj::EngineEnum as _;
+
+        sys::GDExtensionPropertyInfo {
+            type_: VariantType::Nil.sys(),
+            name: std::ptr::null_mut(),
+            class_name: std::ptr::null_mut(),
+            hint: global::PropertyHint::PROPERTY_HINT_NONE.ord() as u32,
+            hint_string: std::ptr::null_mut(),
+            usage: global::PropertyUsageFlags::PROPERTY_USAGE_NONE.ord() as u32,
+        }
+    }
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+/// Rusty abstraction of sys::GDExtensionClassMethodInfo
+
+/// Info relating to an argument or return type in a method.
+pub struct MethodParamOrReturnInfo {
+    info: PropertyInfo,
+    metadata: sys::GDExtensionClassMethodArgumentMetadata,
+}
+
+/// All info needed to register a method for a class with Godot.
+pub struct MethodInfo {
+    class_name: ClassName,
+    method_name: StringName,
+    call_func: sys::GDExtensionClassMethodCall,
+    ptrcall_func: sys::GDExtensionClassMethodPtrCall,
+    method_flags: MethodFlags,
+    return_value: Option<MethodParamOrReturnInfo>,
+    arguments: Vec<MethodParamOrReturnInfo>,
+    default_arguments: Vec<Variant>,
+}
+
+impl MethodInfo {
+    pub fn from_signature<S: VarcallSignatureTuple>(
+        class_name: ClassName,
+        method_name: StringName,
+        call_func: sys::GDExtensionClassMethodCall,
+        ptrcall_func: sys::GDExtensionClassMethodPtrCall,
+        method_flags: MethodFlags,
+        param_names: &[&str],
+        default_arguments: Vec<Variant>,
+    ) -> Self {
+        let return_value = S::return_info();
+        let mut arguments = Vec::new();
+
+        assert_eq!(
+            param_names.len(),
+            S::PARAM_COUNT,
+            "`param_names` should contain one name for each parameter"
+        );
+
+        for (i, name) in param_names.iter().enumerate().take(S::PARAM_COUNT) {
+            arguments.push(S::param_info(i, name).unwrap_or_else(|| {
+                panic!(
+                    "signature with `PARAM_COUNT = {}` should have argument info for index `{i}`",
+                    S::PARAM_COUNT
+                )
+            }))
+        }
+
+        assert!(
+            default_arguments.len() <= arguments.len(),
+            "cannot have more default arguments than arguments"
+        );
+
+        Self {
+            class_name,
+            method_name,
+            call_func,
+            ptrcall_func,
+            method_flags,
+            return_value,
+            arguments,
+            default_arguments,
+        }
+    }
+
+    pub fn register_extension_class_method(&self) {
+        use crate::obj::EngineEnum as _;
+
+        let (return_value_info, return_value_metadata) = match &self.return_value {
+            Some(info) => (Some(&info.info), info.metadata),
+            None => (None, 0),
+        };
+
+        let mut return_value_sys = return_value_info
+            .as_ref()
+            .map(|info| info.property_sys())
+            .unwrap_or(PropertyInfo::empty_sys());
+
+        let mut arguments_info_sys: Vec<sys::GDExtensionPropertyInfo> = self
+            .arguments
+            .iter()
+            .map(|argument| argument.info.property_sys())
+            .collect();
+
+        let mut arguments_metadata: Vec<sys::GDExtensionClassMethodArgumentMetadata> =
+            self.arguments.iter().map(|info| info.metadata).collect();
+
+        let mut default_arguments_sys: Vec<sys::GDExtensionVariantPtr> =
+            self.default_arguments.iter().map(|v| v.var_sys()).collect();
+
+        let method_info_sys = sys::GDExtensionClassMethodInfo {
+            name: self.method_name.string_sys(),
+            method_userdata: std::ptr::null_mut(),
+            call_func: self.call_func,
+            ptrcall_func: self.ptrcall_func,
+            method_flags: self.method_flags.ord() as u32,
+            has_return_value: self.return_value.is_some() as u8,
+            return_value_info: &mut return_value_sys as *mut sys::GDExtensionPropertyInfo,
+            return_value_metadata,
+            argument_count: self
+                .arguments
+                .len()
+                .try_into()
+                .expect("arguments length should fit in u32"),
+            arguments_info: arguments_info_sys.as_mut_ptr(),
+            arguments_metadata: arguments_metadata.as_mut_ptr(),
+            default_argument_count: self
+                .default_arguments
+                .len()
+                .try_into()
+                .expect("default arguments length should fit in u32"),
+            default_arguments: default_arguments_sys.as_mut_ptr(),
+        };
+        // SAFETY:
+        // The lifetime of the data we use here is at least as long as this function's scope. So we can
+        // safely call this function without issue.
+        //
+        // Null pointers will only be passed along if we indicate to Godot that they are unused.
+        unsafe {
+            interface_fn!(classdb_register_extension_class_method)(
+                sys::get_library(),
+                self.class_name.string_sys(),
+                std::ptr::addr_of!(method_info_sys),
+            )
         }
     }
 }

--- a/godot-core/src/builtin/variant/impls.rs
+++ b/godot-core/src/builtin/variant/impls.rs
@@ -213,6 +213,10 @@ impl VariantMetadata for () {
     fn variant_type() -> VariantType {
         VariantType::Nil
     }
+
+    fn return_info() -> Option<meta::MethodParamOrReturnInfo> {
+        None
+    }
 }
 
 impl ToVariant for Variant {

--- a/godot-core/src/macros.rs
+++ b/godot-core/src/macros.rs
@@ -58,11 +58,11 @@ macro_rules! gdext_get_arguments_info {
         {
             use $crate::builtin::meta::*;
 
-            let mut i = -1i32;
+            let mut i: usize = 0;
             [$(
                 {
+                    let prop = <$Signature as VarcallSignatureTuple>::param_property_info(i, stringify!($param));
                     i += 1;
-                    let prop = <$Signature as VarcallSignatureTuple>::property_info(i, stringify!($param));
                     prop
                 },
             )*]

--- a/godot-macros/src/method_registration/register_method.rs
+++ b/godot-macros/src/method_registration/register_method.rs
@@ -12,8 +12,6 @@ use proc_macro2::{Ident, TokenStream};
 use quote::quote;
 use venial::parse_declaration;
 
-use super::SignatureInfo;
-
 // Convenience function to wrap an object's method into a function pointer
 // that can be passed to the engine when registering a class.
 pub fn gdext_register_method(class_name: &Ident, method_signature: &TokenStream) -> TokenStream {
@@ -24,10 +22,17 @@ pub fn gdext_register_method(class_name: &Ident, method_signature: &TokenStream)
         .clone();
     let method_signature = reduce_to_signature(&method_declaration);
     let signature_info = get_signature_info(&method_signature);
-    let method_name = &signature_info.method_name;
-
     let sig = get_sig(&signature_info.ret_type, &signature_info.param_types);
-    let method_info = get_method_info(class_name, &signature_info, sig);
+
+    let method_name = &signature_info.method_name;
+    let param_idents = &signature_info.param_idents;
+
+    let method_flags = method_flags(signature_info.receiver_type);
+
+    let wrapped_method = wrap_with_unpacked_params(class_name, &signature_info);
+
+    let varcall_func = get_varcall_func(class_name, method_name, &sig, &wrapped_method);
+    let ptrcall_func = get_ptrcall_func(class_name, method_name, &sig, &wrapped_method);
 
     quote! {
         {
@@ -35,10 +40,25 @@ pub fn gdext_register_method(class_name: &Ident, method_signature: &TokenStream)
             use godot::builtin::{StringName, Variant};
             use godot::sys;
 
-            let class_name = StringName::from(stringify!(#class_name));
+            let class_name = ClassName::from_static(stringify!(#class_name));
             let method_name = StringName::from(stringify!(#method_name));
 
-            let method_info = #method_info;
+            type Sig = #sig;
+
+            let varcall_func = #varcall_func;
+            let ptrcall_func = #ptrcall_func;
+
+            let method_info = MethodInfo::from_signature::<Sig>(
+                class_name,
+                method_name,
+                Some(varcall_func),
+                Some(ptrcall_func),
+                #method_flags,
+                &[
+                    #( stringify!(#param_idents) ),*
+                ],
+                Vec::new()
+            );
 
             godot::private::out!(
                 "   Register fn:   {}::{}",
@@ -46,77 +66,8 @@ pub fn gdext_register_method(class_name: &Ident, method_signature: &TokenStream)
                 stringify!(#method_name)
             );
 
-            unsafe {
-                sys::interface_fn!(classdb_register_extension_class_method)(
-                    sys::get_library(),
-                    class_name.string_sys(),
-                    std::ptr::addr_of!(method_info),
-                );
-            }
+            method_info.register_extension_class_method();
         };
-    }
-}
-
-fn get_method_info(
-    class_name: &Ident,
-    signature_info: &SignatureInfo,
-    sig: TokenStream,
-) -> TokenStream {
-    let method_name = &signature_info.method_name;
-    let has_return_value = signature_info.has_return_value;
-    let param_idents = &signature_info.param_idents;
-    let num_args = signature_info.num_args;
-
-    let method_flags = method_flags(signature_info.receiver_type);
-
-    let wrapped_method = wrap_with_unpacked_params(class_name, signature_info);
-
-    let varcall_func = get_varcall_func(class_name, method_name, &sig, &wrapped_method);
-    let ptrcall_func = get_ptrcall_func(class_name, method_name, &sig, &wrapped_method);
-
-    quote! {
-        {
-            type Sig = #sig;
-
-            let varcall_func = #varcall_func;
-            let ptrcall_func = #ptrcall_func;
-
-            // Return value meta-information
-            let has_return_value: bool = #has_return_value;
-            let return_value_info = Sig::property_info(-1, "");
-            let mut return_value_info_sys = return_value_info.property_sys();
-            let return_value_metadata = Sig::param_metadata(-1);
-
-            // Arguments meta-information
-            let argument_count = #num_args as u32;
-
-            // We dont want to drop `arguments_info` before we're done with using `arguments_info_sys`.
-            let arguments_info: [PropertyInfo; #num_args] =
-                godot::private::gdext_get_arguments_info!(Sig, #( #param_idents, )*);
-
-            let mut arguments_info_sys: [sys::GDExtensionPropertyInfo; #num_args] =
-                std::array::from_fn(|i| arguments_info[i].property_sys());
-            let mut arguments_metadata: [sys::GDExtensionClassMethodArgumentMetadata;
-                #num_args] = std::array::from_fn(|i| Sig::param_metadata(i as i32));
-
-            let method_info = sys::GDExtensionClassMethodInfo {
-                name: method_name.string_sys(),
-                method_userdata: std::ptr::null_mut(),
-                call_func: Some(varcall_func),
-                ptrcall_func: Some(ptrcall_func),
-                method_flags: #method_flags as u32,
-                has_return_value: has_return_value as u8,
-                return_value_info: std::ptr::addr_of_mut!(return_value_info_sys),
-                return_value_metadata,
-                argument_count,
-                arguments_info: arguments_info_sys.as_mut_ptr(),
-                arguments_metadata: arguments_metadata.as_mut_ptr(),
-                default_argument_count: 0,
-                default_arguments: std::ptr::null_mut(),
-            };
-
-            method_info
-        }
     }
 }
 


### PR DESCRIPTION
Adds an abstraction for `GDExtensionClassMethodInfo` so that we need to do less complicated formatting and reasoning about lifetimes and such in proc-macro outputs, since that can be kinda tricky.

closes #304
again...