### PR TITLE
Delegate majority of engine codegen to type system

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,6 +1,6 @@
 ![logo.png](assets/gdext-ferris.png)
 
-# Rust bindings for GDExtension
+# Rust bindings for Godot 4
 
 _**[Website]** | **[API Docs]** | [Discord] | [Mastodon] | [Twitter]_
 

--- a/godot-codegen/src/central_generator.rs
+++ b/godot-codegen/src/central_generator.rs
@@ -689,8 +689,8 @@ fn make_builtin_lifecycle_table(builtin_types: &BuiltinTypeMap) -> TokenStream {
         },
         method_decls: Vec::with_capacity(len),
         method_inits: Vec::with_capacity(len),
-        class_count: 0,
-        method_count: len,
+        class_count: len,
+        method_count: 0,
     };
 
     // Note: NIL is not part of this iteration, it will be added manually
@@ -705,7 +705,6 @@ fn make_builtin_lifecycle_table(builtin_types: &BuiltinTypeMap) -> TokenStream {
 
         table.method_decls.push(decls);
         table.method_inits.push(inits);
-        table.class_count += 1;
     }
 
     make_named_method_table(table)

--- a/godot-codegen/src/codegen_special_cases.rs
+++ b/godot-codegen/src/codegen_special_cases.rs
@@ -42,7 +42,7 @@ fn is_type_excluded(ty: &str, ctx: &mut Context) -> bool {
                 None => false,
                 Some(class) => is_class_excluded(class.as_str()),
             },
-            RustTy::EngineClass { class, .. } => is_class_excluded(class),
+            RustTy::EngineClass { inner_class, .. } => is_class_excluded(&inner_class.to_string()),
         }
     }
     is_rust_type_excluded(&util::to_rust_type(ty, None, ctx))

--- a/godot-codegen/src/lib.rs
+++ b/godot-codegen/src/lib.rs
@@ -186,9 +186,11 @@ enum RustTy {
 
     /// `Gd<Node>`
     EngineClass {
+        /// Tokens with full `Gd<T>`
         tokens: TokenStream,
-        #[allow(dead_code)] // currently not read
-        class: String,
+        /// only inner `T`
+        #[allow(dead_code)] // only read in minimal config
+        inner_class: Ident,
     },
 }
 

--- a/godot-codegen/src/util.rs
+++ b/godot-codegen/src/util.rs
@@ -144,6 +144,18 @@ pub(crate) fn option_as_slice<T>(option: &Option<Vec<T>>) -> &[T] {
     option.as_ref().map_or(&[], Vec::as_slice)
 }
 
+pub(crate) fn make_imports() -> TokenStream {
+    quote! {
+        use godot_ffi as sys;
+        use crate::builtin::*;
+        use crate::builtin::meta::{ClassName, PtrcallReturnUnit, PtrcallReturnT, PtrcallReturnOptionGdT, PtrcallSignatureTuple, VarcallSignatureTuple};
+        use crate::engine::native::*;
+        use crate::engine::Object;
+        use crate::obj::Gd;
+        use crate::sys::GodotFfi as _;
+    }
+}
+
 // Use &ClassMethod instead of &str, to make sure it's the original Godot name and no rename.
 pub(crate) fn make_class_method_ptr_name(class_ty: &TyName, method: &ClassMethod) -> Ident {
     format_ident!("{}__{}", to_snake_case(&class_ty.godot_ty), method.name)
@@ -693,7 +705,7 @@ fn to_rust_type_uncached(full_ty: &GodotTy, ctx: &mut Context) -> RustTy {
         let ty = rustify_ty(ty);
         RustTy::EngineClass {
             tokens: quote! { Gd<crate::engine::#ty> },
-            class: ty.to_string(),
+            inner_class: ty,
         }
     }
 }

--- a/godot-codegen/src/utilities_generator.rs
+++ b/godot-codegen/src/utilities_generator.rs
@@ -9,8 +9,8 @@ use std::path::Path;
 use quote::quote;
 
 use crate::class_generator::make_utility_function_definition;
-use crate::Context;
 use crate::{api_parser::*, SubmitFn};
+use crate::{util, Context};
 
 pub(crate) fn generate_utilities_file(
     api: &ExtensionApi,
@@ -24,6 +24,8 @@ pub(crate) fn generate_utilities_file(
         .iter()
         .map(|utility_fn| make_utility_function_definition(utility_fn, ctx));
 
+    let imports = util::make_imports();
+
     let tokens = quote! {
         //! Global utility functions.
         //!
@@ -32,11 +34,7 @@ pub(crate) fn generate_utilities_file(
         //!
         //! See also [Godot docs for `@GlobalScope`](https://docs.godotengine.org/en/stable/classes/class_@globalscope.html#methods).
 
-        use godot_ffi as sys;
-        use crate::builtin::*;
-        use crate::obj::Gd;
-        use crate::engine::Object;
-        use sys::GodotFfi as _;
+        #imports
 
         #(#utility_fn_defs)*
     };

--- a/godot-core/src/builtin/meta/mod.rs
+++ b/godot-core/src/builtin/meta/mod.rs
@@ -7,9 +7,13 @@
 pub mod registration;
 
 mod class_name;
+mod return_marshal;
 mod signature;
 
 pub use class_name::*;
+#[doc(hidden)]
+pub use return_marshal::*;
+#[doc(hidden)]
 pub use signature::*;
 
 use godot_ffi as sys;

--- a/godot-core/src/builtin/meta/return_marshal.rs
+++ b/godot-core/src/builtin/meta/return_marshal.rs
@@ -1,0 +1,61 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use crate::obj::{Gd, GodotClass};
+use crate::sys;
+
+/// Specifies how the return type is marshalled in a ptrcall.
+#[doc(hidden)]
+pub trait PtrcallReturn {
+    type Ret;
+
+    unsafe fn call(process_return_ptr: impl FnMut(sys::GDExtensionTypePtr)) -> Self::Ret;
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+
+pub struct PtrcallReturnOptionGdT<R> {
+    _marker: std::marker::PhantomData<R>,
+}
+
+impl<T: GodotClass> PtrcallReturn for PtrcallReturnOptionGdT<Gd<T>> {
+    type Ret = Option<Gd<T>>;
+
+    unsafe fn call(process_return_ptr: impl FnMut(sys::GDExtensionTypePtr)) -> Self::Ret {
+        Gd::<T>::from_sys_init_opt(process_return_ptr)
+    }
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+
+pub struct PtrcallReturnT<R> {
+    _marker: std::marker::PhantomData<R>,
+}
+
+impl<T: sys::GodotFuncMarshal> PtrcallReturn for PtrcallReturnT<T> {
+    type Ret = T;
+
+    unsafe fn call(mut process_return_ptr: impl FnMut(sys::GDExtensionTypePtr)) -> Self::Ret {
+        let via = <T::Via as sys::GodotFfi>::from_sys_init_default(|return_ptr| {
+            process_return_ptr(return_ptr)
+        });
+
+        T::try_from_via(via).unwrap()
+    }
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+
+pub enum PtrcallReturnUnit {}
+
+impl PtrcallReturn for PtrcallReturnUnit {
+    type Ret = ();
+
+    unsafe fn call(mut process_return_ptr: impl FnMut(sys::GDExtensionTypePtr)) -> Self::Ret {
+        let return_ptr = std::ptr::null_mut();
+        process_return_ptr(return_ptr);
+    }
+}

--- a/godot-core/src/builtin/meta/signature.rs
+++ b/godot-core/src/builtin/meta/signature.rs
@@ -7,6 +7,8 @@
 use godot_ffi as sys;
 use std::fmt::Debug;
 
+use sys::{BuiltinMethodBind, ClassMethodBind, UtilityFunctionBind};
+
 #[doc(hidden)]
 pub trait VarcallSignatureTuple: PtrcallSignatureTuple {
     const PARAM_COUNT: usize;
@@ -18,7 +20,7 @@ pub trait VarcallSignatureTuple: PtrcallSignatureTuple {
     // TODO(uninit) - can we use this for varcall/ptrcall?
     // ret: sys::GDExtensionUninitializedVariantPtr
     // ret: sys::GDExtensionUninitializedTypePtr
-    unsafe fn varcall(
+    unsafe fn in_varcall(
         instance_ptr: sys::GDExtensionClassInstancePtr,
         args_ptr: *const sys::GDExtensionConstVariantPtr,
         ret: sys::GDExtensionVariantPtr,
@@ -26,6 +28,22 @@ pub trait VarcallSignatureTuple: PtrcallSignatureTuple {
         func: fn(sys::GDExtensionClassInstancePtr, Self::Params) -> Self::Ret,
         method_name: &str,
     );
+
+    unsafe fn out_class_varcall(
+        method_bind: sys::GDExtensionMethodBindPtr,
+        method_name: &'static str,
+        object_ptr: sys::GDExtensionObjectPtr,
+        args: Self::Params,
+        varargs: &[Variant],
+    ) -> Self::Ret;
+
+    unsafe fn out_utility_ptrcall_varargs(
+        utility_fn: UtilityFunctionBind,
+        args: Self::Params,
+        varargs: &[Variant],
+    ) -> Self::Ret;
+
+    fn format_args(args: &Self::Params) -> String;
 }
 
 #[doc(hidden)]
@@ -35,7 +53,7 @@ pub trait PtrcallSignatureTuple {
 
     // Note: this method imposes extra bounds on GodotFfi, which may not be implemented for user types.
     // We could fall back to varcalls in such cases, and not require GodotFfi categorically.
-    unsafe fn ptrcall(
+    unsafe fn in_ptrcall(
         instance_ptr: sys::GDExtensionClassInstancePtr,
         args_ptr: *const sys::GDExtensionConstTypePtr,
         ret: sys::GDExtensionTypePtr,
@@ -43,6 +61,21 @@ pub trait PtrcallSignatureTuple {
         method_name: &str,
         call_type: sys::PtrcallType,
     );
+
+    unsafe fn out_class_ptrcall<Rr: PtrcallReturn<Ret = Self::Ret>>(
+        method_bind: sys::GDExtensionMethodBindPtr,
+        object_ptr: sys::GDExtensionObjectPtr,
+        args: Self::Params,
+    ) -> Self::Ret;
+
+    unsafe fn out_builtin_ptrcall<Rr: PtrcallReturn<Ret = Self::Ret>>(
+        builtin_fn: BuiltinMethodBind,
+        type_ptr: sys::GDExtensionTypePtr,
+        args: Self::Params,
+    ) -> Self::Ret;
+
+    unsafe fn out_utility_ptrcall(utility_fn: UtilityFunctionBind, args: Self::Params)
+        -> Self::Ret;
 }
 
 // impl<P, const N: usize> Sig for [P; N]
@@ -68,17 +101,20 @@ use super::registration::method::MethodParamOrReturnInfo;
 
 macro_rules! impl_varcall_signature_for_tuple {
     (
-        $PARAM_COUNT:literal,
+        $PARAM_COUNT:literal;
         $R:ident
-        $(, $Pn:ident : $n:literal)*
+        $(, $Pn:ident : $n:tt)* // $n cannot be literal if substituted as tuple index .0
     ) => {
+        // R: FromVariantIndirect, Pn: ToVariant -> when calling engine APIs
+        // R: ToVariant, Pn:
         #[allow(unused_variables)]
         impl<$R, $($Pn,)*> VarcallSignatureTuple for ($R, $($Pn,)*)
-            where $R: VariantMetadata + ToVariant + sys::GodotFuncMarshal + Debug,
-               $( $Pn: VariantMetadata + FromVariant + sys::GodotFuncMarshal + Debug, )*
+            where $R: VariantMetadata + FromVariantIndirect + ToVariant + sys::GodotFuncMarshal + Debug,
+               $( $Pn: VariantMetadata + ToVariant + FromVariant + sys::GodotFuncMarshal + Debug, )*
         {
             const PARAM_COUNT: usize = $PARAM_COUNT;
 
+            #[inline]
             fn param_info(index: usize, param_name: &str) -> Option<MethodParamOrReturnInfo> {
                 match index {
                     $(
@@ -88,10 +124,12 @@ macro_rules! impl_varcall_signature_for_tuple {
                 }
             }
 
+            #[inline]
             fn return_info() -> Option<MethodParamOrReturnInfo> {
                 $R::return_info()
             }
 
+            #[inline]
             fn param_property_info(index: usize, param_name: &str) -> PropertyInfo {
                 match index {
                     $(
@@ -101,9 +139,8 @@ macro_rules! impl_varcall_signature_for_tuple {
                 }
             }
 
-
             #[inline]
-            unsafe fn varcall(
+            unsafe fn in_varcall(
                 instance_ptr: sys::GDExtensionClassInstancePtr,
                 args_ptr: *const sys::GDExtensionConstVariantPtr,
                 ret: sys::GDExtensionVariantPtr,
@@ -119,6 +156,76 @@ macro_rules! impl_varcall_signature_for_tuple {
 
                 varcall_return::<$R>(func(instance_ptr, args), ret, err)
             }
+
+            #[inline]
+            unsafe fn out_class_varcall(
+                method_bind: ClassMethodBind,
+                method_name: &'static str,
+                object_ptr: sys::GDExtensionObjectPtr,
+                args: Self::Params,
+                varargs: &[Variant],
+            ) -> Self::Ret {
+                let class_fn = sys::interface_fn!(object_method_bind_call);
+
+                let explicit_args = [
+                    $(
+                        <$Pn as ToVariant>::to_variant(&args.$n),
+                    )*
+                ];
+
+                let mut variant_ptrs = Vec::with_capacity(explicit_args.len() + varargs.len());
+                variant_ptrs.extend(explicit_args.iter().map(Variant::var_sys_const));
+                variant_ptrs.extend(varargs.iter().map(Variant::var_sys_const));
+
+                let variant = Variant::from_var_sys_init(|return_ptr| {
+                    let mut err = sys::default_call_error();
+                    class_fn(
+                        method_bind,
+                        object_ptr,
+                        variant_ptrs.as_ptr(),
+                        variant_ptrs.len() as i64,
+                        return_ptr,
+                        std::ptr::addr_of_mut!(err),
+                    );
+
+                    check_varcall_error(&err, method_name, &explicit_args, varargs);
+                });
+                <Self::Ret as FromVariantIndirect>::convert(variant)
+            }
+
+            // Note: this is doing a ptrcall, but uses variant conversions for it
+            #[inline]
+            unsafe fn out_utility_ptrcall_varargs(
+                utility_fn: UtilityFunctionBind,
+                args: Self::Params,
+                varargs: &[Variant],
+            ) -> Self::Ret {
+
+                let explicit_args: [Variant; $PARAM_COUNT] = [
+                    $(
+                        <$Pn as ToVariant>::to_variant(&args.$n),
+                    )*
+                ];
+
+                let mut type_ptrs = Vec::with_capacity(explicit_args.len() + varargs.len());
+                type_ptrs.extend(explicit_args.iter().map(sys::GodotFfi::sys_const));
+                type_ptrs.extend(varargs.iter().map(sys::GodotFfi::sys_const));
+
+                // Important: this calls from_sys_init_default().
+                PtrcallReturnT::<$R>::call(|return_ptr| {
+                    utility_fn(return_ptr, type_ptrs.as_ptr(), type_ptrs.len() as i32);
+                })
+            }
+
+            #[inline]
+            fn format_args(args: &Self::Params) -> String {
+                let mut string = String::new();
+                $(
+                    string.push_str(&format!("{:?}, ", args.$n));
+                )*
+                string.remove(string.len() - 2); // remove trailing ", "
+                string
+            }
         }
     };
 }
@@ -126,7 +233,7 @@ macro_rules! impl_varcall_signature_for_tuple {
 macro_rules! impl_ptrcall_signature_for_tuple {
     (
         $R:ident
-        $(, $Pn:ident : $n:literal)*
+        $(, $Pn:ident : $n:tt)* // $n cannot be literal if substituted as tuple index .0
     ) => {
         #[allow(unused_variables)]
         impl<$R, $($Pn,)*> PtrcallSignatureTuple for ($R, $($Pn,)*)
@@ -136,7 +243,8 @@ macro_rules! impl_ptrcall_signature_for_tuple {
             type Params = ($($Pn,)*);
             type Ret = $R;
 
-            unsafe fn ptrcall(
+            #[inline]
+            unsafe fn in_ptrcall(
                 instance_ptr: sys::GDExtensionClassInstancePtr,
                 args_ptr: *const sys::GDExtensionConstTypePtr,
                 ret: sys::GDExtensionTypePtr,
@@ -154,6 +262,79 @@ macro_rules! impl_ptrcall_signature_for_tuple {
                 // `ret` is always a pointer to an initialized value of type $R
                 // TODO: double-check the above
                 ptrcall_return::<$R>(func(instance_ptr, args), ret, method_name, call_type)
+            }
+
+            #[inline]
+            unsafe fn out_class_ptrcall<Rr: PtrcallReturn<Ret = Self::Ret>>(
+                method_bind: ClassMethodBind,
+                object_ptr: sys::GDExtensionObjectPtr,
+                args: Self::Params,
+            ) -> Self::Ret {
+                let class_fn = sys::interface_fn!(object_method_bind_ptrcall);
+
+                #[allow(clippy::let_unit_value)]
+                let marshalled_args = (
+                    $(
+                        <$Pn as sys::GodotFuncMarshal>::try_into_via(args.$n).unwrap(),
+                    )*
+                );
+
+                let type_ptrs = [
+                    $(
+                        sys::GodotFfi::as_arg_ptr(&marshalled_args.$n),
+                    )*
+                ];
+
+                Rr::call(|return_ptr| {
+                    class_fn(method_bind, object_ptr, type_ptrs.as_ptr(), return_ptr);
+                })
+            }
+
+            #[inline]
+            unsafe fn out_builtin_ptrcall<Rr: PtrcallReturn<Ret = Self::Ret>>(
+                builtin_fn: BuiltinMethodBind,
+                type_ptr: sys::GDExtensionTypePtr,
+                args: Self::Params,
+            ) -> Self::Ret {
+                #[allow(clippy::let_unit_value)]
+                let marshalled_args = (
+                    $(
+                        <$Pn as sys::GodotFuncMarshal>::try_into_via(args.$n).unwrap(),
+                    )*
+                );
+
+                let type_ptrs = [
+                    $(
+                        sys::GodotFfi::as_arg_ptr(&marshalled_args.$n),
+                    )*
+                ];
+
+                Rr::call(|return_ptr| {
+                    builtin_fn(type_ptr, type_ptrs.as_ptr(), return_ptr, type_ptrs.len() as i32);
+                })
+            }
+
+            #[inline]
+            unsafe fn out_utility_ptrcall(
+                utility_fn: UtilityFunctionBind,
+                args: Self::Params,
+            ) -> Self::Ret {
+                #[allow(clippy::let_unit_value)]
+                let marshalled_args = (
+                    $(
+                        <$Pn as sys::GodotFuncMarshal>::try_into_via(args.$n).unwrap(),
+                    )*
+                );
+
+                let arg_ptrs = [
+                    $(
+                        sys::GodotFfi::as_arg_ptr(&marshalled_args.$n),
+                    )*
+                ];
+
+                PtrcallReturnT::<$R>::call(|return_ptr| {
+                    utility_fn(return_ptr, arg_ptrs.as_ptr(), arg_ptrs.len() as i32);
+                })
             }
         }
     };
@@ -231,25 +412,86 @@ fn return_error<R>(method_name: &str, arg: &impl Debug) -> ! {
     panic!("{method_name}: return type {return_ty} is unable to store value {arg:?}",);
 }
 
-impl_varcall_signature_for_tuple!(0, R);
+fn check_varcall_error<T>(
+    err: &sys::GDExtensionCallError,
+    fn_name: &str,
+    explicit_args: &[T],
+    varargs: &[Variant],
+) where
+    T: Debug + ToVariant,
+{
+    if err.error == sys::GDEXTENSION_CALL_OK {
+        return;
+    }
+
+    // TODO(optimize): split into non-generic, expensive parts after error check
+
+    let mut arg_types = Vec::with_capacity(explicit_args.len() + varargs.len());
+    arg_types.extend(explicit_args.iter().map(|arg| arg.to_variant().get_type()));
+    arg_types.extend(varargs.iter().map(Variant::get_type));
+
+    let explicit_args_str = join_to_string(explicit_args);
+    let vararg_str = join_to_string(varargs);
+
+    let func_str = format!("{fn_name}({explicit_args_str}; varargs {vararg_str})");
+
+    sys::panic_call_error(err, &func_str, &arg_types);
+}
+
+fn join_to_string<T: Debug>(list: &[T]) -> String {
+    list.iter()
+        .map(|v| format!("{v:?}"))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// Helper trait to support `()` which doesn't implement `FromVariant`.
+trait FromVariantIndirect {
+    fn convert(variant: Variant) -> Self;
+}
+
+impl FromVariantIndirect for () {
+    fn convert(_variant: Variant) -> Self {}
+}
+
+impl<T: FromVariant> FromVariantIndirect for T {
+    fn convert(variant: Variant) -> Self {
+        T::from_variant(&variant)
+    }
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// Poor man's variadic templates.
+// For example, RenderingServer::environment_set_volumetric_fog() has 14 parameters. We may need to extend this if the API adds more such methods.
+
+impl_varcall_signature_for_tuple!(0; R);
+impl_varcall_signature_for_tuple!(1; R, P0: 0);
+impl_varcall_signature_for_tuple!(2; R, P0: 0, P1: 1);
+impl_varcall_signature_for_tuple!(3; R, P0: 0, P1: 1, P2: 2);
+impl_varcall_signature_for_tuple!(4; R, P0: 0, P1: 1, P2: 2, P3: 3);
+impl_varcall_signature_for_tuple!(5; R, P0: 0, P1: 1, P2: 2, P3: 3, P4: 4);
+impl_varcall_signature_for_tuple!(6; R, P0: 0, P1: 1, P2: 2, P3: 3, P4: 4, P5: 5);
+impl_varcall_signature_for_tuple!(7; R, P0: 0, P1: 1, P2: 2, P3: 3, P4: 4, P5: 5, P6: 6);
+impl_varcall_signature_for_tuple!(8; R, P0: 0, P1: 1, P2: 2, P3: 3, P4: 4, P5: 5, P6: 6, P7: 7);
+impl_varcall_signature_for_tuple!(9; R, P0: 0, P1: 1, P2: 2, P3: 3, P4: 4, P5: 5, P6: 6, P7: 7, P8: 8);
+impl_varcall_signature_for_tuple!(10; R, P0: 0, P1: 1, P2: 2, P3: 3, P4: 4, P5: 5, P6: 6, P7: 7, P8: 8, P9: 9);
+impl_varcall_signature_for_tuple!(11; R, P0: 0, P1: 1, P2: 2, P3: 3, P4: 4, P5: 5, P6: 6, P7: 7, P8: 8, P9: 9, P10: 10);
+impl_varcall_signature_for_tuple!(12; R, P0: 0, P1: 1, P2: 2, P3: 3, P4: 4, P5: 5, P6: 6, P7: 7, P8: 8, P9: 9, P10: 10, P11: 11);
+impl_varcall_signature_for_tuple!(13; R, P0: 0, P1: 1, P2: 2, P3: 3, P4: 4, P5: 5, P6: 6, P7: 7, P8: 8, P9: 9, P10: 10, P11: 11, P12: 12);
+impl_varcall_signature_for_tuple!(14; R, P0: 0, P1: 1, P2: 2, P3: 3, P4: 4, P5: 5, P6: 6, P7: 7, P8: 8, P9: 9, P10: 10, P11: 11, P12: 12, P13: 13);
+
 impl_ptrcall_signature_for_tuple!(R);
-impl_varcall_signature_for_tuple!(1, R, P0: 0);
 impl_ptrcall_signature_for_tuple!(R, P0: 0);
-impl_varcall_signature_for_tuple!(2, R, P0: 0, P1: 1);
 impl_ptrcall_signature_for_tuple!(R, P0: 0, P1: 1);
-impl_varcall_signature_for_tuple!(3, R, P0: 0, P1: 1, P2: 2);
 impl_ptrcall_signature_for_tuple!(R, P0: 0, P1: 1, P2: 2);
-impl_varcall_signature_for_tuple!(4, R, P0: 0, P1: 1, P2: 2, P3: 3);
 impl_ptrcall_signature_for_tuple!(R, P0: 0, P1: 1, P2: 2, P3: 3);
-impl_varcall_signature_for_tuple!(5, R, P0: 0, P1: 1, P2: 2, P3: 3, P4: 4);
 impl_ptrcall_signature_for_tuple!(R, P0: 0, P1: 1, P2: 2, P3: 3, P4: 4);
-impl_varcall_signature_for_tuple!(6, R, P0: 0, P1: 1, P2: 2, P3: 3, P4: 4, P5: 5);
 impl_ptrcall_signature_for_tuple!(R, P0: 0, P1: 1, P2: 2, P3: 3, P4: 4, P5: 5);
-impl_varcall_signature_for_tuple!(7, R, P0: 0, P1: 1, P2: 2, P3: 3, P4: 4, P5: 5, P6: 6);
 impl_ptrcall_signature_for_tuple!(R, P0: 0, P1: 1, P2: 2, P3: 3, P4: 4, P5: 5, P6: 6);
-impl_varcall_signature_for_tuple!(8, R, P0: 0, P1: 1, P2: 2, P3: 3, P4: 4, P5: 5, P6: 6, P7: 7);
 impl_ptrcall_signature_for_tuple!(R, P0: 0, P1: 1, P2: 2, P3: 3, P4: 4, P5: 5, P6: 6, P7: 7);
-impl_varcall_signature_for_tuple!(9, R, P0: 0, P1: 1, P2: 2, P3: 3, P4: 4, P5: 5, P6: 6, P7: 7, P8: 8);
 impl_ptrcall_signature_for_tuple!(R, P0: 0, P1: 1, P2: 2, P3: 3, P4: 4, P5: 5, P6: 6, P7: 7, P8: 8);
-impl_varcall_signature_for_tuple!(10, R, P0: 0, P1: 1, P2: 2, P3: 3, P4: 4, P5: 5, P6: 6, P7: 7, P8: 8, P9: 9);
 impl_ptrcall_signature_for_tuple!(R, P0: 0, P1: 1, P2: 2, P3: 3, P4: 4, P5: 5, P6: 6, P7: 7, P8: 8, P9: 9);
+impl_ptrcall_signature_for_tuple!(R, P0: 0, P1: 1, P2: 2, P3: 3, P4: 4, P5: 5, P6: 6, P7: 7, P8: 8, P9: 9, P10: 10);
+impl_ptrcall_signature_for_tuple!(R, P0: 0, P1: 1, P2: 2, P3: 3, P4: 4, P5: 5, P6: 6, P7: 7, P8: 8, P9: 9, P10: 10, P11: 11);
+impl_ptrcall_signature_for_tuple!(R, P0: 0, P1: 1, P2: 2, P3: 3, P4: 4, P5: 5, P6: 6, P7: 7, P8: 8, P9: 9, P10: 10, P11: 11, P12: 12);
+impl_ptrcall_signature_for_tuple!(R, P0: 0, P1: 1, P2: 2, P3: 3, P4: 4, P5: 5, P6: 6, P7: 7, P8: 8, P9: 9, P10: 10, P11: 11, P12: 12, P13: 13);

--- a/godot-core/src/lib.rs
+++ b/godot-core/src/lib.rs
@@ -36,6 +36,7 @@ pub mod engine;
 #[rustfmt::skip]
 #[allow(unused_imports, dead_code, non_upper_case_globals, non_snake_case)]
 #[allow(clippy::too_many_arguments, clippy::let_and_return, clippy::new_ret_no_self)]
+#[allow(clippy::let_unit_value)] // let args = ();
 #[allow(clippy::wrong_self_convention)] // to_string() is const
 #[allow(clippy::upper_case_acronyms)] // TODO remove this line once we transform names
 #[allow(unreachable_code, clippy::unimplemented)] // TODO remove once #153 is implemented

--- a/godot-ffi/src/gdextension_plus.rs
+++ b/godot-ffi/src/gdextension_plus.rs
@@ -73,8 +73,11 @@ pub fn default_call_error() -> GDExtensionCallError {
 pub fn panic_call_error(
     err: &GDExtensionCallError,
     function_name: &str,
-    arg_types: &[VariantType],
+    vararg_types: &[VariantType],
 ) -> ! {
+    // This specializes on reflection-style calls, e.g. call(), rpc() etc.
+    // In these cases, varargs are the _actual_ arguments, with required args being metadata such as method name.
+
     debug_assert_ne!(err.error, GDEXTENSION_CALL_OK); // already checked outside
 
     let GDExtensionCallError {
@@ -83,11 +86,11 @@ pub fn panic_call_error(
         expected,
     } = *err;
 
-    let argc = arg_types.len();
+    let argc = vararg_types.len();
     let reason = match error {
         GDEXTENSION_CALL_ERROR_INVALID_METHOD => "method not found".to_string(),
         GDEXTENSION_CALL_ERROR_INVALID_ARGUMENT => {
-            let from = arg_types[argument as usize];
+            let from = vararg_types[argument as usize];
             let to = VariantType::from_sys(expected as GDExtensionVariantType);
             let i = argument + 1;
 

--- a/godot-ffi/src/godot_ffi.rs
+++ b/godot-ffi/src/godot_ffi.rs
@@ -5,8 +5,9 @@
  */
 
 use crate as sys;
-use std::{error::Error, fmt::Debug, marker::PhantomData, ptr};
-use sys::ptr_then;
+use std::error::Error;
+use std::marker::PhantomData;
+use std::ptr;
 
 /// Adds methods to convert from and to Godot FFI pointers.
 /// See [crate::ffi_methods] for ergonomic implementation.
@@ -147,7 +148,7 @@ where
     T: GodotNullablePtr,
 {
     unsafe fn from_sys(ptr: sys::GDExtensionTypePtr) -> Self {
-        ptr_then(ptr, |ptr| T::from_sys(ptr))
+        crate::ptr_then(ptr, |ptr| T::from_sys(ptr))
     }
 
     unsafe fn from_sys_init(init_fn: impl FnOnce(sys::GDExtensionUninitializedTypePtr)) -> Self {
@@ -215,7 +216,7 @@ unsafe fn option_from_arg_single_ptr<T>(
 where
     T: GodotNullablePtr,
 {
-    ptr_then(ptr, |ptr| T::from_arg_ptr(ptr, call_type))
+    crate::ptr_then(ptr, |ptr| T::from_arg_ptr(ptr, call_type))
 }
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------

--- a/godot-ffi/src/toolbox.rs
+++ b/godot-ffi/src/toolbox.rs
@@ -166,7 +166,7 @@ pub(crate) type GetClassMethod = unsafe extern "C" fn(
     p_hash: sys::GDExtensionInt,
 ) -> sys::GDExtensionMethodBindPtr;
 
-pub(crate) type ClassMethodBind = sys::GDExtensionMethodBindPtr;
+pub type ClassMethodBind = sys::GDExtensionMethodBindPtr;
 
 pub(crate) type GetBuiltinMethod = unsafe extern "C" fn(
     p_type: sys::GDExtensionVariantType,
@@ -175,7 +175,7 @@ pub(crate) type GetBuiltinMethod = unsafe extern "C" fn(
 ) -> sys::GDExtensionPtrBuiltInMethod;
 
 // GDExtensionPtrBuiltInMethod
-pub(crate) type BuiltinMethodBind = unsafe extern "C" fn(
+pub type BuiltinMethodBind = unsafe extern "C" fn(
     p_base: sys::GDExtensionTypePtr,
     p_args: *const sys::GDExtensionConstTypePtr,
     r_return: sys::GDExtensionTypePtr,
@@ -187,7 +187,7 @@ pub(crate) type GetUtilityFunction = unsafe extern "C" fn(
     p_hash: sys::GDExtensionInt,
 ) -> sys::GDExtensionPtrUtilityFunction;
 
-pub(crate) type UtilityFunctionBind = unsafe extern "C" fn(
+pub type UtilityFunctionBind = unsafe extern "C" fn(
     r_return: sys::GDExtensionTypePtr,
     p_args: *const sys::GDExtensionConstTypePtr,
     p_argument_count: std::os::raw::c_int,

--- a/godot-macros/src/class/data_models/func.rs
+++ b/godot-macros/src/class/data_models/func.rs
@@ -322,7 +322,7 @@ fn make_ptrcall_invocation(
     };
 
     quote! {
-         <#sig_tuple as ::godot::builtin::meta::PtrcallSignatureTuple>::ptrcall(
+         <#sig_tuple as ::godot::builtin::meta::PtrcallSignatureTuple>::in_ptrcall(
             instance_ptr,
             args_ptr,
             ret,
@@ -342,7 +342,7 @@ fn make_varcall_invocation(
     let method_name_str = method_name.to_string();
 
     quote! {
-        <#sig_tuple as ::godot::builtin::meta::VarcallSignatureTuple>::varcall(
+        <#sig_tuple as ::godot::builtin::meta::VarcallSignatureTuple>::in_varcall(
             instance_ptr,
             args_ptr,
             ret,


### PR DESCRIPTION
Now uses traits instead of generated code for parameter/return passing. This significantly reduces the amount of generated code, at the cost of more monomorphizations.

## Compile-time impact

This PR **reduces initial build times by ~20%**. Measured with `hyperfine` on Windows -- first this branch, then `master`:

![grafik](https://github.com/godot-rust/gdext/assets/708488/73327d05-e794-409f-90a4-b4add5025f9f)

Another measurement resulted in means of `66.3 s` (this branch) vs. `82.6 s` (master), so pretty similar. I didn't measure incremental build times, but don't think we'll see significant differences between the two branches there.

It seems that for the Rust compiler, many monomorphizations are more favorable than a lot of duplicated source code. Probably something we can benefit from in other places.