### PR TITLE
Let bitfields accept any ordinal, not just its individual flags.

### DIFF
--- a/godot-codegen/src/lib.rs
+++ b/godot-codegen/src/lib.rs
@@ -296,6 +296,7 @@ struct GeneratedBuiltinModule {
 #[cfg(not(feature = "codegen-full"))]
 const SELECTED_CLASSES: &[&str] = &[
     "AnimatedSprite2D",
+    "ArrayMesh",
     "Area2D",
     "AudioStreamPlayer",
     "BaseButton",

--- a/godot-codegen/src/util.rs
+++ b/godot-codegen/src/util.rs
@@ -69,6 +69,23 @@ pub fn make_enum_definition(enum_: &Enum) -> TokenStream {
         None
     };
 
+    let try_from_ord = if enum_.is_bitfield {
+        quote! {
+            fn try_from_ord(ord: i32) -> Option<Self> {
+                Some(Self { ord })
+            }
+        }
+    } else {
+        quote! {
+            fn try_from_ord(ord: i32) -> Option<Self> {
+                match ord {
+                    #( ord @ #unique_ords )|* => Some(Self { ord }),
+                    _ => None,
+                }
+            }
+        }
+    };
+
     let mut derives = vec!["Copy", "Clone", "Eq", "PartialEq", "Debug", "Hash"];
 
     if enum_.is_bitfield {
@@ -100,12 +117,9 @@ pub fn make_enum_definition(enum_: &Enum) -> TokenStream {
             //         _ => None,
             //     }
             // }
-            fn try_from_ord(ord: i32) -> Option<Self> {
-                match ord {
-                    #( ord @ #unique_ords )|* => Some(Self { ord }),
-                    _ => None,
-                }
-            }
+
+            #try_from_ord
+
             fn ord(self) -> i32 {
                 self.ord
             }

--- a/itest/rust/src/enum_test.rs
+++ b/itest/rust/src/enum_test.rs
@@ -5,8 +5,10 @@
  */
 
 use crate::itest;
+use godot::builtin::varray;
 use godot::engine::input::CursorShape;
-use godot::engine::time;
+use godot::engine::mesh::PrimitiveType;
+use godot::engine::{time, ArrayMesh};
 use std::collections::HashSet;
 
 #[itest]
@@ -58,4 +60,12 @@ fn enum_hash() {
     months.insert(time::Month::MONTH_DECEMBER);
 
     assert_eq!(months.len(), 12);
+}
+
+// Testing https://github.com/godot-rust/gdext/issues/335
+// This fails upon calling the function, we dont actually need to make a good call.
+#[itest]
+fn add_surface_from_arrays() {
+    let mut mesh = ArrayMesh::new();
+    mesh.add_surface_from_arrays(PrimitiveType::PRIMITIVE_TRIANGLES, varray![]);
 }


### PR DESCRIPTION
Should we try to do some verification to make sure that the bitfield only has its defined flags set? I'm leaning towards no personally.

closes #335