### PR TITLE
`IndexEnum` trait, doc cleanups w.r.t visibility + notifications

### DIFF
--- a/godot-codegen/src/class_generator.rs
+++ b/godot-codegen/src/class_generator.rs
@@ -186,6 +186,15 @@ impl FnDefinition {
             builders: TokenStream::new(),
         }
     }
+
+    fn into_functions_only(self) -> TokenStream {
+        assert!(
+            self.builders.is_empty(),
+            "definition of this function should not have any builders"
+        );
+
+        self.functions
+    }
 }
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
@@ -196,6 +205,7 @@ struct FnDefinitions {
 }
 
 impl FnDefinitions {
+    /// Combines separate code from multiple function definitions into one, split by functions and builders.
     fn expand(definitions: impl Iterator<Item = FnDefinition>) -> FnDefinitions {
         // Collect needed because borrowed by 2 closures
         let definitions: Vec<_> = definitions.collect();
@@ -1314,11 +1324,8 @@ pub(crate) fn make_utility_function_definition(
         },
     );
 
-    assert!(
-        definition.builders.is_empty(),
-        "utility functions should not have builders"
-    );
-    definition.functions
+    // Utility functions have no builders.
+    definition.into_functions_only()
 }
 
 /// Defines which methods to use to convert between `Variant` and FFI (either variant ptr or type ptr)
@@ -1993,7 +2000,7 @@ fn make_virtual_method(method: &ClassMethod, ctx: &mut Context) -> TokenStream {
     );
 
     // Virtual methods have no builders.
-    definition.functions
+    definition.into_functions_only()
 }
 
 fn make_all_virtual_methods(

--- a/godot-codegen/src/class_generator.rs
+++ b/godot-codegen/src/class_generator.rs
@@ -11,6 +11,7 @@ use quote::{format_ident, quote, ToTokens};
 use std::path::Path;
 
 use crate::central_generator::{collect_builtin_types, BuiltinTypeInfo};
+use crate::context::NotificationEnum;
 use crate::util::{
     ident, option_as_slice, parse_native_structures_format, safe_ident, to_pascal_case,
     to_rust_expr, to_rust_type, to_rust_type_abi, to_snake_case, NativeStructuresField,
@@ -244,9 +245,7 @@ pub(crate) fn generate_class_files(
         modules.push(GeneratedClassModule {
             class_name,
             module_name,
-            own_notification_enum_name: generated_class
-                .has_own_notification_enum
-                .then_some(generated_class.notification_enum_name),
+            own_notification_enum_name: generated_class.notification_enum.try_to_own_name(),
             inherits_macro_ident: generated_class.inherits_macro_ident,
             is_pub_sidecar: generated_class.has_sidecar_module,
         });
@@ -534,7 +533,9 @@ fn make_class(class: &Class, class_name: &TyName, ctx: &mut Context) -> Generate
         &notification_enum_name,
         ctx,
     );
-    let notify_method = make_notify_method(class_name, ctx);
+
+    // notify() and notify_reversed() are added after other methods, to list others first in docs.
+    let notify_methods = make_notify_methods(class_name, ctx);
 
     let memory = if class_name.rust_ty == "Object" {
         ident("DynamicRefCount")
@@ -570,8 +571,8 @@ fn make_class(class: &Class, class_name: &TyName, ctx: &mut Context) -> Generate
             #notification_enum
             impl #class_name {
                 #constructor
-                #notify_method
                 #methods
+                #notify_methods
                 #constants
             }
             unsafe impl crate::obj::GodotClass for #class_name {
@@ -632,15 +633,34 @@ fn make_class(class: &Class, class_name: &TyName, ctx: &mut Context) -> Generate
 
     GeneratedClass {
         code: tokens,
-        notification_enum_name,
-        has_own_notification_enum: notification_enum.is_some(),
+        notification_enum: NotificationEnum {
+            name: notification_enum_name,
+            declared_by_own_class: notification_enum.is_some(),
+        },
         inherits_macro_ident: inherits_macro,
         has_sidecar_module,
     }
 }
 
-fn make_notify_method(class_name: &TyName, ctx: &mut Context) -> TokenStream {
+fn make_notify_methods(class_name: &TyName, ctx: &mut Context) -> TokenStream {
+    // Note: there are two more methods, but only from Node downwards, not from Object:
+    // - notify_thread_safe
+    // - notify_deferred_thread_group
+    // This could be modeled as either a single method, or two methods:
+    //   fn notify(what: XyNotification);
+    //   fn notify_with(what: XyNotification, mode: NotifyMode);
+    // with NotifyMode being an enum of: Normal | Reversed | ThreadSafe | DeferredThreadGroup.
+    // This would need either 2 enums (one starting at Object, one at Node) or have runtime checks.
+
     let enum_name = ctx.notification_enum_name(class_name);
+
+    // If this class does not have its own notification type, do not redefine the methods.
+    // The one from the parent class is fine.
+    if !enum_name.declared_by_own_class {
+        return TokenStream::new();
+    }
+
+    let enum_name = enum_name.name;
 
     quote! {
         /// ⚠️ Sends a Godot notification to all classes inherited by the object.
@@ -675,7 +695,7 @@ fn make_notification_enum(
 ) -> (Option<TokenStream>, Ident) {
     let Some(all_constants) = ctx.notification_constants(class_name) else  {
         // Class has no notification constants: reuse (direct/indirect) base enum
-        return (None, ctx.notification_enum_name(class_name));
+        return (None, ctx.notification_enum_name(class_name).name);
     };
 
     // Collect all notification constants from current and base classes
@@ -688,7 +708,7 @@ fn make_notification_enum(
 
     workaround_constant_collision(&mut all_constants);
 
-    let enum_name = ctx.notification_enum_name(class_name);
+    let enum_name = ctx.notification_enum_name(class_name).name;
     let doc_str = format!(
         "Notification type for class [`{c}`][crate::engine::{c}].",
         c = class_name.rust_ty

--- a/godot-codegen/src/class_generator.rs
+++ b/godot-codegen/src/class_generator.rs
@@ -527,7 +527,12 @@ fn make_class(class: &Class, class_name: &TyName, ctx: &mut Context) -> Generate
     let all_bases = ctx.inheritance_tree().collect_all_bases(class_name);
     let (notification_enum, notification_enum_name) =
         make_notification_enum(class_name, &all_bases, ctx);
-    let has_sidecar_module = !enums.is_empty();
+
+    // Associated "sidecar" module is made public if there are other symbols related to the class, which are not
+    // in top-level godot::engine module (notification enums are not in the sidecar, but in godot::engine::notify).
+    // This checks if token streams (i.e. code) is empty.
+    let has_sidecar_module = !enums.is_empty() || !builders.is_empty();
+
     let class_doc = make_class_doc(
         class_name,
         base_ident_opt,

--- a/godot-codegen/src/lib.rs
+++ b/godot-codegen/src/lib.rs
@@ -29,6 +29,7 @@ use interface_generator::generate_sys_interface_file;
 use util::{ident, to_pascal_case, to_snake_case};
 use utilities_generator::generate_utilities_file;
 
+use crate::context::NotificationEnum;
 use proc_macro2::{Ident, TokenStream};
 use quote::{quote, ToTokens};
 use std::path::{Path, PathBuf};
@@ -265,8 +266,7 @@ impl ToTokens for ModName {
 
 struct GeneratedClass {
     code: TokenStream,
-    notification_enum_name: Ident,
-    has_own_notification_enum: bool,
+    notification_enum: NotificationEnum,
     inherits_macro_ident: Ident,
     /// Sidecars are the associated modules with related enum/flag types, such as `node_3d` for `Node3D` class.
     has_sidecar_module: bool,

--- a/godot-core/src/obj/traits.rs
+++ b/godot-core/src/obj/traits.rs
@@ -146,6 +146,31 @@ pub trait EngineEnum: Copy {
     }
 }
 
+/// Trait for enums that can be used as indices in arrays.
+///
+/// The conditions for a Godot enum to be "index-like" are:
+/// - Contains an enumerator ending in `_MAX`, which has the highest ordinal (denotes the size).
+/// - All other enumerators are consecutive integers inside 0..max (no negative ordinals, no gaps).
+///
+/// Duplicates are explicitly allowed, to allow for renamings/deprecations. The order in which Godot exposes
+/// the enumerators in the JSON is irrelevant.
+pub trait IndexEnum: EngineEnum {
+    /// Number of **distinct** enumerators in the enum.
+    ///
+    /// All enumerators are guaranteed to be in the range `0..ENUMERATOR_COUNT`, so you can use them
+    /// as indices in an array of size `ENUMERATOR_COUNT`.
+    ///
+    /// Keep in mind that two enumerators with the same ordinal are only counted once.
+    const ENUMERATOR_COUNT: usize;
+
+    /// Converts the enumerator to `usize`, which can be used as an array index.
+    ///
+    /// Note that two enumerators may have the same index, if they have the same ordinal.
+    fn to_index(self) -> usize {
+        self.ord() as usize
+    }
+}
+
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 
 /// Capability traits, providing dedicated functionalities for Godot classes

--- a/godot-ffi/src/godot_ffi.rs
+++ b/godot-ffi/src/godot_ffi.rs
@@ -14,6 +14,7 @@ use std::{error::Error, fmt::Debug, marker::PhantomData, ptr};
 ///
 /// [`from_arg_ptr`](GodotFfi::from_arg_ptr) and [`move_return_ptr`](GodotFfi::move_return_ptr)
 /// must properly initialize and clean up values given the [`PtrcallType`] provided by the caller.
+#[doc(hidden)] // shows up in implementors otherwise
 pub unsafe trait GodotFfi {
     /// Construct from Godot opaque pointer.
     ///
@@ -245,6 +246,7 @@ pub enum PtrcallType {
 }
 
 /// Trait implemented for all types that can be passed to and from Godot via function calls.
+#[doc(hidden)] // shows up in implementors otherwise
 pub trait GodotFuncMarshal: Sized {
     /// The type used when passing a value to/from Godot.
     type Via: GodotFfi;

--- a/itest/rust/src/codegen_test.rs
+++ b/itest/rust/src/codegen_test.rs
@@ -65,11 +65,14 @@ pub struct TestBaseRenamed {
     base: Base<HttpRequest>,
 }
 
+#[allow(unused)]
 #[godot_api]
 impl TestBaseRenamed {
-    // Test unnamed parameter in user function
     #[func]
     fn with_unnamed(&self, _: i32) {}
+
+    #[func]
+    fn with_mut(&self, mut param: i32) {}
 
     #[func]
     fn with_many_unnamed(&self, _: i32, _: GodotString) {}


### PR DESCRIPTION
Several changes:

1. `IndexEnum` is a new trait exposing two things:
   * `fn to_index(self) -> usize` -- converts the ordinal to an index.
      Named `to_index()` and not `to_usize()` because that's almost always its intended use.
   * `const ENUMERATOR_COUNT: usize`
      Number of _distinct_ enumerators.

2. Fix doc visibility
    * `GodotFfi` and `GodotFuncMarshal` are hidden, which avoids hundreds of `impl`s with `as_arg_ptr()` etc. in public docs.
    * Some default-param extenders were accidentally hidden, now visible.

3. Clean up `notify()`/`notify_reversed()` methods' appearance in docs
    * They are now listed at the end, no longer taking attention away from the class' specific methods.
    * They are not redeclared if the parent class already exposes a method with the same signature.

Closes #366.
Supersedes #367.