### PR TITLE
Change the default PropertyUsageFlags for var fields

### DIFF
--- a/godot-macros/src/class/data_models/property.rs
+++ b/godot-macros/src/class/data_models/property.rs
@@ -89,7 +89,7 @@ pub fn make_property_impl(class_name: &Ident, fields: &Fields) -> TokenStream {
 
         let usage_flags = match usage_flags {
             UsageFlags::Inferred => {
-                quote! { ::godot::engine::global::PropertyUsageFlags::PROPERTY_USAGE_NO_EDITOR }
+                quote! { ::godot::engine::global::PropertyUsageFlags::PROPERTY_USAGE_NONE }
             }
             UsageFlags::InferredExport => {
                 quote! { ::godot::engine::global::PropertyUsageFlags::PROPERTY_USAGE_DEFAULT }


### PR DESCRIPTION
PROPERTY_USAGE_NO_EDITOR still writes the property to files, which doesn't match the default property for vars in GDScript. PROPERTY_USAGE_NONE indicates that the property should not be saved or shown in the editor.

See https://docs.godotengine.org/en/stable/classes/class_@globalscope.html#class-globalscope-constant-property-usage-none

Fixes #463 