### PR TITLE
Add editor plugins, and registration of classes at the proper initialization level

### DIFF
--- a/godot-codegen/src/class_generator.rs
+++ b/godot-codegen/src/class_generator.rs
@@ -506,6 +506,7 @@ fn make_class(class: &Class, class_name: &TyName, ctx: &mut Context) -> Generate
 
     let constructor = make_constructor(class, ctx);
     let api_level = util::get_api_level(class);
+    let init_level = api_level.to_init_level();
 
     let FnDefinitions {
         functions: methods,
@@ -618,6 +619,7 @@ fn make_class(class: &Class, class_name: &TyName, ctx: &mut Context) -> Generate
                 type Base = #base_ty;
                 type Declarer = crate::obj::dom::EngineDomain;
                 type Mem = crate::obj::mem::#memory;
+                const INIT_LEVEL: Option<crate::init::InitLevel> = #init_level;
 
                 fn class_name() -> ClassName {
                     ClassName::from_ascii_cstr(#class_name_cstr)

--- a/godot-codegen/src/codegen_special_cases.rs
+++ b/godot-codegen/src/codegen_special_cases.rs
@@ -127,6 +127,7 @@ const SELECTED_CLASSES: &[&str] = &[
     "CollisionObject2D",
     "CollisionShape2D",
     "Control",
+    "EditorPlugin",
     "Engine",
     "FileAccess",
     "HTTPRequest",

--- a/godot-codegen/src/special_cases.rs
+++ b/godot-codegen/src/special_cases.rs
@@ -71,9 +71,15 @@ pub(crate) fn is_class_deleted(class_name: &TyName) -> bool {
 
     match class_name {
         // Hardcoded cases that are not accessible.
-        | "JavaClassWrapper" // only on Android.
-        | "JavaScriptBridge" // only on WASM.
-        | "ThemeDB" // lazily loaded; TODO enable this.
+        // Only on Android.
+        | "JavaClassWrapper"
+        | "JNISingleton"
+        | "JavaClass"
+        // Only on WASM.
+        | "JavaScriptBridge"
+        | "JavaScriptObject"
+        // lazily loaded; TODO enable this.
+        | "ThemeDB" 
 
         // Thread APIs.
         | "Thread"
@@ -124,7 +130,6 @@ fn is_class_experimental(class_name: &TyName) -> bool {
         | "NavigationRegion3D"
         | "NavigationServer2D"
         | "NavigationServer3D"
-        | "ProjectSettings"
         | "SkeletonModification2D"
         | "SkeletonModification2DCCDIK"
         | "SkeletonModification2DFABRIK"

--- a/godot-codegen/src/util.rs
+++ b/godot-codegen/src/util.rs
@@ -66,6 +66,15 @@ impl ClassCodegenLevel {
             Self::Lazy => unreachable!("lazy classes should be deleted at the moment"),
         }
     }
+
+    pub fn to_init_level(self) -> TokenStream {
+        match self {
+            Self::Servers => quote! { Some(crate::init::InitLevel::Servers) },
+            Self::Scene => quote! { Some(crate::init::InitLevel::Scene) },
+            Self::Editor => quote! { Some(crate::init::InitLevel::Editor) },
+            Self::Lazy => quote! { None },
+        }
+    }
 }
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------

--- a/godot-core/src/init/mod.rs
+++ b/godot-core/src/init/mod.rs
@@ -92,12 +92,12 @@ fn gdext_on_level_init(level: InitLevel) {
             }
             InitLevel::Scene => {
                 sys::load_class_method_table(sys::ClassApiLevel::Scene);
-                crate::auto_register_classes();
             }
             InitLevel::Editor => {
                 sys::load_class_method_table(sys::ClassApiLevel::Editor);
             }
         }
+        crate::auto_register_classes(level);
     }
 }
 

--- a/godot-core/src/lib.rs
+++ b/godot-core/src/lib.rs
@@ -168,6 +168,9 @@ pub mod private {
         use std::io::Write;
         std::io::stdout().flush().expect("flush stdout");
     }
+
+    /// Ensure `T` is an editor plugin.
+    pub const fn is_editor_plugin<T: crate::obj::Inherits<crate::engine::EditorPlugin>>() {}
 }
 
 macro_rules! generate_gdextension_api_version {

--- a/godot-core/src/obj/traits.rs
+++ b/godot-core/src/obj/traits.rs
@@ -6,6 +6,7 @@
 
 use crate::builder::ClassBuilder;
 use crate::builtin::GodotString;
+use crate::init::InitLevel;
 use crate::obj::Base;
 
 use crate::builtin::meta::ClassName;
@@ -34,6 +35,12 @@ where
     /// Defines the memory strategy.
     type Mem: mem::Memory;
 
+    /// During which initialization level this class is available/should be initialized with Godot.
+    ///
+    /// Is `None` if the class has complicated initialization requirements, and generally cannot be inherited
+    /// from.
+    const INIT_LEVEL: Option<InitLevel>;
+
     /// The name of the class, under which it is registered in Godot.
     ///
     /// This may deviate from the Rust struct name: `HttpRequest::class_name().as_str() == "HTTPRequest"`.
@@ -60,6 +67,7 @@ unsafe impl GodotClass for () {
     type Base = ();
     type Declarer = dom::EngineDomain;
     type Mem = mem::ManualMemory;
+    const INIT_LEVEL: Option<InitLevel> = None;
 
     fn class_name() -> ClassName {
         ClassName::none()

--- a/godot-macros/src/class/godot_api.rs
+++ b/godot-macros/src/class/godot_api.rs
@@ -193,6 +193,7 @@ fn transform_inherent_impl(mut decl: Impl) -> Result<TokenStream, Error> {
                     raw: #prv::callbacks::register_user_binds::<#class_name>,
                 },
             },
+            init_level: <#class_name as ::godot::obj::GodotClass>::INIT_LEVEL,
         });
     };
 
@@ -505,6 +506,7 @@ fn transform_trait_impl(original_impl: Impl) -> Result<TokenStream, Error> {
                 user_on_notification_fn: #on_notification_fn,
                 get_virtual_fn: #prv::callbacks::get_virtual::<#class_name>,
             },
+            init_level: <#class_name as ::godot::obj::GodotClass>::INIT_LEVEL,
         });
     };
 

--- a/godot-macros/src/lib.rs
+++ b/godot-macros/src/lib.rs
@@ -318,6 +318,20 @@ use crate::util::ident;
 /// for more information and further customization.
 ///
 /// This is very similar to [GDScript's `@tool` feature](https://docs.godotengine.org/en/stable/tutorials/plugins/running_code_in_the_editor.html).
+///
+/// # Editor Plugins
+///
+/// If you annotate a class with `#[class(editor_plugin)]`, it will be turned into an editor plugin. The
+/// class must then inherit from `EditorPlugin`, and an instance of that class will be automatically added
+/// to the editor when launched.
+///
+/// See [Godot's documentation of editor plugins](https://docs.godotengine.org/en/stable/tutorials/plugins/editor/index.html)
+/// for more information about editor plugins. But note that you do not need to create and enable the plugin
+/// through Godot's `Create New Plugin` menu for it to work, simply annotating the class with `editor_plugin`
+/// automatically enables it when the library is loaded.
+///
+/// This should usually be combined with `#[class(tool)]` so that the code you write will actually run in the
+/// editor.
 #[proc_macro_derive(GodotClass, attributes(class, base, var, export, init, signal))]
 pub fn derive_godot_class(input: TokenStream) -> TokenStream {
     translate(input, class::derive_godot_class)

--- a/godot-macros/src/util/kv_parser.rs
+++ b/godot-macros/src/util/kv_parser.rs
@@ -82,10 +82,16 @@ impl KvParser {
     /// Handles a key that can only occur without a value, e.g. `#[attr(toggle)]`. Returns whether
     /// the key is present.
     pub fn handle_alone(&mut self, key: &str) -> ParseResult<bool> {
-        match self.handle_any(key) {
-            None => Ok(false),
-            Some(value) => match value {
-                None => Ok(true),
+        self.handle_alone_ident(key).map(|id| id.is_some())
+    }
+
+    /// Handles a key that can only occur without a value, e.g. `#[attr(toggle)]`. Returns the key if it is
+    /// present.
+    pub fn handle_alone_ident(&mut self, key: &str) -> ParseResult<Option<Ident>> {
+        match self.handle_any_entry(key) {
+            None => Ok(None),
+            Some((id, value)) => match value {
+                None => Ok(Some(id)),
                 Some(value) => bail!(&value.tokens[0], "key `{key}` should not have a value"),
             },
         }

--- a/itest/rust/src/object_tests/object_test.rs
+++ b/itest/rust/src/object_tests/object_test.rs
@@ -890,3 +890,12 @@ fn double_use_reference() {
     double_use.free();
     emitter.free();
 }
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+
+// There isn't a good way to test editor plugins, but we can at least declare one to ensure that the macro
+// compiles.
+#[cfg(since_api = "4.1")]
+#[derive(GodotClass)]
+#[class(base = EditorPlugin, editor_plugin)]
+struct CustomEditorPlugin;

--- a/itest/rust/src/register_tests/constant_test.rs
+++ b/itest/rust/src/register_tests/constant_test.rs
@@ -112,6 +112,7 @@ impl ::godot::obj::cap::ImplementsGodotApi for HasOtherConstants {
                 raw: ::godot::private::callbacks::register_user_binds::<HasOtherConstants>,
             },
         },
+        init_level: HasOtherConstants::INIT_LEVEL,
     }
 );
 


### PR DESCRIPTION
# Editor Plugin

Adds `editor_plugin` as another attribute for classes. See [here](https://godot-rust.github.io/docs/gdext/pr-393/godot/bind/derive.GodotClass.html#editor-plugins) for usage.

The project will fail to compile if you try to make something an editor plugin that doesn't inherit from `EditorPlugin`. This is done by adding a doc-hidden constant to `Inherits` and trying to access it.

Attempting to register an editor plugin in Godot 4.0 will print an error, and not add the editor plugin. Since this feature was added in 4.1.

# Class registration

This is needed for editor plugin registration to work, as editor plugins must be registered at the `Editor` level. `GodotClass` now has an `INIT_LEVEL` constant which states the level at which a class is registered, and thus which level its subclasses must also be registered.

If an engine class has an unknown init level, the library panics. Which should be fine since it means something has gone very wrong. However user-classes just do an `godot_error` and fail to register, since that might be user-error and making godot crash for that would probably be more frustrating than anything else.

# Other smaller things

I found some more classes that only exist for WASM/Android so i added them to be excluded, you can't inherit from them anyway.

Unexcluded `ProjectSettings`, it seems to have been excluded by mistake. I also added a test just to ensure that it actually does work.

I didn't find a good way of testing editor plugins. They require the editor to be running, and we dont have any way to test stuff that only runs in the editor afaik.