### PR TITLE
Fix segfaults from premature `free` 

### DIFF
--- a/examples/dodge-the-creeps/rust/src/mob.rs
+++ b/examples/dodge-the-creeps/rust/src/mob.rs
@@ -16,12 +16,12 @@ pub struct Mob {
 impl Mob {
     #[func]
     fn on_visibility_screen_exited(&mut self) {
-        self.base.queue_free();
+        unsafe { self.base.queue_free() };
     }
 
     #[func]
     fn on_start_game(&mut self) {
-        self.base.queue_free();
+        unsafe { self.base.queue_free() };
     }
 }
 

--- a/godot-codegen/src/special_cases.rs
+++ b/godot-codegen/src/special_cases.rs
@@ -62,6 +62,13 @@ pub(crate) fn is_private(class_name: &TyName, godot_method_name: &str) -> bool {
     }
 }
 
+pub(crate) fn is_unsafe(class_name: &TyName, godot_method_name: &str) -> Option<&'static str> {
+    match (class_name.godot_ty.as_str(), godot_method_name) {
+        ("Node", "queue_free") => Some("You must ensure that this object isn't dereferenced again after the object is freed by this function."),
+        _ => None,
+    }
+}
+
 #[rustfmt::skip]
 pub(crate) fn is_excluded_from_default_params(class_name: Option<&TyName>, godot_method_name: &str) -> bool {
     // None if global/utilities function

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -478,8 +478,7 @@ where
     /// # Safety
     ///
     /// You must not use the object again after calling this function. We try to guard against this where
-    /// possible, but not everything can be caught. For a safe version, use
-    /// [`queue_free`](engine::Node::queue_free) instead.
+    /// possible, but not everything can be caught.
     pub unsafe fn free(self) {
         // TODO disallow for singletons, either only at runtime or both at compile time (new memory policy) and runtime
 

--- a/godot-core/src/obj/traits.rs
+++ b/godot-core/src/obj/traits.rs
@@ -95,7 +95,7 @@ pub trait Share {
 /// {
 ///     let up = node.upcast(); // type Gd<Node> inferred
 ///     println!("Node #{} with name {}", up.instance_id(), up.get_name());
-///     up.free();
+///     unsafe { up.free() };
 /// }
 ///
 /// // Call with different types

--- a/itest/rust/src/array_test.rs
+++ b/itest/rust/src/array_test.rs
@@ -359,7 +359,7 @@ fn array_mixed_values() {
 #[itest]
 fn untyped_array_pass_to_godot_func() {
     let mut node = Node::new_alloc();
-    node.queue_free(); // Do not leak even if the test fails.
+    unsafe { node.queue_free() }; // Do not leak even if the test fails.
 
     assert_eq!(
         node.callv(StringName::from("has_signal"), varray!["tree_entered"]),
@@ -374,7 +374,7 @@ fn untyped_array_return_from_godot_func() {
     let mut child = Node::new_alloc();
     child.set_name("child_node".into());
     node.add_child(child.share());
-    node.queue_free(); // Do not leak even if the test fails.
+    unsafe { node.queue_free() }; // Do not leak even if the test fails.
     let result = node.get_node_and_resource("child_node".into());
 
     assert_eq!(result, varray![child, Variant::nil(), NodePath::default()]);
@@ -411,7 +411,7 @@ fn typed_array_return_from_godot_func() {
     let mut child = Node::new_alloc();
     child.set_name("child_node".into());
     node.add_child(child.share());
-    node.queue_free(); // Do not leak even if the test fails.
+    unsafe { node.queue_free() }; // Do not leak even if the test fails.
     let children = node.get_children();
 
     assert_eq!(children, array![child]);

--- a/itest/rust/src/array_test.rs
+++ b/itest/rust/src/array_test.rs
@@ -350,8 +350,10 @@ fn array_mixed_values() {
         ref_counted.instance_id()
     );
 
-    object.free();
-    node.free();
+    unsafe {
+        object.free();
+        node.free();
+    }
 }
 
 #[itest]
@@ -423,7 +425,7 @@ fn typed_array_try_from_untyped() {
         array.to_variant().try_to::<Array<Option<Gd<Node>>>>(),
         Err(VariantConversionError::BadType)
     );
-    node.free();
+    unsafe { node.free() };
 }
 
 #[itest]
@@ -434,7 +436,7 @@ fn untyped_array_try_from_typed() {
         array.to_variant().try_to::<VariantArray>(),
         Err(VariantConversionError::BadType)
     );
-    node.free();
+    unsafe { node.free() };
 }
 
 #[derive(GodotClass, Debug)]

--- a/itest/rust/src/base_test.rs
+++ b/itest/rust/src/base_test.rs
@@ -20,7 +20,7 @@ fn base_instance_id() {
     let base_id = obj.bind().base.instance_id();
 
     assert_eq!(obj_id, base_id);
-    obj.free();
+    unsafe { obj.free() };
 }
 
 #[itest]
@@ -35,7 +35,7 @@ fn base_deref() {
         assert_eq!(guard.base.get_position(), pos);
     }
 
-    obj.free();
+    unsafe { obj.free() };
 }
 
 #[itest]
@@ -51,7 +51,7 @@ fn base_display() {
 
         assert_eq!(actual, expected);
     }
-    obj.free();
+    unsafe { obj.free() };
 }
 
 #[itest]
@@ -67,7 +67,7 @@ fn base_debug() {
 
         assert_eq!(actual, expected);
     }
-    obj.free();
+    unsafe { obj.free() };
 }
 
 #[itest]
@@ -82,7 +82,7 @@ fn base_with_init() {
         assert_eq!(guard.i, 732);
         assert_eq!(guard.get_rotation(), 11.0);
     }
-    obj.free();
+    unsafe { obj.free() };
 }
 
 #[derive(GodotClass)]

--- a/itest/rust/src/builtin_test.rs
+++ b/itest/rust/src/builtin_test.rs
@@ -57,5 +57,5 @@ fn test_builtins_callable() {
     //
     // inner.bindv(array);
 
-    obj.free();
+    unsafe { obj.free() };
 }

--- a/itest/rust/src/codegen_test.rs
+++ b/itest/rust/src/codegen_test.rs
@@ -16,7 +16,7 @@ use godot::prelude::*;
 fn codegen_class_renamed() {
     // Known as `HTTPRequest` in Godot
     let obj = HttpRequest::new_alloc();
-    obj.free();
+    unsafe { obj.free() };
 }
 
 #[itest]
@@ -27,7 +27,7 @@ fn codegen_base_renamed() {
     let obj = Gd::with_base(|base| TestBaseRenamed { base });
     let _id = obj.instance_id();
 
-    obj.free();
+    unsafe { obj.free() };
 }
 
 #[itest]

--- a/itest/rust/src/node_test.rs
+++ b/itest/rust/src/node_test.rs
@@ -34,7 +34,7 @@ fn node_get_node() {
     let found = found.expect("try_get_node_as() returned Some(..)");
     assert_eq!(found.instance_id(), child_id);
 
-    grandparent.free();
+    unsafe { grandparent.free() };
 }
 
 #[itest]
@@ -45,7 +45,7 @@ fn node_get_node_fail() {
     let found = child.try_get_node_as::<Node3D>(NodePath::from("non-existent"));
     assert!(found.is_none());
 
-    child.free();
+    unsafe { child.free() };
 }
 
 #[itest]
@@ -76,9 +76,11 @@ fn node_scene_tree() {
 
     // Note: parent + child are not owned by PackedScene, thus need to be freed
     // (verified by porting this very test to GDScript)
-    tree.free();
-    parent.free();
-    child.free();
+    unsafe {
+        tree.free();
+        parent.free();
+        child.free();
+    }
 }
 
 #[itest]

--- a/itest/rust/src/object_test.rs
+++ b/itest/rust/src/object_test.rs
@@ -684,7 +684,7 @@ fn object_deref_always_valid() {
         )
     }
 
-    child.queue_free();
+    unsafe { child.queue_free() };
 }
 
 // Only kept as an example of why `free` must be an unsafe function.

--- a/itest/rust/src/object_test.rs
+++ b/itest/rust/src/object_test.rs
@@ -66,8 +66,10 @@ fn object_subtype_swap() {
     */
 
     // This should not panic
-    a.free();
-    b.free();
+    unsafe {
+        a.free();
+        b.free();
+    }
 }
 
 #[itest]
@@ -113,7 +115,7 @@ fn object_engine_roundtrip() {
 
     let obj2 = unsafe { Gd::<Node3D>::from_sys(ptr) };
     assert_eq!(obj2.get_position(), pos);
-    obj.free();
+    unsafe { obj.free() };
 }
 
 #[itest]
@@ -135,7 +137,7 @@ fn object_engine_display() {
     let expected = format!(".:<Node3D#{id}>:.");
 
     assert_eq!(actual, expected);
-    obj.free();
+    unsafe { obj.free() };
 }
 
 #[itest]
@@ -147,7 +149,7 @@ fn object_debug() {
     let expected = format!(".:Gd {{ id: {id}, class: Node3D }}:.");
 
     assert_eq!(actual, expected);
-    obj.free();
+    unsafe { obj.free() };
 }
 
 #[itest]
@@ -167,7 +169,7 @@ fn object_instance_id_when_freed() {
     let node: Gd<Node3D> = Node3D::new_alloc();
     assert!(node.is_instance_valid());
 
-    node.share().free(); // destroys object without moving out of reference
+    unsafe { node.share().free() }; // destroys object without moving out of reference
     assert!(!node.is_instance_valid());
 
     expect_panic("instance_id() on dead object", move || {
@@ -196,7 +198,7 @@ fn object_from_instance_id_inherits_type() {
     assert_eq!(node_as_base.instance_id(), id);
     assert_eq!(node_as_base.get_editor_description(), descr);
 
-    node_as_base.free();
+    unsafe { node_as_base.free() };
 }
 
 #[itest]
@@ -210,7 +212,7 @@ fn object_from_instance_id_unrelated_type() {
         "try_from_instance_id() with bad type must fail"
     );
 
-    node.free();
+    unsafe { node.free() };
 }
 
 #[itest]
@@ -238,8 +240,10 @@ fn object_engine_eq() {
     assert_ne!(a1, b1);
     assert_ne!(a2, b1);
 
-    a1.free();
-    b1.free();
+    unsafe {
+        a1.free();
+        b1.free();
+    }
 }
 
 #[itest]
@@ -249,7 +253,7 @@ fn object_dead_eq() {
     let b2 = b.share();
 
     // Destroy b1 without consuming it
-    b.share().free();
+    unsafe { b.share().free() };
 
     {
         let lhs = a.share();
@@ -264,7 +268,7 @@ fn object_dead_eq() {
         });
     }
 
-    a.free();
+    unsafe { a.free() };
 }
 
 #[itest]
@@ -290,7 +294,7 @@ fn object_engine_convert_variant() {
     let obj2 = Gd::<Node3D>::from_variant(&variant);
 
     assert_eq!(obj2.get_position(), pos);
-    obj.free();
+    unsafe { obj.free() };
 }
 
 #[itest]
@@ -369,7 +373,7 @@ fn object_engine_up_deref() {
     assert_eq!(node3d.instance_id(), id);
     assert_eq!(node3d.get_class(), GodotString::from("Node3D"));
 
-    node3d.free();
+    unsafe { node3d.free() };
 }
 
 #[itest]
@@ -385,7 +389,7 @@ fn object_engine_up_deref_mut() {
     node3d_ref.set_message_translation(false);
     assert!(!node3d_ref.can_translate_messages());
 
-    node3d.free();
+    unsafe { node3d.free() };
 }
 
 #[itest]
@@ -398,7 +402,7 @@ fn object_engine_upcast() {
     assert_eq!(object.get_class(), GodotString::from("Node3D"));
 
     // Deliberate free on upcast object
-    object.free();
+    unsafe { object.free() };
 }
 
 #[itest]
@@ -410,7 +414,7 @@ fn object_engine_upcast_reflexive() {
     assert_eq!(object.instance_id(), id);
     assert_eq!(object.get_class(), GodotString::from("Node3D"));
 
-    object.free();
+    unsafe { object.free() };
 }
 
 #[itest]
@@ -427,7 +431,7 @@ fn object_engine_downcast() {
     assert_eq!(node3d.instance_id(), id);
     assert_eq!(node3d.get_position(), pos);
 
-    node3d.free();
+    unsafe { node3d.free() };
 }
 
 #[derive(GodotClass)]
@@ -460,7 +464,7 @@ fn object_engine_downcast_reflexive() {
     let node3d: Gd<Node3D> = node3d.cast::<Node3D>();
     assert_eq!(node3d.instance_id(), id);
 
-    node3d.free();
+    unsafe { node3d.free() };
 }
 
 #[itest]
@@ -470,7 +474,7 @@ fn object_engine_bad_downcast() {
     let node3d: Option<Gd<Node3D>> = object.try_cast::<Node3D>();
 
     assert!(node3d.is_none());
-    free_ref.free();
+    unsafe { free_ref.free() };
 }
 
 #[itest]
@@ -487,7 +491,7 @@ fn object_engine_accept_polymorphic() {
     let actual_class = accept_object(node.share());
     assert_eq!(actual_class, expected_class);
 
-    node.free();
+    unsafe { node.free() };
 }
 
 #[itest]
@@ -566,7 +570,7 @@ fn object_engine_manual_free() {
     {
         let node = Node3D::new_alloc();
         let node2 = node.share();
-        node2.free();
+        unsafe { node2.free() };
     } // drop(node)
 }
 
@@ -576,7 +580,7 @@ fn object_engine_shared_free() {
     {
         let node = Node::new_alloc();
         let _object = node.share().upcast::<Object>();
-        node.free();
+        unsafe { node.free() };
     } // drop(_object)
 }
 
@@ -585,8 +589,10 @@ fn object_engine_manual_double_free() {
     expect_panic("double free()", || {
         let node = Node3D::new_alloc();
         let node2 = node.share();
-        node.free();
-        node2.free();
+        unsafe {
+            node.free();
+            node2.free();
+        }
     });
 }
 
@@ -595,7 +601,9 @@ fn object_engine_refcounted_free() {
     let node = RefCounted::new();
     let node2 = node.share().upcast::<Object>();
 
-    expect_panic("calling free() on RefCounted object", || node2.free())
+    expect_panic("calling free() on RefCounted object", || unsafe {
+        node2.free()
+    })
 }
 
 #[itest]
@@ -627,7 +635,7 @@ fn object_call_no_args() {
     let reflect_id = InstanceId::from_variant(&reflect_id_variant);
 
     assert_eq!(static_id, reflect_id);
-    node.free();
+    unsafe { node.free() };
 }
 
 #[itest]
@@ -644,7 +652,7 @@ fn object_call_with_args() {
 
     assert_eq!(none, Variant::nil());
     assert_eq!(actual_pos, expected_pos.to_variant());
-    node.free();
+    unsafe { node.free() };
 }
 
 #[itest]
@@ -657,6 +665,42 @@ fn object_get_scene_tree(ctx: &TestContext) {
     let count = tree.get_child_count();
     assert_eq!(count, 1);
 } // implicitly tested: node does not leak
+
+#[itest]
+fn object_deref_always_valid() {
+    let mut child = Node::new_alloc();
+    let mut node = Node::new_alloc();
+    let node2 = node.share();
+    // SAFETY: we aren't using `node2` again in a context where liveness is assumed.
+    unsafe { node2.free() };
+
+    {
+        let child = child.share();
+        expect_panic(
+            "dereferencing a freed object should always panic",
+            move || {
+                node.add_child(child);
+            },
+        )
+    }
+
+    child.queue_free();
+}
+
+// Only kept as an example of why `free` must be an unsafe function.
+#[itest(skip)]
+fn object_deref_before_free() {
+    let child = Node::new_alloc();
+    let mut node = Node::new_alloc();
+    let node2 = node.share();
+
+    let node_deref = &mut *node;
+    // SAFETY:
+    // This is unsafe, and is why `free` must be an unsafe function.
+    unsafe { node2.free() };
+    node_deref.add_child(child.share());
+    unsafe { child.free() };
+}
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -729,7 +773,7 @@ pub mod object_test_gd {
         #[func]
         fn pass_object(&self, object: Gd<Object>) -> i64 {
             let i = object.get("i".into()).to();
-            object.free();
+            unsafe { object.free() };
             i
         }
 
@@ -784,7 +828,7 @@ pub mod object_test_gd {
 fn custom_constructor_works() {
     let obj = object_test_gd::CustomConstructor::construct_object(42);
     assert_eq!(obj.bind().val, 42);
-    obj.free();
+    unsafe { obj.free() };
 }
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
@@ -847,8 +891,10 @@ fn double_use_reference() {
 
     std::mem::drop(guard);
 
-    double_use.free();
-    emitter.free();
+    unsafe {
+        double_use.free();
+        emitter.free();
+    }
 }
 
 #[derive(GodotClass)]

--- a/itest/rust/src/option_ffi_test.rs
+++ b/itest/rust/src/option_ffi_test.rs
@@ -17,7 +17,7 @@ fn option_some_sys_conversion() {
     let v2 = unsafe { Option::<Gd<Object>>::from_sys(ptr) };
     assert_eq!(v2, v);
 
-    v.unwrap().free();
+    unsafe { v.unwrap().free() };
 }
 
 #[itest]

--- a/itest/rust/src/signal_test.rs
+++ b/itest/rust/src/signal_test.rs
@@ -90,6 +90,8 @@ fn signals() {
         assert!(receiver.bind().used[i].get());
     }
 
-    receiver.free();
-    emitter.free();
+    unsafe {
+        receiver.free();
+        emitter.free();
+    }
 }

--- a/itest/rust/src/variant_test.rs
+++ b/itest/rust/src/variant_test.rs
@@ -153,7 +153,7 @@ fn variant_call() {
         Variant::from(77).call("to_string", &[]);
     });
 
-    node2d.free();
+    unsafe { node2d.free() };
 }
 
 #[rustfmt::skip]
@@ -290,7 +290,7 @@ fn variant_null_object_is_nil() {
     assert_eq!(raw_type, sys::GDEXTENSION_VARIANT_TYPE_OBJECT);
     assert_eq!(variant.get_type(), VariantType::Nil);
 
-    node.free();
+    unsafe { node.free() };
 }
 
 #[itest]

--- a/itest/rust/src/virtual_methods_test.rs
+++ b/itest/rust/src/virtual_methods_test.rs
@@ -454,7 +454,7 @@ fn test_notifications() {
             ReceivedEvent::Notification(NodeNotification::WmSizeChanged),
         ]
     );
-    obj.free();
+    unsafe { obj.free() };
 }
 
 // Used in `test_collision_object_2d_input_event` in `SpecialTests.gd`.

--- a/itest/rust/src/virtual_methods_test.rs
+++ b/itest/rust/src/virtual_methods_test.rs
@@ -397,7 +397,7 @@ fn test_input_event(test_context: &TestContext) {
 
     assert_eq!(obj.bind().event, Some(event.upcast::<InputEvent>()));
 
-    test_viewport.queue_free();
+    unsafe { test_viewport.queue_free() };
 }
 
 // We were incrementing/decrementing the refcount wrong. Which only showed up if you had multiple virtual
@@ -432,7 +432,7 @@ fn test_input_event_multiple(test_context: &TestContext) {
         assert_eq!(obj.bind().event, Some(event.share().upcast::<InputEvent>()));
     }
 
-    test_viewport.queue_free();
+    unsafe { test_viewport.queue_free() };
 }
 
 #[itest]


### PR DESCRIPTION
Makes `Deref` and `DerefMut` check for liveness, as a best effort to avoid segfaults.

But also makes `free` and `queue_free` unsafe functions. As mentioned [here](https://github.com/godot-rust/gdext/issues/348#issuecomment-1644399374), i dont think there's a good way to avoid this. I'm open to other options though if someone can come up with any.

fixes #348