### PR TITLE
Allow godot-visible functions to receive a Gd instead of self.

### DIFF
--- a/godot-core/src/obj/base.rs
+++ b/godot-core/src/obj/base.rs
@@ -35,6 +35,12 @@ pub struct Base<T: GodotClass> {
 }
 
 impl<T: GodotClass> Base<T> {
+    /// # Safety
+    /// The returned Base is a weak pointer, so holding it will not keep the object alive. It must not be accessed after the object is destroyed.
+    pub(crate) unsafe fn from_base(base: &Base<T>) -> Base<T> {
+        Base::from_obj(Gd::from_obj_sys_weak(base.obj_sys()))
+    }
+
     // Note: not &mut self, to only borrow one field and not the entire struct
     pub(crate) unsafe fn from_sys(base_ptr: sys::GDExtensionObjectPtr) -> Self {
         assert!(!base_ptr.is_null(), "instance base is null pointer");

--- a/godot-core/src/registry.rs
+++ b/godot-core/src/registry.rs
@@ -313,9 +313,9 @@ pub mod callbacks {
             unsafe { interface_fn!(classdb_construct_object)(base_class_name.string_sys()) };
 
         let base = unsafe { Base::from_sys(base_ptr) };
-        let user_instance = make_user_instance(base);
+        let user_instance = make_user_instance(unsafe { Base::from_base(&base) });
 
-        let instance = InstanceStorage::<T>::construct(user_instance);
+        let instance = InstanceStorage::<T>::construct(user_instance, base);
         let instance_ptr = instance.into_raw();
         let instance_ptr = instance_ptr as sys::GDExtensionClassInstancePtr;
 

--- a/godot-macros/src/class/data_models/field_var.rs
+++ b/godot-macros/src/class/data_models/field_var.rs
@@ -195,6 +195,7 @@ impl GetterSetterImpl {
             FuncDefinition {
                 func: signature,
                 rename: None,
+                has_gd_self: false,
             },
         );
 

--- a/godot-macros/src/class/godot_api.rs
+++ b/godot-macros/src/class/godot_api.rs
@@ -47,7 +47,10 @@ pub fn attribute_godot_api(input_decl: Declaration) -> Result<TokenStream, Error
 
 /// Attribute for user-declared function
 enum BoundAttrType {
-    Func { rename: Option<String> },
+    Func {
+        rename: Option<String>,
+        has_gd_self: bool,
+    },
     Signal(AttributeValue),
     Const(AttributeValue),
 }
@@ -229,11 +232,25 @@ fn process_godot_fns(decl: &mut Impl) -> Result<(Vec<FuncDefinition>, Vec<Functi
                 return attr.bail("generic fn parameters are not supported", method);
             }
 
-            match attr.ty {
-                BoundAttrType::Func { rename } => {
+            match &attr.ty {
+                BoundAttrType::Func {
+                    rename,
+                    has_gd_self,
+                } => {
                     // Signatures are the same thing without body
-                    let sig = util::reduce_to_signature(method);
-                    func_definitions.push(FuncDefinition { func: sig, rename });
+                    let mut sig = util::reduce_to_signature(method);
+                    if *has_gd_self {
+                        if sig.params.is_empty() {
+                            return attr.bail("with attribute key `gd_self`, the method must have a first parameter of type Gd<Self>", method);
+                        } else {
+                            sig.params.inner.remove(0);
+                        }
+                    }
+                    func_definitions.push(FuncDefinition {
+                        func: sig,
+                        rename: rename.clone(),
+                        has_gd_self: *has_gd_self,
+                    });
                 }
                 BoundAttrType::Signal(ref _attr_val) => {
                     if method.return_ty.is_some() {
@@ -316,11 +333,15 @@ where
                 let mut parser = KvParser::parse(attributes, "func")?.unwrap();
 
                 let rename = parser.handle_expr("rename")?.map(|ts| ts.to_string());
+                let has_gd_self = parser.handle_alone("gd_self")?;
 
                 Some(BoundAttr {
                     attr_name: attr_name.clone(),
                     index,
-                    ty: BoundAttrType::Func { rename },
+                    ty: BoundAttrType::Func {
+                        rename,
+                        has_gd_self,
+                    },
                 })
             }
             name if name == "signal" => {

--- a/itest/godot/ManualFfiTests.gd
+++ b/itest/godot/ManualFfiTests.gd
@@ -304,3 +304,25 @@ func test_func_rename():
 	assert_eq(func_rename.has_method("renamed_static"), false)
 	assert_eq(func_rename.has_method("spell_static"), true)
 	assert_eq(func_rename.spell_static(), "static")
+
+var gd_self_reference: GdSelfReference
+func update_self_reference(value):
+	gd_self_reference.update_internal(value)
+
+# Todo: Once there is a way to assert for a SCRIPT ERROR failure this can be reenabled.
+"""
+func test_gd_self_reference_fails():
+	# Create the gd_self_reference and connect its signal to a gdscript method that calls back into it.
+	gd_self_reference = GdSelfReference.new()
+	gd_self_reference.update_internal_signal.connect(update_self_reference)
+	
+	# The returned value will still be 0 because update_internal can't be called in update_self_reference due to a borrowing issue.
+	assert_eq(gd_self_reference.fail_to_update_internal_value_due_to_conflicting_borrow(10), 0)
+"""
+
+func test_gd_self_reference_succeeds():
+	# Create the gd_self_reference and connect its signal to a gdscript method that calls back into it.
+	gd_self_reference = GdSelfReference.new()
+	gd_self_reference.update_internal_signal.connect(update_self_reference)
+
+	assert_eq(gd_self_reference.succeed_at_updating_internal_value(10), 10)

--- a/itest/rust/src/register_tests/func_test.rs
+++ b/itest/rust/src/register_tests/func_test.rs
@@ -7,7 +7,7 @@
 use godot::prelude::*;
 
 #[derive(GodotClass)]
-#[class(base=RefCounted)]
+#[class(init, base=RefCounted)]
 struct FuncRename;
 
 #[godot_api]
@@ -40,9 +40,70 @@ impl FuncRename {
     }
 }
 
+#[derive(GodotClass)]
+#[class(base=RefCounted)]
+struct GdSelfReference {
+    internal_value: i32,
+
+    #[base]
+    base: Base<RefCounted>,
+}
+
 #[godot_api]
-impl RefCountedVirtual for FuncRename {
-    fn init(_base: Base<Self::Base>) -> Self {
-        Self
+impl GdSelfReference {
+    // A signal that will be looped back to update_internal through gdscript.
+    #[signal]
+    fn update_internal_signal(new_internal: i32);
+
+    #[func]
+    fn update_internal(&mut self, new_value: i32) {
+        self.internal_value = new_value;
+    }
+
+    #[func]
+    fn fail_to_update_internal_value_due_to_conflicting_borrow(
+        &mut self,
+        new_internal: i32,
+    ) -> i32 {
+        // Since a self reference is held while the signal is emitted, when
+        // GDScript tries to call update_internal(), there will be a failure due
+        // to the double borrow and self.internal_value won't be changed.
+        self.base.emit_signal(
+            "update_internal_signal".into(),
+            &[new_internal.to_variant()],
+        );
+        self.internal_value
+    }
+
+    #[func(gd_self)]
+    fn succeed_at_updating_internal_value(mut this: Gd<Self>, new_internal: i32) -> i32 {
+        // Since this isn't bound while the signal is emitted, GDScript will succeed at calling
+        // update_internal() and self.internal_value will be changed.
+        this.emit_signal(
+            "update_internal_signal".into(),
+            &[new_internal.to_variant()],
+        );
+        return this.bind().internal_value;
+    }
+
+    #[func(gd_self)]
+    fn takes_gd_as_equivalent(mut this: Gd<GdSelfReference>) -> bool {
+        this.bind_mut();
+        true
+    }
+
+    #[func(gd_self)]
+    fn takes_gd_as_self_no_return_type(this: Gd<GdSelfReference>) {
+        this.bind();
+    }
+}
+
+#[godot_api]
+impl RefCountedVirtual for GdSelfReference {
+    fn init(base: Base<Self::Base>) -> Self {
+        Self {
+            internal_value: 0,
+            base,
+        }
     }
 }


### PR DESCRIPTION
This is done by tagging the function with #[func(gd_self)].

I haven't written tests because there was an unrelated issue on my machine, but I have tested with a different project and it seems to work.