### PR TITLE
Add `StringName::from_latin1_with_nul()`, direct construction in `String::from(&str)`

### DIFF
--- a/godot-codegen/src/util.rs
+++ b/godot-codegen/src/util.rs
@@ -181,13 +181,20 @@ pub(crate) fn make_utility_function_ptr_name(function: &UtilityFunction) -> Iden
     safe_ident(&function.name)
 }
 
-// TODO should eventually be removed, as all StringNames are cached
+#[cfg(since_api = "4.2")]
+pub fn make_string_name(identifier: &str) -> TokenStream {
+    let lit = proc_macro2::Literal::byte_string(format!("{identifier}\0").as_bytes());
+    quote! {
+        StringName::from_latin1_with_nul(#lit)
+    }
+}
+
+#[cfg(before_api = "4.2")]
 pub fn make_string_name(identifier: &str) -> TokenStream {
     quote! {
         StringName::from(#identifier)
     }
 }
-
 pub fn make_sname_ptr(identifier: &str) -> TokenStream {
     quote! {
         string_names.fetch(#identifier)

--- a/godot-core/src/builtin/string/macros.rs
+++ b/godot-core/src/builtin/string/macros.rs
@@ -8,16 +8,6 @@
 
 macro_rules! impl_rust_string_conv {
     ($Ty:ty) => {
-        impl<S> From<S> for $Ty
-        where
-            S: AsRef<str>,
-        {
-            fn from(string: S) -> Self {
-                let intermediate = GodotString::from(string.as_ref());
-                Self::from(&intermediate)
-            }
-        }
-
         impl From<&$Ty> for String {
             fn from(string: &$Ty) -> Self {
                 let intermediate = GodotString::from(string);

--- a/godot-core/src/builtin/string/node_path.rs
+++ b/godot-core/src/builtin/string/node_path.rs
@@ -98,6 +98,16 @@ impl fmt::Debug for NodePath {
 
 impl_rust_string_conv!(NodePath);
 
+impl<S> From<S> for NodePath
+where
+    S: AsRef<str>,
+{
+    fn from(string: S) -> Self {
+        let intermediate = GodotString::from(string.as_ref());
+        Self::from(&intermediate)
+    }
+}
+
 impl From<&GodotString> for NodePath {
     fn from(string: &GodotString) -> Self {
         unsafe {

--- a/godot-core/src/log.rs
+++ b/godot-core/src/log.rs
@@ -12,7 +12,7 @@ macro_rules! inner_godot_msg {
     //($($args:tt),* $(,)?) => {
         unsafe {
             let msg = format!("{}\0", format_args!($fmt $(, $args)*));
-            assert!(msg.is_ascii(), "godot_error: message must be ASCII");
+            // assert!(msg.is_ascii(), "godot_error: message must be ASCII");
 
             // Check whether engine is loaded, otherwise fall back to stderr.
             if $crate::sys::is_initialized() {

--- a/godot-ffi/src/toolbox.rs
+++ b/godot-ffi/src/toolbox.rs
@@ -123,10 +123,9 @@ pub fn c_str(s: &[u8]) -> *const std::ffi::c_char {
     s.as_ptr() as *const std::ffi::c_char
 }
 
+/// Returns a C `const char*` for a null-terminated string slice. UTF-8 encoded.
 #[inline]
 pub fn c_str_from_str(s: &str) -> *const std::ffi::c_char {
-    debug_assert!(s.is_ascii());
-
     c_str(s.as_bytes())
 }
 


### PR DESCRIPTION
Allows faster construction for `StringName` instances, especially from literals.