### PR TITLE
Migrate from bors to GitHub merge queues

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -1,3 +1,3 @@
 block_labels = ["status: duplicate", "status: wontfix"]
 delete_merged_branches = true
-status = ["full-ci"]
+status = ["ci-status"]

--- a/.github/composite/rust/action.yml
+++ b/.github/composite/rust/action.yml
@@ -54,11 +54,21 @@ runs:
         # An additional cache key that is added alongside the automatic `job`-based
         # cache key and can be used to further differentiate jobs.
         # default: empty
-        key: ${{ inputs.cache-key }}
+        #key: ${{ inputs.cache-key }}
 
         # Determines if the cache should be saved even when the workflow has failed.
         # default: "false"
         cache-on-failure: true
+
+        # The prefix cache key, this can be changed to start a new cache manually.
+        # default: "v0-rust"
+        #prefix-key: "v1-rust"
+
+        # Determines which crates are cached.
+        # If `true` all crates will be cached, otherwise only dependent crates will be cached.
+        # Useful if additional crates are used for CI tooling.
+        # default: "false"
+        #cache-all-crates: true
 
     - name: "Install LLVM"
       if: inputs.with-llvm == 'true'

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -2,12 +2,12 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-# Full CI workflow
+name: Full CI
+#
 # Runs before merging. Rebases on master to make sure CI passes for latest integration, not only for the PR at the time of creation.
 
-name: Full CI
-
 on:
+  merge_group:
   push:
     branches:
       - staging
@@ -114,7 +114,7 @@ jobs:
       - name: "Test"
         run: cargo test $GDEXT_FEATURES ${{ matrix.rust-extra-args }}
 
-
+  # For complex matrix workflow, see https://stackoverflow.com/a/65434401
   godot-itest:
     name: godot-itest (${{ matrix.name }})
     runs-on: ${{ matrix.os }}
@@ -180,7 +180,7 @@ jobs:
             os: ubuntu-20.04
             artifact-name: linux-nightly
             godot-binary: godot.linuxbsd.editor.dev.x86_64
-            rust-extra-args: --features godot/custom-godot,godot/custom-godot
+            rust-extra-args: --features godot/custom-godot
 
           - name: linux-double
             os: ubuntu-20.04
@@ -194,31 +194,13 @@ jobs:
             godot-binary: godot.linuxbsd.editor.dev.x86_64
             rust-extra-args: --features godot/custom-godot,godot/threads,godot/serde
 
+          # Linux compat
+
           - name: linux-4.1
             os: ubuntu-20.04
             artifact-name: linux-stable
             godot-binary: godot.linuxbsd.editor.dev.x86_64
             #godot-prebuilt-patch: '4.1'
-
-          # Special Godot binaries compiled with AddressSanitizer/LeakSanitizer to detect UB/leaks.
-          # See also https://rustc-dev-guide.rust-lang.org/sanitizers.html.
-          #
-          # Additionally, the Godot source is patched to make dlclose() a no-op, as unloading dynamic libraries loses stacktrace and
-          # cause false positives like println!. See https://github.com/google/sanitizers/issues/89.
-          #
-          # There is also a gcc variant besides clang, which is currently not used.
-          - name: linux-memcheck-nightly
-            os: ubuntu-20.04
-            artifact-name: linux-memcheck-clang-nightly
-            godot-binary: godot.linuxbsd.editor.dev.x86_64.llvm.san
-            godot-args: -- --disallow-focus
-            rust-toolchain: nightly
-            rust-env-rustflags: -Zrandomize-layout -Zsanitizer=address
-            rust-extra-args: --features godot/custom-godot
-            # Sanitizers can't build proc-macros and build scripts; with --target, cargo ignores RUSTFLAGS for those two.
-            rust-target: x86_64-unknown-linux-gnu
-
-          # Linux under Godot 4.0.x
 
           - name: linux-4.0.3
             os: ubuntu-20.04
@@ -243,6 +225,24 @@ jobs:
             artifact-name: linux-4.0.3
             godot-binary: godot.linuxbsd.editor.dev.x86_64
             godot-prebuilt-patch: '4.0'
+
+          # Memory checks: special Godot binaries compiled with AddressSanitizer/LeakSanitizer to detect UB/leaks.
+          # See also https://rustc-dev-guide.rust-lang.org/sanitizers.html.
+          #
+          # Additionally, the Godot source is patched to make dlclose() a no-op, as unloading dynamic libraries loses stacktrace and
+          # cause false positives like println!. See https://github.com/google/sanitizers/issues/89.
+          #
+          # There is also a gcc variant besides clang, which is currently not used.
+          - name: linux-memcheck
+            os: ubuntu-20.04
+            artifact-name: linux-memcheck-clang-nightly
+            godot-binary: godot.linuxbsd.editor.dev.x86_64.llvm.san
+            godot-args: -- --disallow-focus
+            rust-toolchain: nightly
+            rust-env-rustflags: -Zrandomize-layout -Zsanitizer=address
+            rust-extra-args: --features godot/custom-godot
+            # Sanitizers can't build proc-macros and build scripts; with --target, cargo ignores RUSTFLAGS for those two.
+            rust-target: x86_64-unknown-linux-gnu
 
           - name: linux-memcheck-4.0.3
             os: ubuntu-20.04
@@ -289,15 +289,26 @@ jobs:
           mode: check
 
 
-  full-ci:
-    if: github.event_name == 'push' && success()
+  # ---------------------------------------------------------------------------------------------------------------------------------------------
+  # CI status report
+
+  # Job to notify merge queue about success/failure
+  # 'push' is for workflows still triggered by bors
+  ci-status:
+    if: always() && (github.event_name == 'merge_group' || github.event_name == 'push')
     needs:
       - rustfmt
       - clippy
       - unit-test
       - godot-itest
       - license-guard
+
     runs-on: ubuntu-20.04
     steps:
-      - name: "Mark the job as a success"
+      - name: "Success"
+        if: ${{ !(contains(needs.*.result, 'failure')) }}
         run: exit 0
+
+      - name: "Failure"
+        if: ${{ contains(needs.*.result, 'failure') }}
+        run: exit 1

--- a/.github/workflows/minimal-ci.yml
+++ b/.github/workflows/minimal-ci.yml
@@ -2,16 +2,22 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-# Minimal CI workflow
-# Run when someone opens a PR and adds commits to the PR (this is recognized as a push to master)
-# Includes basic checks and unit/integration checks on Linux only
 
 name: Minimal CI
+#
+# Runs when someone opens a PR and pushes commits to the PR.
+# Includes basic checks to catch most common errors, but is followed by merge queue (full-ci).
 
 on:
   pull_request:
     branches:
       - master
+    types:
+      - opened
+      - synchronize
+      - reopened
+      #- ready_for_review # could be enabled if we don't run certain checks in draft mode
+
 
 env:
   GDEXT_FEATURES: ''
@@ -28,6 +34,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+
   rustfmt:
     runs-on: ubuntu-20.04
     steps:
@@ -76,19 +83,96 @@ jobs:
         run: cargo test $GDEXT_FEATURES
 
 
+
+  # For complex matrix workflow, see https://stackoverflow.com/a/65434401
   godot-itest:
-    name: godot-itest
-    runs-on: ubuntu-20.04
-    timeout-minutes: 24
+    name: godot-itest (${{ matrix.name }})
+    runs-on: ${{ matrix.os }}
+    if: github.event.pull_request.draft != true
+    continue-on-error: false
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false # cancel all jobs as soon as one fails?
+      matrix:
+        include:
+          # macOS
+
+          - name: macos
+            os: macos-12
+            artifact-name: macos-nightly
+            godot-binary: godot.macos.editor.dev.x86_64
+            rust-extra-args: --features godot/custom-godot
+
+          # Windows
+
+          - name: windows
+            os: windows-latest
+            artifact-name: windows-nightly
+            godot-binary: godot.windows.editor.dev.x86_64.exe
+            rust-extra-args: --features godot/custom-godot
+
+          # Linux
+
+          - name: linux
+            os: ubuntu-20.04
+            artifact-name: linux-nightly
+            godot-binary: godot.linuxbsd.editor.dev.x86_64
+            rust-extra-args: --features godot/custom-godot
+
+          - name: linux-features
+            os: ubuntu-20.04
+            artifact-name: linux-nightly
+            godot-binary: godot.linuxbsd.editor.dev.x86_64
+            rust-extra-args: --features godot/custom-godot,godot/threads,godot/serde
+
+          # Linux compat
+
+          - name: linux-4.0.3
+            os: ubuntu-20.04
+            artifact-name: linux-4.0.3
+            godot-binary: godot.linuxbsd.editor.dev.x86_64
+            godot-prebuilt-patch: '4.0.3'
+
+          # Memory checkers
+
+          - name: linux-memcheck
+            os: ubuntu-20.04
+            artifact-name: linux-memcheck-clang-nightly
+            godot-binary: godot.linuxbsd.editor.dev.x86_64.llvm.san
+            godot-args: -- --disallow-focus
+            rust-toolchain: nightly
+            rust-env-rustflags: -Zrandomize-layout -Zsanitizer=address
+            rust-extra-args: --features godot/custom-godot
+            # Sanitizers can't build proc-macros and build scripts; with --target, cargo ignores RUSTFLAGS for those two.
+            rust-target: x86_64-unknown-linux-gnu
+
+          - name: linux-memcheck-4.0.3
+            os: ubuntu-20.04
+            artifact-name: linux-memcheck-clang-4.0.3
+            godot-binary: godot.linuxbsd.editor.dev.x86_64.llvm.san
+            godot-args: -- --disallow-focus
+            godot-prebuilt-patch: '4.0.3'
+            rust-toolchain: nightly
+            rust-env-rustflags: -Zrandomize-layout -Zsanitizer=address
+            # Sanitizers can't build proc-macros and build scripts; with --target, cargo ignores RUSTFLAGS for those two.
+            rust-target: x86_64-unknown-linux-gnu
+
     steps:
       - uses: actions/checkout@v3
 
       - name: "Run Godot integration test"
         uses: ./.github/composite/godot-itest
         with:
-          artifact-name: godot-linux-nightly
-          godot-binary: godot.linuxbsd.editor.dev.x86_64
-          rust-extra-args: --features godot/custom-godot,godot/custom-godot
+          artifact-name: godot-${{ matrix.artifact-name }}
+          godot-binary: ${{ matrix.godot-binary }}
+          godot-args: ${{ matrix.godot-args }}
+          godot-prebuilt-patch: ${{ matrix.godot-prebuilt-patch }}
+          rust-extra-args: ${{ matrix.rust-extra-args }}
+          rust-toolchain: ${{ matrix.rust-toolchain || 'stable' }}
+          rust-env-rustflags: ${{ matrix.rust-env-rustflags }}
+          rust-target: ${{ matrix.rust-target }}
+          with-llvm: ${{ contains(matrix.name, 'macos') && contains(matrix.rust-extra-args, 'custom-godot') }}
+          godot-check-header: ${{ matrix.godot-check-header }}
 
 
   license-guard:
@@ -106,12 +190,27 @@ jobs:
           # mode: # optional: Which mode License-Eye should be run in. Choices are `check` or `fix`. The default value is `check`.
           mode: check
 
-#      - name: "Commit changes"
-#        uses: EndBug/add-and-commit@v9
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#        with:
-#          author_name: 'Godot-Rust Automation'
-#          author_email: 'actions@github.com'
-#          message: 'Auto-apply license headers'
 
+
+  # ---------------------------------------------------------------------------------------------------------------------------------------------
+  # CI status report
+
+  # Job to notify merge queue about success/failure
+  ci-status:
+    if: always()
+    needs:
+      - rustfmt
+      - clippy
+      - unit-test
+      - godot-itest
+      - license-guard
+
+    runs-on: ubuntu-20.04
+    steps:
+      - name: "Success"
+        if: ${{ !(contains(needs.*.result, 'failure')) }}
+        run: exit 0
+
+      - name: "Failure"
+        if: ${{ contains(needs.*.result, 'failure') }}
+        run: exit 1

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -31,6 +31,11 @@ jobs:
         if: github.event_name == 'pull_request' && github.event.action != 'closed'
         run: cargo check -p godot $GDEXT_FEATURES
 
+#      - name: "Dump GitHub context"
+#        env:
+#          GITHUB_CONTEXT: ${{ toJson(github) }}
+#        run: echo "$GITHUB_CONTEXT"
+
       # Pushed to master: no PR-related information
       - name: "Construct JSON (for master)"
         if: github.ref == 'refs/heads/master'
@@ -39,6 +44,7 @@ jobs:
           {
             "op": "put",
             "repo": "gdext",
+            "repo-owner": "${{ github.repository_owner }}",
             "num": "master",
             "commit-sha": "${{ github.sha }}",
             "date": "${{ github.event.head_commit.timestamp }}"
@@ -57,6 +63,7 @@ jobs:
           {
             "op": "put",
             "repo": "gdext",
+            "repo-owner": "${{ github.repository_owner }}",
             "num": "${{ github.event.number }}",
             "commit-sha": "${{ github.event.pull_request.head.sha }}",
             "date": "${{ github.event.pull_request.updated_at }}",
@@ -77,6 +84,7 @@ jobs:
           {
               "op": "delete",
               "repo": "gdext",
+              "repo-owner": "${{ github.repository_owner }}",
               "num": "${{ github.event.number }}",
               "date": "${{ github.event.pull_request.updated_at }}"
           }


### PR DESCRIPTION
Closes #255.

Extends the `minimal-ci` with a few more jobs that always run. One option would be to make this conditional on draft/ready PR, but that isn't done for now. We can adjust the number of jobs depending on what we find useful.

`full-ci` remains as is and will run whenever a PR reaches the front of the merge queue. It rebases the commits on `master` and thus always runs checks against the latest version.

For now, bors is still active, but I don't know if it can still be used with new branch protection rules. Over time, `bors try` will no longer be possible and has no equivalent in the merge queue. This should be OK by having a few more checks in the minimal CI; we could also add _all_ checks there, with two stages (and 2nd only running after 1st passes).