### PR TITLE
Fix UB in varcall functions with unit return

### DIFF
--- a/godot-codegen/src/class_generator.rs
+++ b/godot-codegen/src/class_generator.rs
@@ -1787,7 +1787,6 @@ fn make_params_and_args(method_args: &[&FnParam]) -> (Vec<TokenStream>, Vec<Toke
             (quote! { #param_name: #param_ty }, quote! { #param_name })
         })
         .unzip()
-    // .unzip::<(Vec<_>, Vec<_>)>()
 }
 
 fn make_return_and_impl(
@@ -1797,63 +1796,44 @@ fn make_return_and_impl(
     error_fn_context: TokenStream, // only for panic message
     is_virtual: bool,
 ) -> TokenStream {
-    let FnReturn {
-        type_: return_ty, ..
-    } = return_value;
+    let return_ty = &return_value.type_;
 
-    let FnCode {
-        varcall_invocation,
-        ptrcall_invocation,
-        variant_ffi,
-        ..
-    } = code;
+    // Virtual methods
+    if is_virtual {
+        return quote! { unimplemented!() };
+    }
 
-    match (is_virtual, variant_ffi, return_ty) {
-        (true, _, _) => {
-            quote! {
-                unimplemented!()
-            }
-        }
-        (false, Some(variant_ffi), Some(return_ty)) => {
-            // If the return type is not Variant, then convert to concrete target type
-            let return_expr = match return_ty {
-                RustTy::BuiltinIdent(ident) if ident == "Variant" => quote! { variant },
-                _ => quote! { variant.to() },
-            };
-            let from_sys_init_method = &variant_ffi.from_sys_init_method;
+    // Varcall
+    if let Some(variant_ffi) = &code.variant_ffi {
+        // If the return type is not Variant, then convert to concrete target type
+        let return_expr = match return_ty {
+            None => TokenStream::new(), // unit return
+            Some(RustTy::BuiltinIdent(ident)) if ident == "Variant" => quote! { __variant },
+            Some(_) => quote! { __variant.to() },
+        };
+        let from_sys_init_method = &variant_ffi.from_sys_init_method;
+        let varcall_invocation = &code.varcall_invocation;
 
-            // Note: __err may remain unused if the #call does not handle errors (e.g. utility fn, ptrcall, ...)
-            // TODO use Result instead of panic on error
-            quote! {
-                let variant = Variant::#from_sys_init_method(|return_ptr| {
-                    let mut __err = sys::default_call_error();
-                    #varcall_invocation
-                    if __err.error != sys::GDEXTENSION_CALL_OK {
-                        #prepare_arg_types
-                        sys::panic_call_error(&__err, #error_fn_context, &__arg_types);
-                    }
-                });
-                #return_expr
-            }
-        }
-        (false, Some(variant_ffi), None) => {
-            let from_sys_init_method = &variant_ffi.from_sys_init_method;
-
-            // Note: __err may remain unused if the #call does not handle errors (e.g. utility fn, ptrcall, ...)
-            // TODO use Result instead of panic on error
-            quote! {
+        // Note: __err may remain unused if the #call does not handle errors (e.g. utility fn, ptrcall, ...).
+        //       __variant remains unused if the function returns unit.
+        // TODO use Result instead of panic on error
+        return quote! {
+            let __variant = Variant::#from_sys_init_method(|return_ptr| {
                 let mut __err = sys::default_call_error();
-                let _variant = Variant::#from_sys_init_method(|return_ptr| {
-                    #varcall_invocation
-                });
-
+                #varcall_invocation
                 if __err.error != sys::GDEXTENSION_CALL_OK {
                     #prepare_arg_types
                     sys::panic_call_error(&__err, #error_fn_context, &__arg_types);
                 }
-            }
-        }
-        (false, None, Some(RustTy::EngineClass { tokens, .. })) => {
+            });
+            #return_expr
+        };
+    }
+
+    // Ptrcall
+    let ptrcall_invocation = &code.ptrcall_invocation;
+    match return_ty {
+        Some(RustTy::EngineClass { tokens, .. }) => {
             let return_ty = tokens;
             quote! {
                 <#return_ty>::from_sys_init_opt(|return_ptr| {
@@ -1861,7 +1841,7 @@ fn make_return_and_impl(
                 })
             }
         }
-        (false, None, Some(return_ty)) => {
+        Some(return_ty) => {
             quote! {
                 let via = <<#return_ty as sys::GodotFuncMarshal>::Via as sys::GodotFfi>::from_sys_init_default(|return_ptr| {
                     #ptrcall_invocation
@@ -1869,7 +1849,7 @@ fn make_return_and_impl(
                 <#return_ty as sys::GodotFuncMarshal>::try_from_via(via).unwrap()
             }
         }
-        (false, None, None) => {
+        None => {
             quote! {
                 let return_ptr = std::ptr::null_mut();
                 #ptrcall_invocation

--- a/itest/rust/src/node_test.rs
+++ b/itest/rust/src/node_test.rs
@@ -81,8 +81,7 @@ fn node_scene_tree() {
     child.free();
 }
 
-// FIXME: call_group() crashes
-#[itest(skip)]
+#[itest]
 fn node_call_group(ctx: &TestContext) {
     let mut node = ctx.scene_tree.share();
     let mut tree = node.get_tree().unwrap();


### PR DESCRIPTION
Fixes #290. Enables a skipped unit test that checks `call_group()`.

Two of the `match` cases could be collapsed, so I also simplified that code a bit using early return instead.

Thanks a lot to @lilizoey for the debugging assist! ⚽ 
