### PR TITLE
Derive `Hash` for integer Vector types

### DIFF
--- a/godot-core/src/builtin/vectors/vector2i.rs
+++ b/godot-core/src/builtin/vectors/vector2i.rs
@@ -21,7 +21,7 @@ use std::fmt;
 /// required. Note that the values are limited to 32 bits, and unlike [`Vector2`] this cannot be
 /// configured with an engine build option. Use `i64` or [`PackedInt64Array`] if 64-bit values are
 /// needed.
-#[derive(Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
+#[derive(Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(C)]
 pub struct Vector2i {

--- a/godot-core/src/builtin/vectors/vector3i.rs
+++ b/godot-core/src/builtin/vectors/vector3i.rs
@@ -21,7 +21,7 @@ use crate::builtin::Vector3;
 /// required. Note that the values are limited to 32 bits, and unlike [`Vector3`] this cannot be
 /// configured with an engine build option. Use `i64` or [`PackedInt64Array`] if 64-bit values are
 /// needed.
-#[derive(Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
+#[derive(Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(C)]
 pub struct Vector3i {

--- a/godot-core/src/builtin/vectors/vector4i.rs
+++ b/godot-core/src/builtin/vectors/vector4i.rs
@@ -20,7 +20,7 @@ use std::fmt;
 /// required. Note that the values are limited to 32 bits, and unlike [`Vector4`] this cannot be
 /// configured with an engine build option. Use `i64` or [`PackedInt64Array`] if 64-bit values are
 /// needed.
-#[derive(Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
+#[derive(Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(C)]
 pub struct Vector4i {


### PR DESCRIPTION
Related: https://github.com/godot-rust/gdext/issues/297

My Usecase: Putting `Vector2i`'s in a `HashMap`