### PR TITLE
re-introduce TypeStringHint impl for Option<T>

### DIFF
--- a/godot-core/src/property.rs
+++ b/godot-core/src/property.rs
@@ -41,6 +41,12 @@ impl ExportInfo {
     }
 }
 
+impl<T: TypeStringHint> TypeStringHint for Option<T> {
+    fn type_string() -> String {
+        T::type_string()
+    }
+}
+
 impl<T> Property for Option<T>
 where
     T: Property + From<<T as Property>::Intermediate>,


### PR DESCRIPTION
This was initially added in #282 , and subsequently accidentally(?) reverted in #309 .

This patch reintroduces the behavior from #282 .