### PR TITLE
Default func params from Godot

### DIFF
--- a/godot-macros/src/derive_godot_class/property/field_var.rs
+++ b/godot-macros/src/derive_godot_class/property/field_var.rs
@@ -189,13 +189,8 @@ impl GetterSetterImpl {
         };
 
         let signature = util::parse_signature(signature);
-        let export_token = make_method_registration(
-            class_name,
-            FuncDefinition {
-                func: signature,
-                rename: None,
-            },
-        );
+        let export_token =
+            make_method_registration(class_name, FuncDefinition::from_signature(signature));
 
         Self {
             function_name,

--- a/godot-macros/src/method_registration/mod.rs
+++ b/godot-macros/src/method_registration/mod.rs
@@ -33,6 +33,20 @@ pub struct FuncDefinition {
     pub func: venial::Function,
     /// The name the function will be exposed as in Godot. If `None`, the Rust function name is used.
     pub rename: Option<String>,
+    // TODO you-win August 12, 2023: right now, this is an all-or-nothing operation
+    // either all params must have default args or no params have default args
+    /// Default parameters in sequential order.
+    pub default_params: Option<Vec<String>>,
+}
+
+impl FuncDefinition {
+    pub fn from_signature(signature: venial::Function) -> Self {
+        FuncDefinition {
+            func: signature,
+            rename: None,
+            default_params: None,
+        }
+    }
 }
 
 /// Returns a closure expression that forwards the parameters to the Rust instance.

--- a/godot-macros/src/method_registration/mod.rs
+++ b/godot-macros/src/method_registration/mod.rs
@@ -33,13 +33,13 @@ pub struct FuncDefinition {
     pub func: venial::Function,
     /// The name the function will be exposed as in Godot. If `None`, the Rust function name is used.
     pub rename: Option<String>,
-    // TODO you-win August 12, 2023: right now, this is an all-or-nothing operation
     // either all params must have default args or no params have default args
     /// Default parameters in sequential order.
     pub default_params: Option<Vec<String>>,
 }
 
 impl FuncDefinition {
+    /// Convenience function for struct creation with _only_ a signature.
     pub fn from_signature(signature: venial::Function) -> Self {
         FuncDefinition {
             func: signature,
@@ -175,22 +175,22 @@ fn make_ptrcall_invocation(
     }
 }
 
-/// Generate code for a `varcall()` call expression.
-fn make_varcall_invocation(
-    method_name: &Ident,
-    sig_tuple: &TokenStream,
-    wrapped_method: &TokenStream,
-) -> TokenStream {
-    let method_name_str = method_name.to_string();
+//// Generate code for a `varcall()` call expression.
+// fn make_varcall_invocation(
+//     method_name: &Ident,
+//     sig_tuple: &TokenStream,
+//     wrapped_method: &TokenStream,
+// ) -> TokenStream {
+//     let method_name_str = method_name.to_string();
 
-    quote! {
-        <#sig_tuple as ::godot::builtin::meta::VarcallSignatureTuple>::varcall(
-            instance_ptr,
-            args,
-            ret,
-            err,
-            #wrapped_method,
-            #method_name_str,
-        )
-    }
-}
+//     quote! {
+//         <#sig_tuple as ::godot::builtin::meta::VarcallSignatureTuple>::varcall(
+//             instance_ptr,
+//             args,
+//             ret,
+//             err,
+//             #wrapped_method,
+//             #method_name_str,
+//         )
+//     }
+// }

--- a/itest/godot/ManualFfiTests.gd
+++ b/itest/godot/ManualFfiTests.gd
@@ -308,8 +308,9 @@ func test_func_rename():
 func test_default_params_primitives():
 	var tester := DefaultParamsPrimitives.new()
 
-	assert_eq(tester.add_ints(), 3)
 	assert_eq(tester.add_ints(5, 6), 11)
+	assert_eq(tester.add_ints(5), 5)
+	assert_eq(tester.add_ints(), 0)
 
 	assert_eq(tester.pass_string(), "hello")
 	assert_eq(tester.pass_string("world"), "world")

--- a/itest/godot/ManualFfiTests.gd
+++ b/itest/godot/ManualFfiTests.gd
@@ -304,3 +304,12 @@ func test_func_rename():
 	assert_eq(func_rename.has_method("renamed_static"), false)
 	assert_eq(func_rename.has_method("spell_static"), true)
 	assert_eq(func_rename.spell_static(), "static")
+
+func test_default_params_primitives():
+	var tester := DefaultParamsPrimitives.new()
+
+	assert_eq(tester.add_ints(), 3)
+	assert_eq(tester.add_ints(5, 6), 11)
+
+	assert_eq(tester.pass_string(), "hello")
+	assert_eq(tester.pass_string("world"), "world")

--- a/itest/rust/src/func_test.rs
+++ b/itest/rust/src/func_test.rs
@@ -47,6 +47,8 @@ impl RefCountedVirtual for FuncRename {
     }
 }
 
+// TODO you-win August 12, 2023: impl to/from variant for option<T>?
+
 #[derive(GodotClass)]
 #[class(base=RefCounted)]
 struct DefaultParamsPrimitives;
@@ -54,10 +56,8 @@ struct DefaultParamsPrimitives;
 #[godot_api]
 impl DefaultParamsPrimitives {
     #[func(defaults = [1, 2])]
-    fn add_ints(&self, a: Variant, b: Variant) -> i32 {
-        println!("{:?}", a.get_type());
-        println!("{:?}", b.get_type());
-        (if a.is_nil() { 1 } else { a.to::<i32>() }) + (if b.is_nil() { 2 } else { b.to::<i32>() })
+    fn add_ints(&self, a: i32, b: i32) -> i32 {
+        a + b
     }
 
     #[func(defaults = ["hello"])]

--- a/itest/rust/src/func_test.rs
+++ b/itest/rust/src/func_test.rs
@@ -46,3 +46,29 @@ impl RefCountedVirtual for FuncRename {
         Self
     }
 }
+
+#[derive(GodotClass)]
+#[class(base=RefCounted)]
+struct DefaultParamsPrimitives;
+
+#[godot_api]
+impl DefaultParamsPrimitives {
+    #[func(defaults = [1, 2])]
+    fn add_ints(&self, a: Variant, b: Variant) -> i32 {
+        println!("{:?}", a.get_type());
+        println!("{:?}", b.get_type());
+        (if a.is_nil() { 1 } else { a.to::<i32>() }) + (if b.is_nil() { 2 } else { b.to::<i32>() })
+    }
+
+    #[func(defaults = ["hello"])]
+    fn pass_string(&self, text: GodotString) -> GodotString {
+        text
+    }
+}
+
+#[godot_api]
+impl RefCountedVirtual for DefaultParamsPrimitives {
+    fn init(_base: Base<Self::Base>) -> Self {
+        Self
+    }
+}


### PR DESCRIPTION
## Heavily WIP and might not even be desirable.

Adds the ability to omit parameters when calling Rust methods from GDScript and also have default parameters show up in the GDScript bindings.

**This does not actually pass any default values from GDScript. The responsibility is still on the developer to provide their own default values.**

### Notable changes

* pass `arg_count` when using varcall. The current implementation aims for tuples to still be used instead of a `Vec` for params
* varcall now requires parameters to implement `Default`
  * This requirement is awful. I think the ideal would be requiring something that is either a `T` or `Option<T>`, but I'm not sure if that's possible. This requirement also means that the itests are currently broken
  * Maybe separate trait impls might solve this?

## TODO

- [ ] fix itests
- [ ] implement `FromVariant` for `Option<T>`. Needed since things like `Option<i32>` are not valid. Could also just be an impl just for primitive Godot types
- [ ] remove requirement on `Default` for `impl_varcall_signature_for_tuple`?
- [ ] somehow bind default values from the `#[func(defaults = [...]]` macro to varcalls?