### PR TITLE
Cleanup some minor things

### DIFF
--- a/godot-core/src/builtin/variant/variant_traits.rs
+++ b/godot-core/src/builtin/variant/variant_traits.rs
@@ -60,4 +60,28 @@ pub enum VariantConversionError {
 
     /// Variant value is missing a value for the target type
     MissingValue,
+
+    /// Variant value is null but expected to be non-null
+    VariantIsNil,
 }
+
+impl std::fmt::Display for VariantConversionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            VariantConversionError::BadType => {
+                f.write_str("Variant type does not match expected type")
+            }
+            VariantConversionError::BadValue => {
+                f.write_str("Variant value cannot be represented in target type")
+            }
+            VariantConversionError::MissingValue => {
+                f.write_str("Variant value is missing a value for the target type")
+            }
+            VariantConversionError::VariantIsNil => {
+                f.write_str("Variant value is null but expected to be non-null")
+            }
+        }
+    }
+}
+
+impl std::error::Error for VariantConversionError {}

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -788,7 +788,7 @@ impl<T: GodotClass> FromVariant for Gd<T> {
             // TODO(#234) remove this cast when Godot stops allowing illegal conversions
             // (See https://github.com/godot-rust/gdext/issues/158)
             .and_then(|obj| obj.owned_cast().ok())
-            .ok_or(VariantConversionError::BadType)
+            .ok_or(VariantConversionError::VariantIsNil)
     }
 }
 

--- a/godot-ffi/src/plugins.rs
+++ b/godot-ffi/src/plugins.rs
@@ -87,6 +87,7 @@ macro_rules! plugin_foreach_inner {
             .unwrap();
 
         for e in guard.iter() {
+            #[allow(clippy::redundant_closure_call)]
             $closure(e);
         }
     };

--- a/itest/rust/src/object_test.rs
+++ b/itest/rust/src/object_test.rs
@@ -336,7 +336,7 @@ fn object_engine_convert_variant_nil() {
 
     assert_eq!(
         Gd::<Area2D>::try_from_variant(&nil),
-        Err(VariantConversionError::BadType),
+        Err(VariantConversionError::VariantIsNil),
         "try_from_variant(&nil)"
     );
 

--- a/itest/rust/src/option_ffi_test.rs
+++ b/itest/rust/src/option_ffi_test.rs
@@ -17,6 +17,8 @@ fn option_some_sys_conversion() {
     let v2 = unsafe { Option::<Gd<Object>>::from_sys(ptr) };
     assert_eq!(v2, v);
 
+    // We're testing this behavior.
+    #[allow(clippy::unnecessary_literal_unwrap)]
     v.unwrap().free();
 }
 


### PR DESCRIPTION
- Add `VariantConversionError::VariantIsNil`
- Implement `Display` and `Error` for `VariantConversionError`
- Remove `Deref` impl for `Object` with target `()` (this can cause weird things like being able to clone a `Gd<Object>` and get back a `()`)
- Add an `#[allow]` for a clippy lint that was added in 1.72