### PR TITLE
Allow #[cfg] to be used with #[godot_api] - Part 1: inherent impls

### DIFF
--- a/godot-macros/src/class/data_models/field_var.rs
+++ b/godot-macros/src/class/data_models/field_var.rs
@@ -194,6 +194,12 @@ impl GetterSetterImpl {
             class_name,
             FuncDefinition {
                 func: signature,
+                // Since we're analyzing a struct's field, we don't have access to the corresponding get/set function's
+                // external (non-#[func]) attributes. We have to assume the function exists and has the name the user
+                // gave us, with the expected signature.
+                // Ideally, we'd be able to place #[cfg_attr] on #[var(get)] and #[var(set)] to be able to match a
+                // #[cfg()] (for instance) placed on the getter/setter function, but that is not currently supported.
+                external_attributes: Vec::new(),
                 rename: None,
                 has_gd_self: false,
             },

--- a/godot-macros/src/class/godot_api.rs
+++ b/godot-macros/src/class/godot_api.rs
@@ -238,6 +238,7 @@ fn process_godot_fns(decl: &mut Impl) -> Result<(Vec<FuncDefinition>, Vec<Functi
                     rename,
                     has_gd_self,
                 } => {
+                    let external_attributes = method.attributes.clone();
                     // Signatures are the same thing without body
                     let mut sig = util::reduce_to_signature(method);
                     if *has_gd_self {
@@ -249,6 +250,7 @@ fn process_godot_fns(decl: &mut Impl) -> Result<(Vec<FuncDefinition>, Vec<Functi
                     }
                     func_definitions.push(FuncDefinition {
                         func: sig,
+                        external_attributes,
                         rename: rename.clone(),
                         has_gd_self: *has_gd_self,
                     });

--- a/godot-macros/src/util/mod.rs
+++ b/godot-macros/src/util/mod.rs
@@ -227,6 +227,15 @@ pub(crate) fn path_ends_with(path: &[TokenTree], expected: &str) -> bool {
         .unwrap_or(false)
 }
 
+pub(crate) fn extract_cfg_attrs(
+    attrs: &[venial::Attribute],
+) -> impl IntoIterator<Item = &venial::Attribute> {
+    attrs.iter().filter(|attr| {
+        attr.get_single_path_segment()
+            .map_or(false, |name| name == "cfg")
+    })
+}
+
 pub(crate) struct DeclInfo {
     pub where_: Option<WhereClause>,
     pub generic_params: Option<GenericParamList>,

--- a/itest/rust/src/register_tests/func_test.rs
+++ b/itest/rust/src/register_tests/func_test.rs
@@ -152,6 +152,25 @@ impl GdSelfReference {
     #[cfg(all())]
     fn signal_recognized_with_simple_path_attribute_below_signal_attr();
 
+    #[signal]
+    fn cfg_removes_duplicate_signal();
+
+    #[cfg(any())]
+    #[signal]
+    fn cfg_removes_duplicate_signal();
+
+    #[signal]
+    #[cfg(any())]
+    fn cfg_removes_duplicate_signal();
+
+    #[cfg(any())]
+    #[signal]
+    fn cfg_removes_signal();
+
+    #[signal]
+    #[cfg(any())]
+    fn cfg_removes_signal();
+
     #[func]
     fn fail_to_update_internal_value_due_to_conflicting_borrow(
         &mut self,
@@ -208,6 +227,11 @@ fn class_has_method<T: GodotClass>(name: &str) -> bool {
         .done()
 }
 
+/// Checks at runtime if a class has a given signal through [ClassDb].
+fn class_has_signal<T: GodotClass>(name: &str) -> bool {
+    ClassDb::singleton().class_has_signal(T::class_name().to_string_name(), name.into())
+}
+
 #[itest]
 fn cfg_doesnt_interfere_with_valid_method_impls() {
     // If we re-implement this method but the re-implementation is removed, that should keep the non-removed implementation.
@@ -234,4 +258,18 @@ fn cfg_removes_or_keeps_methods() {
         "cfg_removes_duplicate_function_impl"
     ));
     assert!(!class_has_method::<GdSelfReference>("cfg_removes_function"));
+}
+
+#[itest]
+fn cfg_removes_or_keeps_signals() {
+    assert!(class_has_signal::<GdSelfReference>(
+        "signal_recognized_with_simple_path_attribute_above_signal_attr"
+    ));
+    assert!(class_has_signal::<GdSelfReference>(
+        "signal_recognized_with_simple_path_attribute_below_signal_attr"
+    ));
+    assert!(class_has_signal::<GdSelfReference>(
+        "cfg_removes_duplicate_signal"
+    ));
+    assert!(!class_has_signal::<GdSelfReference>("cfg_removes_signal"));
 }


### PR DESCRIPTION
This is my attempt at allowing `#[cfg]` to work with items in `#[godot_api]` impl blocks. **This PR only covers inherent impls** (non-virtual `#[godot_api] impl` blocks). As such, **this does not close the #399 issue**. That's the job of PR #444.

This PR implements solution 1 mentioned in https://github.com/godot-rust/gdext/issues/379#issuecomment-1746326196. That is, this is a solution specifically for `#[cfg]`, and does not guard against other possible conditional compilation macros. **Those should be used on the entire `impl` if possible** (so as to run before `#[godot_api]`).
If solution 2 is ever made viable, it would supersede this PR, but ATM there doesn't seem to be an easy and viable way for it, so this should work in the meantime.

The gist of this PR is that, for every Godot API attribute type (`func`, `signal`, `constant`), we store the attributes specified by the user, and later filter them specifically looking for `#[cfg]` attributes. Matching attributes are directly forwarded to the generated FFI glue corresponding to each func/signal/constant, such that nothing is registered to Godot if the func/signal/constant is conditionally removed from compilation **through `#[cfg]`** (since it would necessarily also remove the FFI glue).

Added some tests to `itests` as proposed in https://github.com/godot-rust/gdext/issues/379#issuecomment-1746417183, although the tests can't catch everything as, e.g., signals are always removed from the final `impl` block so they don't error on duplicates (for instance) regardless of this PR.

# Examples

## `#[func]`

Consider the following _modified_ code from the Dodge the Creeps example:

```rust
#[godot_api]
impl Main {
    #[cfg(any())]
    #[func]
    fn game_over(&mut self) {
    /* ... */
}
```

**Before this PR:** Does not compile:

```
    Checking dodge-the-creeps v0.1.0 (/.../gdext/examples/dodge-the-creeps/rust)
error[E0599]: no method named `game_over` found for struct `RefMut<'_, Main>` in the current scope
  --> examples/dodge-the-creeps/rust/src/main_scene.rs:27:8
   |
27 |     fn game_over(&mut self) {
   |        ^^^^^^^^^ method not found in `RefMut<'_, Main>`

For more information about this error, try `rustc --explain E0599`.
error: could not compile `dodge-the-creeps` (lib) due to previous error
```

**After this PR:** compiles (with some warnings since the methods it uses are now unused!).

## `#[signal]`

Consider the following _modified_ code from the Dodge the Creeps example:

```rust
#[godot_api]
impl Player {
    #[cfg(any())]
    #[signal]
    fn hit();
    /* ... */
}
```

It will compile with or without this PR since the `hit()` function is actually removed, so its implementation is not referred to by the FFI glue. But we can note that, **without this PR,** the signal **is still registered in Godot:**

![The signal's FFI registration block is still run, even when the signal is removed from compilation](https://github.com/godot-rust/gdext/assets/9021226/ba61657b-509f-4dae-9a2b-785c017ee945)

**With this PR,** the `cfg` attribute is passed through to the FFI registration block, and thus it will disappear with the signal itself, ensuring the signal won't be registered if it is removed from compilation through `#[cfg]`.

![`#[cfg(any())]` now appears above the signal's FFI registration block](https://github.com/godot-rust/gdext/assets/9021226/5f238f9f-5e2c-4c5d-b9aa-f96fe54de0e5)

## `#[constant]`

Consider the following added code to the Dodge the Creeps example:

```rust
#[godot_api]
impl Player {
    #[cfg(any())]
    #[constant]
    const MY_CONST: bool = true;
    /* ... */
}
```

**Before this PR:** Does not compile:

```
Checking dodge-the-creeps v0.1.0 (/.../gdext/examples/dodge-the-creeps/rust)
error[E0599]: no associated item named `MY_CONST` found for struct `Player` in the current scope
  --> examples/dodge-the-creeps/rust/src/player.rs:18:11
   |
6  |   pub struct Player {
   |   ----------------- associated item `MY_CONST` not found for this struct
...
15 |   impl Player {
   |  ______-
16 | |     #[cfg(any())]
17 | |     #[constant]
18 | |     const MY_CONST: bool = true;
   | |          -^^^^^^^^ associated item not found in `Player`
   | |__________|
   | 

For more information about this error, try `rustc --explain E0599`.
error: could not compile `dodge-the-creeps` (lib) due to previous error
```

**After this PR:** Compiles.

# Other details

## Commits

I divided this PR in 3 commits: one for `#[func]`, one for `#[signal]` and one for `#[constant]`. While this organization is nice to work with, the commits can be squashed if needed.

## `#[cfg(any())]`

This is a `cfg` call that represents a contradiction / something which is always false (equivalent to the `#[cfg(FALSE)]` idea, but more robust). Used in tests to ensure that the annotated member will be unconditionally removed from compilation, in order to verify that this doesn't cause errors.

# Discussion points

1. I made this relatively quickly, so this might need some thoughts regarding design and stuff. The main one is: I created not only an `attributes` field at `FuncDefinition` (to store attributes specified above the function), but also the (analogous) `SignalDefinition` struct in order to store both the signal's function signature but also the attributes it originally used. This is because, currently, the `reduce_to_signature` function removes all attributes from the `Function` object it returns:

    https://github.com/godot-rust/gdext/blob/88a79344ba7426288fd5511628c2ee258b0041df/godot-macros/src/util/mod.rs#L68-L71
    
    And all the signatures used with `#[func]` and `#[signal]` attributes go through that function. So, in order to reduce the "blast radius" of the PR (as it could be a breaking change to pass around attributes with said signature objects), I simply added an additional `attributes` field for `FuncDefinition`, and created `SignalDefinition` to be able to have a similar attribute for signals.
    
    (On an unrelated note, I believe it could be wise to apply the newtype pattern to create a `struct Signature(Function)` type to enforce statically that our invariants for signatures uphold, instead of passing raw `Function` objects, returned by `reduce_to_signature`, around - but that is a separate discussion, and is probably largely off-topic for this PR.)
    
    Note that `#[constant]` didn't have to undergo much change, as their attributes are not cleared.
    
    Another approach here, instead of creating new `attributes` fields, would be to just _not_ clear attributes from signatures, but I don't know if that is safe (I took a look around where they are used, but couldn't determine with full certainty yet), mostly because they could be placed somewhere else and it might be bad for attributes to wherever that is too (...or it could also be desired, unless the attribute changes the body of the function). So, feel free to make a decision here.

2. I added a TODO comment which deserves a look; I added a review comment for it below.

3. Please feel free to suggest how I could add some runtime tests for this (to ensure the methods were _actually_ 'deleted'). If that'd be excessive, feel free to say so as well.
