### PR TITLE
Move `Deref/DerefMut` out of `T` to `Gd<T>`; `InstanceStorage` safety

### DIFF
--- a/.github/workflows/minimal-ci.yml
+++ b/.github/workflows/minimal-ci.yml
@@ -90,7 +90,6 @@ jobs:
   godot-itest:
     name: godot-itest (${{ matrix.name }})
     runs-on: ${{ matrix.os }}
-    if: github.event.pull_request.draft != true
     continue-on-error: false
     timeout-minutes: 15
     strategy:

--- a/examples/dodge-the-creeps/rust/src/main_scene.rs
+++ b/examples/dodge-the-creeps/rust/src/main_scene.rs
@@ -94,18 +94,19 @@ impl Main {
         self.base.add_child(mob_scene.share().upcast());
 
         let mut mob = mob_scene.cast::<mob::Mob>();
-        {
-            // Local scope to bind `mob`
-            let mut mob = mob.bind_mut();
-            let range = rng.gen_range(mob.min_speed..mob.max_speed);
+        let range = {
+            // Local scope to bind `mob` user object
+            let mob = mob.bind();
+            rng.gen_range(mob.min_speed..mob.max_speed)
+        };
 
-            mob.set_linear_velocity(Vector2::new(range, 0.0));
-            let lin_vel = mob.get_linear_velocity().rotated(real::from_f32(direction));
-            mob.set_linear_velocity(lin_vel);
-        }
+        let mut mob = mob.base_mut();
+        mob.set_linear_velocity(Vector2::new(range, 0.0));
+        let lin_vel = mob.get_linear_velocity().rotated(real::from_f32(direction));
+        mob.set_linear_velocity(lin_vel);
 
         let mut hud = self.base.get_node_as::<Hud>("Hud");
-        hud.bind_mut().connect(
+        hud.base_mut().connect(
             "start_game".into(),
             Callable::from_object_method(mob, "on_start_game"),
         );

--- a/examples/dodge-the-creeps/rust/src/main_scene.rs
+++ b/examples/dodge-the-creeps/rust/src/main_scene.rs
@@ -100,13 +100,12 @@ impl Main {
             rng.gen_range(mob.min_speed..mob.max_speed)
         };
 
-        let mut mob = mob.base_mut();
         mob.set_linear_velocity(Vector2::new(range, 0.0));
         let lin_vel = mob.get_linear_velocity().rotated(real::from_f32(direction));
         mob.set_linear_velocity(lin_vel);
 
         let mut hud = self.base.get_node_as::<Hud>("Hud");
-        hud.base_mut().connect(
+        hud.connect(
             "start_game".into(),
             Callable::from_object_method(mob, "on_start_game"),
         );

--- a/examples/dodge-the-creeps/rust/src/player.rs
+++ b/examples/dodge-the-creeps/rust/src/player.rs
@@ -58,8 +58,6 @@ impl Area2DVirtual for Player {
     }
 
     fn process(&mut self, delta: f64) {
-        println!("process");
-
         let mut animated_sprite = self
             .base
             .get_node_as::<AnimatedSprite2D>("AnimatedSprite2D");

--- a/godot-core/src/obj/traits.rs
+++ b/godot-core/src/obj/traits.rs
@@ -260,6 +260,8 @@ pub mod dom {
 
     /// Trait that specifies who declares a given `GodotClass`.
     pub trait Domain: Sealed {
+        type DerefTarget<T: GodotClass>;
+
         #[doc(hidden)]
         fn scoped_mut<T, F, R>(obj: &mut Gd<T>, closure: F) -> R
         where
@@ -271,6 +273,8 @@ pub mod dom {
     pub enum EngineDomain {}
     impl Sealed for EngineDomain {}
     impl Domain for EngineDomain {
+        type DerefTarget<T: GodotClass> = T;
+
         fn scoped_mut<T, F, R>(obj: &mut Gd<T>, closure: F) -> R
         where
             T: GodotClass<Declarer = EngineDomain>,
@@ -284,6 +288,8 @@ pub mod dom {
     pub enum UserDomain {}
     impl Sealed for UserDomain {}
     impl Domain for UserDomain {
+        type DerefTarget<T: GodotClass> = T::Base;
+
         fn scoped_mut<T, F, R>(obj: &mut Gd<T>, closure: F) -> R
         where
             T: GodotClass<Declarer = Self>,

--- a/godot-core/src/obj/traits.rs
+++ b/godot-core/src/obj/traits.rs
@@ -122,17 +122,18 @@ pub trait Inherits<Base>: GodotClass {}
 
 impl<T: GodotClass> Inherits<T> for T {}
 
-/// Trait implemented for all objects that inherit from `Resource` or `Node`. As those are the only objects
-/// you can export to the editor.
+/// Trait implemented for all objects that inherit from `Resource` or `Node`.
+///
+/// Those are the only objects you can export to the editor.
 pub trait ExportableObject: GodotClass {}
 
-/// Auto-implemented for all engine-provided classes
+/// Auto-implemented for all engine-provided classes.
 pub trait EngineClass: GodotClass {
     fn as_object_ptr(&self) -> sys::GDExtensionObjectPtr;
     fn as_type_ptr(&self) -> sys::GDExtensionTypePtr;
 }
 
-/// Auto-implemented for all engine-provided enums
+/// Auto-implemented for all engine-provided enums.
 pub trait EngineEnum: Copy {
     fn try_from_ord(ord: i32) -> Option<Self>;
 
@@ -176,6 +177,7 @@ pub trait IndexEnum: EngineEnum {
 /// Capability traits, providing dedicated functionalities for Godot classes
 pub mod cap {
     use super::*;
+    use crate::obj::Gd;
 
     /// Trait for all classes that are constructible from the Godot engine.
     ///
@@ -190,6 +192,17 @@ pub mod cap {
     pub trait GodotInit: GodotClass {
         #[doc(hidden)]
         fn __godot_init(base: Base<Self::Base>) -> Self;
+    }
+
+    /// Trait that's implemented for user-defined classes that provide a `#[base]` field.
+    ///
+    /// Gives direct access to the base pointer without going through upcast FFI.
+    pub trait WithBaseField: GodotClass {
+        #[doc(hidden)]
+        fn __godot_base(&self) -> &Gd<Self::Base>;
+
+        #[doc(hidden)]
+        fn __godot_base_mut(&mut self) -> &mut Gd<Self::Base>;
     }
 
     // TODO Evaluate whether we want this public or not

--- a/godot-core/src/registry.rs
+++ b/godot-core/src/registry.rs
@@ -311,10 +311,7 @@ pub mod callbacks {
         let base = unsafe { Base::from_sys(base_ptr) };
         let user_instance = make_user_instance(base);
 
-        // Create 2nd base to cache inside storage. This one will remain weak forever (no action on destruction).
-        let cached_base = unsafe { Base::from_sys(base_ptr) };
-
-        let instance = InstanceStorage::<T>::construct(user_instance, cached_base);
+        let instance = InstanceStorage::<T>::construct(user_instance);
         let instance_ptr = instance.into_raw();
         let instance_ptr = instance_ptr as sys::GDExtensionClassInstancePtr;
 

--- a/godot-macros/src/derive_godot_class/mod.rs
+++ b/godot-macros/src/derive_godot_class/mod.rs
@@ -35,8 +35,6 @@ pub fn transform(decl: Declaration) -> ParseResult<TokenStream> {
     let inherits_macro = format_ident!("inherits_transitive_{}", base_ty);
 
     let prv = quote! { ::godot::private };
-    let deref_impl = make_deref_impl(class_name, &fields);
-
     let godot_exports_impl = make_property_impl(class_name, &fields);
 
     let (godot_init_impl, create_fn);
@@ -61,7 +59,6 @@ pub fn transform(decl: Declaration) -> ParseResult<TokenStream> {
 
         #godot_init_impl
         #godot_exports_impl
-        #deref_impl
 
         ::godot::sys::plugin_add!(__GODOT_PLUGIN_REGISTRY in #prv; #prv::ClassPlugin {
             class_name: #class_name_obj,
@@ -226,29 +223,6 @@ fn make_godot_init_impl(class_name: &Ident, fields: Fields) -> TokenStream {
                     #( #rest_init )*
                     #base_init
                 }
-            }
-        }
-    }
-}
-
-fn make_deref_impl(class_name: &Ident, fields: &Fields) -> TokenStream {
-    let base_field = if let Some(Field { name, .. }) = &fields.base_field {
-        name
-    } else {
-        return TokenStream::new();
-    };
-
-    quote! {
-        impl std::ops::Deref for #class_name {
-            type Target = <Self as ::godot::obj::GodotClass>::Base;
-
-            fn deref(&self) -> &Self::Target {
-                &*self.#base_field
-            }
-        }
-        impl std::ops::DerefMut for #class_name {
-            fn deref_mut(&mut self) -> &mut Self::Target {
-                &mut *self.#base_field
             }
         }
     }

--- a/itest/rust/src/base_test.rs
+++ b/itest/rust/src/base_test.rs
@@ -27,12 +27,9 @@ fn base_instance_id() {
 fn base_access_unbound() {
     let mut obj = Gd::<Based>::new_default();
 
-    {
-        let pos = Vector2::new(-5.5, 7.0);
-        obj.base_mut().set_position(pos);
-
-        assert_eq!(obj.base().get_position(), pos);
-    }
+    let pos = Vector2::new(-5.5, 7.0);
+    obj.set_position(pos);
+    assert_eq!(obj.get_position(), pos);
 
     obj.free();
 }
@@ -42,12 +39,9 @@ fn base_access_unbound() {
 fn base_access_unbound_no_field() {
     let mut obj = Gd::<Baseless>::new_default();
 
-    {
-        let pos = Vector2::new(-5.5, 7.0);
-        obj.base_mut().set_position(pos);
-
-        assert_eq!(obj.base().get_position(), pos);
-    }
+    let pos = Vector2::new(-5.5, 7.0);
+    obj.set_position(pos);
+    assert_eq!(obj.get_position(), pos);
 
     obj.free();
 }

--- a/itest/rust/src/base_test.rs
+++ b/itest/rust/src/base_test.rs
@@ -15,7 +15,7 @@ fn base_test_is_weak() {
 
 #[itest]
 fn base_instance_id() {
-    let obj = Gd::<BaseHolder>::new_default();
+    let obj = Gd::<Based>::new_default();
     let obj_id = obj.instance_id();
     let base_id = obj.bind().base.instance_id();
 
@@ -24,15 +24,29 @@ fn base_instance_id() {
 }
 
 #[itest]
-fn base_deref() {
-    let mut obj = Gd::<BaseHolder>::new_default();
+fn base_access_unbound() {
+    let mut obj = Gd::<Based>::new_default();
 
     {
-        let mut guard = obj.bind_mut();
         let pos = Vector2::new(-5.5, 7.0);
-        guard.set_position(pos); // GdMut as DerefMut
+        obj.base_mut().set_position(pos);
 
-        assert_eq!(guard.base.get_position(), pos);
+        assert_eq!(obj.base().get_position(), pos);
+    }
+
+    obj.free();
+}
+
+// Tests whether access to base is possible from outside the Gd<T>, even if there is no `#[base]` field.
+#[itest]
+fn base_access_unbound_no_field() {
+    let mut obj = Gd::<Baseless>::new_default();
+
+    {
+        let pos = Vector2::new(-5.5, 7.0);
+        obj.base_mut().set_position(pos);
+
+        assert_eq!(obj.base().get_position(), pos);
     }
 
     obj.free();
@@ -40,14 +54,14 @@ fn base_deref() {
 
 #[itest]
 fn base_display() {
-    let obj = Gd::<BaseHolder>::new_default();
+    let obj = Gd::<Based>::new_default();
     {
         let guard = obj.bind();
         let id = guard.base.instance_id();
 
-        // We expect the dynamic type to be part of Godot's to_string(), so BaseHolder and not Node2D
+        // We expect the dynamic type to be part of Godot's to_string(), so Based and not Node2D
         let actual = format!(".:{}:.", guard.base);
-        let expected = format!(".:<BaseHolder#{id}>:.");
+        let expected = format!(".:<Based#{id}>:.");
 
         assert_eq!(actual, expected);
     }
@@ -56,14 +70,14 @@ fn base_display() {
 
 #[itest]
 fn base_debug() {
-    let obj = Gd::<BaseHolder>::new_default();
+    let obj = Gd::<Based>::new_default();
     {
         let guard = obj.bind();
         let id = guard.base.instance_id();
 
-        // We expect the dynamic type to be part of Godot's to_string(), so BaseHolder and not Node2D
+        // We expect the dynamic type to be part of Godot's to_string(), so Based and not Node2D
         let actual = format!(".:{:?}:.", guard.base);
-        let expected = format!(".:Base {{ id: {id}, class: BaseHolder }}:.");
+        let expected = format!(".:Base {{ id: {id}, class: Based }}:.");
 
         assert_eq!(actual, expected);
     }
@@ -72,23 +86,30 @@ fn base_debug() {
 
 #[itest]
 fn base_with_init() {
-    let obj = Gd::<BaseHolder>::with_base(|mut base| {
+    let obj = Gd::<Based>::with_base(|mut base| {
         base.set_rotation(11.0);
-        BaseHolder { base, i: 732 }
+        Based { base, i: 732 }
     });
 
     {
         let guard = obj.bind();
         assert_eq!(guard.i, 732);
-        assert_eq!(guard.get_rotation(), 11.0);
+        assert_eq!(guard.base.get_rotation(), 11.0);
     }
     obj.free();
 }
 
 #[derive(GodotClass)]
 #[class(init, base=Node2D)]
-struct BaseHolder {
+struct Based {
     #[base]
     base: Base<Node2D>,
+
     i: i32,
+}
+
+#[derive(GodotClass)]
+#[class(init, base=Node2D)]
+struct Baseless {
+    // No need for fields, we just test if we can access this as Gd<Node2D>.
 }

--- a/itest/rust/src/callable_test.rs
+++ b/itest/rust/src/callable_test.rs
@@ -6,17 +6,14 @@
 
 use godot::bind::{godot_api, GodotClass};
 use godot::builtin::{varray, Callable, ToVariant, Variant};
-use godot::engine::{Object, RefCounted};
-use godot::obj::{Base, Gd, Share};
+use godot::engine::Object;
+use godot::obj::{Gd, Share};
 use godot::prelude::GodotString;
 use godot::test::itest;
 
 #[derive(GodotClass)]
 #[class(init, base=RefCounted)]
 struct CallableTestObj {
-    #[base]
-    base: Base<RefCounted>,
-
     value: i32,
 }
 

--- a/itest/rust/src/codegen_test.rs
+++ b/itest/rust/src/codegen_test.rs
@@ -24,7 +24,7 @@ fn codegen_base_renamed() {
     // The registration is done at startup time, so it may already fail during GDExtension init.
     // Nevertheless, try to instantiate an object with base HttpRequest here.
 
-    let obj = Gd::with_base(|base| TestBaseRenamed { base });
+    let obj = Gd::with_base(|base| TestBaseRenamed { _base: base });
     let _id = obj.instance_id();
 
     obj.free();
@@ -62,7 +62,7 @@ fn codegen_constants() {
 #[class(base=HttpRequest)]
 pub struct TestBaseRenamed {
     #[base]
-    base: Base<HttpRequest>,
+    _base: Base<HttpRequest>,
 }
 
 #[allow(unused)]
@@ -81,7 +81,7 @@ impl TestBaseRenamed {
 #[godot_api]
 impl HttpRequestVirtual for TestBaseRenamed {
     fn init(base: Base<HttpRequest>) -> Self {
-        TestBaseRenamed { base }
+        TestBaseRenamed { _base: base }
     }
 
     // Test unnamed parameter in virtual function

--- a/itest/rust/src/native_structures_test.rs
+++ b/itest/rust/src/native_structures_test.rs
@@ -15,8 +15,6 @@ use std::cell::Cell;
 #[derive(GodotClass)]
 #[class(base=TextServerExtension)]
 pub struct TestTextServer {
-    #[base]
-    base: Base<TextServerExtension>,
     glyphs: [Glyph; 2],
     cell: Cell<Option<(Rid, i64)>>,
 }
@@ -40,9 +38,8 @@ fn sample_glyph(start: i32) -> Glyph {
 
 #[godot_api]
 impl TextServerExtensionVirtual for TestTextServer {
-    fn init(base: Base<TextServerExtension>) -> Self {
+    fn init(_base: Base<TextServerExtension>) -> Self {
         TestTextServer {
-            base,
             glyphs: [sample_glyph(99), sample_glyph(700)],
             cell: Cell::new(None),
         }

--- a/itest/rust/src/object_test.rs
+++ b/itest/rust/src/object_test.rs
@@ -5,7 +5,6 @@
  */
 
 use std::cell::{Cell, RefCell};
-use std::mem;
 use std::rc::Rc;
 
 use godot::bind::{godot_api, GodotClass};
@@ -56,7 +55,7 @@ fn object_subtype_swap() {
     println!("..swap..");
     */
 
-    mem::swap(&mut *a, &mut *b);
+    std::mem::swap(&mut *a, &mut *b);
 
     /*
     dbg!(a_id);
@@ -792,9 +791,6 @@ fn custom_constructor_works() {
 #[derive(GodotClass)]
 #[class(init, base=Object)]
 struct DoubleUse {
-    #[base]
-    base: Base<Object>,
-
     used: Cell<bool>,
 }
 
@@ -849,26 +845,4 @@ fn double_use_reference() {
 
     double_use.free();
     emitter.free();
-}
-
-#[derive(GodotClass)]
-#[class(init, base=Object)]
-struct GodotApiTest {
-    #[base]
-    base: Base<Object>,
-}
-
-#[godot_api]
-impl GodotApiTest {
-    #[func]
-    fn func_only_mut(&mut self, mut _a: Gd<Object>, mut _b: Gd<Object>) {}
-    #[func]
-    fn func_mut_and_not_mut(&mut self, _a: Gd<Object>, mut _b: Gd<Object>, _c: Gd<Object>) {}
-    // #[func]
-    // fn func_optional(&mut self, _a: Gd<Object>, mut _b: Gd<Object>, #[opt(987)] _c: i32) {}
-    // #[func] // waiting https://github.com/godotengine/godot/pull/75415
-    // /// Godot Docs
-    // fn func_docs(&mut self, _a: Gd<Object>, mut _b: Gd<Object>) {}
-    // #[func]
-    // fn func_lifetime<'a>(&'a mut self) {}
 }

--- a/itest/rust/src/object_test.rs
+++ b/itest/rust/src/object_test.rs
@@ -763,9 +763,6 @@ pub mod object_test_gd {
     #[derive(GodotClass)]
     #[class(base=Object)]
     pub struct CustomConstructor {
-        #[base]
-        base: Base<Object>,
-
         #[var]
         pub val: i64,
     }
@@ -774,7 +771,7 @@ pub mod object_test_gd {
     impl CustomConstructor {
         #[func]
         pub fn construct_object(val: i64) -> Gd<CustomConstructor> {
-            Gd::with_base(|base| Self { base, val })
+            Gd::with_base(|_base| Self { val })
         }
     }
 }
@@ -804,10 +801,7 @@ impl DoubleUse {
 
 #[derive(GodotClass)]
 #[class(init, base=Object)]
-struct SignalEmitter {
-    #[base]
-    base: Base<Object>,
-}
+struct SignalEmitter {}
 
 #[godot_api]
 impl SignalEmitter {

--- a/itest/rust/src/property_test.rs
+++ b/itest/rust/src/property_test.rs
@@ -15,28 +15,33 @@ use godot::{
 #[derive(GodotClass)]
 #[class(base=Node)]
 struct HasProperty {
-    #[base]
-    base: Base<Node>,
-
     #[var]
     int_val: i32,
+
     #[var(get = get_int_val_read)]
     int_val_read: i32,
+
     #[var(set = set_int_val_write)]
     int_val_write: i32,
+
     #[var(get = get_int_val_rw, set = set_int_val_rw)]
     int_val_rw: i32,
+
     #[var(get = get_int_val_getter, set)]
     int_val_getter: i32,
+
     #[var(get, set = set_int_val_setter)]
     int_val_setter: i32,
 
     #[var(get = get_string_val, set = set_string_val)]
     string_val: GodotString,
+
     #[var(get = get_object_val, set = set_object_val)]
     object_val: Option<Gd<Object>>,
+
     #[var]
     texture_val: Gd<Texture>,
+
     #[var(get = get_texture_val, set = set_texture_val, hint = PROPERTY_HINT_RESOURCE_TYPE, hint_string = "Texture")]
     texture_val_rw: Option<Gd<Texture>>,
 }
@@ -120,7 +125,7 @@ impl HasProperty {
 
 #[godot_api]
 impl NodeVirtual for HasProperty {
-    fn init(base: Base<Node>) -> Self {
+    fn init(_base: Base<Node>) -> Self {
         HasProperty {
             int_val: 0,
             int_val_read: 2,
@@ -132,7 +137,6 @@ impl NodeVirtual for HasProperty {
             string_val: GodotString::new(),
             texture_val: Texture::new(),
             texture_val_rw: None,
-            base,
         }
     }
 }

--- a/itest/rust/src/signal_test.rs
+++ b/itest/rust/src/signal_test.rs
@@ -82,10 +82,10 @@ fn signals() {
         let receiver_name = format!("receive_{i}_arg");
 
         emitter
-            .bind_mut()
+            .base_mut()
             .connect(signal_name.clone().into(), receiver.callable(receiver_name));
 
-        emitter.bind_mut().emit_signal(signal_name.into(), arg);
+        emitter.base_mut().emit_signal(signal_name.into(), arg);
 
         assert!(receiver.bind().used[i].get());
     }

--- a/itest/rust/src/signal_test.rs
+++ b/itest/rust/src/signal_test.rs
@@ -17,10 +17,7 @@ use crate::itest;
 
 #[derive(GodotClass)]
 #[class(init, base=Object)]
-struct Emitter {
-    #[base]
-    base: Base<Object>,
-}
+struct Emitter {}
 
 #[godot_api]
 impl Emitter {
@@ -81,11 +78,8 @@ fn signals() {
         let signal_name = format!("signal_{i}_arg");
         let receiver_name = format!("receive_{i}_arg");
 
-        emitter
-            .base_mut()
-            .connect(signal_name.clone().into(), receiver.callable(receiver_name));
-
-        emitter.base_mut().emit_signal(signal_name.into(), arg);
+        emitter.connect(signal_name.clone().into(), receiver.callable(receiver_name));
+        emitter.emit_signal(signal_name.into(), arg);
 
         assert!(receiver.bind().used[i].get());
     }


### PR DESCRIPTION
No more implicit access to base from _inside_ the object. Access to base objects inside `Gd<T>` _must_ go through the `#[base]` field. For detailed motivation, see #131.

Instead, `Deref` and `DerefMut` are now implemented for _all_ `Gd<T>` pointers, not just the engine ones. This means that calling Godot methods will be uniform, and there is always a clear separation between accessing the Godot object and the user object.

|| user object | engine object |
|---|---|---|
| inside `T` | `self` | _(not possible)_ |
| outside `Gd<T>` | `gd.bind/bind_mut()` | `gd.method()` |


Also, `InstanceStorage` is now only accessed via shared-ref, which should fix some soundness issues with previously unbounded `&mut`. All its fields are immutable or have interior mutability.

Closes #131.

---

### Outdated

Where I'm still not sure is, if we can provide `Deref`/`DerefMut` on `Gd<T>` into `&T::Base` and `&mut T::Base`.
This is different from the current behavior, where `Deref`/`DerefMut` was implemented on the user-object `T`.

A big unknown is especially the mutable case -- how would we avoid aliased `&mut` when two `Gd<T>` are concurrently mut-derefed?
```rs
#[derive(GodotClass)]
#[class(base=Node)]
struct MyClass {...}

let mut a: Gd<MyClass>= ...;
let mut b: Gd<MyClass> = a.share();

// using DerefMut:
let base_a: &mut Node = *a;
let base_b: &mut Node = *b;
```

We do already something similar for `Gd<T>` with engine types, but there, the engine instances (`Node` handles) have physically different locations. As of this PR's current state, they have one location (inside `InstanceStorage`) -- but maybe it would be possible to re-interpret the opaque object inside `Gd` directly (or if that doesn't work, create a new field with the `Node` itself).

_(All in all it's rather an academic problem, as we're not actually mutating the engine object, but Rust's aliasing rules are potentially problematic here.)_

---

Solution to the above: instead of storing a central `Base<T>` in the storage, as it was done in the earlier commit, we directly transmute the `Gd.opaque` field into `T`. This object is at a distinct memory location for each `Gd` pointer, as such there is no `&mut` aliasing when using `DerefMut` on aliased `Gd` pointers.