### PR TITLE
Add support for exporting constants

### DIFF
--- a/godot-codegen/src/class_generator.rs
+++ b/godot-codegen/src/class_generator.rs
@@ -659,7 +659,7 @@ fn make_notification_enum(
     all_bases: &Vec<TyName>,
     ctx: &mut Context,
 ) -> (Option<TokenStream>, Ident) {
-    let Some(all_constants) = ctx.notification_constants(class_name) else  {
+    let Some(all_constants) = ctx.notification_constants(class_name) else {
         // Class has no notification constants: reuse (direct/indirect) base enum
         return (None, ctx.notification_enum_name(class_name));
     };

--- a/godot-codegen/src/interface_generator.rs
+++ b/godot-codegen/src/interface_generator.rs
@@ -103,7 +103,7 @@ fn generate_proc_address_funcs(h_path: &Path) -> TokenStream {
 fn parse_function_pointers(header_code: &str) -> Vec<GodotFuncPtr> {
     // See https://docs.rs/regex/latest/regex for docs.
     let regex = Regex::new(
-        r#"(?xms)
+        r"(?xms)
         # x: ignore whitespace and allow line comments (starting with `#`)
         # m: multi-line mode, ^ and $ match start and end of line
         # s: . matches newlines; would otherwise require (:?\n|\r\n|\r)
@@ -131,7 +131,7 @@ fn parse_function_pointers(header_code: &str) -> Vec<GodotFuncPtr> {
         # Parameters:                (GDExtensionVariantType p_from, GDExtensionVariantType p_to);
         .+?;
         # $ omitted, because there can be comments after `;`
-    "#,
+    ",
     )
     .unwrap();
 
@@ -142,9 +142,9 @@ fn parse_function_pointers(header_code: &str) -> Vec<GodotFuncPtr> {
         let doc = cap.name("doc");
 
         let (Some(name), Some(funcptr_ty), Some(doc)) = (name, funcptr_ty, doc) else {
-			// Skip unparseable ones, instead of breaking build (could just be a /** */ comment around something else)
-			continue;
-		};
+            // Skip unparseable ones, instead of breaking build (could just be a /** */ comment around something else)
+            continue;
+        };
 
         func_ptrs.push(GodotFuncPtr {
             name: ident(name.as_str()),

--- a/godot-codegen/src/lib.rs
+++ b/godot-codegen/src/lib.rs
@@ -305,6 +305,7 @@ const SELECTED_CLASSES: &[&str] = &[
     "Camera3D",
     "CanvasItem",
     "CanvasLayer",
+    "ClassDB",
     "CollisionObject2D",
     "CollisionShape2D",
     "Control",

--- a/godot-core/src/builtin/meta/mod.rs
+++ b/godot-core/src/builtin/meta/mod.rs
@@ -4,17 +4,20 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+pub mod registration;
+
 mod class_name;
 mod signature;
 
 pub use class_name::*;
 pub use signature::*;
-use sys::interface_fn;
 
 use crate::builtin::*;
-use crate::engine::global::{self, MethodFlags};
+use crate::engine::global;
 
 use godot_ffi as sys;
+
+use registration::method::MethodParamOrReturnInfo;
 
 /// Stores meta-information about registered types or properties.
 ///
@@ -44,17 +47,14 @@ pub trait VariantMetadata {
     }
 
     fn argument_info(property_name: &str) -> MethodParamOrReturnInfo {
-        MethodParamOrReturnInfo {
-            info: Self::property_info(property_name),
-            metadata: Self::param_metadata(),
-        }
+        MethodParamOrReturnInfo::new(Self::property_info(property_name), Self::param_metadata())
     }
 
     fn return_info() -> Option<MethodParamOrReturnInfo> {
-        Some(MethodParamOrReturnInfo {
-            info: Self::property_info(""),
-            metadata: Self::param_metadata(),
-        })
+        Some(MethodParamOrReturnInfo::new(
+            Self::property_info(""),
+            Self::param_metadata(),
+        ))
     }
 }
 
@@ -108,135 +108,6 @@ impl PropertyInfo {
             hint: global::PropertyHint::PROPERTY_HINT_NONE.ord() as u32,
             hint_string: std::ptr::null_mut(),
             usage: global::PropertyUsageFlags::PROPERTY_USAGE_NONE.ord() as u32,
-        }
-    }
-}
-
-// ----------------------------------------------------------------------------------------------------------------------------------------------
-/// Rusty abstraction of sys::GDExtensionClassMethodInfo
-
-/// Info relating to an argument or return type in a method.
-pub struct MethodParamOrReturnInfo {
-    info: PropertyInfo,
-    metadata: sys::GDExtensionClassMethodArgumentMetadata,
-}
-
-/// All info needed to register a method for a class with Godot.
-pub struct MethodInfo {
-    class_name: ClassName,
-    method_name: StringName,
-    call_func: sys::GDExtensionClassMethodCall,
-    ptrcall_func: sys::GDExtensionClassMethodPtrCall,
-    method_flags: MethodFlags,
-    return_value: Option<MethodParamOrReturnInfo>,
-    arguments: Vec<MethodParamOrReturnInfo>,
-    default_arguments: Vec<Variant>,
-}
-
-impl MethodInfo {
-    pub fn from_signature<S: VarcallSignatureTuple>(
-        class_name: ClassName,
-        method_name: StringName,
-        call_func: sys::GDExtensionClassMethodCall,
-        ptrcall_func: sys::GDExtensionClassMethodPtrCall,
-        method_flags: MethodFlags,
-        param_names: &[&str],
-        default_arguments: Vec<Variant>,
-    ) -> Self {
-        let return_value = S::return_info();
-        let mut arguments = Vec::new();
-
-        assert_eq!(
-            param_names.len(),
-            S::PARAM_COUNT,
-            "`param_names` should contain one name for each parameter"
-        );
-
-        for (i, name) in param_names.iter().enumerate().take(S::PARAM_COUNT) {
-            arguments.push(S::param_info(i, name).unwrap_or_else(|| {
-                panic!(
-                    "signature with `PARAM_COUNT = {}` should have argument info for index `{i}`",
-                    S::PARAM_COUNT
-                )
-            }))
-        }
-
-        assert!(
-            default_arguments.len() <= arguments.len(),
-            "cannot have more default arguments than arguments"
-        );
-
-        Self {
-            class_name,
-            method_name,
-            call_func,
-            ptrcall_func,
-            method_flags,
-            return_value,
-            arguments,
-            default_arguments,
-        }
-    }
-
-    pub fn register_extension_class_method(&self) {
-        use crate::obj::EngineEnum as _;
-
-        let (return_value_info, return_value_metadata) = match &self.return_value {
-            Some(info) => (Some(&info.info), info.metadata),
-            None => (None, 0),
-        };
-
-        let mut return_value_sys = return_value_info
-            .as_ref()
-            .map(|info| info.property_sys())
-            .unwrap_or(PropertyInfo::empty_sys());
-
-        let mut arguments_info_sys: Vec<sys::GDExtensionPropertyInfo> = self
-            .arguments
-            .iter()
-            .map(|argument| argument.info.property_sys())
-            .collect();
-
-        let mut arguments_metadata: Vec<sys::GDExtensionClassMethodArgumentMetadata> =
-            self.arguments.iter().map(|info| info.metadata).collect();
-
-        let mut default_arguments_sys: Vec<sys::GDExtensionVariantPtr> =
-            self.default_arguments.iter().map(|v| v.var_sys()).collect();
-
-        let method_info_sys = sys::GDExtensionClassMethodInfo {
-            name: self.method_name.string_sys(),
-            method_userdata: std::ptr::null_mut(),
-            call_func: self.call_func,
-            ptrcall_func: self.ptrcall_func,
-            method_flags: self.method_flags.ord() as u32,
-            has_return_value: self.return_value.is_some() as u8,
-            return_value_info: &mut return_value_sys as *mut sys::GDExtensionPropertyInfo,
-            return_value_metadata,
-            argument_count: self
-                .arguments
-                .len()
-                .try_into()
-                .expect("arguments length should fit in u32"),
-            arguments_info: arguments_info_sys.as_mut_ptr(),
-            arguments_metadata: arguments_metadata.as_mut_ptr(),
-            default_argument_count: self
-                .default_arguments
-                .len()
-                .try_into()
-                .expect("default arguments length should fit in u32"),
-            default_arguments: default_arguments_sys.as_mut_ptr(),
-        };
-        // SAFETY:
-        // The lifetime of the data we use here is at least as long as this function's scope. So we can
-        // safely call this function without issue.
-        //
-        // Null pointers will only be passed along if we indicate to Godot that they are unused.
-        unsafe {
-            interface_fn!(classdb_register_extension_class_method)(
-                sys::get_library(),
-                self.class_name.string_sys(),
-                std::ptr::addr_of!(method_info_sys),
-            )
         }
     }
 }

--- a/godot-core/src/builtin/meta/registration/constant.rs
+++ b/godot-core/src/builtin/meta/registration/constant.rs
@@ -1,0 +1,91 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use godot_ffi as sys;
+
+use sys::interface_fn;
+
+use crate::builtin::{meta::ClassName, StringName};
+
+/// A constant named `name` with the value `value`.
+pub struct IntegerConstant {
+    name: StringName,
+    value: i64,
+}
+
+impl IntegerConstant {
+    pub fn new<T: TryInto<i64> + std::fmt::Debug + Copy>(name: StringName, value: T) -> Self {
+        Self {
+            name,
+            value: value.try_into().ok().unwrap_or_else(|| {
+                panic!("exported constant `{value:?}` must be representable as `i64`")
+            }),
+        }
+    }
+
+    fn register(&self, class_name: &ClassName, enum_name: &StringName, is_bitfield: bool) {
+        unsafe {
+            interface_fn!(classdb_register_extension_class_integer_constant)(
+                sys::get_library(),
+                class_name.string_sys(),
+                enum_name.string_sys(),
+                self.name.string_sys(),
+                self.value,
+                is_bitfield as sys::GDExtensionBool,
+            );
+        }
+    }
+}
+
+/// Whether the constant should be interpreted as a single integer, an enum with several variants, or a
+/// bitfield with several flags.
+pub enum ConstantKind {
+    Integer(IntegerConstant),
+    Enum {
+        name: StringName,
+        enumerators: Vec<IntegerConstant>,
+    },
+    Bitfield {
+        name: StringName,
+        flags: Vec<IntegerConstant>,
+    },
+}
+
+impl ConstantKind {
+    fn register(&self, class_name: &ClassName) {
+        match self {
+            ConstantKind::Integer(integer) => {
+                integer.register(class_name, &StringName::default(), false)
+            }
+            ConstantKind::Enum { name, enumerators } => {
+                for enumerator in enumerators.iter() {
+                    enumerator.register(class_name, name, false)
+                }
+            }
+            ConstantKind::Bitfield { name, flags } => {
+                for flag in flags.iter() {
+                    flag.register(class_name, name, true)
+                }
+            }
+        }
+    }
+}
+
+/// All the info needed to export a constant to Godot.
+pub struct ExportConstant {
+    class_name: ClassName,
+    kind: ConstantKind,
+}
+
+impl ExportConstant {
+    pub fn new(class_name: ClassName, kind: ConstantKind) -> Self {
+        Self { class_name, kind }
+    }
+
+    pub fn register(&self) {
+        self.kind.register(&self.class_name)
+    }
+}

--- a/godot-core/src/builtin/meta/registration/method.rs
+++ b/godot-core/src/builtin/meta/registration/method.rs
@@ -114,7 +114,7 @@ impl MethodInfo {
             .map(|argument| argument.info.property_sys())
             .collect();
 
-        let mut arguments_metadata: Vec<u32> =
+        let mut arguments_metadata: Vec<sys::GDExtensionClassMethodArgumentMetadata> =
             self.arguments.iter().map(|info| info.metadata).collect();
 
         let mut default_arguments_sys: Vec<sys::GDExtensionVariantPtr> =

--- a/godot-core/src/builtin/meta/registration/method.rs
+++ b/godot-core/src/builtin/meta/registration/method.rs
@@ -1,0 +1,165 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use godot_ffi as sys;
+use sys::interface_fn;
+
+use crate::builtin::meta::{ClassName, PropertyInfo, VarcallSignatureTuple};
+use crate::builtin::{StringName, Variant};
+use crate::engine::global::MethodFlags;
+
+/// Info relating to an argument or return type in a method.
+pub struct MethodParamOrReturnInfo {
+    info: PropertyInfo,
+    metadata: sys::GDExtensionClassMethodArgumentMetadata,
+}
+
+impl MethodParamOrReturnInfo {
+    pub fn new(info: PropertyInfo, metadata: sys::GDExtensionClassMethodArgumentMetadata) -> Self {
+        Self { info, metadata }
+    }
+}
+
+/// All info needed to register a method for a class with Godot.
+pub struct MethodInfo {
+    class_name: ClassName,
+    method_name: StringName,
+    call_func: sys::GDExtensionClassMethodCall,
+    ptrcall_func: sys::GDExtensionClassMethodPtrCall,
+    method_flags: MethodFlags,
+    return_value: Option<MethodParamOrReturnInfo>,
+    arguments: Vec<MethodParamOrReturnInfo>,
+    default_arguments: Vec<Variant>,
+}
+
+impl MethodInfo {
+    /// # Safety
+    ///
+    /// `ptrcall_func`, if provided, must:
+    ///
+    /// - Interpret its parameters according to the types specified in `S`.
+    /// - Return the value that is specified in `S`, or return nothing if the return value is `()`.
+    ///
+    /// `call_func`, if provided, must:
+    ///
+    /// - Interpret its parameters as a list of `S::PARAM_COUNT` `Variant`s.
+    /// - Return a `Variant`.
+    ///
+    /// `call_func` and `ptrcall_func`, if provided, must:
+    ///
+    /// - Follow the behavior expected from the `method_flags`.
+    pub unsafe fn from_signature<S: VarcallSignatureTuple>(
+        class_name: ClassName,
+        method_name: StringName,
+        call_func: sys::GDExtensionClassMethodCall,
+        ptrcall_func: sys::GDExtensionClassMethodPtrCall,
+        method_flags: MethodFlags,
+        param_names: &[&str],
+        default_arguments: Vec<Variant>,
+    ) -> Self {
+        let return_value = S::return_info();
+        let mut arguments = Vec::new();
+
+        assert_eq!(
+            param_names.len(),
+            S::PARAM_COUNT,
+            "`param_names` should contain one name for each parameter"
+        );
+
+        for (i, name) in param_names.iter().enumerate().take(S::PARAM_COUNT) {
+            arguments.push(S::param_info(i, name).unwrap_or_else(|| {
+                panic!(
+                    "signature with `PARAM_COUNT = {}` should have argument info for index `{i}`",
+                    S::PARAM_COUNT
+                )
+            }))
+        }
+
+        assert!(
+            default_arguments.len() <= arguments.len(),
+            "cannot have more default arguments than arguments"
+        );
+
+        Self {
+            class_name,
+            method_name,
+            call_func,
+            ptrcall_func,
+            method_flags,
+            return_value,
+            arguments,
+            default_arguments,
+        }
+    }
+
+    pub fn register_extension_class_method(&self) {
+        use crate::obj::EngineEnum as _;
+
+        let (return_value_info, return_value_metadata) = match &self.return_value {
+            Some(info) => (Some(&info.info), info.metadata),
+            None => (None, 0),
+        };
+
+        let mut return_value_sys = return_value_info
+            .as_ref()
+            .map(|info| info.property_sys())
+            .unwrap_or(PropertyInfo::empty_sys());
+
+        let mut arguments_info_sys: Vec<sys::GDExtensionPropertyInfo> = self
+            .arguments
+            .iter()
+            .map(|argument| argument.info.property_sys())
+            .collect();
+
+        let mut arguments_metadata: Vec<u32> =
+            self.arguments.iter().map(|info| info.metadata).collect();
+
+        let mut default_arguments_sys: Vec<sys::GDExtensionVariantPtr> =
+            self.default_arguments.iter().map(|v| v.var_sys()).collect();
+
+        let method_info_sys = sys::GDExtensionClassMethodInfo {
+            name: self.method_name.string_sys(),
+            method_userdata: std::ptr::null_mut(),
+            call_func: self.call_func,
+            ptrcall_func: self.ptrcall_func,
+            method_flags: self.method_flags.ord() as u32,
+            has_return_value: self.return_value.is_some() as u8,
+            return_value_info: std::ptr::addr_of_mut!(return_value_sys),
+            return_value_metadata,
+            argument_count: self.argument_count(),
+            arguments_info: arguments_info_sys.as_mut_ptr(),
+            arguments_metadata: arguments_metadata.as_mut_ptr(),
+            default_argument_count: self.default_argument_count(),
+            default_arguments: default_arguments_sys.as_mut_ptr(),
+        };
+        // SAFETY:
+        // The lifetime of the data we use here is at least as long as this function's scope. So we can
+        // safely call this function without issue.
+        //
+        // Null pointers will only be passed along if we indicate to Godot that they are unused.
+        unsafe {
+            interface_fn!(classdb_register_extension_class_method)(
+                sys::get_library(),
+                self.class_name.string_sys(),
+                std::ptr::addr_of!(method_info_sys),
+            )
+        }
+    }
+
+    fn argument_count(&self) -> u32 {
+        self.arguments
+            .len()
+            .try_into()
+            .expect("arguments length should fit in u32")
+    }
+
+    fn default_argument_count(&self) -> u32 {
+        self.default_arguments
+            .len()
+            .try_into()
+            .expect("arguments length should fit in u32")
+    }
+}

--- a/godot-core/src/builtin/meta/registration/mod.rs
+++ b/godot-core/src/builtin/meta/registration/mod.rs
@@ -1,0 +1,10 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+//! Helpers used for registering various things with Godot.
+
+pub mod constant;
+pub mod method;

--- a/godot-core/src/builtin/meta/signature.rs
+++ b/godot-core/src/builtin/meta/signature.rs
@@ -64,6 +64,8 @@ pub trait PtrcallSignatureTuple {
 use crate::builtin::meta::*;
 use crate::builtin::{FromVariant, ToVariant, Variant};
 
+use super::registration::method::MethodParamOrReturnInfo;
+
 macro_rules! impl_varcall_signature_for_tuple {
     (
         $PARAM_COUNT:literal,

--- a/godot-core/src/builtin/variant/impls.rs
+++ b/godot-core/src/builtin/variant/impls.rs
@@ -5,6 +5,7 @@
  */
 
 use super::*;
+use crate::builtin::meta::registration::method::MethodParamOrReturnInfo;
 use crate::builtin::meta::{PropertyInfo, VariantMetadata};
 use crate::builtin::*;
 use crate::engine::global;
@@ -214,7 +215,7 @@ impl VariantMetadata for () {
         VariantType::Nil
     }
 
-    fn return_info() -> Option<meta::MethodParamOrReturnInfo> {
+    fn return_info() -> Option<MethodParamOrReturnInfo> {
         None
     }
 }

--- a/godot-core/src/obj/traits.rs
+++ b/godot-core/src/obj/traits.rs
@@ -185,6 +185,8 @@ pub mod cap {
     pub trait ImplementsGodotApi: GodotClass {
         #[doc(hidden)]
         fn __register_methods();
+        #[doc(hidden)]
+        fn __register_constants();
     }
 
     pub trait ImplementsGodotExports: GodotClass {

--- a/godot-core/src/registry.rs
+++ b/godot-core/src/registry.rs
@@ -423,6 +423,7 @@ pub mod callbacks {
 
         //T::register_methods(class_builder);
         T::__register_methods();
+        T::__register_constants();
         T::__register_exports();
     }
 }

--- a/godot-macros/src/util/list_parser.rs
+++ b/godot-macros/src/util/list_parser.rs
@@ -128,7 +128,9 @@ impl ListParser {
     ///
     /// Returns `Ok(None)` if there are no more elements left.
     pub fn next_ident(&mut self) -> ParseResult<Option<Ident>> {
-        let Some(kv) = self.pop_next() else { return Ok(None) };
+        let Some(kv) = self.pop_next() else {
+            return Ok(None);
+        };
 
         Ok(Some(kv.ident()?))
     }
@@ -137,7 +139,9 @@ impl ListParser {
     ///
     /// Returns `Ok(None)` if there are no more elements left or the next element isn't an identifier.
     pub fn try_next_ident(&mut self) -> ParseResult<Option<Ident>> {
-        let Some(kv) = self.peek() else { return Ok(None) };
+        let Some(kv) = self.peek() else {
+            return Ok(None);
+        };
 
         let id = kv.as_ident()?;
 
@@ -150,7 +154,9 @@ impl ListParser {
     ///
     /// Returns `Ok(None)` if there are no more elements left.
     pub fn next_any_ident(&mut self, ids: &[&str]) -> ParseResult<Option<Ident>> {
-        let Some(next_id) = self.try_next_ident()? else { return Ok(None) };
+        let Some(next_id) = self.try_next_ident()? else {
+            return Ok(None);
+        };
 
         for id in ids {
             if next_id == id {

--- a/itest/rust/src/lib.rs
+++ b/itest/rust/src/lib.rs
@@ -32,6 +32,7 @@ mod property_test;
 mod quaternion_test;
 mod rect2_test;
 mod rect2i_test;
+mod registration;
 mod rid_test;
 mod signal_test;
 mod singleton_test;

--- a/itest/rust/src/object_test.rs
+++ b/itest/rust/src/object_test.rs
@@ -348,7 +348,10 @@ fn object_engine_convert_variant_nil() {
 
 #[itest]
 fn object_engine_returned_refcount() {
-    let Some(file) = FileAccess::open("res://itest.gdextension".into(), file_access::ModeFlags::READ) else {
+    let Some(file) = FileAccess::open(
+        "res://itest.gdextension".into(),
+        file_access::ModeFlags::READ,
+    ) else {
         panic!("failed to open file used to test FileAccess")
     };
     assert!(file.is_open());

--- a/itest/rust/src/registration/constant_test.rs
+++ b/itest/rust/src/registration/constant_test.rs
@@ -1,0 +1,178 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use crate::itest;
+use godot::{
+    engine::ClassDb,
+    prelude::{meta::ClassName, *},
+};
+
+#[derive(GodotClass)]
+struct HasConstants {}
+
+#[godot_api]
+impl HasConstants {
+    #[constant]
+    const A: i64 = 128;
+
+    #[constant]
+    const B: i128 = -600;
+
+    #[constant]
+    const C: u8 = u8::MAX;
+
+    #[constant]
+    const D: usize = 20 + 33 * 45;
+}
+
+#[itest]
+fn constants_correct_value() {
+    let class_name = ClassName::of::<HasConstants>();
+    const CONSTANTS: [(&str, i64); 4] = [
+        ("A", HasConstants::A),
+        ("B", HasConstants::B as i64),
+        ("C", HasConstants::C as i64),
+        ("D", HasConstants::D as i64),
+    ];
+
+    let constants = ClassDb::singleton()
+        .class_get_integer_constant_list_ex(class_name.clone().into())
+        .no_inheritance(true)
+        .done();
+
+    for (constant_name, constant_value) in CONSTANTS {
+        assert!(constants.contains(constant_name.into()));
+        assert_eq!(
+            ClassDb::singleton()
+                .class_get_integer_constant(class_name.clone().into(), constant_name.into()),
+            constant_value
+        );
+    }
+}
+
+#[derive(GodotClass)]
+struct HasOtherConstants {}
+
+impl HasOtherConstants {
+    const ENUM_NAME: &str = "SomeEnum";
+    const ENUM_A: i64 = 0;
+    const ENUM_B: i64 = 1;
+    const ENUM_C: i64 = 2;
+
+    const BITFIELD_NAME: &str = "SomeBitfield";
+    const BITFIELD_A: i64 = 1;
+    const BITFIELD_B: i64 = 2;
+    const BITFIELD_C: i64 = 4;
+}
+
+// TODO: replace with proc-macro api when constant enums and bitfields can be exported through the
+// proc-macro.
+impl ::godot::obj::cap::ImplementsGodotApi for HasOtherConstants {
+    fn __register_methods() {}
+    fn __register_constants() {
+        use ::godot::builtin::meta::registration::constant::*;
+        // Try exporting an enum.
+        ExportConstant::new(
+            ClassName::from_static("HasOtherConstants"),
+            ConstantKind::Enum {
+                name: Self::ENUM_NAME.into(),
+                enumerators: vec![
+                    IntegerConstant::new("ENUM_A".into(), Self::ENUM_A),
+                    IntegerConstant::new("ENUM_B".into(), Self::ENUM_B),
+                    IntegerConstant::new("ENUM_C".into(), Self::ENUM_C),
+                ],
+            },
+        )
+        .register();
+
+        // Try exporting an enum.
+        ExportConstant::new(
+            ClassName::from_static("HasOtherConstants"),
+            ConstantKind::Bitfield {
+                name: Self::BITFIELD_NAME.into(),
+                flags: vec![
+                    IntegerConstant::new("BITFIELD_A".into(), Self::BITFIELD_A),
+                    IntegerConstant::new("BITFIELD_B".into(), Self::BITFIELD_B),
+                    IntegerConstant::new("BITFIELD_C".into(), Self::BITFIELD_C),
+                ],
+            },
+        )
+        .register();
+    }
+}
+
+::godot::sys::plugin_add!(
+    __GODOT_PLUGIN_REGISTRY  in::godot::private;
+    ::godot::private::ClassPlugin {
+        class_name: "HasOtherConstants",
+        component: ::godot::private::PluginComponent::UserMethodBinds {
+            generated_register_fn: ::godot::private::ErasedRegisterFn {
+                raw: ::godot::private::callbacks::register_user_binds::<HasOtherConstants>,
+            },
+        },
+    }
+);
+
+macro_rules! test_enum_export {
+    (
+        $class:ty, $enum_name:ident, [$($enumerators:ident),* $(,)?];
+        // Include the `attr` here to so we can easily do things like `#[itest(focus)]`.
+        #$attr:tt
+        fn $test_name:ident() { .. }
+    ) => {
+        #$attr
+        fn $test_name() {
+            let class_name = ClassName::of::<$class>();
+            let enum_name = StringName::from(<$class>::$enum_name);
+            let variants = [
+                $((stringify!($enumerators), <$class>::$enumerators)),*
+            ];
+
+            assert!(ClassDb::singleton()
+                .class_has_enum_ex(
+                    class_name.clone().into(),
+                    enum_name.clone(),
+                )
+                .no_inheritance(true)
+                .done());
+
+            let godot_variants = ClassDb::singleton()
+                .class_get_enum_constants_ex(
+                    class_name.clone().into(),
+                    enum_name.into(),
+                )
+                .no_inheritance(true)
+                .done();
+
+            let constants = ClassDb::singleton()
+                .class_get_integer_constant_list_ex(class_name.clone().into())
+                .no_inheritance(true)
+                .done();
+
+            for (variant_name, variant_value) in variants {
+                assert!(godot_variants.contains(variant_name.into()));
+                assert!(constants.contains(variant_name.into()));
+                assert_eq!(
+                    ClassDb::singleton()
+                        .class_get_integer_constant(class_name.clone().into(), variant_name.into()),
+                    variant_value
+                );
+            }
+        }
+    }
+}
+
+test_enum_export!(
+    HasOtherConstants, ENUM_NAME, [ENUM_A, ENUM_B, ENUM_C];
+    #[itest]
+    fn enum_export_correct_values() { .. }
+);
+
+test_enum_export!(
+    HasOtherConstants, BITFIELD_NAME, [BITFIELD_A, BITFIELD_B, BITFIELD_C];
+    #[itest]
+    fn bitfield_export_correct_values() { .. }
+);

--- a/itest/rust/src/registration/mod.rs
+++ b/itest/rust/src/registration/mod.rs
@@ -1,0 +1,7 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+mod constant_test;

--- a/itest/rust/src/virtual_methods_test.rs
+++ b/itest/rust/src/virtual_methods_test.rs
@@ -120,19 +120,19 @@ struct ReturnVirtualTest {
 impl PrimitiveMeshVirtual for ReturnVirtualTest {
     fn create_mesh_array(&self) -> VariantArray {
         varray![
-            PackedVector3Array::from_iter([Vector3::LEFT].into_iter()),
-            PackedVector3Array::from_iter([Vector3::LEFT].into_iter()),
-            PackedFloat32Array::from_iter([0.0, 0.0, 0.0, 1.0].into_iter()),
+            PackedVector3Array::from_iter([Vector3::LEFT]),
+            PackedVector3Array::from_iter([Vector3::LEFT]),
+            PackedFloat32Array::from_iter([0.0, 0.0, 0.0, 1.0]),
             PackedColorArray::from_iter([Color::from_rgb(1.0, 1.0, 1.0)]),
             PackedVector2Array::from_iter([Vector2::LEFT]),
             PackedVector2Array::from_iter([Vector2::LEFT]),
-            PackedByteArray::from_iter([0, 1, 2, 3].into_iter()),
-            PackedByteArray::from_iter([0, 1, 2, 3].into_iter()),
-            PackedByteArray::from_iter([0, 1, 2, 3].into_iter()),
-            PackedByteArray::from_iter([0, 1, 2, 3].into_iter()),
-            PackedInt32Array::from_iter([0, 1, 2, 3].into_iter()),
-            PackedFloat32Array::from_iter([0.0, 1.0, 2.0, 3.0].into_iter()),
-            PackedInt32Array::from_iter([0].into_iter()),
+            PackedByteArray::from_iter([0, 1, 2, 3]),
+            PackedByteArray::from_iter([0, 1, 2, 3]),
+            PackedByteArray::from_iter([0, 1, 2, 3]),
+            PackedByteArray::from_iter([0, 1, 2, 3]),
+            PackedInt32Array::from_iter([0, 1, 2, 3]),
+            PackedFloat32Array::from_iter([0.0, 1.0, 2.0, 3.0]),
+            PackedInt32Array::from_iter([0]),
         ]
     }
 }


### PR DESCRIPTION
Builds on top of #319, mainly to avoid conflicts with that PR since it touches related code

Adds the ability to do 
```rs
#[godot_api]
impl MyClass {
  #[constant]
  const FOO: i64 = 10;
}
```
And have it show up in godot so you can do things like `MyClass.FOO`.

closes #318

## TODO:
- [x] Add tests
- [ ] Bikeshed syntax
- [x] Allow exporting other integer-types than just i64
- [x] Test the other parts of the `ExportConstant` struct (exporting enums and bitfields), as i think it'd be a bit too big to add some proc-macro stuff for it. But i dont want to make an incomplete abstraction over the `classdb_register_extension_class_integer_constant` call. But i should test that the rest actually works if im gonna include it in this PR.