### PR TITLE
Split function table constructor into separate methods per class

### DIFF
--- a/godot-codegen/src/codegen_special_cases.rs
+++ b/godot-codegen/src/codegen_special_cases.rs
@@ -11,7 +11,7 @@ use crate::context::Context;
 use crate::{special_cases, TyName};
 
 pub(crate) fn is_builtin_method_excluded(method: &BuiltinClassMethod) -> bool {
-    // Builtin class methods that need varcall are not currently available in GDExtension.
+    // TODO Fall back to varcall (recent addition in GDExtension API).
     // See https://github.com/godot-rust/gdext/issues/382.
     method.is_vararg
 }

--- a/godot-codegen/src/interface_generator.rs
+++ b/godot-codegen/src/interface_generator.rs
@@ -31,7 +31,7 @@ pub(crate) fn generate_sys_interface_file(
             #[path = "../compat/compat_4_0.rs"]
             mod compat_4_0;
 
-            pub use compat_4_0::InitCompat;
+            pub use compat_4_0::*;
         }
     } else {
         generate_proc_address_funcs(h_path)

--- a/godot-ffi/src/compat/compat_4_0.rs
+++ b/godot-ffi/src/compat/compat_4_0.rs
@@ -55,3 +55,22 @@ impl BindingCompat for *const sys::GDExtensionInterface {
         unsafe { **self }
     }
 }
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// Polyfill for types referenced in function pointer tables
+
+pub(crate) type GDExtensionInterfaceVariantGetPtrBuiltinMethod = Option<
+    unsafe extern "C" fn(
+        p_type: crate::GDExtensionVariantType,
+        p_method: crate::GDExtensionConstStringNamePtr,
+        p_hash: crate::GDExtensionInt,
+    ) -> crate::GDExtensionPtrBuiltInMethod,
+>;
+
+pub(crate) type GDExtensionInterfaceClassdbGetMethodBind = Option<
+    unsafe extern "C" fn(
+        p_classname: crate::GDExtensionConstStringNamePtr,
+        p_methodname: crate::GDExtensionConstStringNamePtr,
+        p_hash: crate::GDExtensionInt,
+    ) -> crate::GDExtensionMethodBindPtr,
+>;


### PR DESCRIPTION
Reduces the number of local variables and expressions needed, which seems to cause problems for certain compilations (WASM or release mode in general), taking a long time and using a lot of RAM.