### PR TITLE
Improve API soundness wrt reference counted `Gd`

### DIFF
--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -684,7 +684,8 @@ impl<T: GodotClass> Drop for Gd<T> {
         // No-op for manually managed objects
 
         out!("Gd::drop   <{}>", std::any::type_name::<T>());
-        let is_last = T::Mem::maybe_dec_ref(self); // may drop
+        // SAFETY: This `Gd` wont be dropped again after this.
+        let is_last = unsafe { T::Mem::maybe_dec_ref(self) }; // may drop
         if is_last {
             unsafe {
                 interface_fn!(object_destroy)(self.obj_sys());


### PR DESCRIPTION
Document the safety invariants that need to be upheld for reference counted `Gd`. 
Make `Mem::maybe_dec_ref` an unsafe function, as it can be used to bypass the safety invariants of a reference counted `Gd`.

The `maybe_dec_ref` api is admittedly private (doc-hidden), however i still believe it is useful for us to properly label it as `unsafe` anyway. So we can more easily tell that it's being used correctly.