### PR TITLE
Callables for custom Rust functions

### DIFF
--- a/godot-core/src/builtin/array.rs
+++ b/godot-core/src/builtin/array.rs
@@ -178,6 +178,8 @@ impl<T: VariantMetadata> Array<T> {
             interface_fn!(array_operator_index_const)(self.sys(), index)
         };
 
+        // Signature is wrong in GDExtension, semantically this is a const ptr
+        let variant_ptr = sys::to_const_ptr(variant_ptr);
         Variant::ptr_from_sys(variant_ptr)
     }
 

--- a/godot-core/src/builtin/meta/signature.rs
+++ b/godot-core/src/builtin/meta/signature.rs
@@ -393,6 +393,7 @@ unsafe fn varcall_return<R: ToVariant>(
 ///
 /// # Safety
 /// See [`varcall_return`].
+#[cfg(since_api = "4.2")] // unused before
 pub(crate) unsafe fn varcall_return_checked<R: ToVariant>(
     ret_val: Result<R, ()>, // TODO Err should be custom CallError enum
     ret: sys::GDExtensionVariantPtr,

--- a/godot-core/src/builtin/meta/signature.rs
+++ b/godot-core/src/builtin/meta/signature.rs
@@ -389,6 +389,23 @@ unsafe fn varcall_return<R: ToVariant>(
     (*err).error = sys::GDEXTENSION_CALL_OK;
 }
 
+/// Moves `ret_val` into `ret`, if it is `Ok(...)`. Otherwise sets an error.
+///
+/// # Safety
+/// See [`varcall_return`].
+pub(crate) unsafe fn varcall_return_checked<R: ToVariant>(
+    ret_val: Result<R, ()>, // TODO Err should be custom CallError enum
+    ret: sys::GDExtensionVariantPtr,
+    err: *mut sys::GDExtensionCallError,
+) {
+    if let Ok(ret_val) = ret_val {
+        varcall_return(ret_val, ret, err);
+    } else {
+        *err = sys::default_call_error();
+        (*err).error = sys::GDEXTENSION_CALL_ERROR_INVALID_ARGUMENT;
+    }
+}
+
 /// Convert the `N`th argument of `args_ptr` into a value of type `P`.
 ///
 /// # Safety

--- a/godot-core/src/builtin/variant/mod.rs
+++ b/godot-core/src/builtin/variant/mod.rs
@@ -229,8 +229,22 @@ impl Variant {
     }
 
     /// Converts to variant pointer; can be a null pointer.
-    pub(crate) fn ptr_from_sys(variant_ptr: sys::GDExtensionVariantPtr) -> *const Variant {
+    pub(crate) fn ptr_from_sys(variant_ptr: sys::GDExtensionConstVariantPtr) -> *const Variant {
         variant_ptr as *const Variant
+    }
+
+    /// # Safety
+    ///
+    pub(crate) unsafe fn unbounded_refs_from_sys<'a>(
+        variant_ptr_array: *const sys::GDExtensionConstVariantPtr,
+        length: usize,
+    ) -> &'a [&'a Variant] {
+        let variant_ptr_array: &'a [sys::GDExtensionConstVariantPtr] =
+            std::slice::from_raw_parts(variant_ptr_array, length);
+
+        // SAFETY: raw pointers and references have the same memory layout.
+        // See https://doc.rust-lang.org/reference/type-layout.html#pointers-and-references-layout.
+        unsafe { std::mem::transmute(variant_ptr_array) }
     }
 
     /// Converts to variant mut pointer; can be a null pointer.

--- a/godot-core/src/builtin/variant/mod.rs
+++ b/godot-core/src/builtin/variant/mod.rs
@@ -6,10 +6,9 @@
 
 use crate::builtin::{GodotString, StringName};
 use godot_ffi as sys;
-use godot_ffi::GodotFfi;
 use std::{fmt, ptr};
 use sys::types::OpaqueVariant;
-use sys::{ffi_methods, interface_fn};
+use sys::{ffi_methods, interface_fn, GodotFfi};
 
 mod impls;
 mod variant_traits;

--- a/godot-core/src/builtin/variant/mod.rs
+++ b/godot-core/src/builtin/variant/mod.rs
@@ -234,7 +234,9 @@ impl Variant {
     }
 
     /// # Safety
-    ///
+    /// `variant_ptr_array` must be a valid pointer to an array of `length` variant pointers.
+    /// The caller is responsible of keeping the backing storage alive while the unbounded references exist.
+    #[cfg(since_api = "4.2")] // unused before
     pub(crate) unsafe fn unbounded_refs_from_sys<'a>(
         variant_ptr_array: *const sys::GDExtensionConstVariantPtr,
         length: usize,

--- a/godot-core/src/registry.rs
+++ b/godot-core/src/registry.rs
@@ -397,6 +397,7 @@ pub mod callbacks {
         storage.on_dec_ref();
     }
 
+    // ----------------------------------------------------------------------------------------------------------------------------------------------
     // Safe, higher-level methods
 
     /// Abstracts the `GodotInit` away, for contexts where this trait bound is not statically available
@@ -434,7 +435,9 @@ pub mod callbacks {
     }
 }
 
-// Substitute for Default impl
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// Substitutes for Default impl
+
 // Yes, bindgen can implement Default, but only for _all_ types (with single exceptions).
 // For FFI types, it's better to have explicit initialization in the general case though.
 fn default_registration_info(class_name: ClassName) -> ClassRegistrationInfo {

--- a/itest/rust/src/builtin_tests/containers/callable_test.rs
+++ b/itest/rust/src/builtin_tests/containers/callable_test.rs
@@ -6,9 +6,7 @@
 
 use godot::bind::{godot_api, GodotClass};
 use godot::builtin::inner::InnerCallable;
-use godot::builtin::{
-    varray, Callable, GodotString, StringName, ToVariant, Variant, VariantOperator,
-};
+use godot::builtin::{varray, Callable, GodotString, StringName, ToVariant, Variant};
 use godot::engine::{Node2D, Object};
 use godot::obj::Gd;
 
@@ -128,14 +126,20 @@ fn callable_call_engine() {
     obj.free();
 }
 
-// #[cfg(since_api = "4.2")]
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// Tests and infrastructure for custom callables
+
+#[cfg(since_api = "4.2")]
 mod custom_callable {
     use super::*;
     use godot::builtin::Dictionary;
+    use std::fmt;
+    use std::hash::Hash;
+    use std::sync::{Arc, Mutex};
 
     #[itest]
     fn callable_custom_invoke() {
-        let my_rust_callable = Adder { sum: 0 };
+        let my_rust_callable = Adder::new(0);
         let callable = Callable::from_custom(my_rust_callable);
 
         assert!(callable.is_valid());
@@ -152,31 +156,117 @@ mod custom_callable {
 
     #[itest]
     fn callable_custom_to_string() {
-        let my_rust_callable = Adder { sum: 0 };
+        let my_rust_callable = Adder::new(-2);
         let callable = Callable::from_custom(my_rust_callable);
 
-        println!("to_string: {}", callable);
-        println!("equal: {}", callable == callable);
-        println!("equal2: {}", callable.to_variant() == callable.to_variant());
-        println!("hash: {}", callable.hash());
+        let variant = callable.to_variant();
+        assert_eq!(variant.stringify(), GodotString::from("Adder(sum=-2)"));
     }
 
     #[itest]
-    fn callable_custom_equal() {
-        let a = Callable::from_custom(Adder { sum: 0 });
-        let b = Callable::from_custom(Adder { sum: 0 });
-        println!("equal: {}", a == b);
-        println!("equal2: {}", a.to_variant() == b.to_variant());
+    fn callable_custom_eq() {
+        // Godot only invokes custom equality function if the operands are not the same instance of the Callable.
+
+        let at = Tracker::new();
+        let bt = Tracker::new();
+        let ct = Tracker::new();
+
+        let a = Callable::from_custom(Adder::new_tracked(3, at.clone()));
+        let b = Callable::from_custom(Adder::new_tracked(3, bt.clone()));
+        let c = Callable::from_custom(Adder::new_tracked(4, ct.clone()));
+
+        assert_eq!(a, a);
+        assert_eq!(
+            eq_count(&at),
+            0,
+            "if it's the same Callable, Godot does not invoke custom eq"
+        );
+
+        assert_eq!(a, b);
+        assert_eq!(eq_count(&at), 1);
+        assert_eq!(eq_count(&bt), 1);
+
+        assert_ne!(a, c);
+        assert_eq!(eq_count(&at), 2);
+        assert_eq!(eq_count(&ct), 1);
+
+        assert_eq!(a.to_variant(), b.to_variant(), "equality inside Variant");
+        assert_eq!(eq_count(&at), 3);
+        assert_eq!(eq_count(&bt), 2);
+
+        assert_ne!(a.to_variant(), c.to_variant(), "inequality inside Variant");
+        assert_eq!(eq_count(&at), 4);
+        assert_eq!(eq_count(&ct), 2);
+    }
+
+    #[itest]
+    fn callable_custom_eq_hash() {
+        // Godot only invokes custom equality function if the operands are not the same instance of the Callable.
+
+        let at = Tracker::new();
+        let bt = Tracker::new();
+
+        let a = Callable::from_custom(Adder::new_tracked(3, at.clone()));
+        let b = Callable::from_custom(Adder::new_tracked(3, bt.clone()));
 
         let mut dict = Dictionary::new();
 
-        dict.insert(a, "hello");
-        dict.insert(b, "hi");
-    }
+        dict.set(a, "hello");
+        assert_eq!(hash_count(&at), 1, "hash needed for a dict key");
+        assert_eq!(eq_count(&at), 0, "eq not needed if dict bucket is empty");
 
+        dict.set(b, "hi");
+        assert_eq!(hash_count(&at), 1, "hash for a untouched if b is inserted");
+        assert_eq!(hash_count(&bt), 1, "hash needed for b dict key");
+        assert_eq!(eq_count(&at), 1, "hash collision, eq for a needed");
+        assert_eq!(eq_count(&bt), 1, "hash collision, eq for b needed");
+    }
 
     struct Adder {
         sum: i32,
+
+        // Track usage of PartialEq and Hash
+        tracker: Arc<Mutex<Tracker>>,
+    }
+
+    impl Adder {
+        fn new(sum: i32) -> Self {
+            Self {
+                sum,
+                tracker: Tracker::new(),
+            }
+        }
+
+        fn new_tracked(sum: i32, tracker: Arc<Mutex<Tracker>>) -> Self {
+            Self { sum, tracker }
+        }
+    }
+
+    impl PartialEq for Adder {
+        fn eq(&self, other: &Self) -> bool {
+            let mut guard = self.tracker.lock().unwrap();
+            guard.eq_counter += 1;
+
+            let mut guard = other.tracker.lock().unwrap();
+            guard.eq_counter += 1;
+
+            self.sum == other.sum
+        }
+    }
+
+    impl Hash for Adder {
+        fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+            let mut guard = self.tracker.lock().unwrap();
+            guard.hash_counter += 1;
+
+            self.sum.hash(state);
+        }
+    }
+
+    impl fmt::Display for Adder {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "Adder(sum={})", self.sum)
+        }
     }
 
     impl godot::builtin::RustCallable for Adder {
@@ -188,4 +278,28 @@ mod custom_callable {
             Ok(self.sum.to_variant())
         }
     }
+
+    struct Tracker {
+        eq_counter: usize,
+        hash_counter: usize,
+    }
+
+    impl Tracker {
+        fn new() -> Arc<Mutex<Self>> {
+            Arc::new(Mutex::new(Self {
+                eq_counter: 0,
+                hash_counter: 0,
+            }))
+        }
+    }
+
+    fn eq_count(tracker: &Arc<Mutex<Tracker>>) -> usize {
+        tracker.lock().unwrap().eq_counter
+    }
+
+    fn hash_count(tracker: &Arc<Mutex<Tracker>>) -> usize {
+        tracker.lock().unwrap().hash_counter
+    }
 }
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------

--- a/itest/rust/src/builtin_tests/containers/callable_test.rs
+++ b/itest/rust/src/builtin_tests/containers/callable_test.rs
@@ -138,6 +138,37 @@ mod custom_callable {
     use std::sync::{Arc, Mutex};
 
     #[itest]
+    fn callable_from_fn() {
+        let callable = Callable::from_fn("sum", sum);
+
+        assert!(callable.is_valid());
+        assert!(!callable.is_null());
+        assert!(callable.is_custom());
+        assert!(callable.object().is_none());
+
+        let sum1 = callable.callv(varray![1, 2, 4, 8]);
+        assert_eq!(sum1, 15.to_variant());
+
+        let sum2 = callable.callv(varray![5]);
+        assert_eq!(sum2, 5.to_variant());
+    }
+
+    #[itest]
+    fn callable_from_fn_eq() {
+        let a = Callable::from_fn("sum", sum);
+        let b = a.clone();
+        let c = Callable::from_fn("sum", sum);
+
+        assert_eq!(a, b, "same function, same instance -> equal");
+        assert_ne!(a, c, "same function, different instance -> not equal");
+    }
+
+    fn sum(args: &[&Variant]) -> Result<Variant, ()> {
+        let sum: i32 = args.iter().map(|arg| arg.to::<i32>()).sum();
+        Ok(sum.to_variant())
+    }
+
+    #[itest]
     fn callable_custom_invoke() {
         let my_rust_callable = Adder::new(0);
         let callable = Callable::from_custom(my_rust_callable);

--- a/itest/rust/src/framework/runner.rs
+++ b/itest/rust/src/framework/runner.rs
@@ -82,6 +82,11 @@ impl IntegrationTests {
 
     #[func]
     fn run_all_benchmarks(&mut self, scene_tree: Gd<Node>) {
+        if self.focus_run {
+            println!("  Benchmarks skipped (focused run).");
+            return;
+        }
+
         println!("\n\n{}Run{} Godot benchmarks...", FMT_CYAN_BOLD, FMT_END);
 
         self.warn_if_debug();


### PR DESCRIPTION
Adds two methods to `Callable`:
* `from_custom()`, which accepts a highly configurable object that can receive calls from Godot.
* `from_fn()`, which takes a name and a Rust function or closure.

Needs still a bit of tweaking for equality.

At a later stage, we could let the `from_fn()` directly accept a "Godot signature", e.g. `(i64, String, bool)` parameters and non-`Result` return type. The call would then only fail when the variant slice cannot be mapped to the parameter tuple.