### PR TITLE
#[derive(Property, Export)] for enums

### DIFF
--- a/godot-macros/src/derive_export.rs
+++ b/godot-macros/src/derive_export.rs
@@ -1,0 +1,77 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote;
+use venial::{Declaration, StructFields};
+
+use crate::util::{bail, decl_get_info, DeclInfo};
+use crate::ParseResult;
+
+pub fn transform(decl: Declaration) -> ParseResult<TokenStream2> {
+    let DeclInfo { name, .. } = decl_get_info(&decl);
+
+    let enum_ = match decl {
+        Declaration::Enum(e) => e,
+        Declaration::Struct(s) => {
+            return bail!(s.tk_struct, "Export can only be derived on enums for now")
+        }
+        Declaration::Union(u) => {
+            return bail!(u.tk_union, "Export can only be derived on enums for now")
+        }
+        _ => unreachable!(),
+    };
+
+    let hint_string = if enum_.variants.is_empty() {
+        return bail!(
+            enum_.name,
+            "In order to derive Export, enums must have at least one variant"
+        );
+    } else {
+        let mut hint_string_segments = Vec::new();
+        for (enum_v, _) in enum_.variants.inner.iter() {
+            let v_name = enum_v.name.clone();
+            let v_disc = if let Some(c) = enum_v.value.clone() {
+                c.value
+            } else {
+                return bail!(
+                    v_name,
+                    "Property can only be derived on enums with explicit discriminants in all their variants"
+                );
+            };
+            let v_disc_trimmed = v_disc
+                .to_string()
+                .trim_matches(['(', ')'].as_slice())
+                .to_string();
+
+            hint_string_segments.push(format!("{v_name}:{v_disc_trimmed}"));
+
+            match &enum_v.contents {
+                StructFields::Unit => {}
+                _ => {
+                    return bail!(
+                        v_name,
+                        "Property can only be derived on enums with only unit variants for now"
+                    )
+                }
+            };
+        }
+        hint_string_segments.join(",")
+    };
+
+    let out = quote! {
+        #[allow(unused_parens)]
+        impl godot::bind::property::Export for #name {
+            fn default_export_info() -> godot::bind::property::ExportInfo {
+                godot::bind::property::ExportInfo {
+                    hint: godot::engine::global::PropertyHint::PROPERTY_HINT_ENUM,
+                    hint_string: godot::prelude::GodotString::from(#hint_string),
+                }
+            }
+        }
+    };
+    Ok(out)
+}

--- a/godot-macros/src/derive_property.rs
+++ b/godot-macros/src/derive_property.rs
@@ -1,0 +1,121 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use proc_macro2::TokenStream as TokenStream2;
+use quote::{quote, ToTokens};
+use venial::{Declaration, StructFields};
+
+use crate::util::{bail, decl_get_info, ident, DeclInfo};
+use crate::ParseResult;
+
+pub fn transform(decl: Declaration) -> ParseResult<TokenStream2> {
+    let DeclInfo {
+        name, name_string, ..
+    } = decl_get_info(&decl);
+
+    let body_get;
+    let body_set;
+    let intermediate;
+
+    let enum_ = match decl {
+        Declaration::Enum(e) => e,
+        Declaration::Struct(s) => {
+            return bail!(s.tk_struct, "Property can only be derived on enums for now")
+        }
+        Declaration::Union(u) => {
+            return bail!(u.tk_union, "Property can only be derived on enums for now")
+        }
+        _ => unreachable!(),
+    };
+
+    if enum_.variants.is_empty() {
+        return bail!(
+            enum_.name,
+            "In order to derive Property, enums must have at least one variant"
+        );
+    } else {
+        let mut matches_get = quote! {};
+        let mut matches_set = quote! {};
+        intermediate = if let Some(attr) = enum_
+            .attributes
+            .iter()
+            .find(|attr| attr.get_single_path_segment() == Some(&ident("repr")))
+        {
+            attr.value.to_token_stream()
+        } else {
+            return bail!(
+                name,
+                "Property can only be derived on enums with an explicit `#[repr(i*/u*)]` type"
+            );
+        };
+
+        for (enum_v, _) in enum_.variants.inner.iter() {
+            let v_name = enum_v.name.clone();
+            let v_disc = if let Some(c) = enum_v.value.clone() {
+                c.value
+            } else {
+                return bail!(
+                    v_name,
+                    "Property can only be derived on enums with explicit discriminants in all their variants"
+                );
+            };
+
+            let match_content_get;
+            let match_content_set;
+            match &enum_v.contents {
+                StructFields::Unit => {
+                    match_content_get = quote! {
+                        Self::#v_name => #v_disc,
+                    };
+                    match_content_set = quote! {
+                        #v_disc => Self::#v_name,
+                    };
+                }
+                _ => {
+                    return bail!(
+                        v_name,
+                        "Property can only be derived on enums with only unit variants for now"
+                    )
+                }
+            };
+            matches_get = quote! {
+                #matches_get
+                #match_content_get
+            };
+            matches_set = quote! {
+                #matches_set
+                #match_content_set
+            };
+        }
+        body_get = quote! {
+            match &self {
+                #matches_get
+            }
+        };
+        body_set = quote! {
+            *self = match value {
+                #matches_set
+                _ => panic!("Incorrect conversion from {} to {}", stringify!(#intermediate), #name_string),
+            }
+        };
+    }
+
+    let out = quote! {
+        #[allow(unused_parens)]
+        impl godot::bind::property::Property for #name {
+            type Intermediate = #intermediate;
+
+            fn get_property(&self) -> #intermediate {
+                #body_get
+            }
+
+            fn set_property(&mut self, value: #intermediate) {
+                #body_set
+            }
+        }
+    };
+    Ok(out)
+}

--- a/godot/src/lib.rs
+++ b/godot/src/lib.rs
@@ -169,7 +169,7 @@ pub mod init {
 /// Export user-defined classes and methods to be called by the engine.
 pub mod bind {
     pub use godot_core::property;
-    pub use godot_macros::{godot_api, FromVariant, GodotClass, ToVariant};
+    pub use godot_macros::{godot_api, Export, FromVariant, GodotClass, Property, ToVariant};
 }
 
 /// Testing facilities (unstable).
@@ -184,7 +184,7 @@ pub use godot_core::private;
 /// Often-imported symbols.
 pub mod prelude {
     pub use super::bind::property::{Export, Property, TypeStringHint};
-    pub use super::bind::{godot_api, FromVariant, GodotClass, ToVariant};
+    pub use super::bind::{godot_api, Export, FromVariant, GodotClass, Property, ToVariant};
 
     pub use super::builtin::math::FloatExt as _;
     pub use super::builtin::*;


### PR DESCRIPTION
MVP macros for deriving Property and Export in enums.

Not done yet, but hoping for reviews since this is my first contribution to a library of this size.

### Commits will be squashed later, please review as one for now.

Current requirements for deriving these traits:
- Must be an enum
- Must have an explicit `#[repr(i*/u*)]` type
- Variants must be unit/fieldless and have explicit discriminant numbers (`A = 2` instead of `A(u32) = 2` or `A`)

From earlier attempts, it seemed like ToVariant and FromVariant were needed as well? Doesn't seem to be the case anymore, weirdly.

TODO list:

- [x] `#[derive(Property)]`
    - [x] Implement
    - [x] Create tests
    - [x] Document
    - [ ] Expand support?
- [x] `#[derive(Export)]`
    - [x] Implement
    - [x] Create tests
    - [x] Document
    - [ ] Expand support?