### PR TITLE
`Share` trait: deprecate + replace with `Clone`

### DIFF
--- a/examples/dodge-the-creeps/rust/src/main_scene.rs
+++ b/examples/dodge-the-creeps/rust/src/main_scene.rs
@@ -91,7 +91,7 @@ impl Main {
 
         mob_scene.set_rotation(direction);
 
-        self.base.add_child(mob_scene.share().upcast());
+        self.base.add_child(mob_scene.clone().upcast());
 
         let mut mob = mob_scene.cast::<mob::Mob>();
         let range = {

--- a/godot-core/src/builtin/string/godot_string.rs
+++ b/godot-core/src/builtin/string/godot_string.rs
@@ -108,7 +108,7 @@ impl GodotString {
 // - `from_arg_ptr`
 //   Strings are properly initialized through a `from_sys` call, but the ref-count should be
 //   incremented as that is the callee's responsibility. Which we do by calling
-//   `std::mem::forget(string.share())`.
+//   `std::mem::forget(string.clone())`.
 unsafe impl GodotFfi for GodotString {
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Opaque;
         fn from_sys;

--- a/godot-core/src/builtin/string/node_path.rs
+++ b/godot-core/src/builtin/string/node_path.rs
@@ -46,7 +46,7 @@ impl NodePath {
 // - `from_arg_ptr`
 //   NodePaths are properly initialized through a `from_sys` call, but the ref-count should be
 //   incremented as that is the callee's responsibility. Which we do by calling
-//   `std::mem::forget(node_path.share())`.
+//   `std::mem::forget(node_path.clone())`.
 unsafe impl GodotFfi for NodePath {
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Opaque;
         fn from_sys;

--- a/godot-core/src/builtin/string/string_name.rs
+++ b/godot-core/src/builtin/string/string_name.rs
@@ -73,7 +73,7 @@ impl StringName {
 // - `from_arg_ptr`
 //   StringNames are properly initialized through a `from_sys` call, but the ref-count should be
 //   incremented as that is the callee's responsibility. Which we do by calling
-//   `std::mem::forget(string_name.share())`.
+//   `std::mem::forget(string_name.clone())`.
 unsafe impl GodotFfi for StringName {
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Opaque;
         fn from_sys;

--- a/godot-core/src/engine.rs
+++ b/godot-core/src/engine.rs
@@ -112,10 +112,8 @@ where
         // This would need more sophisticated upcast design, e.g. T::upcast_{ref|mut}::<U>() for indirect relations
         // to make the indirect Deref more explicit
 
-        use crate::obj::Share;
-
         let path = path.into();
-        let node = self.share().upcast::<Node>();
+        let node = self.clone().upcast::<Node>();
 
         <Node as NodeExt>::try_get_node_as(&*node, path)
     }

--- a/godot-core/src/obj/traits.rs
+++ b/godot-core/src/obj/traits.rs
@@ -71,6 +71,7 @@ pub trait Share {
     /// Creates a new reference that points to the same object.
     ///
     /// If the referred-to object is reference-counted, this will increment the count.
+    #[deprecated = "Replaced with `Clone::clone()`."]
     fn share(&self) -> Self;
 }
 

--- a/godot/src/lib.rs
+++ b/godot/src/lib.rs
@@ -12,7 +12,13 @@
 //!
 //! Godot is written in C++, which doesn't have the same strict guarantees about safety and
 //! mutability that Rust does. As a result, not everything in this crate will look and feel
-//! entirely "rusty". We distinguish four different kinds of types:
+//! entirely "rusty".
+//!
+//! Traits such as `Clone`, `PartialEq` or `PartialOrd` are designed to mirror Godot semantics,
+//! except in cases where Rust is stricter (e.g. float ordering). Cloning a type results in the
+//! same observable behavior as assignment or parameter-passing of a GDScript variable.
+//!
+//! We distinguish four different kinds of types:
 //!
 //! 1. **Value types**: `i64`, `f64`, and mathematical types like
 //!    [`Vector2`][crate::builtin::Vector2] and [`Color`][crate::builtin::Color].
@@ -43,11 +49,9 @@
 //!    careful when using such types. For example, when iterating over an `Array`, make sure that
 //!    it isn't being modified at the same time through another reference.
 //!
-//!    To avoid confusion these types don't implement `Clone`. You can use
-//!    [`Share`][crate::obj::Share] to create a new reference to the same instance, and
-//!    type-specific methods such as
-//!    [`Array::duplicate_deep()`][crate::builtin::Array::duplicate_deep] to make actual
-//!    copies. <br><br>
+//!    `Clone::clone()` on these types creates a new reference to the same instance, while
+//!    type-specific methods such as [`Array::duplicate_deep()`][crate::builtin::Array::duplicate_deep]
+//!    can be used to make actual copies. <br><br>
 //!
 //! 4. **Manually managed types**: [`Gd<T>`][crate::obj::Gd] where `T` inherits from
 //!    [`Object`][crate::engine::Object] but not from [`RefCounted`][crate::engine::RefCounted];

--- a/itest/rust/src/builtin_tests/containers/array_test.rs
+++ b/itest/rust/src/builtin_tests/containers/array_test.rs
@@ -99,7 +99,7 @@ fn array_hash() {
 #[itest]
 fn array_share() {
     let mut array = array![1, 2];
-    let shared = array.share();
+    let shared = array.clone();
     array.set(0, 3);
     assert_eq!(shared.get(0), 3);
 }
@@ -372,7 +372,7 @@ fn untyped_array_return_from_godot_func() {
     let mut node = Node::new_alloc();
     let mut child = Node::new_alloc();
     child.set_name("child_node".into());
-    node.add_child(child.share());
+    node.add_child(child.clone());
     node.queue_free(); // Do not leak even if the test fails.
     let result = node.get_node_and_resource("child_node".into());
 
@@ -409,7 +409,7 @@ fn typed_array_return_from_godot_func() {
     let mut node = Node::new_alloc();
     let mut child = Node::new_alloc();
     child.set_name("child_node".into());
-    node.add_child(child.share());
+    node.add_child(child.clone());
     node.queue_free(); // Do not leak even if the test fails.
     let children = node.get_children();
 
@@ -419,7 +419,7 @@ fn typed_array_return_from_godot_func() {
 #[itest]
 fn typed_array_try_from_untyped() {
     let node = Node::new_alloc();
-    let array = VariantArray::from(&[node.share().to_variant()]);
+    let array = VariantArray::from(&[node.clone().to_variant()]);
     assert_eq!(
         array.to_variant().try_to::<Array<Option<Gd<Node>>>>(),
         Err(VariantConversionError::BadType)
@@ -430,7 +430,7 @@ fn typed_array_try_from_untyped() {
 #[itest]
 fn untyped_array_try_from_typed() {
     let node = Node::new_alloc();
-    let array = Array::<Option<Gd<Node>>>::from(&[Some(node.share())]);
+    let array = Array::<Option<Gd<Node>>>::from(&[Some(node.clone())]);
     assert_eq!(
         array.to_variant().try_to::<VariantArray>(),
         Err(VariantConversionError::BadType)

--- a/itest/rust/src/builtin_tests/containers/callable_test.rs
+++ b/itest/rust/src/builtin_tests/containers/callable_test.rs
@@ -8,7 +8,7 @@ use godot::bind::{godot_api, GodotClass};
 use godot::builtin::inner::InnerCallable;
 use godot::builtin::{varray, Callable, GodotString, StringName, ToVariant, Variant};
 use godot::engine::{Node2D, Object};
-use godot::obj::{Gd, Share};
+use godot::obj::Gd;
 
 use crate::framework::itest;
 
@@ -66,7 +66,7 @@ fn callable_object_method() {
     let obj = Gd::<CallableTestObj>::new_default();
     let callable = obj.callable("foo");
 
-    assert_eq!(callable.object(), Some(obj.share().upcast::<Object>()));
+    assert_eq!(callable.object(), Some(obj.clone().upcast::<Object>()));
     assert_eq!(callable.object_id(), Some(obj.instance_id()));
     assert_eq!(callable.method_name(), Some("foo".into()));
 
@@ -109,7 +109,7 @@ fn callable_call_return() {
 #[itest]
 fn callable_call_engine() {
     let obj = Node2D::new_alloc();
-    let cb = Callable::from_object_method(obj.share(), "set_position");
+    let cb = Callable::from_object_method(obj.clone(), "set_position");
     let inner: InnerCallable = cb.as_inner();
 
     assert!(!inner.is_null());

--- a/itest/rust/src/builtin_tests/containers/dictionary_test.rs
+++ b/itest/rust/src/builtin_tests/containers/dictionary_test.rs
@@ -7,7 +7,6 @@
 use std::collections::{HashMap, HashSet};
 
 use godot::builtin::{dict, varray, Dictionary, FromVariant, ToVariant, Variant};
-use godot::obj::Share;
 
 use crate::framework::{expect_panic, itest};
 
@@ -94,10 +93,10 @@ fn dictionary_clone() {
     };
     let dictionary = dict! {
         "foo": 0,
-        "bar": subdictionary.share()
+        "bar": subdictionary.clone()
     };
     #[allow(clippy::redundant_clone)]
-    let clone = dictionary.share();
+    let clone = dictionary.clone();
     Dictionary::from_variant(&clone.get("bar").unwrap()).insert("final", 4);
     assert_eq!(subdictionary.get("final"), Some(4.to_variant()));
 }
@@ -120,7 +119,7 @@ fn dictionary_duplicate_deep() {
     };
     let dictionary = dict! {
         "foo": 0,
-        "bar": subdictionary.share()
+        "bar": subdictionary.clone()
     };
     let clone = dictionary.duplicate_deep();
     Dictionary::from_variant(&clone.get("bar").unwrap()).insert("baz", 4);
@@ -139,7 +138,7 @@ fn dictionary_duplicate_shallow() {
     };
     let dictionary = dict! {
         "foo": 0,
-        "bar": subdictionary.share()
+        "bar": subdictionary.clone()
     };
     let mut clone = dictionary.duplicate_shallow();
     Dictionary::from_variant(&clone.get("bar").unwrap()).insert("baz", 4);
@@ -374,7 +373,7 @@ fn dictionary_iter_insert() {
         "baz": "foobar",
         "nil": Variant::nil(),
     };
-    let mut dictionary2 = dictionary.share();
+    let mut dictionary2 = dictionary.clone();
 
     let mut iter = dictionary.iter_shared();
     iter.next();
@@ -396,7 +395,7 @@ fn dictionary_iter_insert_after_completion() {
         "baz": "foobar",
         "nil": Variant::nil(),
     };
-    let mut dictionary2 = dictionary.share();
+    let mut dictionary2 = dictionary.clone();
     let mut iter = dictionary.iter_shared();
     for _ in 0..4 {
         iter.next();
@@ -411,7 +410,7 @@ fn dictionary_iter_insert_after_completion() {
 #[itest]
 fn dictionary_iter_big() {
     let dictionary: Dictionary = (0..256).zip(0..256).collect();
-    let mut dictionary2 = dictionary.share();
+    let mut dictionary2 = dictionary.clone();
     let mut iter = dictionary.iter_shared();
 
     for _ in 0..4 {
@@ -511,7 +510,7 @@ fn dictionary_iter_clear() {
         "baz": "foobar",
         "nil": Variant::nil(),
     };
-    let mut dictionary2 = dictionary.share();
+    let mut dictionary2 = dictionary.clone();
 
     let mut iter = dictionary.iter_shared();
     iter.next();
@@ -552,7 +551,7 @@ fn dictionary_iter_erase() {
         "baz": "foobar",
         "nil": Variant::nil(),
     };
-    let mut dictionary2 = dictionary.share();
+    let mut dictionary2 = dictionary.clone();
 
     let mut iter = dictionary.iter_shared();
     iter.next();

--- a/itest/rust/src/builtin_tests/containers/signal_test.rs
+++ b/itest/rust/src/builtin_tests/containers/signal_test.rs
@@ -10,7 +10,7 @@ use godot::bind::{godot_api, GodotClass};
 use godot::builtin::{GodotString, Variant};
 
 use godot::engine::Object;
-use godot::obj::{Base, Gd, Share};
+use godot::obj::{Base, Gd};
 use godot::sys;
 
 use crate::framework::itest;
@@ -50,7 +50,7 @@ impl Receiver {
     }
     #[func]
     fn receive_2_arg(&self, arg1: Gd<Object>, arg2: GodotString) {
-        assert_eq!(self.base.share(), arg1);
+        assert_eq!(self.base.clone(), arg1);
         assert_eq!(SIGNAL_ARG_STRING, arg2.to_string());
 
         self.used[2].set(true);
@@ -69,7 +69,7 @@ fn signals() {
         vec![],
         vec![Variant::from(987)],
         vec![
-            Variant::from(receiver.share()),
+            Variant::from(receiver.clone()),
             Variant::from(SIGNAL_ARG_STRING),
         ],
     ];

--- a/itest/rust/src/builtin_tests/containers/variant_test.rs
+++ b/itest/rust/src/builtin_tests/containers/variant_test.rs
@@ -116,9 +116,8 @@ fn variant_equal() {
 
 #[itest]
 fn variant_call() {
-    use godot::obj::Share;
     let node2d = Node2D::new_alloc();
-    let variant = Variant::from(node2d.share());
+    let variant = Variant::from(node2d.clone());
 
     // Object
     let position = Vector2::new(4.0, 5.0);

--- a/itest/rust/src/engine_tests/native_structures_test.rs
+++ b/itest/rust/src/engine_tests/native_structures_test.rs
@@ -8,7 +8,7 @@ use crate::framework::itest;
 use godot::engine::native::{AudioFrame, CaretInfo, Glyph};
 use godot::engine::text_server::Direction;
 use godot::engine::{TextServer, TextServerExtension, TextServerExtensionVirtual};
-use godot::prelude::{godot_api, Base, Gd, GodotClass, Rect2, Rid, Share, Variant};
+use godot::prelude::{godot_api, Base, Gd, GodotClass, Rect2, Rid, Variant};
 
 use std::cell::Cell;
 
@@ -94,7 +94,7 @@ fn test_native_structure_out_parameter() {
     // function which uses an 'out' pointer parameter.
     let mut ext: Gd<TestTextServer> = Gd::new_default();
     let result = ext
-        .share()
+        .clone()
         .upcast::<TextServer>()
         .shaped_text_get_carets(Rid::new(100), 200);
 
@@ -127,7 +127,7 @@ fn test_native_structure_pointer_to_array_parameter() {
     // Instantiate a TextServerExtension.
     let ext: Gd<TestTextServer> = Gd::new_default();
     let result = ext
-        .share()
+        .clone()
         .upcast::<TextServer>()
         .shaped_text_get_glyphs(Rid::new(100));
 

--- a/itest/rust/src/engine_tests/node_test.rs
+++ b/itest/rust/src/engine_tests/node_test.rs
@@ -8,7 +8,6 @@ use std::str::FromStr;
 
 use godot::builtin::{NodePath, Variant};
 use godot::engine::{global, Node, Node3D, NodeExt, PackedScene, SceneTree};
-use godot::obj::Share;
 
 use crate::framework::{itest, TestContext};
 
@@ -20,11 +19,11 @@ fn node_get_node() {
 
     let mut parent = Node3D::new_alloc();
     parent.set_name("parent".into());
-    parent.add_child(child.share().upcast());
+    parent.add_child(child.clone().upcast());
 
     let mut grandparent = Node::new_alloc();
     grandparent.set_name("grandparent".into());
-    grandparent.add_child(parent.share().upcast());
+    grandparent.add_child(parent.clone().upcast());
 
     // Directly on Gd<T>
     let found = grandparent.get_node_as::<Node3D>(NodePath::from("parent/child"));
@@ -51,7 +50,7 @@ fn node_get_node_fail() {
 
 #[itest]
 fn node_path_from_str(ctx: &TestContext) {
-    let child = ctx.scene_tree.share();
+    let child = ctx.scene_tree.clone();
     assert_eq!(
         child.get_path().to_string(),
         NodePath::from_str("/root/TestRunner").unwrap().to_string()
@@ -65,10 +64,10 @@ fn node_scene_tree() {
 
     let mut parent = Node::new_alloc();
     parent.set_name("parent".into());
-    parent.add_child(child.share());
+    parent.add_child(child.clone());
 
     let mut scene = PackedScene::new();
-    let err = scene.pack(parent.share());
+    let err = scene.pack(parent.clone());
     assert_eq!(err, global::Error::OK);
 
     let mut tree = SceneTree::new_alloc();
@@ -84,7 +83,7 @@ fn node_scene_tree() {
 
 #[itest]
 fn node_call_group(ctx: &TestContext) {
-    let mut node = ctx.scene_tree.share();
+    let mut node = ctx.scene_tree.clone();
     let mut tree = node.get_tree().unwrap();
 
     node.add_to_group("group".into());


### PR DESCRIPTION
Addresses part of #297.

What I'm not yet sure is whether the `impl Property` will still be needed for `Gd`, `Array` and `Dictionary`, now that they support cloning.

---

In a 2nd step, I would like to revisit the names of the `Gd` constructors. Some ideas:
* `new_default` -> `with_init`, `new`, ...
* `new` -> `from_standalone`, `from_object`, `manage`, ...
* `with_base` -> `from_base_fn`, `from_base_ctor`, ...

I don't want to implement `Default` for now due to the risk of manually managed types leaking.