### PR TITLE
Exclude OpenXR from macOS in Godot < 4.2; run `codegen-full` in full-ci

### DIFF
--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -281,7 +281,7 @@ jobs:
           godot-binary: ${{ matrix.godot-binary }}
           godot-args: ${{ matrix.godot-args }}
           godot-prebuilt-patch: ${{ matrix.godot-prebuilt-patch }}
-          rust-extra-args: ${{ matrix.rust-extra-args }}
+          rust-extra-args: ${{ matrix.rust-extra-args }} --features godot/codegen-full
           rust-toolchain: ${{ matrix.rust-toolchain || 'stable' }}
           rust-env-rustflags: ${{ matrix.rust-env-rustflags }}
           rust-target: ${{ matrix.rust-target }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "godot-bindings",
     "godot-codegen",

--- a/godot-codegen/src/special_cases.rs
+++ b/godot-codegen/src/special_cases.rs
@@ -38,6 +38,8 @@ pub(crate) fn is_deleted(class_name: &TyName, godot_method_name: &str) -> bool {
 
 #[rustfmt::skip]
 pub(crate) fn is_class_deleted(class_name: &TyName) -> bool {
+    let class_name = class_name.godot_ty.as_str();
+
     // TODO feature-gate experimental classes.
     /*
     if !cfg!(feature = "experimental-godot-api") && is_class_experimental(class_name) {
@@ -45,7 +47,23 @@ pub(crate) fn is_class_deleted(class_name: &TyName) -> bool {
     }
     */
 
-    match class_name.godot_ty.as_str() {
+    // OpenXR has not been available for macOS before 4.2.
+    // See e.g. https://github.com/GodotVR/godot-xr-tools/issues/479.
+    #[cfg(all(before_api = "4.2", target_os = "macos"))]
+    match class_name {
+        | "OpenXRHand"
+        | "OpenXRAction"
+        | "OpenXRActionMap"
+        | "OpenXRActionSet"
+        | "OpenXRInteractionProfile"
+        | "OpenXRIPBinding"
+        | "OpenXRInterface"
+
+          => return true,
+        _ => {}
+    }
+
+    match class_name {
         // Hardcoded cases that are not accessible.
         | "JavaClassWrapper" // only on Android.
         | "JavaScriptBridge" // only on WASM.

--- a/godot-codegen/src/util.rs
+++ b/godot-codegen/src/util.rs
@@ -453,10 +453,16 @@ fn to_hardcoded_rust_ident(full_ty: &GodotTy) -> Option<&str> {
         ("int", Some("uint32")) => "u32",
         ("int", Some("uint16")) => "u16",
         ("int", Some("uint8")) => "u8",
+        ("int", Some(meta)) => panic!("unhandled type int with meta {meta:?}"),
 
-        // Floats
+        // Floats (with single precision builds)
         ("float", Some("double") | None) => "f64",
         ("float", Some("float")) => "f32",
+        ("float", Some(meta)) => panic!("unhandled type float with meta {meta:?}"),
+
+        // Doubles (with double precision builds)
+        ("double", None) => "f64",
+        ("double", Some(meta)) => panic!("unhandled type double with meta {meta:?}"),
 
         // Others
         ("bool", None) => "bool",
@@ -474,6 +480,9 @@ fn to_hardcoded_rust_ident(full_ty: &GodotTy) -> Option<&str> {
         ("int64_t", None) => "i64",
         ("real_t", None) => "real",
         ("void", None) => "c_void",
+
+        (ty, Some(meta)) => panic!("unhandled type {ty:?} with meta {meta:?}"),
+
         _ => return None,
     };
 


### PR DESCRIPTION
Godot does not support `OpenXR*` classes under macOS for versions <= 4.1.x, we thus conditionally exclude them given that configuration.

Now also runs CI on the full generated code (in `full-ci` during merging, _not_ in `minimal-ci`). This would catch the problem with macOS.