### PR TITLE
PoC: Use an environment variable to filter generated classes.

### DIFF
--- a/godot-core/build.rs
+++ b/godot-core/build.rs
@@ -17,6 +17,7 @@ fn main() {
 
     godot_codegen::generate_core_files(gen_path);
     println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-env-changed=RUST_GDEXT_USED_CLASS_NAMES");
 
     godot_bindings::emit_godot_version_cfg();
 }


### PR DESCRIPTION
The variable is RUST_GDEXT_USED_CLASS_NAMES and it is a comma separated list.
It isn't correctly picked up by cargo to cause a rebuild.