### PR TITLE
Add ability to rename functions bound to Godot

### DIFF
--- a/godot-macros/src/derive_godot_class/property/field_var.rs
+++ b/godot-macros/src/derive_godot_class/property/field_var.rs
@@ -6,6 +6,7 @@
 
 use crate::derive_godot_class::{make_existence_check, Field, FieldHint};
 use crate::method_registration::make_method_registration;
+use crate::method_registration::FuncDefinition;
 use crate::util::KvParser;
 use crate::{util, ParseResult};
 use proc_macro2::{Ident, TokenStream};
@@ -188,7 +189,13 @@ impl GetterSetterImpl {
         };
 
         let signature = util::parse_signature(signature);
-        let export_token = make_method_registration(class_name, signature);
+        let export_token = make_method_registration(
+            class_name,
+            FuncDefinition {
+                func: signature,
+                rename: None,
+            },
+        );
 
         Self {
             function_name,

--- a/godot-macros/src/method_registration/mod.rs
+++ b/godot-macros/src/method_registration/mod.rs
@@ -27,6 +27,14 @@ struct SignatureInfo {
     pub ret_type: TokenStream,
 }
 
+/// Information used for registering a Rust function with Godot.
+pub struct FuncDefinition {
+    /// Raw information about the Rust function.
+    pub func: venial::Function,
+    /// The name the function will be exposed as in Godot. If `None`, the Rust function name is used.
+    pub rename: Option<String>,
+}
+
 /// Returns a closure expression that forwards the parameters to the Rust instance.
 fn make_forwarding_closure(class_name: &Ident, signature_info: &SignatureInfo) -> TokenStream {
     let method_name = &signature_info.method_name;

--- a/godot-macros/src/method_registration/register_method.rs
+++ b/godot-macros/src/method_registration/register_method.rs
@@ -15,9 +15,9 @@ use quote::quote;
 /// Generates code that registers the specified method for the given class.
 pub fn make_method_registration(
     class_name: &Ident,
-    method_signature: venial::Function,
+    func_definition: super::FuncDefinition,
 ) -> TokenStream {
-    let signature_info = get_signature_info(&method_signature);
+    let signature_info = get_signature_info(&func_definition.func);
     let sig_tuple =
         util::make_signature_tuple_type(&signature_info.ret_type, &signature_info.param_types);
 
@@ -33,7 +33,11 @@ pub fn make_method_registration(
 
     // String literals
     let class_name_str = class_name.to_string();
-    let method_name_str = method_name.to_string();
+    let method_name_str = if let Some(rename) = func_definition.rename {
+        rename
+    } else {
+        method_name.to_string()
+    };
     let param_ident_strs = param_idents.iter().map(|ident| ident.to_string());
 
     quote! {

--- a/godot-macros/src/util/kv_parser.rs
+++ b/godot-macros/src/util/kv_parser.rs
@@ -18,6 +18,7 @@ pub(crate) type KvMap = HashMap<Ident, Option<KvValue>>;
 pub(crate) struct KvParser {
     map: KvMap,
     span: Span,
+    index: usize,
 }
 
 #[allow(dead_code)] // some functions will be used later
@@ -41,7 +42,7 @@ impl KvParser {
     pub fn parse(attributes: &[Attribute], expected: &str) -> ParseResult<Option<Self>> {
         let mut found_attr: Option<Self> = None;
 
-        for attr in attributes.iter() {
+        for (index, attr) in attributes.iter().enumerate() {
             let path = &attr.path;
             if path_is_single(path, expected) {
                 if found_attr.is_some() {
@@ -51,6 +52,7 @@ impl KvParser {
                 let attr_name = expected.to_string();
                 found_attr = Some(Self {
                     span: attr.tk_brackets.span,
+                    index,
                     map: ParserState::parse(attr_name, &attr.value)?,
                 });
             }
@@ -61,6 +63,10 @@ impl KvParser {
 
     pub fn span(&self) -> Span {
         self.span
+    }
+
+    pub fn index(&self) -> usize {
+        self.index
     }
 
     /// - For missing keys, returns `None`.

--- a/itest/godot/ManualFfiTests.gd
+++ b/itest/godot/ManualFfiTests.gd
@@ -289,3 +289,18 @@ func test_option_export():
 	assert_eq(obj.optional_export, null)
 
 	test_node.free()
+
+func test_func_rename():
+	var func_rename := FuncRename.new()
+
+	assert_eq(func_rename.has_method("long_function_name_for_is_true"), false)
+	assert_eq(func_rename.has_method("is_true"), true)
+	assert_eq(func_rename.is_true(), true)
+
+	assert_eq(func_rename.has_method("give_one_inner"), false)
+	assert_eq(func_rename.has_method("give_one"), true)
+	assert_eq(func_rename.give_one(), 1)
+
+	assert_eq(func_rename.has_method("renamed_static"), false)
+	assert_eq(func_rename.has_method("spell_static"), true)
+	assert_eq(func_rename.spell_static(), "static")

--- a/itest/rust/src/func_test.rs
+++ b/itest/rust/src/func_test.rs
@@ -1,0 +1,48 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use godot::prelude::*;
+
+#[derive(GodotClass)]
+#[class(base=RefCounted)]
+struct FuncRename;
+
+#[godot_api]
+impl FuncRename {
+    #[func(rename=is_true)]
+    fn long_function_name_for_is_true(&self) -> bool {
+        true
+    }
+
+    #[func(rename=give_one)]
+    fn give_one_inner(&self) -> i32 {
+        self.give_one()
+    }
+
+    #[func(rename=spell_static)]
+    fn renamed_static() -> GodotString {
+        GodotString::from("static")
+    }
+}
+
+impl FuncRename {
+    /// Unused but present to demonstrate how `rename = ...` can be used to avoid name clashes.
+    #[allow(dead_code)]
+    fn is_true(&self) -> bool {
+        false
+    }
+
+    fn give_one(&self) -> i32 {
+        1
+    }
+}
+
+#[godot_api]
+impl RefCountedVirtual for FuncRename {
+    fn init(_base: Base<Self::Base>) -> Self {
+        Self
+    }
+}

--- a/itest/rust/src/lib.rs
+++ b/itest/rust/src/lib.rs
@@ -19,6 +19,7 @@ mod color_test;
 mod derive_variant;
 mod dictionary_test;
 mod enum_test;
+mod func_test;
 mod gdscript_ffi_test;
 mod init_test;
 mod native_structures_test;


### PR DESCRIPTION
* Modify func macro to accept a 'rename = ...' attribute
* Add integration tests to cover renamed functions

## Comments

Please let me know if it would be better to break this functionality out like with [field_var.rs](https://github.com/godot-rust/gdext/blob/master/godot-macros/src/derive_godot_class/property/field_var.rs). I tried to keep the number of changed files to a minimum.

There are also `TODO`s left in the file as a starting point for discussion, but feel free to start picking at the PR wherever you want.

## Still missing
- [ ] signal renaming
- [ ] docs
- [ ] unit tests?