### PR TITLE
Update to Godot 4.1

### DIFF
--- a/.github/composite/godot-install/action.yml
+++ b/.github/composite/godot-install/action.yml
@@ -45,6 +45,8 @@ runs:
       run: |
         if [[ $ARTIFACT_NAME == *"stable"* ]]; then
           url="https://nightly.link/Bromeon/godot4-nightly/workflows/compile-godot-stable/master/$ARTIFACT_NAME.zip"
+        elif [[ $ARTIFACT_NAME == *"4.0.3"* ]]; then
+          url="https://nightly.link/Bromeon/godot4-nightly/workflows/compile-godot-4.0.3/master/$ARTIFACT_NAME.zip"
         else
           url="https://nightly.link/Bromeon/godot4-nightly/workflows/compile-godot-nightly/master/$ARTIFACT_NAME.zip"
         fi

--- a/.github/composite/godot-itest/action.yml
+++ b/.github/composite/godot-itest/action.yml
@@ -90,16 +90,19 @@ runs:
       run: |
         echo "Patch prebuilt version to $VERSION..."
         
-        # For newer versions, update the compatibility_minimum in .gdextension files to 4.1
-        # Once a 4.1.0 is released, we can invert this and set compatibility_minimum to 4.0 for older versions.
-        if [[ "$VERSION" == "4.1" ]]; then
-          echo "Update compatibility_minimum in .gdextension files..."
+        # Reduce version to "major.minor" format
+        apiVersion=$(echo $VERSION | sed -E 's/([0-9]+\.[0-9]+)\.[0-9]+/\1/')
+        
+        # For newer versions, update the compatibility_minimum in .gdextension files to the respective version.
+        # Nothing needs to be done for 4.0.x, as compatibility_minimum didn't exist back then.
+        if [[ "$apiVersion" == "4.2" ]]; then
+          echo "Update compatibility_minimum in .gdextension files to '$apiVersion'..."
           dirs=("itest" "examples")
           for dir in "${dirs[@]}"; do
-              find "$dir" -type f -name "*.gdextension" -exec sed -i'.bak' 's/compatibility_minimum = 4\.0/compatibility_minimum = 4.1/' {} +
+              find "$dir" -type f -name "*.gdextension" -exec sed -i'.bak' 's/compatibility_minimum = 4\.1/compatibility_minimum = $apiVersion/' {} +
           done
         
-        # Versions 4.0.x
+        # Apply Cargo.toml patch for godot4-prebuilt crate
         else
           # Patch only needed if version is not already set
           if grep -E 'godot4-prebuilt = { .+ branch = "$VERSION" }' godot-bindings/Cargo.toml; then

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -139,20 +139,18 @@ jobs:
             artifact-name: macos-nightly
             godot-binary: godot.macos.editor.dev.x86_64
             rust-extra-args: --features godot/custom-godot
-            godot-prebuilt-patch: '4.1'
 
           - name: macos-double
             os: macos-12
             artifact-name: macos-double-nightly
             godot-binary: godot.macos.editor.dev.double.x86_64
             rust-extra-args: --features godot/custom-godot,godot/double-precision
-            godot-prebuilt-patch: '4.1'
 
-          - name: macos-4.0.3
+          - name: macos-4.1
             os: macos-12
             artifact-name: macos-stable
             godot-binary: godot.macos.editor.dev.x86_64
-            godot-prebuilt-patch: '4.0.3'
+            #godot-prebuilt-patch: '4.1'
 
           # Windows
 
@@ -161,20 +159,18 @@ jobs:
             artifact-name: windows-nightly
             godot-binary: godot.windows.editor.dev.x86_64.exe
             rust-extra-args: --features godot/custom-godot
-            godot-prebuilt-patch: '4.1'
 
           - name: windows-double
             os: windows-latest
             artifact-name: windows-double-nightly
             godot-binary: godot.windows.editor.dev.double.x86_64.exe
             rust-extra-args: --features godot/custom-godot,godot/double-precision
-            godot-prebuilt-patch: '4.1'
 
-          - name: windows-4.0.3
+          - name: windows-4.1
             os: windows-latest
             artifact-name: windows-stable
             godot-binary: godot.windows.editor.dev.x86_64.exe
-            godot-prebuilt-patch: '4.0.3'
+            #godot-prebuilt-patch: '4.1'
 
           # Linux
 
@@ -185,21 +181,24 @@ jobs:
             artifact-name: linux-nightly
             godot-binary: godot.linuxbsd.editor.dev.x86_64
             rust-extra-args: --features godot/custom-godot,godot/custom-godot
-            godot-prebuilt-patch: '4.1'
 
           - name: linux-double
             os: ubuntu-20.04
             artifact-name: linux-double-nightly
             godot-binary: godot.linuxbsd.editor.dev.double.x86_64
             rust-extra-args: --features godot/custom-godot,godot/double-precision
-            godot-prebuilt-patch: '4.1'
 
           - name: linux-features
             os: ubuntu-20.04
             artifact-name: linux-nightly
             godot-binary: godot.linuxbsd.editor.dev.x86_64
             rust-extra-args: --features godot/custom-godot,godot/threads,godot/serde
-            godot-prebuilt-patch: '4.1'
+
+          - name: linux-4.1
+            os: ubuntu-20.04
+            artifact-name: linux-stable
+            godot-binary: godot.linuxbsd.editor.dev.x86_64
+            #godot-prebuilt-patch: '4.1'
 
           # Special Godot binaries compiled with AddressSanitizer/LeakSanitizer to detect UB/leaks.
           # See also https://rustc-dev-guide.rust-lang.org/sanitizers.html.
@@ -218,38 +217,39 @@ jobs:
             rust-extra-args: --features godot/custom-godot
             # Sanitizers can't build proc-macros and build scripts; with --target, cargo ignores RUSTFLAGS for those two.
             rust-target: x86_64-unknown-linux-gnu
-            godot-prebuilt-patch: '4.1'
 
           # Linux under Godot 4.0.x
 
           - name: linux-4.0.3
             os: ubuntu-20.04
-            artifact-name: linux-stable
+            artifact-name: linux-4.0.3
             godot-binary: godot.linuxbsd.editor.dev.x86_64
+            godot-prebuilt-patch: '4.0.3'
 
           - name: linux-4.0.2
             os: ubuntu-20.04
-            artifact-name: linux-stable
+            artifact-name: linux-4.0.3
             godot-binary: godot.linuxbsd.editor.dev.x86_64
             godot-prebuilt-patch: '4.0.2'
 
           - name: linux-4.0.1
             os: ubuntu-20.04
-            artifact-name: linux-stable
+            artifact-name: linux-4.0.3
             godot-binary: godot.linuxbsd.editor.dev.x86_64
             godot-prebuilt-patch: '4.0.1'
 
           - name: linux-4.0
             os: ubuntu-20.04
-            artifact-name: linux-stable
+            artifact-name: linux-4.0.3
             godot-binary: godot.linuxbsd.editor.dev.x86_64
             godot-prebuilt-patch: '4.0'
 
           - name: linux-memcheck-4.0.3
             os: ubuntu-20.04
-            artifact-name: linux-memcheck-clang-stable
+            artifact-name: linux-memcheck-clang-4.0.3
             godot-binary: godot.linuxbsd.editor.dev.x86_64.llvm.san
             godot-args: -- --disallow-focus
+            godot-prebuilt-patch: '4.0.3'
             rust-toolchain: nightly
             rust-env-rustflags: -Zrandomize-layout -Zsanitizer=address
             # Sanitizers can't build proc-macros and build scripts; with --target, cargo ignores RUSTFLAGS for those two.

--- a/.github/workflows/minimal-ci.yml
+++ b/.github/workflows/minimal-ci.yml
@@ -89,7 +89,7 @@ jobs:
           artifact-name: godot-linux-nightly
           godot-binary: godot.linuxbsd.editor.dev.x86_64
           rust-extra-args: --features godot/custom-godot,godot/custom-godot
-          godot-prebuilt-patch: '4.1'
+
 
   license-guard:
     runs-on: ubuntu-20.04

--- a/examples/dodge-the-creeps/godot/DodgeTheCreeps.gdextension
+++ b/examples/dodge-the-creeps/godot/DodgeTheCreeps.gdextension
@@ -1,6 +1,6 @@
 [configuration]
 entry_symbol = "gdext_rust_init"
-compatibility_minimum = 4.0
+compatibility_minimum = 4.1
 
 [libraries]
 linux.debug.x86_64 = "res://../../../target/debug/libdodge_the_creeps.so"

--- a/godot-bindings/Cargo.toml
+++ b/godot-bindings/Cargo.toml
@@ -18,7 +18,7 @@ custom-godot = ["dep:bindgen", "dep:regex", "dep:which"]
 custom-godot-extheader = []
 
 [dependencies]
-godot4-prebuilt = { optional = true, git = "https://github.com/godot-rust/godot4-prebuilt", branch = "4.0.3" }
+godot4-prebuilt = { optional = true, git = "https://github.com/godot-rust/godot4-prebuilt", branch = "4.1" }
 
 # Version >= 1.5.5 for security: https://blog.rust-lang.org/2022/03/08/cve-2022-24713.html
 # 'unicode-gencat' needed for \d, see: https://docs.rs/regex/1.5.5/regex/#unicode-features

--- a/itest/godot/itest.gdextension
+++ b/itest/godot/itest.gdextension
@@ -1,6 +1,6 @@
 [configuration]
 entry_symbol = "itest_init"
-compatibility_minimum = 4.0
+compatibility_minimum = 4.1
 
 [libraries]
 linux.debug.x86_64 = "res://../../target/debug/libitest.so"


### PR DESCRIPTION
Changes the default prebuilt version from 4.0.3 to 4.1.

Updates CI jobs to use a combination of these versions:
- nightly (the majority)
- 4.1 (one per platform)
- 4.0.x (Linux only)