### PR TITLE
CI: update LLVM from 10.0 to 15.0.7 -> fix spurious macOS failures

### DIFF
--- a/.github/composite/llvm/action.yml
+++ b/.github/composite/llvm/action.yml
@@ -5,11 +5,11 @@
 name: llvm
 description: "Install LLVM + Clang, with caching"
 
-#inputs:
-#  llvm:
-#    required: false
-#    default: 'true'
-#    description: "Whether LLVM should be installed ('true' by default)"
+inputs:
+  llvm-version:
+    required: false
+    default: '15.0.7'
+    description: "LLVM versions. Greater than 15 may not be supported in all runners."
 
 runs:
   using: "composite"
@@ -31,12 +31,13 @@ runs:
 #          C:/Program Files/LLVM
 #          ./llvm
         path: ${{ env.LLVM_INSTALL_DIR }}
-        key: llvm-10.0
+        key: "llvm-${{ inputs.llvm-version }}"
 
     - uses: KyleMayes/install-llvm-action@v1
       # if: inputs.llvm == 'true'
       with:
-        version: "10.0"
+        # Newer versions failed on macOS with "Unsupported target! (platform='darwin', version='17.0.2')"
+        version: "${{ inputs.llvm-version }}"
         directory: ${{ env.LLVM_INSTALL_DIR }}
         cached: ${{ steps.cache-llvm.outputs.cache-hit }}
 

--- a/godot-bindings/src/godot_exe.rs
+++ b/godot-bindings/src/godot_exe.rs
@@ -104,7 +104,7 @@ pub(crate) fn read_godot_version(godot_bin: &Path) -> GodotVersion {
     cmd.arg("--version");
 
     let output = execute(cmd, "read Godot version");
-    let stdout = String::from_utf8(output.stdout).expect("convert Godot version to UTF-8");
+    let stdout = std::str::from_utf8(&output.stdout).expect("convert Godot version to UTF-8");
 
     match parse_godot_version(&stdout) {
         Ok(parsed) => {
@@ -277,21 +277,13 @@ fn try_execute(mut cmd: Command, error_message: &str) -> Result<Output, String> 
         .output()
         .map_err(|_| format!("failed to invoke command ({error_message})\n\t{cmd:?}"))?;
 
+    println!("[stdout] {}", std::str::from_utf8(&output.stdout).unwrap());
+    println!("[stderr] {}", std::str::from_utf8(&output.stderr).unwrap());
+    println!("[status] {}", output.status);
+
     if output.status.success() {
-        println!(
-            "[stdout] {}",
-            String::from_utf8(output.stdout.clone()).unwrap()
-        );
-        println!(
-            "[stderr] {}",
-            String::from_utf8(output.stderr.clone()).unwrap()
-        );
-        println!("[status] {}", output.status);
         Ok(output)
     } else {
-        println!("[stdout] {}", String::from_utf8(output.stdout).unwrap());
-        println!("[stderr] {}", String::from_utf8(output.stderr).unwrap());
-        println!("[status] {}", output.status);
         Err(format!(
             "command returned error ({error_message})\n\t{cmd:?}"
         ))


### PR DESCRIPTION
Fixes an issue where macOS CI spuriously failed, because it could not read the Godot version (or invoke the Rust Command API on Godot in general). Trying to look for the issue in all sorts of dimensions (Godot version, rustc version, gdext's own config changes), it turned out that LLVM was the only thing that could sustainably address it. Which is also a bit strange, since v10.0 has not caused issues before, only since around start of October 2023. If it reappears, one more thing to look into would be versions of GitHub actions (that are not locked, but auto-updated).


<details><summaryContext of the original error</summary>

```
Caused by:
  process didn't exit successfully: `/Users/runner/work/gdext/gdext/target/debug/build/godot-codegen-14a3ee58d8774426/build-script-build` (exit status: 101)
  --- stdout
  Found GODOT4_BIN with path to executable: '/Users/runner/work/_temp/godot_bin/godot.macos.editor.dev.x86_64'
  cargo:rerun-if-env-changed=GODOT4_BIN
  Godot version: 

  --- stderr
  thread 'main' panicked at godot-bindings/src/godot_exe.rs:129:13:
  failed to parse Godot version '': Version substring cannot be parsed: ``
  stack backtrace:
     0: rust_begin_unwind
               at /rustc/cc66ad468955717ab92600c770da8c1601a4ff33/library/std/src/panicking.rs:595:5
     1: core::panicking::panic_fmt
               at /rustc/cc66ad468955717ab92600c770da8c1601a4ff33/library/core/src/panicking.rs:67:14
     2: godot_bindings::custom::godot_exe::read_godot_version
     3: godot_bindings::custom::get_godot_version
     4: godot_bindings::emit_godot_version_cfg
     5: build_script_build::main
     6: core::ops::function::FnOnce::call_once
  note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
warning: build failed, waiting for other jobs to finish...
error: failed to run custom build command for `godot-macros v0.1.0 (/Users/runner/work/gdext/gdext/godot-macros)`
note: To improve backtraces for build dependencies, set the CARGO_PROFILE_DEV_BUILD_OVERRIDE_DEBUG=true environment variable to enable debug information generation.

Caused by:
  process didn't exit successfully: `/Users/runner/work/gdext/gdext/target/debug/build/godot-macros-c8f15e61b1eedc58/build-script-build` (exit status: 101)
  --- stdout
  Found GODOT4_BIN with path to executable: '/Users/runner/work/_temp/godot_bin/godot.macos.editor.dev.x86_64'
  cargo:rerun-if-env-changed=GODOT4_BIN
  Godot version: 

  --- stderr
  thread 'main' panicked at godot-bindings/src/godot_exe.rs:129:13:
  failed to parse Godot version '': Version substring cannot be parsed: ``
  stack backtrace:
     0: rust_begin_unwind
               at /rustc/cc66ad468955717ab92600c770da8c1601a4ff33/library/std/src/panicking.rs:595:5
     1: core::panicking::panic_fmt
               at /rustc/cc66ad468955717ab92600c770da8c1601a4ff33/library/core/src/panicking.rs:67:14
     2: godot_bindings::custom::godot_exe::read_godot_version
     3: godot_bindings::custom::get_godot_version
     4: godot_bindings::emit_godot_version_cfg
     5: build_script_build::main
     6: core::ops::function::FnOnce::call_once
  note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
error: failed to run custom build command for `itest v0.1.0 (/Users/runner/work/gdext/gdext/itest/rust)`
note: To improve backtraces for build dependencies, set the CARGO_PROFILE_DEV_BUILD_OVERRIDE_DEBUG=true environment variable to enable debug information generation.
```

</details>

Commits with experiments: 716dd3889d8d3defbd5b1e6ad8252a8a683c2ac5, 3c0d4f2e9379342ec49194fa3639e5bda3e0dbed, https://github.com/Bromeon/godot4-mass-tester/commit/7bc4f70700762ddd85c4b7e012ab943724089d6e