### PR TITLE
Fix custom callable no longer working on latest Godot master

### DIFF
--- a/godot-core/Cargo.toml
+++ b/godot-core/Cargo.toml
@@ -11,7 +11,10 @@ categories = ["game-engines", "graphics"]
 default = []
 codegen-fmt = ["godot-ffi/codegen-fmt", "godot-codegen/codegen-fmt"]
 codegen-full = ["godot-codegen/codegen-full"]
-codegen-lazy-fptrs = ["godot-ffi/codegen-lazy-fptrs", "godot-codegen/codegen-lazy-fptrs"]
+codegen-lazy-fptrs = [
+    "godot-ffi/codegen-lazy-fptrs",
+    "godot-codegen/codegen-lazy-fptrs",
+]
 custom-godot = ["godot-ffi/custom-godot", "godot-codegen/custom-godot"]
 double-precision = ["godot-codegen/double-precision"]
 experimental-godot-api = ["godot-codegen/experimental-godot-api"]


### PR DESCRIPTION
Makes `GDExtensionCallableCustomInfo` use `object_id` instead of `object`.

Also adds a `use-latest-preview-build` feature since beta 3 was released yesterday so it's likely gonna be a week or two until the latest preview build actually has this commit included in it. So now if people wanna run gdext with beta 3 they can just add the `use-latest-preview-build` feature. 

Ideally we'd have a CI set up to run integration tests using this feature on the latest preview build. But im not familiar enough with all the CI to set that up.