### PR TITLE
`#[cfg(before_api)]` and `#[cfg(since_api)]` 

### DIFF
--- a/godot-bindings/src/lib.rs
+++ b/godot-bindings/src/lib.rs
@@ -135,7 +135,17 @@ pub fn emit_godot_version_cfg() {
         ..
     } = get_godot_version();
 
-    println!(r#"cargo:rustc-cfg=gdextension_api="{major}.{minor}""#);
+    // Start at 1; checking for "since/before 4.0" makes no sense
+    let max = 2;
+    for m in 1..=minor {
+        println!(r#"cargo:rustc-cfg=since_api="{major}.{m}""#);
+    }
+    for m in minor + 1..=max {
+        println!(r#"cargo:rustc-cfg=before_api="{major}.{m}""#);
+    }
+
+    // The below configuration keys are very rarely needed and should generally not be used.
+    println!(r#"cargo:rustc-cfg=gdextension_minor_api="{major}.{minor}""#);
 
     // Godot drops the patch version if it is 0.
     if patch != 0 {

--- a/godot-core/src/builtin/basis.rs
+++ b/godot-core/src/builtin/basis.rs
@@ -144,18 +144,19 @@ impl Basis {
     /// orthonormalized. The `target` and `up` vectors cannot be zero, and
     /// cannot be parallel to each other.
     ///
-    #[cfg(gdextension_api = "4.0")]
+    #[cfg(before_api = "4.1")]
     /// _Godot equivalent: `Basis.looking_at()`_
     #[doc(alias = "looking_at")]
     pub fn new_looking_at(target: Vector3, up: Vector3) -> Self {
         super::inner::InnerBasis::looking_at(target, up)
     }
-    #[cfg(not(gdextension_api = "4.0"))]
+
     /// If `use_model_front` is true, the +Z axis (asset front) is treated as forward (implies +X is left)
     /// and points toward the target position. By default, the -Z axis (camera forward) is treated as forward
     /// (implies +X is right).
     ///
     /// _Godot equivalent: `Basis.looking_at()`_
+    #[cfg(since_api = "4.1")]
     pub fn new_looking_at(target: Vector3, up: Vector3, use_model_front: bool) -> Self {
         super::inner::InnerBasis::looking_at(target, up, use_model_front)
     }

--- a/godot-core/src/builtin/transform3d.rs
+++ b/godot-core/src/builtin/transform3d.rs
@@ -156,7 +156,7 @@ impl Transform3D {
     /// See [`Basis::new_looking_at()`] for more information.
     ///
     /// _Godot equivalent: Transform3D.looking_at()_
-    #[cfg(gdextension_api = "4.0")]
+    #[cfg(before_api = "4.1")]
     #[must_use]
     pub fn looking_at(self, target: Vector3, up: Vector3) -> Self {
         Self {
@@ -165,7 +165,7 @@ impl Transform3D {
         }
     }
 
-    #[cfg(not(gdextension_api = "4.0"))]
+    #[cfg(since_api = "4.1")]
     #[must_use]
     pub fn looking_at(self, target: Vector3, up: Vector3, use_model_front: bool) -> Self {
         Self {

--- a/godot-core/src/builtin/variant/mod.rs
+++ b/godot-core/src/builtin/variant/mod.rs
@@ -207,7 +207,7 @@ impl Variant {
     /// # Safety
     ///
     /// See [`GodotFfi::from_sys_init`] and [`GodotFfi::from_sys_init_default`].
-    #[cfg(gdextension_api = "4.0")]
+    #[cfg(before_api = "4.1")]
     pub unsafe fn from_var_sys_init_or_init_default(
         init_fn: impl FnOnce(sys::GDExtensionVariantPtr),
     ) -> Self {
@@ -217,7 +217,7 @@ impl Variant {
     /// # Safety
     ///
     /// See [`GodotFfi::from_sys_init`] and [`GodotFfi::from_sys_init_default`].
-    #[cfg(not(gdextension_api = "4.0"))]
+    #[cfg(since_api = "4.1")]
     pub unsafe fn from_var_sys_init_or_init_default(
         init_fn: impl FnOnce(sys::GDExtensionUninitializedVariantPtr),
     ) -> Self {

--- a/godot-core/src/lib.rs
+++ b/godot-core/src/lib.rs
@@ -178,7 +178,7 @@ generate_gdextension_api_version!(
         "4.0.3",
         "4.1",
     },
-    (GDEXTENSION_API, gdextension_api) => {
+    (GDEXTENSION_API, gdextension_minor_api) => {
         "4.0",
         "4.1",
     },

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -355,7 +355,7 @@ impl<T: GodotClass> Gd<T> {
         U: GodotClass,
     {
         // Workaround for bug in Godot 4.0 that makes casts always succeed (https://github.com/godot-rust/gdext/issues/158).
-        // TODO once fixed in Godot, use #[cfg(gdextension_api = "4.0")]
+        // TODO once fixed in Godot, use #[cfg(before_api = "4.1")]
         if !self.is_cast_valid::<U>() {
             return Err(self);
         }
@@ -561,7 +561,7 @@ where
             // ptr is `Ref<T>*`
             // See the docs for `PtrcallType::Virtual` for more info on `Ref<T>`.
             interface_fn!(ref_get_object)(ptr as sys::GDExtensionRefPtr)
-        } else if !cfg!(gdextension_api = "4.0") || matches!(call_type, PtrcallType::Virtual) {
+        } else if cfg!(since_api = "4.1") || matches!(call_type, PtrcallType::Virtual) {
             // ptr is `T**`
             *(ptr as *mut sys::GDExtensionObjectPtr)
         } else {
@@ -594,9 +594,13 @@ where
         // can't perform virtual method calls currently, so they are always `T*`.
         //
         // In 4.1 argument pointers were standardized to always be `T**`.
-        if cfg!(gdextension_api = "4.0") {
+        #[cfg(before_api = "4.1")]
+        {
             self.sys_const()
-        } else {
+        }
+
+        #[cfg(since_api = "4.1")]
+        {
             std::ptr::addr_of!(self.opaque) as sys::GDExtensionConstTypePtr
         }
     }

--- a/godot-ffi/src/godot_ffi.rs
+++ b/godot-ffi/src/godot_ffi.rs
@@ -107,7 +107,7 @@ pub unsafe trait GodotFfi {
 /// # Safety
 ///
 /// See [`GodotFfi::from_sys_init`] and [`GodotFfi::from_sys_init_default`].
-#[cfg(gdextension_api = "4.0")]
+#[cfg(before_api = "4.1")]
 pub unsafe fn from_sys_init_or_init_default<T: GodotFfi>(
     init_fn: impl FnOnce(sys::GDExtensionTypePtr),
 ) -> T {
@@ -117,7 +117,7 @@ pub unsafe fn from_sys_init_or_init_default<T: GodotFfi>(
 /// # Safety
 ///
 /// See [`GodotFfi::from_sys_init`] and [`GodotFfi::from_sys_init_default`].
-#[cfg(not(gdextension_api = "4.0"))]
+#[cfg(since_api = "4.1")]
 pub unsafe fn from_sys_init_or_init_default<T: GodotFfi>(
     init_fn: impl FnOnce(sys::GDExtensionUninitializedTypePtr),
 ) -> T {
@@ -162,7 +162,7 @@ where
         }
     }
 
-    #[cfg(gdextension_api = "4.0")]
+    #[cfg(before_api = "4.1")]
     unsafe fn from_arg_ptr(ptr: sys::GDExtensionTypePtr, call_type: PtrcallType) -> Self {
         match call_type {
             PtrcallType::Standard => option_from_arg_single_ptr(ptr, call_type),
@@ -170,7 +170,7 @@ where
         }
     }
 
-    #[cfg(not(gdextension_api = "4.0"))]
+    #[cfg(since_api = "4.1")]
     unsafe fn from_arg_ptr(ptr: sys::GDExtensionTypePtr, call_type: PtrcallType) -> Self {
         option_from_arg_double_ptr(ptr, call_type)
     }
@@ -201,7 +201,7 @@ where
 }
 
 // 4.1 represents every object as `T**`.
-#[cfg(gdextension_api = "4.0")]
+#[cfg(before_api = "4.1")]
 /// Return an `Option<T>` when `T` is a nullable pointer type and `ptr` is represented as `T*`.
 ///
 /// # Safety

--- a/itest/rust/Cargo.toml
+++ b/itest/rust/Cargo.toml
@@ -17,6 +17,8 @@ default = []
 godot = { path = "../../godot", default-features = false }
 
 [build-dependencies]
+godot-bindings = { path = "../../godot-bindings" }
 # Minimum versions compatible with -Zminimal-versions
 proc-macro2 = "1.0.63"
 quote = "1.0.29"
+

--- a/itest/rust/build.rs
+++ b/itest/rust/build.rs
@@ -127,6 +127,8 @@ fn main() {
     println!("cargo:rerun-if-changed={}", gdscript_template.display());
 
     rustfmt_if_needed(vec![rust_file]);
+
+    godot_bindings::emit_godot_version_cfg();
 }
 
 // TODO remove, or remove code duplication with codegen

--- a/itest/rust/src/init_test.rs
+++ b/itest/rust/src/init_test.rs
@@ -4,6 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+use crate::itest;
 use godot::prelude::*;
 
 #[derive(GodotClass)]
@@ -24,3 +25,10 @@ struct WithInitDefaults {
 // TODO Remove once https://github.com/godot-rust/gdext/issues/187 is fixed
 #[godot_api]
 impl WithInitDefaults {}
+
+#[itest]
+fn cfg_test() {
+    // Makes sure that since_api and before_api are mutually exclusive
+    assert_ne!(cfg!(since_api = "4.1"), cfg!(before_api = "4.1"));
+    assert_ne!(cfg!(since_api = "4.2"), cfg!(before_api = "4.2"));
+}


### PR DESCRIPTION
Addresses the fact that we almost always want to know if an API is larger than a given version, not equal to it.

Also adds to cfgs that are considerably nicer to use:

```rs
#[cfg(gdextension_api = "4.0")]       ->  #[cfg(before_api = "4.1")]
#[cfg(not(gdextension_api = "4.0"))]  ->  #[cfg(since_api = "4.1")]
```

I preserved the old macros as `gdextension_minor_api` and `gdextension_exact_api` for now, but if they find no use, we may remove them later.