### PR TITLE
`#[class(tool)]` for per-class editor run behavior

### DIFF
--- a/godot-core/src/builtin/real.rs
+++ b/godot-core/src/builtin/real.rs
@@ -199,7 +199,7 @@ macro_rules! real {
 
 /// Array of reals.
 ///
-/// ### Examples
+/// # Example
 /// ```
 /// use godot_core::builtin::{real, reals};
 ///

--- a/godot-core/src/engine.rs
+++ b/godot-core/src/engine.rs
@@ -160,7 +160,7 @@ where
 ///
 /// The path must be absolute (typically starting with `res://`), a local path will fail.
 ///
-/// # Example:
+/// # Example
 /// Loads a scene called `Main` located in the `path/to` subdirectory of the Godot project and caches it in a variable.
 /// The resource is directly stored with type `PackedScene`.
 ///

--- a/godot-core/src/lib.rs
+++ b/godot-core/src/lib.rs
@@ -63,6 +63,23 @@ pub mod private {
         sys::plugin_foreach!(__GODOT_PLUGIN_REGISTRY; visitor);
     }
 
+    pub struct ClassConfig {
+        pub is_tool: bool,
+    }
+
+    pub fn is_class_inactive(is_tool: bool) -> bool {
+        if is_tool {
+            return false;
+        }
+
+        // SAFETY: only invoked after global library initialization.
+        let global_config = unsafe { sys::config() };
+        let is_editor = || crate::engine::Engine::singleton().is_editor_hint();
+
+        global_config.tool_only_in_editor //.
+            && *global_config.is_editor.get_or_init(is_editor)
+    }
+
     fn print_panic(err: Box<dyn std::any::Any + Send>) {
         if let Some(s) = err.downcast_ref::<&'static str>() {
             print_panic_message(s);

--- a/godot-core/src/registry.rs
+++ b/godot-core/src/registry.rs
@@ -20,6 +20,10 @@ use std::any::Any;
 use std::collections::HashMap;
 use std::{fmt, ptr};
 
+// TODO(bromeon): some information coming from the proc-macro API is deferred through PluginComponent, while others is directly
+// translated to code. Consider moving more code to the PluginComponent, which allows for more dynamic registration and will
+// be easier for a future builder API.
+
 /// Piece of information that is gathered by the self-registration ("plugin") system.
 #[derive(Debug)]
 pub struct ClassPlugin {

--- a/godot-ffi/src/lib.rs
+++ b/godot-ffi/src/lib.rs
@@ -61,7 +61,7 @@ struct GdextRuntimeMetadata {
 }
 
 pub struct GdextConfig {
-    pub virtuals_active_in_editor: bool,
+    pub tool_only_in_editor: bool,
     pub is_editor: cell::OnceCell<bool>,
 }
 

--- a/godot-macros/src/derive_godot_class/mod.rs
+++ b/godot-macros/src/derive_godot_class/mod.rs
@@ -210,7 +210,7 @@ fn make_godot_init_impl(class_name: &Ident, fields: Fields) -> TokenStream {
     let rest_init = fields.all_fields.into_iter().map(|field| {
         let field_name = field.name;
         let value_expr = match field.default {
-            None => quote!(::std::default::Default::default()),
+            None => quote! { ::std::default::Default::default() },
             Some(default) => default,
         };
         quote! { #field_name: #value_expr, }

--- a/godot-macros/src/godot_api.rs
+++ b/godot-macros/src/godot_api.rs
@@ -469,12 +469,8 @@ fn transform_trait_impl(original_impl: Impl) -> Result<TokenStream, Error> {
             fn __virtual_call(name: &str) -> ::godot::sys::GDExtensionClassCallVirtual {
                 //println!("virtual_call: {}.{}", std::any::type_name::<Self>(), name);
 
-                let __config = unsafe { ::godot::sys::config() };
-
-                if __config.tools_only {
-                     && *__config.is_editor.get_or_init(|| ::godot::engine::Engine::singleton().is_editor_hint()) {
-                        return None;
-                    }
+                if ::godot::private::is_class_inactive(Self::__config().is_tool) {
+                    return None;
                 }
 
                 match name {

--- a/godot-macros/src/godot_api.rs
+++ b/godot-macros/src/godot_api.rs
@@ -419,6 +419,10 @@ fn transform_trait_impl(original_impl: Impl) -> Result<TokenStream, Error> {
                 on_notification_impl = quote! {
                     impl ::godot::obj::cap::GodotNotification for #class_name {
                         fn __godot_notification(&mut self, what: i32) {
+                            if ::godot::private::is_class_inactive(Self::__config().is_tool) {
+                                return;
+                            }
+
                             <Self as #trait_name>::on_notification(self, what.into())
                         }
                     }

--- a/godot-macros/src/lib.rs
+++ b/godot-macros/src/lib.rs
@@ -100,6 +100,7 @@ mod util;
 /// Derive macro for [the `GodotClass` trait](../obj/trait.GodotClass.html) on structs. You must use this
 /// macro; manual implementations of the `GodotClass` trait are not supported.
 ///
+///
 /// # Construction
 ///
 /// To generate a constructor that will let you call `MyStruct.new()` from GDScript, annotate your
@@ -180,7 +181,8 @@ mod util;
 /// }
 /// ```
 ///
-/// # Exported properties
+///
+/// # Properties and exports
 ///
 /// In GDScript, there is a distinction between
 /// [properties](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_basics.html#properties-setters-and-getters)
@@ -382,6 +384,17 @@ mod util;
 ///
 /// The `#[signal]` attribute is accepted, but not yet implemented. See [issue
 /// #8](https://github.com/godot-rust/gdext/issues/8).
+///
+///
+/// # Running code in the editor
+///
+/// If you annotate a class with `#[class(tool)]`, its lifecycle methods (`ready()`, `process()` etc.) will be invoked in the editor. This
+/// is useful for writing custom editor plugins, as opposed to classes running simply in-game.
+///
+/// See [`ExtensionLibrary::editor_run_behavior()`](../init/trait.ExtensionLibrary.html#method.editor_run_behavior)
+/// for more information and further customization.
+///
+/// This is very similar to [GDScript's `@tool` feature](https://docs.godotengine.org/en/stable/tutorials/plugins/running_code_in_the_editor.html).
 #[proc_macro_derive(GodotClass, attributes(class, base, var, export, init, signal))]
 pub fn derive_native_class(input: TokenStream) -> TokenStream {
     translate(input, derive_godot_class::transform)

--- a/godot-macros/src/lib.rs
+++ b/godot-macros/src/lib.rs
@@ -27,9 +27,9 @@
 ///
 /// # Examples
 ///
-/// ## Example with `RefCounted` as a base
+/// ## `RefCounted` as a base
 ///
-/// ```
+/// ```no_run
 ///# use godot::prelude::*;
 ///
 /// #[derive(GodotClass)]
@@ -58,9 +58,9 @@
 /// Note that you have to implement init otherwise you won't be able to call new or any
 /// other methods from GDScript.
 ///
-/// ## Example with `Node` as a Base
+/// ## `Node` as a base
 ///
-/// ```
+/// ```no_run
 ///# use godot::prelude::*;
 ///
 /// #[derive(GodotClass)]
@@ -389,32 +389,32 @@ pub fn derive_native_class(input: TokenStream) -> TokenStream {
 
 /// Derive macro for [ToVariant](godot::builtin::ToVariant) on structs or enums.
 ///
-/// Example :
+/// # Example
 ///
-/// ```ignore
+/// ```no_run
+/// # use godot::prelude::*;
 /// #[derive(FromVariant, ToVariant, PartialEq, Debug)]
 /// struct StructNamed {
 ///     field1: String,
 ///     field2: i32,
 /// }
 ///
+/// let obj = StructNamed {
+///     field1: "1".to_string(),
+///     field2: 2,
+/// };
+/// let dict = dict! {
+///    "StructNamed": dict! {
+///        "field1": "four",
+///        "field2": 5,
+///    }
+/// };
+///
 /// // This would not panic.
-/// assert!(
-///     StructNamed {
-///         field1: "1".to_string(),
-///         field2: 2,
-///     }
-///     .to_variant()
-///         == dict! {
-///           "StructNamed":dict!{
-///             "field1":"four","field2":5
-///           }
-///         }
-///         .to_variant()
-/// );
+/// assert_eq!(obj.to_variant(), dict.to_variant());
 /// ```
 ///
-/// You can use the skip attribute to ignore a field from being converted to ToVariant.
+/// You can use the `#[skip]` attribute to ignore a field from being converted to `ToVariant`.
 #[proc_macro_derive(ToVariant, attributes(variant))]
 pub fn derive_to_variant(input: TokenStream) -> TokenStream {
     translate(input, derive_to_variant::transform)
@@ -422,29 +422,29 @@ pub fn derive_to_variant(input: TokenStream) -> TokenStream {
 
 /// Derive macro for [FromVariant](godot::builtin::FromVariant) on structs or enums.
 ///
-/// Example :
+/// # Example
 ///
-/// ```ignore
+/// ```no_run
+/// # use godot::prelude::*;
 /// #[derive(FromVariant, ToVariant, PartialEq, Debug)]
 /// struct StructNamed {
 ///     field1: String,
 ///     field2: i32,
 /// }
 ///
+/// let obj = StructNamed {
+///     field1: "1".to_string(),
+///     field2: 2,
+/// };
+/// let dict_variant = dict! {
+///    "StructNamed": dict! {
+///        "field1": "four",
+///        "field2": 5,
+///    }
+/// }.to_variant();
+///
 /// // This would not panic.
-/// assert!(
-///     StructNamed::from_variant(
-///         &dict! {
-///           "StructNamed":dict!{
-///             "field1":"four","field2":5
-///           }
-///         }
-///         .to_variant()
-///     ) == StructNamed {
-///         field1: "1".to_string(),
-///         field2: 2,
-///     }
-/// );
+/// assert_eq!(StructNamed::from_variant(&dict_variant), obj);
 /// ```
 ///
 /// You can use the skip attribute to ignore a field from the provided variant and use `Default::default()`

--- a/godot-macros/src/method_registration/mod.rs
+++ b/godot-macros/src/method_registration/mod.rs
@@ -10,7 +10,7 @@ use proc_macro2::{Ident, TokenStream};
 use quote::{format_ident, quote};
 
 pub use register_method::make_method_registration;
-pub use virtual_method_callback::gdext_virtual_method_callback;
+pub use virtual_method_callback::make_virtual_method_callback;
 
 #[derive(Copy, Clone, Eq, PartialEq)]
 enum ReceiverType {
@@ -49,7 +49,7 @@ fn make_forwarding_closure(class_name: &Ident, signature_info: &SignatureInfo) -
                     let ( #(#params,)* ) = params;
 
                     let storage =
-                        unsafe { godot::private::as_storage::<#class_name>(instance_ptr) };
+                        unsafe { ::godot::private::as_storage::<#class_name>(instance_ptr) };
                     #instance_decl
 
                     instance.#method_name(#(#params),*)
@@ -142,7 +142,7 @@ fn make_ptrcall_invocation(
     };
 
     quote! {
-         <#sig_tuple as godot::builtin::meta::PtrcallSignatureTuple>::ptrcall(
+         <#sig_tuple as ::godot::builtin::meta::PtrcallSignatureTuple>::ptrcall(
             instance_ptr,
             args,
             ret,
@@ -162,7 +162,7 @@ fn make_varcall_invocation(
     let method_name_str = method_name.to_string();
 
     quote! {
-        <#sig_tuple as godot::builtin::meta::VarcallSignatureTuple>::varcall(
+        <#sig_tuple as ::godot::builtin::meta::VarcallSignatureTuple>::varcall(
             instance_ptr,
             args,
             ret,

--- a/godot-macros/src/method_registration/register_method.rs
+++ b/godot-macros/src/method_registration/register_method.rs
@@ -38,10 +38,10 @@ pub fn make_method_registration(
 
     quote! {
         {
-            use godot::obj::GodotClass;
-            use godot::builtin::meta::registration::method::MethodInfo;
-            use godot::builtin::{StringName, Variant};
-            use godot::sys;
+            use ::godot::obj::GodotClass;
+            use ::godot::builtin::meta::registration::method::MethodInfo;
+            use ::godot::builtin::{StringName, Variant};
+            use ::godot::sys;
 
             type Sig = #sig_tuple;
 
@@ -67,7 +67,7 @@ pub fn make_method_registration(
                 )
             };
 
-            godot::private::out!(
+            ::godot::private::out!(
                 "   Register fn:   {}::{}",
                 #class_name_str,
                 #method_name_str
@@ -97,7 +97,7 @@ fn make_varcall_func(
                 ret: sys::GDExtensionVariantPtr,
                 err: *mut sys::GDExtensionCallError,
             ) {
-                let success = godot::private::handle_panic(
+                let success = ::godot::private::handle_panic(
                     || stringify!(#method_name),
                     || #invocation
                 );
@@ -132,7 +132,7 @@ fn make_ptrcall_func(
                 args: *const sys::GDExtensionConstTypePtr,
                 ret: sys::GDExtensionTypePtr,
             ) {
-                let success = godot::private::handle_panic(
+                let success = ::godot::private::handle_panic(
                     || stringify!(#method_name),
                     || #invocation
                 );

--- a/godot-macros/src/method_registration/virtual_method_callback.rs
+++ b/godot-macros/src/method_registration/virtual_method_callback.rs
@@ -4,7 +4,7 @@
 * file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 
-use proc_macro2::{Ident, TokenStream as TokenStream2};
+use proc_macro2::{Ident, TokenStream};
 use quote::quote;
 use venial::Function;
 
@@ -17,10 +17,10 @@ use crate::util;
 //
 // There are currently no virtual static methods. Additionally, virtual static methods dont really make a lot
 // of sense. Therefore there is no need to support them.
-pub fn gdext_virtual_method_callback(
+pub fn make_virtual_method_callback(
     class_name: &Ident,
     method_signature: &Function,
-) -> TokenStream2 {
+) -> TokenStream {
     let signature_info = get_signature_info(method_signature);
     let method_name = &method_signature.name;
 
@@ -32,7 +32,7 @@ pub fn gdext_virtual_method_callback(
 
     quote! {
         {
-            use godot::sys;
+            use ::godot::sys;
 
             unsafe extern "C" fn function(
                 instance_ptr: sys::GDExtensionClassInstancePtr,

--- a/godot-macros/src/util/mod.rs
+++ b/godot-macros/src/util/mod.rs
@@ -217,29 +217,29 @@ pub(crate) fn path_ends_with(path: &[TokenTree], expected: &str) -> bool {
 pub(crate) struct DeclInfo {
     pub where_: Option<WhereClause>,
     pub generic_params: Option<GenericParamList>,
-    pub name: proc_macro2::Ident,
+    pub name: Ident,
     pub name_string: String,
 }
 
 pub(crate) fn decl_get_info(decl: &venial::Declaration) -> DeclInfo {
-    let (where_, generic_params, name, name_string) =
-        if let venial::Declaration::Struct(struct_) = decl {
-            (
-                struct_.where_clause.clone(),
-                struct_.generic_params.clone(),
-                struct_.name.clone(),
-                struct_.name.to_string(),
-            )
-        } else if let venial::Declaration::Enum(enum_) = decl {
-            (
-                enum_.where_clause.clone(),
-                enum_.generic_params.clone(),
-                enum_.name.clone(),
-                enum_.name.to_string(),
-            )
-        } else {
-            panic!("only enums and structs are supported at the moment.")
-        };
+    let (where_, generic_params, name, name_string) = match decl {
+        venial::Declaration::Struct(struct_) => (
+            struct_.where_clause.clone(),
+            struct_.generic_params.clone(),
+            struct_.name.clone(),
+            struct_.name.to_string(),
+        ),
+        venial::Declaration::Enum(enum_) => (
+            enum_.where_clause.clone(),
+            enum_.generic_params.clone(),
+            enum_.name.clone(),
+            enum_.name.to_string(),
+        ),
+        _ => {
+            panic!("only enums and structs are supported at the moment")
+        }
+    };
+
     DeclInfo {
         where_,
         generic_params,


### PR DESCRIPTION
Builds on top of #365 to allow per-class granularity.

If you want a class' lifecycle callbacks to be run within the Godot editor, add the `#[class(tool)]` key.
```rs
#[derive(GodotClass)]
#[class(init, tool, base=Node2D)]
struct MyClass { ... }
```

By default, only tool classes are run in the editor now. You can still enable _all_ classes in `ExtensionLibrary`, which can be useful if you are building an editor plugin rather than a game.

Also fixes a bug where `on_notification()` was still running by default.