### PR TITLE
Allow different class names in rust and Godot

### DIFF
--- a/godot-macros/src/lib.rs
+++ b/godot-macros/src/lib.rs
@@ -332,6 +332,30 @@ use crate::util::ident;
 ///
 /// This should usually be combined with `#[class(tool)]` so that the code you write will actually run in the
 /// editor.
+///
+/// # Class Renaming
+///
+/// You may want to have structs with the same name. With Rust, this is allowed using `mod`. However in GDScript,
+/// there are no modules, namespaces, or any such disambiguation.  Therefore, you need to change the names before they
+/// can get to Godot. You can use the `rename` key while defining your `GodotClass` for this.
+///
+/// ```
+/// mod animal {
+///     # use godot::prelude::*;
+///     #[derive(GodotClass)]
+///     #[class(init, rename=AnimalToad)]
+///     pub struct Toad {}
+/// }
+///
+/// mod npc {
+///     # use godot::prelude::*;
+///     #[derive(GodotClass)]
+///     #[class(init, rename=NpcToad)]
+///     pub struct Toad {}
+/// }
+/// ```
+///
+/// These classes will appear in the Godot editor and GDScript as "AnimalToad" or "NpcToad".
 #[proc_macro_derive(GodotClass, attributes(class, base, var, export, init, signal))]
 pub fn derive_godot_class(input: TokenStream) -> TokenStream {
     translate(input, class::derive_godot_class)

--- a/itest/rust/src/object_tests/class_rename_test.rs
+++ b/itest/rust/src/object_tests/class_rename_test.rs
@@ -1,0 +1,33 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use crate::framework::itest;
+use godot::prelude::*;
+
+pub mod dont_rename {
+    use super::*;
+
+    #[derive(GodotClass)]
+    pub struct RepeatMe {}
+}
+
+pub mod rename {
+    use super::*;
+
+    #[derive(GodotClass)]
+    #[class(rename = NoRepeat)]
+    pub struct RepeatMe {}
+}
+
+#[itest]
+fn renaming_changes_the_name() {
+    assert_ne!(
+        dont_rename::RepeatMe::class_name(),
+        rename::RepeatMe::class_name()
+    );
+    assert_eq!(dont_rename::RepeatMe::class_name().as_str(), "RepeatMe");
+    assert_eq!(rename::RepeatMe::class_name().as_str(), "NoRepeat");
+}

--- a/itest/rust/src/object_tests/mod.rs
+++ b/itest/rust/src/object_tests/mod.rs
@@ -5,6 +5,7 @@
  */
 
 mod base_test;
+mod class_rename_test;
 mod object_test;
 mod property_test;
 mod singleton_test;


### PR DESCRIPTION
There's an issue that two structs with the same name in different modules will conflict with each other when sent to Godot since only the struct name is considered.  This resolves that by allowing the API user to manually change the name of the class as Godot understands it.  This also improves the error message that occurs when theres are aliased classes.

Future work may seek to catch this issue at compile time rather than at runtime.

Relevant to https://github.com/godot-rust/gdext/issues/332