### PR TITLE
Added 32-bit support.

### DIFF
--- a/godot-codegen/src/api_parser.rs
+++ b/godot-codegen/src/api_parser.rs
@@ -241,15 +241,22 @@ impl MethodReturn {
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Implementation
 
-pub fn load_extension_api(watch: &mut godot_bindings::StopWatch) -> (ExtensionApi, &'static str) {
+pub fn load_extension_api(
+    watch: &mut godot_bindings::StopWatch,
+) -> (ExtensionApi, [&'static str; 2]) {
     // For float/double inference, see:
     // * https://github.com/godotengine/godot-proposals/issues/892
     // * https://github.com/godotengine/godot-cpp/pull/728
-    #[cfg(feature = "double-precision")]
-    let build_config = "double_64"; // TODO infer this
-    #[cfg(not(feature = "double-precision"))]
-    let build_config = "float_64"; // TODO infer this
-
+    // Have to do target_pointer_width check after code generation
+    // So pass a [32bit, 64bit] around of appropriate precision
+    // For why see: https://github.com/rust-lang/rust/issues/42587
+    let build_config: [&'static str; 2] = {
+        if cfg!(feature = "double-precision") {
+            ["double_32", "double_64"]
+        } else {
+            ["float_32", "float_64"]
+        }
+    };
     // Use type inference, so we can accept both String (dynamically resolved) and &str (prebuilt).
     // #[allow]: as_ref() acts as impl AsRef<str>, but with conditional compilation
 

--- a/godot-codegen/src/class_generator.rs
+++ b/godot-codegen/src/class_generator.rs
@@ -213,7 +213,7 @@ impl FnDefinitions {
 pub(crate) fn generate_class_files(
     api: &ExtensionApi,
     ctx: &mut Context,
-    _build_config: &str,
+    _build_config: [&str; 2],
     gen_path: &Path,
     submit_fn: &mut SubmitFn,
 ) {
@@ -261,7 +261,7 @@ pub(crate) fn generate_class_files(
 pub(crate) fn generate_builtin_class_files(
     api: &ExtensionApi,
     ctx: &mut Context,
-    _build_config: &str,
+    _build_config: [&str; 2],
     gen_path: &Path,
     submit_fn: &mut SubmitFn,
 ) {
@@ -307,7 +307,7 @@ pub(crate) fn generate_builtin_class_files(
 pub(crate) fn generate_native_structures_files(
     api: &ExtensionApi,
     ctx: &mut Context,
-    _build_config: &str,
+    _build_config: [&str; 2],
     gen_path: &Path,
     submit_fn: &mut SubmitFn,
 ) {

--- a/godot-ffi/src/opaque.rs
+++ b/godot-ffi/src/opaque.rs
@@ -9,9 +9,10 @@
 
 /// Stores an opaque object of a certain size, with very restricted operations
 ///
-/// Note: due to `align(8)` and not `packed` repr, this type may be bigger than `N` bytes
+/// Note: due to `align(4)` / `align(8)` and not `packed` repr, this type may be bigger than `N` bytes
 /// (which should be OK since C++ just needs to read/write those `N` bytes reliably).
-#[repr(C, align(8))]
+#[cfg_attr(target_pointer_width = "32", repr(C, align(4)))]
+#[cfg_attr(target_pointer_width = "64", repr(C, align(8)))]
 #[derive(Copy, Clone)]
 pub struct Opaque<const N: usize> {
     storage: [u8; N],


### PR DESCRIPTION
For issue #347

Main two things are causing it to pull and output both the 32 and 64 bit versions of float/double in the codegen. Unfortunately can't check `target_pointer_width` in codegen (it only sees your host width, not target) so that check has to be after codegen.

Also, need to change the align on Opaque for pointer casting.  AFAIK this should be complete besides tests.