### PR TITLE
Default parameters in Engine API + meta param/return types

### DIFF
--- a/examples/dodge-the-creeps/rust/src/hud.rs
+++ b/examples/dodge-the-creeps/rust/src/hud.rs
@@ -20,7 +20,7 @@ impl Hud {
         message_label.show();
 
         let mut timer = self.base.get_node_as::<Timer>("MessageTimer");
-        timer.start(0.0);
+        timer.start();
     }
 
     pub fn show_game_over(&self) {

--- a/examples/dodge-the-creeps/rust/src/main_scene.rs
+++ b/examples/dodge-the-creeps/rust/src/main_scene.rs
@@ -1,11 +1,12 @@
 use crate::hud::Hud;
 use crate::mob;
 use crate::player;
-use godot::engine::node::InternalMode;
+
 use godot::engine::{Marker2D, PathFollow2D, RigidBody2D, Timer};
 use godot::prelude::*;
+
 use rand::Rng as _;
-use std::f64::consts::PI;
+use std::f32::consts::PI;
 
 // Deriving GodotClass makes the class available to Godot
 #[derive(GodotClass)]
@@ -33,7 +34,7 @@ impl Main {
         hud.bind_mut().show_game_over();
 
         self.music().stop();
-        self.death_sound().play(0.0);
+        self.death_sound().play();
     }
 
     #[func]
@@ -45,22 +46,22 @@ impl Main {
         self.score = 0;
 
         player.bind_mut().start(start_position.get_position());
-        start_timer.start(0.0);
+        start_timer.start();
 
         let mut hud = self.base.get_node_as::<Hud>("Hud");
         let hud = hud.bind_mut();
         hud.update_score(self.score);
         hud.show_message("Get Ready".into());
 
-        self.music().play(0.0);
+        self.music().play();
     }
 
     #[func]
     fn on_start_timer_timeout(&self) {
         let mut mob_timer = self.base.get_node_as::<Timer>("MobTimer");
         let mut score_timer = self.base.get_node_as::<Timer>("ScoreTimer");
-        mob_timer.start(0.0);
-        score_timer.start(0.0);
+        mob_timer.start();
+        score_timer.start();
     }
 
     #[func]
@@ -82,7 +83,7 @@ impl Main {
         let mut rng = rand::thread_rng();
         let progress = rng.gen_range(u32::MIN..u32::MAX);
 
-        mob_spawn_location.set_progress(progress.into());
+        mob_spawn_location.set_progress(progress as f32);
         mob_scene.set_position(mob_spawn_location.get_position());
 
         let mut direction = mob_spawn_location.get_rotation() + PI / 2.0;
@@ -90,11 +91,7 @@ impl Main {
 
         mob_scene.set_rotation(direction);
 
-        self.base.add_child(
-            mob_scene.share().upcast(),
-            false,
-            InternalMode::INTERNAL_MODE_DISABLED,
-        );
+        self.base.add_child(mob_scene.share().upcast());
 
         let mut mob = mob_scene.cast::<mob::Mob>();
         {
@@ -103,7 +100,7 @@ impl Main {
             let range = rng.gen_range(mob.min_speed..mob.max_speed);
 
             mob.set_linear_velocity(Vector2::new(range, 0.0));
-            let lin_vel = mob.get_linear_velocity().rotated(real::from_f64(direction));
+            let lin_vel = mob.get_linear_velocity().rotated(real::from_f32(direction));
             mob.set_linear_velocity(lin_vel);
         }
 
@@ -111,7 +108,6 @@ impl Main {
         hud.bind_mut().connect(
             "start_game".into(),
             Callable::from_object_method(mob, "on_start_game"),
-            0,
         );
     }
 

--- a/examples/dodge-the-creeps/rust/src/mob.rs
+++ b/examples/dodge-the-creeps/rust/src/mob.rs
@@ -40,7 +40,7 @@ impl RigidBody2DVirtual for Mob {
             .base
             .get_node_as::<AnimatedSprite2D>("AnimatedSprite2D");
 
-        sprite.play("".into(), 1.0, false);
+        sprite.play();
         let anim_names = sprite.get_sprite_frames().unwrap().get_animation_names();
 
         // TODO use pick_random() once implemented

--- a/examples/dodge-the-creeps/rust/src/player.rs
+++ b/examples/dodge-the-creeps/rust/src/player.rs
@@ -74,16 +74,16 @@ impl Area2DVirtual for Player {
 
         // Note: exact=false by default, in Rust we have to provide it explicitly
         let input = Input::singleton();
-        if input.is_action_pressed("move_right".into(), false) {
+        if input.is_action_pressed("move_right".into()) {
             velocity += Vector2::RIGHT;
         }
-        if input.is_action_pressed("move_left".into(), false) {
+        if input.is_action_pressed("move_left".into()) {
             velocity += Vector2::LEFT;
         }
-        if input.is_action_pressed("move_down".into(), false) {
+        if input.is_action_pressed("move_down".into()) {
             velocity += Vector2::DOWN;
         }
-        if input.is_action_pressed("move_up".into(), false) {
+        if input.is_action_pressed("move_up".into()) {
             velocity += Vector2::UP;
         }
 
@@ -103,7 +103,7 @@ impl Area2DVirtual for Player {
                 animated_sprite.set_flip_v(velocity.y > 0.0)
             }
 
-            animated_sprite.play(animation.into(), 1.0, false);
+            animated_sprite.play_ex().name(animation.into()).done();
         } else {
             animated_sprite.stop();
         }

--- a/godot-codegen/Cargo.toml
+++ b/godot-codegen/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["gamedev", "godot", "engine", "codegen"]
 categories = ["game-engines", "graphics"]
 
 [features]
-default = []
+default = ["codegen-fmt"]
 codegen-fmt = []
 codegen-full = []
 double-precision = []

--- a/godot-codegen/src/api_parser.rs
+++ b/godot-codegen/src/api_parser.rs
@@ -217,7 +217,7 @@ pub struct MethodArg {
     pub name: String,
     #[nserde(rename = "type")]
     pub type_: String,
-    // pub meta: Option<String>,
+    pub meta: Option<String>,
     pub default_value: Option<String>,
 }
 
@@ -226,13 +226,14 @@ pub struct MethodArg {
 pub struct MethodReturn {
     #[nserde(rename = "type")]
     pub type_: String,
-    // pub meta: Option<String>,
+    pub meta: Option<String>,
 }
 
 impl MethodReturn {
-    pub fn from_type(type_: &str) -> Self {
+    pub fn from_type_no_meta(type_: &str) -> Self {
         Self {
             type_: type_.to_owned(),
+            meta: None,
         }
     }
 }

--- a/godot-codegen/src/api_parser.rs
+++ b/godot-codegen/src/api_parser.rs
@@ -218,6 +218,7 @@ pub struct MethodArg {
     #[nserde(rename = "type")]
     pub type_: String,
     // pub meta: Option<String>,
+    pub default_value: Option<String>,
 }
 
 // Example: get_available_point_id -> {type: "int", meta: "int64"}

--- a/godot-codegen/src/central_generator.rs
+++ b/godot-codegen/src/central_generator.rs
@@ -522,7 +522,7 @@ fn make_enumerator(
 ) -> (Ident, TokenStream, Literal) {
     let enumerator_name = &type_names.json_builtin_name;
     let pascal_name = to_pascal_case(enumerator_name);
-    let rust_ty = to_rust_type(enumerator_name, ctx);
+    let rust_ty = to_rust_type(enumerator_name, None, ctx);
     let ord = Literal::i32_unsuffixed(value);
 
     (ident(&pascal_name), rust_ty.to_token_stream(), ord)

--- a/godot-codegen/src/context.rs
+++ b/godot-codegen/src/context.rs
@@ -5,7 +5,7 @@
  */
 
 use crate::api_parser::Class;
-use crate::{util, ExtensionApi, RustTy, TyName};
+use crate::{util, ExtensionApi, GodotTy, RustTy, TyName};
 use proc_macro2::Ident;
 use quote::format_ident;
 use std::collections::{HashMap, HashSet};
@@ -17,7 +17,7 @@ pub(crate) struct Context<'a> {
     native_structures_types: HashSet<&'a str>,
     singletons: HashSet<&'a str>,
     inheritance_tree: InheritanceTree,
-    cached_rust_types: HashMap<String, RustTy>,
+    cached_rust_types: HashMap<GodotTy, RustTy>,
     notifications_by_class: HashMap<TyName, Vec<(Ident, i32)>>,
     notification_enum_names_by_class: HashMap<TyName, Ident>,
 }
@@ -151,7 +151,7 @@ impl<'a> Context<'a> {
         &self.inheritance_tree
     }
 
-    pub fn find_rust_type(&'a self, ty: &str) -> Option<&'a RustTy> {
+    pub fn find_rust_type(&'a self, ty: &GodotTy) -> Option<&'a RustTy> {
         self.cached_rust_types.get(ty)
     }
 
@@ -166,8 +166,8 @@ impl<'a> Context<'a> {
             .clone()
     }
 
-    pub fn insert_rust_type(&mut self, ty: &str, resolved: RustTy) {
-        let prev = self.cached_rust_types.insert(ty.to_string(), resolved);
+    pub fn insert_rust_type(&mut self, godot_ty: GodotTy, resolved: RustTy) {
+        let prev = self.cached_rust_types.insert(godot_ty, resolved);
         assert!(prev.is_none(), "no overwrites of RustTy");
     }
 }

--- a/godot-codegen/src/lib.rs
+++ b/godot-codegen/src/lib.rs
@@ -134,6 +134,25 @@ fn rustfmt_if_needed(_out_files: Vec<PathBuf>) {}
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Shared utility types
 
+// Same as above, without lifetimes
+
+#[derive(Clone, Eq, PartialEq, Hash, Debug)]
+struct GodotTy {
+    ty: String,
+    meta: Option<String>,
+}
+
+// impl GodotTy {
+//     fn new<'a>(ty: &'a String, meta: &'a Option<String>) -> Self {
+//         Self {
+//             ty: ty.clone(),
+//             meta: meta.clone(),
+//         }
+//     }
+// }
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+
 #[derive(Clone, Debug)]
 enum RustTy {
     /// `bool`, `Vector3i`

--- a/godot-codegen/src/lib.rs
+++ b/godot-codegen/src/lib.rs
@@ -212,7 +212,6 @@ impl ToTokens for RustTy {
             RustTy::EngineArray { tokens: path, .. } => path.to_tokens(tokens),
             RustTy::EngineEnum { tokens: path, .. } => path.to_tokens(tokens),
             RustTy::EngineClass { tokens: path, .. } => path.to_tokens(tokens),
-            //RustTy::Other(path) => path.to_tokens(tokens),
         }
     }
 }

--- a/godot-codegen/src/lib.rs
+++ b/godot-codegen/src/lib.rs
@@ -134,7 +134,7 @@ fn rustfmt_if_needed(_out_files: Vec<PathBuf>) {}
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Shared utility types
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 enum RustTy {
     /// `bool`, `Vector3i`
     BuiltinIdent(Ident),

--- a/godot-codegen/src/special_cases.rs
+++ b/godot-codegen/src/special_cases.rs
@@ -15,6 +15,8 @@
 
 // NOTE: the methods are generally implemented on Godot types (e.g. AABB, not Aabb)
 
+#![allow(clippy::match_like_matches_macro)] // if there is only one rule
+
 use crate::TyName;
 
 #[rustfmt::skip]
@@ -54,6 +56,18 @@ pub(crate) fn is_private(class_name: &TyName, godot_method_name: &str) -> bool {
         | ("RefCounted", "init_ref")
         | ("RefCounted", "reference")
         | ("RefCounted", "unreference")
+        | ("Object", "notification")
+
+        => true, _ => false
+    }
+}
+
+#[rustfmt::skip]
+pub(crate) fn is_excluded_from_default_params(class_name: Option<&TyName>, godot_method_name: &str) -> bool {
+    // None if global/utilities function
+    let class_name = class_name.map_or("", |ty| ty.godot_ty.as_str());
+
+    match (class_name, godot_method_name) {
         | ("Object", "notification")
 
         => true, _ => false

--- a/godot-codegen/src/utilities_generator.rs
+++ b/godot-codegen/src/utilities_generator.rs
@@ -17,13 +17,11 @@ pub(crate) fn generate_utilities_file(
     gen_path: &Path,
     out_files: &mut Vec<PathBuf>,
 ) {
-    let mut utility_fn_defs = vec![];
-    for utility_fn in &api.utility_functions {
-        // note: category unused -> could be their own mod
-
-        let def = make_utility_function_definition(utility_fn, ctx);
-        utility_fn_defs.push(def);
-    }
+    // note: category unused -> could be their own mod
+    let utility_fn_defs = api
+        .utility_functions
+        .iter()
+        .map(|utility_fn| make_utility_function_definition(utility_fn, ctx));
 
     let tokens = quote! {
         //! Global utility functions.

--- a/godot-core/src/builtin/callable.rs
+++ b/godot-core/src/builtin/callable.rs
@@ -53,6 +53,18 @@ impl Callable {
         }
     }
 
+    /// Creates an invalid/empty object that is not able to be called.
+    ///
+    /// _Godot equivalent: `Callable()`_
+    pub fn invalid() -> Self {
+        unsafe {
+            Self::from_sys_init(|self_ptr| {
+                let ctor = ::godot_ffi::builtin_fn!(callable_construct_default);
+                ctor(self_ptr, std::ptr::null_mut())
+            })
+        }
+    }
+
     /// Calls the method represented by this callable.
     ///
     /// Arguments passed should match the method's signature.
@@ -162,7 +174,9 @@ impl Callable {
 
 impl_builtin_traits! {
     for Callable {
-        Default => callable_construct_default;
+        // Currently no Default::default() to encourage explicit valid initialization.
+        //Default => callable_construct_default;
+
         // Equality for custom callables depend on the equality implementation of that custom callable. This
         // is from what i can tell currently implemented as total equality in all cases, but i dont believe
         // there are any guarantees that all implementations of equality for custom callables will be.
@@ -182,7 +196,7 @@ unsafe impl GodotFfi for Callable {
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Opaque; .. }
 
     unsafe fn from_sys_init_default(init_fn: impl FnOnce(sys::GDExtensionTypePtr)) -> Self {
-        let mut result = Self::default();
+        let mut result = Self::invalid();
         init_fn(result.sys_mut());
         result
     }

--- a/godot-core/src/builtin/transform2d.rs
+++ b/godot-core/src/builtin/transform2d.rs
@@ -112,6 +112,21 @@ impl Transform2D {
         )
     }
 
+    /// Unstable, used to simplify codegen. Too many parameters for public API and easy to have off-by-one, `from_cols()` is preferred.
+    #[doc(hidden)]
+    #[rustfmt::skip]
+    #[allow(clippy::too_many_arguments)]
+    pub const fn __internal_codegen(
+       ax: real, ay: real,
+       bx: real, by: real,
+       ox: real, oy: real,
+    ) -> Self {
+        Self::from_cols(
+            Vector2::new(ax, ay),
+            Vector2::new(bx, by),
+            Vector2::new(ox, oy),
+        )
+    }
     /// Create a reference to the first two columns of the transform
     /// interpreted as a [`Basis2D`].
     fn basis<'a>(&'a self) -> &'a Basis2D {

--- a/godot-core/src/builtin/transform3d.rs
+++ b/godot-core/src/builtin/transform3d.rs
@@ -92,6 +92,24 @@ impl Transform3D {
         }
     }
 
+    /// Unstable, used to simplify codegen. Too many parameters for public API and easy to have off-by-one, `from_cols()` is preferred.
+    #[doc(hidden)]
+    #[rustfmt::skip]
+    #[allow(clippy::too_many_arguments)]
+    pub const fn __internal_codegen(
+        ax: real, ay: real, az: real,
+        bx: real, by: real, bz: real,
+        cx: real, cy: real, cz: real,
+        ox: real, oy: real, oz: real
+    ) -> Self {
+        Self::from_cols(
+            Vector3::new(ax, ay, az),
+            Vector3::new(bx, by, bz),
+            Vector3::new(cx, cy, cz),
+            Vector3::new(ox, oy, oz),
+        )
+    }
+
     /// Returns the inverse of the transform, under the assumption that the
     /// transformation is composed of rotation, scaling and translation.
     ///

--- a/godot-core/src/builtin/vectors/vector_axis.rs
+++ b/godot-core/src/builtin/vectors/vector_axis.rs
@@ -5,6 +5,7 @@
  */
 
 use crate::builtin::{real, Vector2, Vector2i, Vector3, Vector3i, Vector4, Vector4i};
+use crate::obj::EngineEnum;
 use godot_ffi as sys;
 use sys::{ffi_methods, GodotFfi};
 
@@ -62,6 +63,8 @@ macro_rules! swizzle {
     }};
 }
 
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+
 /// Trait that allows conversion from tuples to vectors.
 ///
 /// Is implemented instead of `From`/`Into` because it provides type inference.
@@ -81,11 +84,27 @@ pub enum Vector2Axis {
     Y,
 }
 
+impl EngineEnum for Vector2Axis {
+    fn try_from_ord(ord: i32) -> Option<Self> {
+        match ord {
+            0 => Some(Self::X),
+            1 => Some(Self::Y),
+            _ => None,
+        }
+    }
+
+    fn ord(self) -> i32 {
+        self as i32
+    }
+}
+
 // SAFETY:
 // This type is represented as `Self` in Godot, so `*mut Self` is sound.
 unsafe impl GodotFfi for Vector2Axis {
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Self; .. }
 }
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
 
 /// Enumerates the axes in a [`Vector3`].
 // TODO auto-generate this, alongside all the other builtin type's enums
@@ -102,11 +121,28 @@ pub enum Vector3Axis {
     Z,
 }
 
+impl EngineEnum for Vector3Axis {
+    fn try_from_ord(ord: i32) -> Option<Self> {
+        match ord {
+            0 => Some(Self::X),
+            1 => Some(Self::Y),
+            2 => Some(Self::Z),
+            _ => None,
+        }
+    }
+
+    fn ord(self) -> i32 {
+        self as i32
+    }
+}
+
 // SAFETY:
 // This type is represented as `Self` in Godot, so `*mut Self` is sound.
 unsafe impl GodotFfi for Vector3Axis {
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Self; .. }
 }
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
 
 /// Enumerates the axes in a [`Vector4`].
 #[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
@@ -125,11 +161,29 @@ pub enum Vector4Axis {
     W,
 }
 
+impl EngineEnum for Vector4Axis {
+    fn try_from_ord(ord: i32) -> Option<Self> {
+        match ord {
+            0 => Some(Self::X),
+            1 => Some(Self::Y),
+            2 => Some(Self::Z),
+            3 => Some(Self::W),
+            _ => None,
+        }
+    }
+
+    fn ord(self) -> i32 {
+        self as i32
+    }
+}
+
 // SAFETY:
 // This type is represented as `Self` in Godot, so `*mut Self` is sound.
 unsafe impl GodotFfi for Vector4Axis {
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Self; .. }
 }
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
 
 impl_vector_index!(Vector2, real, (x, y), Vector2Axis, (X, Y));
 impl_vector_index!(Vector2i, i32, (x, y), Vector2Axis, (X, Y));

--- a/godot-core/src/engine.rs
+++ b/godot-core/src/engine.rs
@@ -10,7 +10,6 @@
 use crate::builtin::{GodotString, NodePath};
 use crate::obj::dom::EngineDomain;
 use crate::obj::{Gd, GodotClass, Inherits};
-use resource_loader::CacheMode;
 
 pub use crate::gen::central::global;
 pub use crate::gen::classes::*;
@@ -26,8 +25,6 @@ pub use crate::gen::utilities;
 pub mod native {
     pub use crate::gen::native::*;
 }
-
-use self::packed_scene::GenEditState;
 
 /// Extension trait for convenience functions on `PackedScene`
 pub trait PackedSceneExt {
@@ -56,8 +53,7 @@ impl PackedSceneExt for PackedScene {
     where
         T: Inherits<Node>,
     {
-        self.instantiate(GenEditState::GEN_EDIT_STATE_DISABLED)
-            .and_then(|gd| gd.try_cast::<T>())
+        self.instantiate().and_then(|gd| gd.try_cast::<T>())
     }
 }
 
@@ -224,10 +220,8 @@ where
     let type_hint = T::CLASS_NAME;
 
     ResourceLoader::singleton()
-        .load(
-            path.clone(), /* TODO unclone */
-            type_hint.into(),
-            CacheMode::CACHE_MODE_REUSE,
-        )
+        .load_ex(path.clone())
+        .type_hint(type_hint.into())
+        .done() // TODO unclone
         .and_then(|res| res.try_cast::<T>())
 }

--- a/godot-core/src/lib.rs
+++ b/godot-core/src/lib.rs
@@ -35,9 +35,11 @@ pub mod engine;
 
 // Output of generated code. Mimics the file structure, symbols are re-exported.
 #[rustfmt::skip]
-#[allow(unused_imports, dead_code, non_upper_case_globals, non_snake_case, clippy::too_many_arguments, clippy::let_and_return, clippy::new_ret_no_self)]
+#[allow(unused_imports, dead_code, non_upper_case_globals, non_snake_case)]
+#[allow(clippy::too_many_arguments, clippy::let_and_return, clippy::new_ret_no_self)]
+#[allow(clippy::wrong_self_convention)] // to_string() is const
 #[allow(clippy::upper_case_acronyms)] // TODO remove this line once we transform names
-#[allow(clippy::wrong_self_convention)] // TODO remove once to_string is const
+#[allow(unreachable_code, clippy::unimplemented)] // TODO remove once #153 is implemented
 mod gen;
 
 #[doc(hidden)]

--- a/itest/rust/build.rs
+++ b/itest/rust/build.rs
@@ -62,7 +62,7 @@ fn collect_inputs() -> Vec<Input> {
     push!(inputs; Vector4, Vector4, Vector4(-18.5, 24.75, -1.25, 777.875), Vector4::new(-18.5, 24.75, -1.25, 777.875));
     push!(inputs; Vector2i, Vector2i, Vector2i(-2147483648, 2147483647), Vector2i::new(-2147483648, 2147483647));
     push!(inputs; Vector3i, Vector3i, Vector3i(-1, -2147483648, 2147483647), Vector3i::new(-1, -2147483648, 2147483647));
-    push!(inputs; Callable, Callable, Callable(), Callable::default());
+    push!(inputs; Callable, Callable, Callable(), Callable::invalid());
 
     // Data structures
     // TODO enable below, when GDScript has typed array literals, or find a hack with eval/lambdas

--- a/itest/rust/src/array_test.rs
+++ b/itest/rust/src/array_test.rs
@@ -367,14 +367,11 @@ fn untyped_array_pass_to_godot_func() {
 
 #[itest]
 fn untyped_array_return_from_godot_func() {
-    use godot::engine::node::InternalMode;
-    use godot::engine::Node;
-
     // There aren't many API functions that return an untyped array.
     let mut node = Node::new_alloc();
     let mut child = Node::new_alloc();
     child.set_name("child_node".into());
-    node.add_child(child.share(), false, InternalMode::INTERNAL_MODE_DISABLED);
+    node.add_child(child.share());
     node.queue_free(); // Do not leak even if the test fails.
     let result = node.get_node_and_resource("child_node".into());
 
@@ -408,15 +405,12 @@ fn typed_array_pass_to_godot_func() {
 
 #[itest]
 fn typed_array_return_from_godot_func() {
-    use godot::engine::node::InternalMode;
-    use godot::engine::Node;
-
     let mut node = Node::new_alloc();
     let mut child = Node::new_alloc();
     child.set_name("child_node".into());
-    node.add_child(child.share(), false, InternalMode::INTERNAL_MODE_DISABLED);
+    node.add_child(child.share());
     node.queue_free(); // Do not leak even if the test fails.
-    let children = node.get_children(false);
+    let children = node.get_children();
 
     assert_eq!(children, array![child]);
 }

--- a/itest/rust/src/callable_test.rs
+++ b/itest/rust/src/callable_test.rs
@@ -50,10 +50,10 @@ fn callable_validity() {
     assert!(obj.callable("doesn't_exist").object().is_some());
 
     // null object
-    assert!(!Callable::default().is_valid());
-    assert!(Callable::default().is_null());
-    assert!(!Callable::default().is_custom());
-    assert!(Callable::default().object().is_none());
+    assert!(!Callable::invalid().is_valid());
+    assert!(Callable::invalid().is_null());
+    assert!(!Callable::invalid().is_custom());
+    assert!(Callable::invalid().object().is_none());
 }
 
 #[itest]
@@ -72,9 +72,9 @@ fn callable_object_method() {
     assert_eq!(callable.object_id(), Some(obj.instance_id()));
     assert_eq!(callable.method_name(), Some("foo".into()));
 
-    assert_eq!(Callable::default().object(), None);
-    assert_eq!(Callable::default().object_id(), None);
-    assert_eq!(Callable::default().method_name(), None);
+    assert_eq!(Callable::invalid().object(), None);
+    assert_eq!(Callable::invalid().object_id(), None);
+    assert_eq!(Callable::invalid().method_name(), None);
 }
 
 #[itest]
@@ -91,7 +91,7 @@ fn callable_call() {
     // errors in godot but does not crash
     assert_eq!(callable.callv(varray!["string"]), Variant::nil());
 
-    assert_eq!(Callable::default().callv(varray![1, 2, 3]), Variant::nil());
+    assert_eq!(Callable::invalid().callv(varray![1, 2, 3]), Variant::nil());
 }
 
 #[itest]

--- a/itest/rust/src/node_test.rs
+++ b/itest/rust/src/node_test.rs
@@ -6,7 +6,7 @@
 
 use crate::{itest, TestContext};
 use godot::builtin::{NodePath, Variant};
-use godot::engine::{global, node, Node, Node3D, NodeExt, PackedScene, SceneTree};
+use godot::engine::{global, Node, Node3D, NodeExt, PackedScene, SceneTree};
 use godot::obj::Share;
 
 use std::str::FromStr;
@@ -19,19 +19,11 @@ fn node_get_node() {
 
     let mut parent = Node3D::new_alloc();
     parent.set_name("parent".into());
-    parent.add_child(
-        child.share().upcast(),
-        false,
-        node::InternalMode::INTERNAL_MODE_DISABLED,
-    );
+    parent.add_child(child.share().upcast());
 
     let mut grandparent = Node::new_alloc();
     grandparent.set_name("grandparent".into());
-    grandparent.add_child(
-        parent.share().upcast(),
-        false,
-        node::InternalMode::INTERNAL_MODE_DISABLED,
-    );
+    grandparent.add_child(parent.share().upcast());
 
     // Directly on Gd<T>
     let found = grandparent.get_node_as::<Node3D>(NodePath::from("parent/child"));
@@ -72,11 +64,7 @@ fn node_scene_tree() {
 
     let mut parent = Node::new_alloc();
     parent.set_name("parent".into());
-    parent.add_child(
-        child.share(),
-        false,
-        node::InternalMode::INTERNAL_MODE_DISABLED,
-    );
+    parent.add_child(child.share());
 
     let mut scene = PackedScene::new();
     let err = scene.pack(parent.share());
@@ -99,6 +87,6 @@ fn node_call_group(ctx: &TestContext) {
     let mut node = ctx.scene_tree.share();
     let mut tree = node.get_tree().unwrap();
 
-    node.add_to_group("group".into(), true);
+    node.add_to_group("group".into());
     tree.call_group("group".into(), "set_name".into(), &[Variant::from("name")]);
 }

--- a/itest/rust/src/object_test.rs
+++ b/itest/rust/src/object_test.rs
@@ -12,7 +12,6 @@ use godot::bind::{godot_api, GodotClass};
 use godot::builtin::{
     FromVariant, GodotString, StringName, ToVariant, Variant, VariantConversionError, Vector3,
 };
-use godot::engine::node::InternalMode;
 use godot::engine::{
     file_access, Area2D, Camera3D, FileAccess, Node, Node3D, Object, RefCounted, RefCountedVirtual,
 };
@@ -658,9 +657,9 @@ fn object_get_scene_tree(ctx: &TestContext) {
     let node = Node3D::new_alloc();
 
     let mut tree = ctx.scene_tree.share();
-    tree.add_child(node.upcast(), false, InternalMode::INTERNAL_MODE_DISABLED);
+    tree.add_child(node.upcast());
 
-    let count = tree.get_child_count(false);
+    let count = tree.get_child_count();
     assert_eq!(count, 1);
 } // implicitly tested: node does not leak
 
@@ -838,7 +837,7 @@ fn double_use_reference() {
     emitter
         .share()
         .upcast::<Object>()
-        .connect("do_use".into(), double_use.callable("use_1"), 0);
+        .connect("do_use".into(), double_use.callable("use_1"));
 
     let guard = double_use.bind();
 

--- a/itest/rust/src/signal_test.rs
+++ b/itest/rust/src/signal_test.rs
@@ -81,11 +81,9 @@ fn signals() {
         let signal_name = format!("signal_{i}_arg");
         let receiver_name = format!("receive_{i}_arg");
 
-        emitter.bind_mut().connect(
-            signal_name.clone().into(),
-            receiver.callable(receiver_name),
-            0,
-        );
+        emitter
+            .bind_mut()
+            .connect(signal_name.clone().into(), receiver.callable(receiver_name));
 
         emitter.bind_mut().emit_signal(signal_name.into(), arg);
 


### PR DESCRIPTION
# Default parameters in Engine API

Example [`RenderingServer::environment_set_ambient_light`](https://docs.godotengine.org/en/stable/classes/class_renderingserver.html#class-renderingserver-method-environment-set-ambient-light) with signature:
```gdscript
void environment_set_ambient_light(
    RID env,
    Color color,
    EnvironmentAmbientSource ambient=0,
    float energy=1.0,
    float sky_contibution=0.0, 
    EnvironmentReflectionSource reflection_source=0
)
```

Previous gdext syntax:
```rs
server.environment_set_ambient_light(rid, color, 0, 1.0, 0.0, 0)
```

Now:
```rs
server.environment_set_ambient_light(rid, color)
```

With default arguments:
```rs
// select what you like, skip out-of-order:
server.environment_set_ambient_light_ex(rid, color).energy(2.0).done()

// provide all:
server.environment_set_ambient_light_ex(rid, color)
    .ambient(0)
    .energy(1.0)
    .sky_contribution(0.0)
    .reflection_source(0)
    .done()
```

See also [this commit](https://github.com/godot-rust/gdext/commit/01ce0bb2bea2d830ccdfad651c54ecb78cecd723) for the real-world impact this change has, within gdext alone.

---

## Mechanics

Methods accepting default parameters come in two flavors: `method` and `method_ex`.


The `_ex` overload returns an "extender", a builder object providing a fluent API to accept values overriding the defaults. The arguments can be provided in any order, and arbitrary ones can be skipped. **This is different from C++ and GDScript, where you have to provide all default arguments in their positional order.**

This effectively implements an API similar to the one discussed in https://github.com/godot-rust/gdnative/issues/814#issuecomment-1331814701, however in a non-generic way and without enforcing ordering. Theoretically it's possible to specify the same argument twice, but that's a risk I'm gladly taking if I can avoid type-state with its compile-time and complexity implications.

---

## Other changes

This pull request comes with a few collateral features:

* **Support for _meta_ fields in the JSON file.**
  Parameter or return types can have an extra "meta" type which constrains the domain for non-GDScript languages. For example, a parameter `int` can come with meta field `uint16`. These are translated to Rust, so that the correct type is passed (here `u16`).
  
* **GDScript expression parser.**
  Implementing default parameters means we have to understand syntax like `Vector2(1, 2)` which is provided as the `default_value` field in GDScript. This one is then translated to an equivalent Rust representation when populating the extender struct.
  This turned out to be much more complex than anticipated, due to things like `0` meaning "enum" rather than "int", or beautiful expressions like `Array[RDPipelineSpecializationConstant]([])`.
  
* **Refactor `class_generator.rs`.**
  Quite a lot of functionality in the code generator was touched. Already in #315, I added a domain representation for function arguments and parameters, distinct from the JSON models. The function to generate method definitions now accepts consolidated structs instead of a dozen parameters. I cleaned up a few other things on-the-fly. Possibly I'll do a few follow-up cleanups, but they can be done independently of this functionality.
  
* **Implement `EngineEnum` for `Vector*Axis` enums.**
  This allows ordinal conversion from/to those types, just like other engine enums.