### PR TITLE
`GodotClass` is now an unsafe trait; document public API guarantees

### DIFF
--- a/godot-codegen/src/class_generator.rs
+++ b/godot-codegen/src/class_generator.rs
@@ -562,7 +562,7 @@ fn make_class(class: &Class, class_name: &TyName, ctx: &mut Context) -> Generate
                 #methods
                 #constants
             }
-            impl crate::obj::GodotClass for #class_name {
+            unsafe impl crate::obj::GodotClass for #class_name {
                 type Base = #base_ty;
                 type Declarer = crate::obj::dom::EngineDomain;
                 type Mem = crate::obj::mem::#memory;

--- a/godot-core/src/obj/traits.rs
+++ b/godot-core/src/obj/traits.rs
@@ -14,8 +14,12 @@ use godot_ffi as sys;
 ///
 /// The behavior of types implementing this trait is influenced by the associated types; check their documentation for information.
 ///
-/// You wouldn't usually implement this trait yourself; use the [`GodotClass`](godot_macros::GodotClass) derive macro instead.
-pub trait GodotClass: 'static
+/// # Safety
+///
+/// Internal.
+/// You **must not** implement this trait yourself; use [`#[derive(GodotClass)`](../bind/derive.GodotClass.html) instead.
+// Above intra-doc link to the derive-macro only works as HTML, not as symbol link.
+pub unsafe trait GodotClass: 'static
 where
     Self: Sized,
 {
@@ -51,7 +55,7 @@ where
 }
 
 /// Unit impl only exists to represent "no base", and is used for exactly one class: `Object`.
-impl GodotClass for () {
+unsafe impl GodotClass for () {
     type Base = ();
     type Declarer = dom::EngineDomain;
     type Mem = mem::ManualMemory;
@@ -286,6 +290,8 @@ pub mod mem {
             false
         }
     }
+
+    #[doc(hidden)]
     pub trait PossiblyManual {}
 
     /// Memory managed through Godot reference counter (always present).

--- a/godot-core/src/obj/traits.rs
+++ b/godot-core/src/obj/traits.rs
@@ -213,13 +213,16 @@ pub mod dom {
     use crate::obj::{Gd, GodotClass};
     use std::ops::DerefMut;
 
+    /// Trait that specifies who declares a given `GodotClass`.
     pub trait Domain: Sealed {
+        #[doc(hidden)]
         fn scoped_mut<T, F, R>(obj: &mut Gd<T>, closure: F) -> R
         where
             T: GodotClass<Declarer = Self>,
             F: FnOnce(&mut T) -> R;
     }
 
+    /// Expresses that a class is declared by the Godot engine.
     pub enum EngineDomain {}
     impl Sealed for EngineDomain {}
     impl Domain for EngineDomain {
@@ -232,6 +235,7 @@ pub mod dom {
         }
     }
 
+    /// Expresses that a class is declared by the user.
     pub enum UserDomain {}
     impl Sealed for UserDomain {}
     impl Domain for UserDomain {
@@ -255,23 +259,29 @@ pub mod mem {
     use crate::obj::{Gd, GodotClass};
     use crate::out;
 
+    /// Specifies the memory
     pub trait Memory: Sealed {
         /// Initialize reference counter
+        #[doc(hidden)]
         fn maybe_init_ref<T: GodotClass>(obj: &Gd<T>);
 
         /// If ref-counted, then increment count
+        #[doc(hidden)]
         fn maybe_inc_ref<T: GodotClass>(obj: &Gd<T>);
 
         /// If ref-counted, then decrement count
+        #[doc(hidden)]
         fn maybe_dec_ref<T: GodotClass>(obj: &Gd<T>) -> bool;
 
         /// Check if ref-counted, return `None` if information is not available (dynamic and obj dead)
+        #[doc(hidden)]
         fn is_ref_counted<T: GodotClass>(obj: &Gd<T>) -> Option<bool>;
 
         /// Returns `true` if argument and return pointers are passed as `Ref<T>` pointers given this
         /// [`PtrcallType`].
         ///
         /// See [`PtrcallType::Virtual`] for information about `Ref<T>` objects.
+        #[doc(hidden)]
         fn pass_as_ref(_call_type: PtrcallType) -> bool {
             false
         }

--- a/godot-macros/src/derive_godot_class/mod.rs
+++ b/godot-macros/src/derive_godot_class/mod.rs
@@ -44,7 +44,7 @@ pub fn transform(decl: Declaration) -> ParseResult<TokenStream> {
     };
 
     Ok(quote! {
-        impl ::godot::obj::GodotClass for #class_name {
+        unsafe impl ::godot::obj::GodotClass for #class_name {
             type Base = ::godot::engine::#base_ty;
             type Declarer = ::godot::obj::dom::UserDomain;
             type Mem = <Self::Base as ::godot::obj::GodotClass>::Mem;

--- a/godot-macros/src/lib.rs
+++ b/godot-macros/src/lib.rs
@@ -96,8 +96,9 @@ mod itest;
 mod method_registration;
 mod util;
 
-/// Derive macro for [`GodotClass`](godot_core::obj::GodotClass) on structs. You should normally use
-/// this macro, rather than implement `GodotClass` manually for your type.
+// Below intra-doc link to the trait only works as HTML, not as symbol link.
+/// Derive macro for [the `GodotClass` trait](../obj/trait.GodotClass.html) on structs. You must use this
+/// macro; manual implementations of the `GodotClass` trait are not supported.
 ///
 /// # Construction
 ///

--- a/godot/src/lib.rs
+++ b/godot/src/lib.rs
@@ -136,9 +136,28 @@
 //!   Experimental threading support. This enables `Send`/`Sync` traits for `Gd<T>` and makes the guard types `Gd`/`GdMut` aware of
 //!   multi-threaded references. The safety aspects of this are not ironed out yet; use at your own risk. The API may also change
 //!   at any time.
+//!
+//! # Public API
+//!
+//! Some symbols in the API are not intended for users, however Rust's visibility feature is not strong enough to express that in all cases
+//! (for example, proc-macros and separated crates may need access to internals).
+//!
+//! The following API symbols are considered private:
+//!
+//! * Symbols annotated with `#[doc(hidden)]`.
+//! * Any of the dependency crates (crate `godot` is the only public interface).
+//! * Modules named `private` and all their contents.
+//!
+//! Being private means a workflow is not supported. As such, there are **no guarantees** regarding API stability, robustness or correctness.
+//! Problems arising from using such APIs are not considered bugs, and anything relying on them may stop working without announcement.
+//! Please refrain from using undocumented and private features; if you are missing certain functionality, bring it up for discussion instead.
+//! This allows us to decide whether it fits the scope of the library and to design proper APIs for it.
 
 #[doc(inline)]
-pub use godot_core::{builtin, engine, log, obj, sys};
+pub use godot_core::{builtin, engine, log, obj};
+
+#[doc(hidden)]
+pub use godot_core::sys;
 
 pub mod init {
     pub use godot_core::init::*;


### PR DESCRIPTION
Closes #345.