### PR TITLE
Add `instance_id_or_none_unchecked` to `Gd`

### DIFF
--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -252,6 +252,14 @@ impl<T: GodotClass> Gd<T> {
         }
     }
 
+    /// ⚠️ Returns the instance ID of this object, or `None` if no instance ID is cached.
+    ///
+    /// This function does not check that the returned instance ID points to a valid instance!
+    /// Unless performance is a problem, use [`instance_id_or_none`].
+    pub fn instance_id_or_none_unchecked(&self) -> Option<InstanceId> {
+        self.cached_instance_id.get()
+    }
+
     /// ⚠️ Returns the instance ID of this object (panics when dead).
     ///
     /// # Panics


### PR DESCRIPTION
`Gd::instance_id` and `Gd::instance_id_or_none` both end up calling `is_instance_id_valid`, which itself eventually calls `ObjectDB::get_instance`, which actually locks the `ObjectDB` spinlock. For most users, this is fine, but if you need to query _a lot_ of instance IDs and you're sure that the cached instance IDs are valid, this becomes a performance problem (for example, doing instance ID voodoo during parallel scene creation).

This PR adds an `instance_id_or_none_unchecked` method to `Gd` that skips the validity check and just returns the `Gd`'s cached ID (if present).