### PR TITLE
Update Godot version to 4.1.1, compat to 4.0.4

### DIFF
--- a/.github/composite/godot-install/action.yml
+++ b/.github/composite/godot-install/action.yml
@@ -45,8 +45,8 @@ runs:
       run: |
         if [[ $ARTIFACT_NAME == *"stable"* ]]; then
           url="https://nightly.link/Bromeon/godot4-nightly/workflows/compile-godot-stable/master/$ARTIFACT_NAME.zip"
-        elif [[ $ARTIFACT_NAME == *"4.0.3"* ]]; then
-          url="https://nightly.link/Bromeon/godot4-nightly/workflows/compile-godot-4.0.3/master/$ARTIFACT_NAME.zip"
+        elif [[ $ARTIFACT_NAME == *"4.0.4"* ]]; then
+          url="https://nightly.link/Bromeon/godot4-nightly/workflows/compile-godot-4.0/master/$ARTIFACT_NAME.zip"
         else
           url="https://nightly.link/Bromeon/godot4-nightly/workflows/compile-godot-nightly/master/$ARTIFACT_NAME.zip"
         fi

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -76,6 +76,7 @@ jobs:
         with:
           components: clippy
 
+      # Note: could use `-- --no-deps` to not lint dependencies, however it doesn't really speed up and also skips deps in workspace.
       - name: "Check clippy"
         run: |
           cargo clippy --all-targets $GDEXT_FEATURES ${{ matrix.rust-extra-args }} -- \
@@ -216,35 +217,24 @@ jobs:
 
           # Linux compat
 
+          - name: linux-4.1.1
+            os: ubuntu-20.04
+            artifact-name: linux-stable
+            godot-binary: godot.linuxbsd.editor.dev.x86_64
+            #godot-prebuilt-patch: '4.1.1'
+
           - name: linux-4.1
             os: ubuntu-20.04
             artifact-name: linux-stable
             godot-binary: godot.linuxbsd.editor.dev.x86_64
-            #godot-prebuilt-patch: '4.1'
+            godot-prebuilt-patch: '4.1'
 
-          - name: linux-4.0.3
+          - name: linux-4.0.4
             os: ubuntu-20.04
-            artifact-name: linux-4.0.3
+            artifact-name: linux-4.0.4
             godot-binary: godot.linuxbsd.editor.dev.x86_64
-            godot-prebuilt-patch: '4.0.3'
+            godot-prebuilt-patch: '4.0.4'
 
-          - name: linux-4.0.2
-            os: ubuntu-20.04
-            artifact-name: linux-4.0.3
-            godot-binary: godot.linuxbsd.editor.dev.x86_64
-            godot-prebuilt-patch: '4.0.2'
-
-          - name: linux-4.0.1
-            os: ubuntu-20.04
-            artifact-name: linux-4.0.3
-            godot-binary: godot.linuxbsd.editor.dev.x86_64
-            godot-prebuilt-patch: '4.0.1'
-
-          - name: linux-4.0
-            os: ubuntu-20.04
-            artifact-name: linux-4.0.3
-            godot-binary: godot.linuxbsd.editor.dev.x86_64
-            godot-prebuilt-patch: '4.0'
 
           # Memory checks: special Godot binaries compiled with AddressSanitizer/LeakSanitizer to detect UB/leaks.
           # See also https://rustc-dev-guide.rust-lang.org/sanitizers.html.
@@ -264,12 +254,12 @@ jobs:
             # Sanitizers can't build proc-macros and build scripts; with --target, cargo ignores RUSTFLAGS for those two.
             rust-target: x86_64-unknown-linux-gnu
 
-          - name: linux-memcheck-4.0.3
+          - name: linux-memcheck-4.0.4
             os: ubuntu-20.04
-            artifact-name: linux-memcheck-clang-4.0.3
+            artifact-name: linux-memcheck-clang-4.0.4
             godot-binary: godot.linuxbsd.editor.dev.x86_64.llvm.san
             godot-args: -- --disallow-focus
-            godot-prebuilt-patch: '4.0.3'
+            godot-prebuilt-patch: '4.0.4'
             rust-toolchain: nightly
             rust-env-rustflags: -Zrandomize-layout -Zsanitizer=address
             # Sanitizers can't build proc-macros and build scripts; with --target, cargo ignores RUSTFLAGS for those two.

--- a/.github/workflows/minimal-ci.yml
+++ b/.github/workflows/minimal-ci.yml
@@ -147,11 +147,11 @@ jobs:
 
           # Linux compat
 
-          - name: linux-4.0.3
+          - name: linux-4.0.4
             os: ubuntu-20.04
-            artifact-name: linux-4.0.3
+            artifact-name: linux-4.0.4
             godot-binary: godot.linuxbsd.editor.dev.x86_64
-            godot-prebuilt-patch: '4.0.3'
+            godot-prebuilt-patch: '4.0.4'
 
           # Memory checkers
 
@@ -166,12 +166,12 @@ jobs:
             # Sanitizers can't build proc-macros and build scripts; with --target, cargo ignores RUSTFLAGS for those two.
             rust-target: x86_64-unknown-linux-gnu
 
-          - name: linux-memcheck-4.0.3
+          - name: linux-memcheck-4.0.4
             os: ubuntu-20.04
-            artifact-name: linux-memcheck-clang-4.0.3
+            artifact-name: linux-memcheck-clang-4.0.4
             godot-binary: godot.linuxbsd.editor.dev.x86_64.llvm.san
             godot-args: -- --disallow-focus
-            godot-prebuilt-patch: '4.0.3'
+            godot-prebuilt-patch: '4.0.4'
             rust-toolchain: nightly
             rust-env-rustflags: -Zrandomize-layout -Zsanitizer=address
             # Sanitizers can't build proc-macros and build scripts; with --target, cargo ignores RUSTFLAGS for those two.

--- a/godot-bindings/Cargo.toml
+++ b/godot-bindings/Cargo.toml
@@ -18,7 +18,7 @@ custom-godot = ["dep:bindgen", "dep:regex", "dep:which"]
 custom-godot-extheader = []
 
 [dependencies]
-godot4-prebuilt = { optional = true, git = "https://github.com/godot-rust/godot4-prebuilt", branch = "4.1" }
+godot4-prebuilt = { optional = true, git = "https://github.com/godot-rust/godot4-prebuilt", branch = "4.1.1" }
 
 # Version >= 1.5.5 for security: https://blog.rust-lang.org/2022/03/08/cve-2022-24713.html
 # 'unicode-gencat' needed for \d, see: https://docs.rs/regex/1.5.5/regex/#unicode-features

--- a/godot-core/src/lib.rs
+++ b/godot-core/src/lib.rs
@@ -193,7 +193,9 @@ generate_gdextension_api_version!(
         "4.0.1",
         "4.0.2",
         "4.0.3",
+        "4.0.4",
         "4.1",
+        "4.1.1",
     },
     (GDEXTENSION_API, gdextension_minor_api) => {
         "4.0",


### PR DESCRIPTION
Removes CI checking for older 4.0.x version, as we phase out support for them.