### PR TITLE
Re-enable `ThemeDb` + impl `GodotConvert` for `*mut c_void`

### DIFF
--- a/godot-codegen/src/special_cases.rs
+++ b/godot-codegen/src/special_cases.rs
@@ -67,6 +67,14 @@ pub(crate) fn is_class_deleted(class_name: &TyName) -> bool {
         _ => {}
     }
 
+    // ThemeDB was previously loaded lazily
+    // in 4.2 it loads at the Scene level
+    // see: https://github.com/godotengine/godot/pull/81305
+    #[cfg(before_api = "4.2")]
+    if class_name == "ThemeDB" {
+        return true;
+    }
+
     match class_name {
         // Hardcoded cases that are not accessible.
         // Only on Android.
@@ -76,8 +84,6 @@ pub(crate) fn is_class_deleted(class_name: &TyName) -> bool {
         // Only on WASM.
         | "JavaScriptBridge"
         | "JavaScriptObject"
-        // lazily loaded; TODO enable this.
-        | "ThemeDB" 
 
         // Thread APIs.
         | "Thread"

--- a/godot-codegen/src/util.rs
+++ b/godot-codegen/src/util.rs
@@ -27,9 +27,6 @@ pub enum ClassCodegenLevel {
     Servers,
     Scene,
     Editor,
-
-    /// Not pre-fetched because Godot does not load them in time.
-    Lazy,
 }
 
 impl ClassCodegenLevel {
@@ -54,7 +51,6 @@ impl ClassCodegenLevel {
             Self::Servers => "servers",
             Self::Scene => "scene",
             Self::Editor => "editor",
-            Self::Lazy => unreachable!("lazy classes should be deleted at the moment"),
         }
     }
 
@@ -63,7 +59,6 @@ impl ClassCodegenLevel {
             Self::Servers => "Servers",
             Self::Scene => "Scene",
             Self::Editor => "Editor",
-            Self::Lazy => unreachable!("lazy classes should be deleted at the moment"),
         }
     }
 
@@ -72,7 +67,6 @@ impl ClassCodegenLevel {
             Self::Servers => quote! { Some(crate::init::InitLevel::Servers) },
             Self::Scene => quote! { Some(crate::init::InitLevel::Scene) },
             Self::Editor => quote! { Some(crate::init::InitLevel::Editor) },
-            Self::Lazy => quote! { None },
         }
     }
 }
@@ -203,10 +197,7 @@ pub fn make_sname_ptr(identifier: &str) -> TokenStream {
 }
 
 pub fn get_api_level(class: &Class) -> ClassCodegenLevel {
-    if class.name == "ThemeDB" {
-        // registered in C++ register_scene_singletons(), after MODULE_INITIALIZATION_LEVEL_EDITOR happens.
-        ClassCodegenLevel::Lazy
-    } else if class.name.ends_with("Server") {
+    if class.name.ends_with("Server") {
         ClassCodegenLevel::Servers
     } else if class.api_type == "core" {
         ClassCodegenLevel::Scene

--- a/godot-core/src/builtin/meta/godot_convert/impls.rs
+++ b/godot-core/src/builtin/meta/godot_convert/impls.rs
@@ -223,6 +223,7 @@ impl_godot_scalar!(
 // Raw pointers
 
 // const void* is used in some APIs like OpenXrApiExtension::transform_from_pose().
+// void* is used by ScriptExtension::instance_create().
 // Other impls for raw pointers are generated for native structures.
 
 impl GodotConvert for *const std::ffi::c_void {
@@ -236,6 +237,22 @@ impl ToGodot for *const std::ffi::c_void {
 }
 
 impl FromGodot for *const std::ffi::c_void {
+    fn try_from_godot(via: Self::Via) -> Option<Self> {
+        Some(via as Self)
+    }
+}
+
+impl GodotConvert for *mut std::ffi::c_void {
+    type Via = i64;
+}
+
+impl ToGodot for *mut std::ffi::c_void {
+    fn to_godot(&self) -> Self::Via {
+        *self as i64
+    }
+}
+
+impl FromGodot for *mut std::ffi::c_void {
     fn try_from_godot(via: Self::Via) -> Option<Self> {
         Some(via as Self)
     }


### PR DESCRIPTION
- ThemeDB has been fixed (https://github.com/godotengine/godot/pull/81305) and is instantiated before Editor level, so we can now reenable it

- *mut c_void is needed for the `instance_create` signature of Godot's `ScriptExtension` class, so I added the impls for it