### PR TITLE
Add missing integer vector methods

### DIFF
--- a/godot-core/src/builtin/math/mod.rs
+++ b/godot-core/src/builtin/math/mod.rs
@@ -13,7 +13,6 @@ pub use approx_eq::ApproxEq;
 pub use float::FloatExt;
 
 // Internal glam re-exports
-pub(crate) use glam::{IVec2, IVec3, IVec4};
 pub(crate) use glam_helpers::*;
 
 #[cfg(test)]

--- a/godot-core/src/builtin/vectors/vector_macros.rs
+++ b/godot-core/src/builtin/vectors/vector_macros.rs
@@ -282,6 +282,32 @@ macro_rules! impl_float_vector_glam_fns {
     };
 }
 
+/// Implements common constants and methods for integer type vectors. Works for any vector type that
+/// has `to_glam`, `from_glam` and `to_glam_real` functions.
+macro_rules! impl_integer_vector_glam_fns {
+    (
+        // Name of the vector type.
+        $Vector:ty,
+        // Type of target component, for example `real`.
+        $Scalar:ty
+    ) => {
+        impl $Vector {
+            /// Length (magnitude) of this vector.
+            #[inline]
+            pub fn length(self) -> $Scalar {
+                self.to_glam_real().length()
+            }
+
+            /// A new vector with each component set to 1 if it's positive, -1 if it's negative,
+            /// and 0 if it's zero.
+            #[inline]
+            pub fn sign(self) -> Self {
+                Self::from_glam(self.to_glam().signum())
+            }
+        }
+    };
+}
+
 /// Implements common constants and methods for floating-point type vectors based on their components.
 macro_rules! impl_float_vector_component_fns {
     (
@@ -378,6 +404,44 @@ macro_rules! impl_float_vector_component_fns {
             #[inline]
             fn approx_eq(&self, other: &Self) -> bool {
                 $( self.$comp.approx_eq(&other.$comp) )&&*
+            }
+        }
+    };
+}
+
+/// Implements common constants and methods for integer type vectors based on their components.
+macro_rules! impl_integer_vector_component_fns {
+    (
+        // Name of the vector type.
+        $Vector:ty,
+        // Type of target component, for example `real`.
+        $Scalar:ty,
+        // Names of the components, with parentheses, for example `(x, y)`.
+        ($($comp:ident),*)
+    ) => {
+        impl $Vector {
+            /// Squared length (squared magnitude) of this vector.
+            ///
+            /// Runs faster than `length`, so prefer it if you need to compare vectors or need the
+            /// squared distance for some formula.
+            #[inline]
+            pub fn length_squared(self) -> i64 {
+                let mut val = 0;
+
+                $(
+                    val += self.$comp as i64 * self.$comp as i64;
+                )*
+
+                val
+            }
+
+            /// A new vector with each component snapped to the closest multiple of the corresponding
+            /// component in step.
+            #[inline]
+            pub fn snapped(self, step: Self) -> Self {
+                Self::new(
+                    $( (self.$comp as $Scalar).snapped(step.$comp as $Scalar) as i32 ),*
+                )
             }
         }
     };


### PR DESCRIPTION
Saw these unimplemented on #310. I haven't tested any as it is straightforward. Let me know if rest of this PR is verbose for the little amount of work I did. 😅

## Coverage
- abs: already implemented by impl_common_vector_fns
- aspect: Vector2i only
- clamp: Ord provides it
- length
- length_squared
- max_axis_index
- min_axis_index
- sign
- snapped

## Extra

I created two new macros for common implementations. I don't know if that's the preferable way of doing stuff, but I saw macros implemented some methods, so I did the same.

``Vector4i::max_axis_index`` and ``Vector4i::min_axis_index`` are rustified version of C++ implementation. I used an **unwrap** there while using ``Vector4Axis::try_from_ord``. But it has no chance of failing so I just added a comment without documenting it as "panics".

Added a utility method similar to ``to_glam`` named ``to_glam_real``. Using it for length implementation on RVec's.

Due to trailing addition (+) causing issues with the vector component macro, I created a variable and increased it for each component. It results in a similar assembly with optimization level 0, and the same assembly with optimization level 1 and above.