### PR TITLE
Array-based function pointer tables

### DIFF
--- a/godot-codegen/src/lib.rs
+++ b/godot-codegen/src/lib.rs
@@ -72,16 +72,16 @@ pub fn generate_sys_files(
     watch.record("generate_central_file");
 
     let builtin_types = BuiltinTypeMap::load(&api);
-    generate_sys_builtin_methods_file(&api, &builtin_types, sys_gen_path, &mut submit_fn);
+    generate_sys_builtin_methods_file(&api, &builtin_types, sys_gen_path, &mut ctx, &mut submit_fn);
     watch.record("generate_builtin_methods_file");
 
     generate_sys_builtin_lifecycle_file(&builtin_types, sys_gen_path, &mut submit_fn);
     watch.record("generate_builtin_lifecycle_file");
 
-    generate_sys_classes_file(&api, &mut ctx, sys_gen_path, watch, &mut submit_fn);
+    generate_sys_classes_file(&api, sys_gen_path, watch, &mut ctx, &mut submit_fn);
     // watch records inside the function.
 
-    generate_sys_utilities_file(&api, &mut ctx, sys_gen_path, &mut submit_fn);
+    generate_sys_utilities_file(&api, sys_gen_path, &mut ctx, &mut submit_fn);
     watch.record("generate_utilities_file");
 
     let is_godot_4_0 = api.header.version_major == 4 && api.header.version_minor == 0;
@@ -224,6 +224,7 @@ impl ToTokens for RustTy {
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 
 /// Contains multiple naming conventions for types (classes, builtin classes, enums).
+// TODO(bromeon, 2023-09): see if it makes sense to unify this with TypeNames (which is mostly used in central generator)
 #[derive(Clone, Eq, PartialEq, Hash)]
 pub(crate) struct TyName {
     godot_ty: String,

--- a/godot-core/src/lib.rs
+++ b/godot-core/src/lib.rs
@@ -105,6 +105,7 @@ pub mod private {
     struct GodotPanicInfo {
         line: u32,
         file: String,
+        //backtrace: Backtrace, // for future use
     }
 
     /// Executes `code`. If a panic is thrown, it is caught and an error message is printed to Godot.
@@ -128,6 +129,7 @@ pub mod private {
                     *info.lock().unwrap() = Some(GodotPanicInfo {
                         file: location.file().to_string(),
                         line: location.line(),
+                        //backtrace: Backtrace::capture(),
                     });
                 } else {
                     println!("panic occurred but can't get location information...");
@@ -154,6 +156,7 @@ pub mod private {
                     info.line,
                     error_context()
                 );
+                //eprintln!("Backtrace:\n{}", info.backtrace);
                 print_panic(err);
                 None
             }


### PR DESCRIPTION
Class and builtin function tables now use giant arrays instead of named fields.

Reduces the amount of generated code and thus compile time, while providing the same functionality. In particular, this should address the clippy issue.

Utility functions and builtin lifecycle methods still keep named method tables, as those have a higher chance of being used via names, and they are not that big in comparison.
