### PR TITLE
No longer run Rust classes inside Godot editor

### DIFF
--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -93,7 +93,7 @@ jobs:
 
           - name: linux
             os: ubuntu-20.04
-            rust-toolchain: '1.66.0'
+            rust-toolchain: '1.70.0'
             rust-special: -msrv
 
     steps:

--- a/examples/dodge-the-creeps/rust/Cargo.toml
+++ b/examples/dodge-the-creeps/rust/Cargo.toml
@@ -2,7 +2,7 @@
 name = "dodge-the-creeps"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.66"
+rust-version = "1.70"
 publish = false
 
 [lib]

--- a/examples/dodge-the-creeps/rust/src/player.rs
+++ b/examples/dodge-the-creeps/rust/src/player.rs
@@ -1,6 +1,4 @@
-use godot::engine::{
-    AnimatedSprite2D, Area2D, Area2DVirtual, CollisionShape2D, Engine, PhysicsBody2D,
-};
+use godot::engine::{AnimatedSprite2D, Area2D, Area2DVirtual, CollisionShape2D, PhysicsBody2D};
 use godot::prelude::*;
 
 #[derive(GodotClass)]
@@ -60,11 +58,7 @@ impl Area2DVirtual for Player {
     }
 
     fn process(&mut self, delta: f64) {
-        // Don't process if running in editor. This part should be removed when
-        // issue is resolved: https://github.com/godot-rust/gdext/issues/70
-        if Engine::singleton().is_editor_hint() {
-            return;
-        }
+        println!("process");
 
         let mut animated_sprite = self
             .base

--- a/godot-bindings/Cargo.toml
+++ b/godot-bindings/Cargo.toml
@@ -2,7 +2,7 @@
 name = "godot-bindings"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.66"
+rust-version = "1.70"
 license = "MPL-2.0"
 keywords = ["gamedev", "godot", "engine", "ffi", "sys"]
 categories = ["game-engines", "graphics"]

--- a/godot-codegen/Cargo.toml
+++ b/godot-codegen/Cargo.toml
@@ -2,7 +2,7 @@
 name = "godot-codegen"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.66"
+rust-version = "1.70"
 license = "MPL-2.0"
 keywords = ["gamedev", "godot", "engine", "codegen"]
 categories = ["game-engines", "graphics"]

--- a/godot-core/Cargo.toml
+++ b/godot-core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "godot-core"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.66"
+rust-version = "1.70"
 license = "MPL-2.0"
 keywords = ["gamedev", "godot", "engine", "2d", "3d"] # possibly: "ffi"
 categories = ["game-engines", "graphics"]

--- a/godot-ffi/Cargo.toml
+++ b/godot-ffi/Cargo.toml
@@ -2,7 +2,7 @@
 name = "godot-ffi"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.66"
+rust-version = "1.70"
 license = "MPL-2.0"
 keywords = ["gamedev", "godot", "engine", "ffi"]
 categories = ["game-engines", "graphics"]

--- a/godot-macros/Cargo.toml
+++ b/godot-macros/Cargo.toml
@@ -2,7 +2,7 @@
 name = "godot-macros"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.66"
+rust-version = "1.70"
 license = "MPL-2.0"
 keywords = ["gamedev", "godot", "engine", "derive", "macro"]
 categories = ["game-engines", "graphics"]

--- a/godot-macros/src/godot_api.rs
+++ b/godot-macros/src/godot_api.rs
@@ -468,6 +468,13 @@ fn transform_trait_impl(original_impl: Impl) -> Result<TokenStream, Error> {
             fn __virtual_call(name: &str) -> ::godot::sys::GDExtensionClassCallVirtual {
                 //println!("virtual_call: {}.{}", std::any::type_name::<Self>(), name);
 
+                let __config = unsafe { ::godot::sys::config() };
+
+                if !__config.virtuals_active_in_editor
+                 && *__config.is_editor.get_or_init(|| ::godot::engine::Engine::singleton().is_editor_hint()) {
+                    return None;
+                }
+
                 match name {
                     #(
                        #virtual_method_names => #virtual_method_callbacks,

--- a/godot-macros/src/lib.rs
+++ b/godot-macros/src/lib.rs
@@ -469,7 +469,7 @@ pub fn itest(meta: TokenStream, input: TokenStream) -> TokenStream {
 
 /// Proc-macro attribute to be used in combination with the [`ExtensionLibrary`] trait.
 ///
-/// [`ExtensionLibrary`]: crate::init::ExtensionLibrary
+/// [`ExtensionLibrary`]: trait.ExtensionLibrary.html
 // FIXME intra-doc link
 #[proc_macro_attribute]
 pub fn gdextension(meta: TokenStream, input: TokenStream) -> TokenStream {

--- a/godot/Cargo.toml
+++ b/godot/Cargo.toml
@@ -2,7 +2,7 @@
 name = "godot"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.66"
+rust-version = "1.70"
 license = "MPL-2.0"
 keywords = ["gamedev", "godot", "engine", "2d", "3d"] # possibly: "ffi"
 categories = ["game-engines", "graphics"]

--- a/itest/rust/Cargo.toml
+++ b/itest/rust/Cargo.toml
@@ -2,7 +2,7 @@
 name = "itest"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.66"
+rust-version = "1.70"
 publish = false
 
 [lib]


### PR DESCRIPTION
Closes #70.
Closes #132.

Raises MSRV from 1.66 to 1.70.

So far, the workaround to prevent Rust classes from running in the editor was:
```rs
if Engine::singleton().is_editor_hint() {
    return;
}
```

With this PR, this is no longer necessary. By default, all virtual callbacks (`ready`, `process` etc.) are no longer invoked.
Note that classes will still be registered (this is necessary as scene trees would be broken otherwise).

This is still quite rudimentary and can be refined over time, but it should already improve the user experience.

The old behavior -- which may be desired by plugins/extensions rather than games -- can be restored with a configuration in the init trait:
```rs
#[gdextension]
unsafe impl ExtensionLibrary for DodgeTheCreeps {
    fn editor_run_behavior() -> EditorRunBehavior {
        EditorRunBehavior::Full
    }
}
```

See API Docs for more information.