### PR TITLE
Use the class_name for the field when building PropertyInfo

### DIFF
--- a/godot-core/src/builtin/macros.rs
+++ b/godot-core/src/builtin/macros.rs
@@ -68,10 +68,10 @@ macro_rules! impl_builtin_traits_inner {
         impl Eq for $Type {}
     };
 
-    ( PartialOrd for $Type:ty => $gd_method:ident ) => {
-        impl PartialOrd for $Type {
+    ( Ord for $Type:ty => $gd_method:ident ) => {
+        impl Ord for $Type {
             #[inline]
-            fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+            fn cmp(&self, other: &Self) -> std::cmp::Ordering {
                 let op_less = |lhs, rhs| unsafe {
                     let mut result = false;
                     ::godot_ffi::builtin_call! {
@@ -81,22 +81,18 @@ macro_rules! impl_builtin_traits_inner {
                 };
 
                 if op_less(self.sys(), other.sys()) {
-                    Some(std::cmp::Ordering::Less)
+                    std::cmp::Ordering::Less
                 } else if op_less(other.sys(), self.sys()) {
-                    Some(std::cmp::Ordering::Greater)
+                    std::cmp::Ordering::Greater
                 } else {
-                    Some(std::cmp::Ordering::Equal)
+                    std::cmp::Ordering::Equal
                 }
             }
         }
-    };
-
-    ( Ord for $Type:ty => $gd_method:ident ) => {
-        impl_builtin_traits_inner!(PartialOrd for $Type => $gd_method);
-        impl Ord for $Type {
+        impl PartialOrd for $Type {
             #[inline]
-            fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-                PartialOrd::partial_cmp(self, other).expect("PartialOrd::partial_cmp")
+            fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+                Some(self.cmp(other))
             }
         }
     };

--- a/godot-macros/src/class/data_models/property.rs
+++ b/godot-macros/src/class/data_models/property.rs
@@ -67,6 +67,8 @@ pub fn make_property_impl(class_name: &Ident, fields: &Fields) -> TokenStream {
             continue;
         };
 
+        let field_variant_type = util::property_variant_type(field_type);
+        let field_class_name = util::property_variant_class_name(field_type);
         let field_name = field_ident.to_string();
 
         // rustfmt wont format this if we put it in the let-else.
@@ -178,8 +180,8 @@ pub fn make_property_impl(class_name: &Ident, fields: &Fields) -> TokenStream {
             let usage = #usage_flags;
 
             let property_info = ::godot::builtin::meta::PropertyInfo {
-                variant_type: <<#field_type as ::godot::bind::property::Property>::Intermediate as ::godot::builtin::meta::VariantMetadata>::variant_type(),
-                class_name: #class_name_obj,
+                variant_type: #field_variant_type,
+                class_name: #field_class_name,
                 property_name: #field_name.into(),
                 hint,
                 hint_string,
@@ -194,7 +196,7 @@ pub fn make_property_impl(class_name: &Ident, fields: &Fields) -> TokenStream {
             unsafe {
                 ::godot::sys::interface_fn!(classdb_register_extension_class_property)(
                     ::godot::sys::get_library(),
-                    #class_name::class_name().string_sys(),
+                    #class_name_obj.string_sys(),
                     std::ptr::addr_of!(property_info_sys),
                     setter_name.string_sys(),
                     getter_name.string_sys(),

--- a/godot-macros/src/util/list_parser.rs
+++ b/godot-macros/src/util/list_parser.rs
@@ -167,7 +167,7 @@ impl ListParser {
 
     /// Take the next element of the list, if it is a key-value pair of the form `key = expression`.
     pub(crate) fn try_next_key_value(&mut self) -> Option<(Ident, KvValue)> {
-        let Some(kv) = self.peek() else { return None };
+        let kv = self.peek()?;
 
         if let Ok((key, value)) = kv.as_key_value() {
             _ = self.pop_next();

--- a/godot-macros/src/util/mod.rs
+++ b/godot-macros/src/util/mod.rs
@@ -32,6 +32,16 @@ pub fn class_name_obj(class: &impl ToTokens) -> TokenStream {
     quote! { <#class as ::godot::obj::GodotClass>::class_name() }
 }
 
+pub fn property_variant_type(property_type: &impl ToTokens) -> TokenStream {
+    let property_type = property_type.to_token_stream();
+    quote! {<<#property_type as ::godot::bind::property::Property>::Intermediate as ::godot::builtin::meta::VariantMetadata>::variant_type()}
+}
+
+pub fn property_variant_class_name(property_type: &impl ToTokens) -> TokenStream {
+    let property_type = property_type.to_token_stream();
+    quote! {<<#property_type as ::godot::bind::property::Property>::Intermediate as ::godot::builtin::meta::VariantMetadata>::class_name()}
+}
+
 pub fn bail_fn<R, T>(msg: impl AsRef<str>, tokens: T) -> ParseResult<R>
 where
     T: Spanned,

--- a/itest/rust/src/framework/runner.rs
+++ b/itest/rust/src/framework/runner.rs
@@ -364,7 +364,7 @@ fn get_execution_time(test: &Variant) -> Option<Duration> {
 fn get_errors(test: &Variant) -> Array<GodotString> {
     test.call("get", &["errors".to_variant()])
         .try_to::<Array<GodotString>>()
-        .unwrap_or(Array::new())
+        .unwrap_or_default()
 }
 
 #[must_use]


### PR DESCRIPTION
Godot uses the class_name to construct an instance of the right type in a few places, in particular for the PROPERTY_USAGE_EDITOR_INSTANTIATE_OBJECT flag.

Partial fix for #440 