### PR TITLE
Fix #[func]-like attrs being ignored with macros below them

### DIFF
--- a/godot-macros/src/class/godot_api.rs
+++ b/godot-macros/src/class/godot_api.rs
@@ -337,42 +337,43 @@ where
                 let rename = parser.handle_expr("rename")?.map(|ts| ts.to_string());
                 let has_gd_self = parser.handle_alone("gd_self")?;
 
-                Some(BoundAttr {
+                BoundAttr {
                     attr_name: attr_name.clone(),
                     index,
                     ty: BoundAttrType::Func {
                         rename,
                         has_gd_self,
                     },
-                })
+                }
             }
             name if name == "signal" => {
                 // TODO once parameters are supported, this should probably be moved to the struct definition
                 // E.g. a zero-sized type Signal<(i32, String)> with a provided emit(i32, String) method
                 // This could even be made public (callable on the struct obj itself)
-                Some(BoundAttr {
+                BoundAttr {
                     attr_name: attr_name.clone(),
                     index,
                     ty: BoundAttrType::Signal(attr.value.clone()),
-                })
+                }
             }
-            name if name == "constant" => Some(BoundAttr {
+            name if name == "constant" => BoundAttr {
                 attr_name: attr_name.clone(),
                 index,
                 ty: BoundAttrType::Const(attr.value.clone()),
-            }),
-            _ => None,
+            },
+            // Ignore unknown attributes
+            _ => continue,
         };
 
         // Validate at most 1 attribute
-        if found.is_some() && new_found.is_some() {
+        if found.is_some() {
             bail!(
                 &error_scope,
                 "at most one #[func], #[signal], or #[constant] attribute per declaration allowed",
             )?;
         }
 
-        found = new_found;
+        found = Some(new_found);
     }
 
     Ok(found)

--- a/itest/rust/src/register_tests/constant_test.rs
+++ b/itest/rust/src/register_tests/constant_test.rs
@@ -4,9 +4,13 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+// Needed for Clippy to accept #[cfg(all())]
+#![allow(clippy::non_minimal_cfg)]
+
 use crate::framework::itest;
 use godot::engine::ClassDb;
 use godot::prelude::*;
+use godot::sys::static_assert;
 
 #[derive(GodotClass)]
 struct HasConstants {}
@@ -28,6 +32,14 @@ impl HasConstants {
     #[constant]
     #[rustfmt::skip]
     const DONT_PANIC_WITH_SEGMENTED_PATH_ATTRIBUTE: bool = true;
+
+    #[cfg(all())]
+    #[constant]
+    const CONSTANT_RECOGNIZED_WITH_SIMPLE_PATH_ATTRIBUTE_ABOVE_CONST_ATTR: bool = true;
+
+    #[constant]
+    #[cfg(all())]
+    const CONSTANT_RECOGNIZED_WITH_SIMPLE_PATH_ATTRIBUTE_BELOW_CONST_ATTR: bool = true;
 }
 
 #[itest]
@@ -54,6 +66,10 @@ fn constants_correct_value() {
             constant_value
         );
     }
+
+    // Ensure the constants are still present and are equal to 'true'
+    static_assert!(HasConstants::CONSTANT_RECOGNIZED_WITH_SIMPLE_PATH_ATTRIBUTE_ABOVE_CONST_ATTR);
+    static_assert!(HasConstants::CONSTANT_RECOGNIZED_WITH_SIMPLE_PATH_ATTRIBUTE_BELOW_CONST_ATTR);
 }
 
 #[derive(GodotClass)]
@@ -73,7 +89,7 @@ impl HasOtherConstants {
 
 // TODO: replace with proc-macro api when constant enums and bitfields can be exported through the
 // proc-macro.
-impl ::godot::obj::cap::ImplementsGodotApi for HasOtherConstants {
+impl godot::obj::cap::ImplementsGodotApi for HasOtherConstants {
     fn __register_methods() {}
     fn __register_constants() {
         use ::godot::builtin::meta::registration::constant::*;
@@ -107,8 +123,8 @@ impl ::godot::obj::cap::ImplementsGodotApi for HasOtherConstants {
     }
 }
 
-::godot::sys::plugin_add!(
-    __GODOT_PLUGIN_REGISTRY  in::godot::private;
+godot::sys::plugin_add!(
+    __GODOT_PLUGIN_REGISTRY in ::godot::private;
     ::godot::private::ClassPlugin {
         class_name: HasOtherConstants::class_name(),
         component: ::godot::private::PluginComponent::UserMethodBinds {

--- a/itest/rust/src/register_tests/func_test.rs
+++ b/itest/rust/src/register_tests/func_test.rs
@@ -4,6 +4,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+// Needed for Clippy to accept #[cfg(all())]
+#![allow(clippy::non_minimal_cfg)]
+
 use godot::prelude::*;
 
 #[derive(GodotClass)]
@@ -66,9 +69,37 @@ impl GdSelfReference {
         true
     }
 
+    #[cfg(all())]
+    #[func]
+    fn func_recognized_with_simple_path_attribute_above_func_attr() -> bool {
+        true
+    }
+
+    #[func]
+    #[cfg(all())]
+    fn func_recognized_with_simple_path_attribute_below_func_attr() -> bool {
+        true
+    }
+
+    #[func]
+    fn funcs_above_are_kept() -> bool {
+        let f2 = Self::func_recognized_with_simple_path_attribute_above_func_attr();
+        let f1 = Self::func_recognized_with_simple_path_attribute_below_func_attr();
+
+        f1 && f2
+    }
+
     #[signal]
     #[rustfmt::skip]
     fn signal_shouldnt_panic_with_segmented_path_attribute();
+
+    #[cfg(all())]
+    #[signal]
+    fn signal_recognized_with_simple_path_attribute_above_signal_attr();
+
+    #[signal]
+    #[cfg(all())]
+    fn signal_recognized_with_simple_path_attribute_below_signal_attr();
 
     #[func]
     fn fail_to_update_internal_value_due_to_conflicting_borrow(


### PR DESCRIPTION
This fixes the bug mentioned in https://github.com/godot-rust/gdext/issues/379#issuecomment-1746272903.

To better explain the problem, consider the following _modified_ code from the Dodge the Creeps example.
```rust
#[godot_api]
impl Mob {
    #[func]
    #[cfg(all())]
    fn on_visibility_screen_exited(&mut self) {
        self.base.queue_free();
    }
   /* ... */
}
```
_Note:_ `#[cfg(all())]` is a `#[cfg]` check which should always pass / be a tautology (something like `#[cfg(TRUE)]`, but that doesn't work by itself). **This PR does not fix (yet) errors which appear when `#[cfg]` removes the  function.**

**Before this PR:** compile-time error:
```
    Checking dodge-the-creeps v0.1.0 (/.../gdext/examples/dodge-the-creeps/rust)
error: cannot find attribute `func` in this scope
  --> examples/dodge-the-creeps/rust/src/mob.rs:17:7
   |
17 |     #[func]
   |       ^^^^

error: could not compile `dodge-the-creeps` (lib) due to previous error
```

**After this PR:** compiles.

The problem, as mentioned in my original response, is that the `extract_attributes` function would keep re-assigning the `found: Option<BoundAttr>` variable even after a `#[func]`-like attr was already found, thus setting it to `None` when some unrecognized attribute appeared under `#[func]`. This fixes the problem by just skipping unrecognized attributes - `found` is only re-assigned if a `#[func]`-like attribute is actually found (and this preserves the error when two consecutive `#[func]`-like attributes are specified).

Added tests under `itest`.

(Also no idea why clippy is failing here lol, I didn't change that file!)
