### PR TITLE
Ensure object validity in class method calls

### DIFF
--- a/.github/composite/godot-itest/action.yml
+++ b/.github/composite/godot-itest/action.yml
@@ -179,10 +179,12 @@ runs:
       # * grep -q:  no output, use exit code 0 if found -> thus also &&
       # * pkill:    stop Godot execution (since it hangs in headless mode); simple 'head -1' did not work as expected
       # * exit:     the terminated process would return 143, but this is more explicit and future-proof
+      #
+      # --disallow-focus: fail if #[itest(focus)] is encountered, to prevent running only a few tests for full CI
       run: |
         cd itest/godot
         echo "OUTCOME=itest" >> $GITHUB_ENV
-        $GODOT4_BIN --headless ${{ inputs.godot-args }} 2>&1 \
+        $GODOT4_BIN --headless -- --disallow-focus ${{ inputs.godot-args }} 2>&1 \
         | tee "${{ runner.temp }}/log.txt" \
         | tee >(grep -E "SCRIPT ERROR:|Can't open dynamic library" -q && {
         	printf "\n::error::godot-itest: unrecoverable Godot error, abort...\n";

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -153,8 +153,6 @@ jobs:
         # Naming: {os}[-{runtimeVersion}]-{apiVersion}
         # runtimeVersion = version of Godot binary; apiVersion = version of GDExtension API against which gdext is compiled.
 
-        # --disallow-focus: fail if #[itest(focus)] is encountered, to prevent running only a few tests for full CI
-
         # Order this way because macOS typically has the longest duration, followed by Windows, so it benefits total workflow execution time.
         # Additionally, the 'linux (msrv *)' special case will then be listed next to the other 'linux' jobs.
         # Note: Windows uses '--target x86_64-pc-windows-msvc' by default as Cargo argument.
@@ -253,7 +251,6 @@ jobs:
             os: ubuntu-20.04
             artifact-name: linux-memcheck-clang-nightly
             godot-binary: godot.linuxbsd.editor.dev.x86_64.llvm.san
-            godot-args: -- --disallow-focus
             rust-toolchain: nightly
             rust-env-rustflags: -Zrandomize-layout -Zsanitizer=address
             rust-extra-args: --features godot/custom-godot
@@ -264,7 +261,6 @@ jobs:
             os: ubuntu-20.04
             artifact-name: linux-memcheck-clang-4.0.4
             godot-binary: godot.linuxbsd.editor.dev.x86_64.llvm.san
-            godot-args: -- --disallow-focus
             godot-prebuilt-patch: '4.0.4'
             rust-toolchain: nightly
             rust-env-rustflags: -Zrandomize-layout -Zsanitizer=address
@@ -279,7 +275,7 @@ jobs:
         with:
           artifact-name: godot-${{ matrix.artifact-name }}
           godot-binary: ${{ matrix.godot-binary }}
-          godot-args: ${{ matrix.godot-args }}
+          godot-args: ${{ matrix.godot-args }} # currently unused
           godot-prebuilt-patch: ${{ matrix.godot-prebuilt-patch }}
           rust-extra-args: ${{ matrix.rust-extra-args }} --features godot/codegen-full
           rust-toolchain: ${{ matrix.rust-toolchain || 'stable' }}

--- a/.github/workflows/minimal-ci.yml
+++ b/.github/workflows/minimal-ci.yml
@@ -165,7 +165,6 @@ jobs:
             os: ubuntu-20.04
             artifact-name: linux-memcheck-clang-nightly
             godot-binary: godot.linuxbsd.editor.dev.x86_64.llvm.san
-            godot-args: -- --disallow-focus
             rust-toolchain: nightly
             rust-env-rustflags: -Zrandomize-layout -Zsanitizer=address
             rust-extra-args: --features godot/custom-godot
@@ -176,7 +175,6 @@ jobs:
             os: ubuntu-20.04
             artifact-name: linux-memcheck-clang-4.0.4
             godot-binary: godot.linuxbsd.editor.dev.x86_64.llvm.san
-            godot-args: -- --disallow-focus
             godot-prebuilt-patch: '4.0.4'
             rust-toolchain: nightly
             rust-env-rustflags: -Zrandomize-layout -Zsanitizer=address
@@ -191,7 +189,7 @@ jobs:
         with:
           artifact-name: godot-${{ matrix.artifact-name }}
           godot-binary: ${{ matrix.godot-binary }}
-          godot-args: ${{ matrix.godot-args }}
+          godot-args: ${{ matrix.godot-args }} # currently unused
           godot-prebuilt-patch: ${{ matrix.godot-prebuilt-patch }}
           rust-extra-args: ${{ matrix.rust-extra-args }}
           rust-toolchain: ${{ matrix.rust-toolchain || 'stable' }}


### PR DESCRIPTION


Engine-based class types such as Node now store a 2nd field `instance_id`, through which an object's validity can be verified in a safe way. This is now done for ptrcalls and varcalls to the engine. Dead objects cause a panic.

For user types, `Gd::bind()` and `Gd::bind_mut()` also check whether the instance is still alive.

The internal `Gd::cached_instance_id` field has been changed from `Option<InstanceId>` to `InstanceId` to increase type safety. Previously, dead instances were cached as `None`, but this use case is not frequent enough to justify nullability. The method `Gd::instance_id_unchecked()` thus also returns `InstanceId` instead of `Option<InstanceId>` now.


Closes #348.
