### PR TITLE
Add macro for manually registering properties

### DIFF
--- a/godot-macros/src/class/data_models/field.rs
+++ b/godot-macros/src/class/data_models/field.rs
@@ -16,7 +16,17 @@ pub struct Field {
 }
 
 impl Field {
-    pub fn new(field: &venial::NamedField) -> Self {
+    pub fn new(name: Ident, ty: venial::TyExpr) -> Self {
+        Self {
+            name,
+            ty,
+            default: None,
+            var: None,
+            export: None,
+        }
+    }
+
+    pub fn from_named_field(field: &venial::NamedField) -> Self {
         Self {
             name: field.name.clone(),
             ty: field.ty.clone(),

--- a/godot-macros/src/class/data_models/field_var.rs
+++ b/godot-macros/src/class/data_models/field_var.rs
@@ -87,7 +87,7 @@ pub enum GetterSetter {
 }
 
 impl GetterSetter {
-    pub(super) fn parse(parser: &mut KvParser, key: &str) -> ParseResult<Self> {
+    pub(crate) fn parse(parser: &mut KvParser, key: &str) -> ParseResult<Self> {
         let getter_setter = match parser.handle_any(key) {
             // No `get` argument
             None => GetterSetter::Omitted,
@@ -125,6 +125,10 @@ impl GetterSetter {
 
     pub fn is_omitted(&self) -> bool {
         matches!(self, GetterSetter::Omitted)
+    }
+
+    pub fn is_generated(&self) -> bool {
+        matches!(self, GetterSetter::Generated)
     }
 }
 
@@ -205,7 +209,8 @@ impl GetterSetterImpl {
         }
     }
 
-    fn from_custom_impl(function_name: &Ident) -> Self {
+    /// Create a getters/setter impl from a user-defined function.
+    pub(super) fn from_custom_impl(function_name: &Ident) -> Self {
         Self {
             function_name: function_name.clone(),
             function_impl: TokenStream::new(),

--- a/godot-macros/src/lib.rs
+++ b/godot-macros/src/lib.rs
@@ -302,6 +302,33 @@ use crate::util::ident;
 /// impl MyStruct {}
 /// ```
 ///
+/// Alternatively, a property can be manually registered with Godot. This can be useful
+/// when accessing nested structs or when a custom property name is needed. Automatically
+/// generated getters/setters are not supported in this attribute. Custom property hints,
+/// hint strings, and usage flags are supported.
+/// ```
+/// use godot::prelude::*;
+///
+/// #[derive(GodotClass)]
+/// // Registers `my_field` as `my_int` with a getter and setter
+/// #[property(name = my_int, type = i64, get = get_my_field, set = set_my_field)]
+/// struct MyStruct {
+///     my_field: i64,
+/// }
+///
+/// #[godot_api]
+/// impl MyStruct {
+///     #[func]
+///     pub fn get_my_field(&self) -> i64 {
+///         self.my_field
+///     }
+///
+///     #[func]
+///     pub fn set_my_field(&mut self, value: i64) {
+///         self.my_field = value;
+///     }
+/// }
+/// ```
 ///
 /// # Signals
 ///
@@ -318,7 +345,10 @@ use crate::util::ident;
 /// for more information and further customization.
 ///
 /// This is very similar to [GDScript's `@tool` feature](https://docs.godotengine.org/en/stable/tutorials/plugins/running_code_in_the_editor.html).
-#[proc_macro_derive(GodotClass, attributes(class, base, var, export, init, signal))]
+#[proc_macro_derive(
+    GodotClass,
+    attributes(class, base, var, export, init, signal, property)
+)]
 pub fn derive_godot_class(input: TokenStream) -> TokenStream {
     translate(input, class::derive_godot_class)
 }

--- a/godot-macros/src/util/kv_parser.rs
+++ b/godot-macros/src/util/kv_parser.rs
@@ -59,6 +59,24 @@ impl KvParser {
         Ok(found_attr)
     }
 
+    /// Create many new parsers which check for the presence of many `#[expected]` attributes.
+    pub fn parse_many(attributes: &[Attribute], expected: &str) -> ParseResult<Vec<Self>> {
+        let mut found_attrs = vec![];
+
+        for attr in attributes.iter() {
+            let path = &attr.path;
+            if path_is_single(path, expected) {
+                let attr_name = expected.to_string();
+                found_attrs.push(Self {
+                    span: attr.tk_brackets.span,
+                    map: ParserState::parse(attr_name, &attr.value)?,
+                });
+            }
+        }
+
+        Ok(found_attrs)
+    }
+
     pub fn span(&self) -> Span {
         self.span
     }

--- a/godot-macros/src/util/list_parser.rs
+++ b/godot-macros/src/util/list_parser.rs
@@ -15,9 +15,9 @@ use crate::ParseResult;
 /// Parses a list of tokens as an ordered list of values. Unlike [`KvParser`] which treats the tokens as a
 /// set of values.
 pub struct ListParser {
-    lists: VecDeque<KvValue>,
+    pub(super) lists: VecDeque<KvValue>,
     /// The last span of the list, usually a closing parenthesis.
-    span_close: Span,
+    pub(super) span_close: Span,
 }
 
 impl ListParser {
@@ -192,6 +192,18 @@ impl ListParser {
             Ok(None) => Ok(None),
             Err(err) => bail!(err.span(), "expected `key [= value]`"),
         }
+    }
+
+    /// Takes the next list element of the list.
+    ///
+    /// # Example
+    /// `((name = foo), (name = boo))` will yield `(name = foo)`
+    pub(crate) fn try_next_list(&mut self, delimiter: Delimiter) -> ParseResult<Option<Self>> {
+        let Some(kv) = self.pop_next() else {
+            return Ok(None);
+        };
+
+        Ok(Some(ListParser::new_from_tree(kv.single()?, delimiter)?))
     }
 
     /// Ensure all values have been consumed.

--- a/itest/godot/ManualFfiTests.gd
+++ b/itest/godot/ManualFfiTests.gd
@@ -304,3 +304,22 @@ func test_func_rename():
 	assert_eq(func_rename.has_method("renamed_static"), false)
 	assert_eq(func_rename.has_method("spell_static"), true)
 	assert_eq(func_rename.spell_static(), "static")
+
+func test_standalone_property():
+	var standalone_property := StandaloneProperty.new()
+
+	assert_eq(standalone_property.my_int, 0)
+	assert_eq(standalone_property.readonly_int, 0)
+	assert_eq(standalone_property.int_array, [0])
+
+	standalone_property.my_int = 2
+
+	assert_eq(standalone_property.my_int, 2)
+	assert_eq(standalone_property.readonly_int, 2)
+	assert_eq(standalone_property.int_array, [2])
+
+	standalone_property.int_array = [10, 11]
+
+	assert_eq(standalone_property.my_int, 10)
+	assert_eq(standalone_property.readonly_int, 10)
+	assert_eq(standalone_property.int_array, [10])

--- a/itest/godot/ManualFfiTests.gd
+++ b/itest/godot/ManualFfiTests.gd
@@ -323,3 +323,6 @@ func test_standalone_property():
 	assert_eq(standalone_property.my_int, 10)
 	assert_eq(standalone_property.readonly_int, 10)
 	assert_eq(standalone_property.int_array, [10])
+
+	assert_eq(standalone_property.first_int, 10)
+	assert_eq(standalone_property.second_int, 10)

--- a/itest/rust/src/object_tests/property_test.rs
+++ b/itest/rust/src/object_tests/property_test.rs
@@ -368,6 +368,12 @@ fn derive_export() {
 }
 
 #[derive(GodotClass)]
+#[class(
+    properties = [
+        (name = first_int, type = i32, get = get_integer),
+        (name = second_int, type = i32, get = get_integer)
+    ]
+)]
 #[property(name = my_int, type = i32, get = get_integer, set = set_integer)]
 #[property(name = readonly_int, type = i32, get = get_integer)]
 #[property(name = int_array, type = Array<i32>, get = get_integer_as_array, set = set_integer_from_array_front)]


### PR DESCRIPTION
Adds a new struct-level macro for manually registering properties.

This is primarily useful for cases like this:
```rust
// Struct containing some shared data not exposed to Godot
struct Foo {
    data: Whatever
}

#[derive(GodotClass)]
#[property(name = data, type = i32, get = get_data)]
struct Bar {
    foo: Foo
}

... impl RefCountedVirtual ...

#[godot_api]
impl Bar {
    #[func]
    fn get_data(&self) -> i32 {
        self.foo.data.some_func()
    }
}
```

The macro syntax was chosen to (kind of) mirror how [godot-cpp](https://github.com/godotengine/godot-cpp) handles [property registration](https://github.com/godotengine/godot-cpp/blob/d5fab0b9f813396500acbf46d6b7fdf2c5bc5b73/test/src/example.cpp#L195).

TODO:
- [x] Usage flags and field hints aren't implemented yet
- [x] ~~Automatically generated getters/setters~~ ignore this, brain was confused. This is not possible since manually registered properties are not associated with any struct field

~~For the above todos, I think it should be possible to pass all manually registered properties as `FieldVar`s to reduce code duplication as the logic is mostly the same. I will need to investigate further.~~

Refactored to treat manually registered properties as `FieldVar`s. It might be worth it to rename some types since a `#[property]` is not actually associated with any struct fields, thus the field name and type need to be explicitly provided.