### PR TITLE
Fix usage of segmented path attribute with #[func]

### DIFF
--- a/godot-macros/src/class/godot_api.rs
+++ b/godot-macros/src/class/godot_api.rs
@@ -322,9 +322,10 @@ where
 {
     let mut found = None;
     for (index, attr) in attributes.iter().enumerate() {
-        let attr_name = attr
-            .get_single_path_segment()
-            .expect("get_single_path_segment");
+        let Some(attr_name) = attr.get_single_path_segment() else {
+            // Attribute of the form #[segmented::path] can't be what we are looking for
+            continue;
+        };
 
         let new_found = match attr_name {
             name if name == "func" => {

--- a/itest/rust/src/register_tests/constant_test.rs
+++ b/itest/rust/src/register_tests/constant_test.rs
@@ -24,6 +24,10 @@ impl HasConstants {
 
     #[constant]
     const D: usize = 20 + 33 * 45;
+
+    #[constant]
+    #[rustfmt::skip]
+    const DONT_PANIC_WITH_SEGMENTED_PATH_ATTRIBUTE: bool = true;
 }
 
 #[itest]

--- a/itest/rust/src/register_tests/func_test.rs
+++ b/itest/rust/src/register_tests/func_test.rs
@@ -61,6 +61,16 @@ impl GdSelfReference {
     }
 
     #[func]
+    #[rustfmt::skip]
+    fn func_shouldnt_panic_with_segmented_path_attribute() -> bool {
+        true
+    }
+
+    #[signal]
+    #[rustfmt::skip]
+    fn signal_shouldnt_panic_with_segmented_path_attribute();
+
+    #[func]
     fn fail_to_update_internal_value_due_to_conflicting_borrow(
         &mut self,
         new_internal: i32,


### PR DESCRIPTION
Currently, using `#[godot_api]` on bare (non-virtual) `impl`s will panic if a `#[segmented::path::attr]` is used together with `#[func]` (as described in https://github.com/godot-rust/gdext/issues/379#issuecomment-1743861243). This is due to an `.expect()` while searching for `#[func]`, `#[signal]` or `#[constant]` in `godot-macros/../godot_api.rs` - those attribute macros (the expected attributes) don't have more than one path segment, which is fair, but a panic is excessive (since other unexpected macros that don't have a segmented path are just kept there, above the function, so the same should happen for unexpected segmented path attributes - they should just stay). Note that the same problem would happen with a `#[signal]` or `#[constant]` for the same reason.

This PR fixes the problem by replacing the panic with a `continue;` (skip this attribute - it's clearly not `#[func]`, `#[signal]` or `#[constant]`).

(As a consequence, attribute macros such as `#[::something]` will also be considered unexpected and skipped - I don't think this is a problem at all.)

~~I don't know where I'd add tests for this; feel free to suggest a location if needed.~~ (Local tests on the Dodge the Creeps example have worked, however.)

_Update:_ Added tests under `itest/rust/src/register_tests/func_test.rs`, as suggested by @lilizoey, and `itest/rust/src/register_tests/constant_test.rs`.

**NB:** It seems the panicking behavior observed here was introduced with the rest of the logic in this commit: https://github.com/godot-rust/gdext/commit/078d8cb327c7c78d777c8f09d8ea611171c45e52