### PR TITLE
Make `with_checked_type` return `Result<Self, VariantConversionError>`

### DIFF
--- a/godot-core/src/builtin/array.rs
+++ b/godot-core/src/builtin/array.rs
@@ -333,13 +333,12 @@ impl<T: VariantMetadata> Array<T> {
     }
 
     /// Checks that the inner array has the correct type set on it for storing elements of type `T`.
-    ///
-    /// # Panics
-    ///
-    /// If the inner type doesn't match `T` or no type is set at all.
-    fn with_checked_type(self) -> Self {
-        assert_eq!(self.type_info(), TypeInfo::new::<T>());
-        self
+    fn with_checked_type(self) -> Result<Self, VariantConversionError> {
+        if self.type_info() == TypeInfo::new::<T>() {
+            Ok(self)
+        } else {
+            Err(VariantConversionError::BadType)
+        }
     }
 
     /// Sets the type of the inner array. Can only be called once, directly after creation.
@@ -635,7 +634,9 @@ impl<T: VariantMetadata> Share for Array<T> {
                 ctor(self_ptr, args.as_ptr());
             })
         };
-        array.with_checked_type()
+        array
+            .with_checked_type()
+            .expect("copied array should have same type as original array")
     }
 }
 
@@ -729,7 +730,7 @@ impl<T: VariantMetadata> FromVariant for Array<T> {
             })
         };
 
-        Ok(array.with_checked_type())
+        array.with_checked_type()
     }
 }
 

--- a/itest/rust/src/array_test.rs
+++ b/itest/rust/src/array_test.rs
@@ -415,6 +415,28 @@ fn typed_array_return_from_godot_func() {
     assert_eq!(children, array![child]);
 }
 
+#[itest]
+fn typed_array_try_from_untyped() {
+    let node = Node::new_alloc();
+    let array = VariantArray::from(&[node.share().to_variant()]);
+    assert_eq!(
+        array.to_variant().try_to::<Array<Option<Gd<Node>>>>(),
+        Err(VariantConversionError::BadType)
+    );
+    node.free();
+}
+
+#[itest]
+fn untyped_array_try_from_typed() {
+    let node = Node::new_alloc();
+    let array = Array::<Option<Gd<Node>>>::from(&[Some(node.share())]);
+    assert_eq!(
+        array.to_variant().try_to::<VariantArray>(),
+        Err(VariantConversionError::BadType)
+    );
+    node.free();
+}
+
 #[derive(GodotClass, Debug)]
 #[class(init, base=RefCounted)]
 struct ArrayTest;


### PR DESCRIPTION
Now `try_to()` for arrays will fail without panicking for wrong types.

closes #339