### PR TITLE
Rename all virtual traits: `*Virtual` -> `I*`

### DIFF
--- a/examples/dodge-the-creeps/rust/src/hud.rs
+++ b/examples/dodge-the-creeps/rust/src/hud.rs
@@ -1,4 +1,4 @@
-use godot::engine::{Button, CanvasLayer, CanvasLayerVirtual, Label, Timer};
+use godot::engine::{Button, CanvasLayer, ICanvasLayer, Label, Timer};
 use godot::prelude::*;
 
 #[derive(GodotClass)]
@@ -61,7 +61,7 @@ impl Hud {
 }
 
 #[godot_api]
-impl CanvasLayerVirtual for Hud {
+impl ICanvasLayer for Hud {
     fn init(base: Base<Self::Base>) -> Self {
         Self { base }
     }

--- a/examples/dodge-the-creeps/rust/src/main_scene.rs
+++ b/examples/dodge-the-creeps/rust/src/main_scene.rs
@@ -121,7 +121,7 @@ impl Main {
 }
 
 #[godot_api]
-impl NodeVirtual for Main {
+impl INode for Main {
     fn init(base: Base<Node>) -> Self {
         Main {
             mob_scene: PackedScene::new(),

--- a/examples/dodge-the-creeps/rust/src/mob.rs
+++ b/examples/dodge-the-creeps/rust/src/mob.rs
@@ -1,4 +1,4 @@
-use godot::engine::{AnimatedSprite2D, RigidBody2D, RigidBody2DVirtual};
+use godot::engine::{AnimatedSprite2D, IRigidBody2D, RigidBody2D};
 use godot::prelude::*;
 use rand::seq::SliceRandom;
 
@@ -26,7 +26,7 @@ impl Mob {
 }
 
 #[godot_api]
-impl RigidBody2DVirtual for Mob {
+impl IRigidBody2D for Mob {
     fn init(base: Base<RigidBody2D>) -> Self {
         Mob {
             min_speed: 150.0,

--- a/examples/dodge-the-creeps/rust/src/player.rs
+++ b/examples/dodge-the-creeps/rust/src/player.rs
@@ -1,4 +1,4 @@
-use godot::engine::{AnimatedSprite2D, Area2D, Area2DVirtual, CollisionShape2D, PhysicsBody2D};
+use godot::engine::{AnimatedSprite2D, Area2D, CollisionShape2D, IArea2D, PhysicsBody2D};
 use godot::prelude::*;
 
 #[derive(GodotClass)]
@@ -42,7 +42,7 @@ impl Player {
 }
 
 #[godot_api]
-impl Area2DVirtual for Player {
+impl IArea2D for Player {
     fn init(base: Base<Area2D>) -> Self {
         Player {
             speed: 400.0,

--- a/godot-codegen/src/class_generator.rs
+++ b/godot-codegen/src/class_generator.rs
@@ -391,6 +391,8 @@ fn make_class_doc(
         godot_ty.to_ascii_lowercase()
     );
 
+    let trait_name = class_name.virtual_trait_name();
+
     format!(
         "Godot class `{godot_ty}.`\n\n\
         \
@@ -398,7 +400,7 @@ fn make_class_doc(
         \
         Related symbols:\n\n\
         {sidecar_line}\
-        * [`{rust_ty}Virtual`][crate::engine::{rust_ty}Virtual]: virtual methods\n\
+        * [`{trait_name}`][crate::engine::{trait_name}]: virtual methods\n\
         {notify_line}\
         \n\n\
         See also [Godot docs for `{godot_ty}`]({online_link}).\n\n",

--- a/godot-codegen/src/lib.rs
+++ b/godot-codegen/src/lib.rs
@@ -250,7 +250,7 @@ impl TyName {
     }
 
     fn virtual_trait_name(&self) -> String {
-        format!("{}Virtual", self.rust_ty)
+        format!("I{}", self.rust_ty)
     }
 }
 

--- a/godot-core/src/lib.rs
+++ b/godot-core/src/lib.rs
@@ -23,7 +23,7 @@ pub use registry::*;
 ///
 /// This module contains the following symbols:
 /// * Classes: `CanvasItem`, etc.
-/// * Virtual traits: `CanvasItemVirtual`, etc.
+/// * Virtual traits: `ICanvasItem`, etc.
 /// * Enum/flag modules: `canvas_item`, etc.
 ///
 /// Noteworthy sub-modules are:

--- a/godot-core/src/registry.rs
+++ b/godot-core/src/registry.rs
@@ -353,8 +353,8 @@ fn fill_class_info(component: PluginComponent, c: &mut ClassRegistrationInfo) {
         } => {
             c.user_register_fn = user_register_fn;
 
-            // following unwraps of fill_into shouldn't panic since rustc will error if there's
-            // multiple `impl {Class}Virtual for Thing` definitions
+            // The following unwraps of fill_into() shouldn't panic, since rustc will error if there are
+            // multiple `impl I{Class} for Thing` definitions.
 
             fill_into(&mut c.godot_params.create_instance_func, user_create_fn).unwrap();
 

--- a/godot-macros/src/lib.rs
+++ b/godot-macros/src/lib.rs
@@ -376,11 +376,11 @@ pub fn derive_godot_class(input: TokenStream) -> TokenStream {
 ///
 /// // 2) trait impl block: implement Godot-specific APIs
 /// #[godot_api]
-/// impl NodeVirtual for MyClass { /* ... */ }
+/// impl INode for MyClass { /* ... */ }
 /// ```
 ///
-/// The second case works by implementing the corresponding trait `<Base>Virtual` for the base class of your class
-/// (for example `RefCountedVirtual` or `Node3DVirtual`). Then, you can add functionality such as:
+/// The second case works by implementing the corresponding trait `I<Base>` for the base class of your class
+/// (for example `IRefCounted` or `INode3D`). Then, you can add functionality such as:
 /// * `init` constructors
 /// * lifecycle methods like `ready` or `process`
 /// * `on_notification` method
@@ -408,7 +408,7 @@ pub fn derive_godot_class(input: TokenStream) -> TokenStream {
 /// }
 ///
 /// #[godot_api]
-/// impl RefCountedVirtual for MyStruct {
+/// impl IRefCounted for MyStruct {
 ///     fn init(_base: Base<RefCounted>) -> Self {
 ///         MyStruct
 ///     }
@@ -431,7 +431,7 @@ pub fn derive_godot_class(input: TokenStream) -> TokenStream {
 /// }
 ///
 /// #[godot_api]
-/// impl NodeVirtual for MyNode {
+/// impl INode for MyNode {
 ///     fn ready(&mut self) {
 ///         godot_print!("Hello World!");
 ///     }

--- a/godot-macros/src/util/mod.rs
+++ b/godot-macros/src/util/mod.rs
@@ -173,11 +173,11 @@ pub(crate) fn validate_trait_impl_virtual(
     // Validate trait
     if !typename
         .as_ref()
-        .map_or(false, |seg| seg.ident.to_string().ends_with("Virtual"))
+        .map_or(false, |seg| seg.ident.to_string().starts_with('I'))
     {
         return bail!(
             original_impl,
-            "#[{attr}] for trait impls requires a virtual method trait (trait name should end in 'Virtual')",
+            "#[{attr}] for trait impls requires a virtual method trait (trait name should start with 'I')",
         );
     }
 

--- a/godot/src/lib.rs
+++ b/godot/src/lib.rs
@@ -214,11 +214,10 @@ pub mod prelude {
     pub use super::builtin::*;
     pub use super::builtin::{array, dict, varray}; // Re-export macros.
     pub use super::engine::{
-        load, try_load, utilities, AudioStreamPlayer, AudioStreamPlayerVirtual, Camera2D,
-        Camera2DVirtual, Camera3D, Camera3DVirtual, Input, Node, Node2D, Node2DVirtual, Node3D,
-        Node3DVirtual, NodeVirtual, Object, ObjectVirtual, PackedScene, PackedSceneExt,
-        PackedSceneVirtual, RefCounted, RefCountedVirtual, Resource, ResourceVirtual, SceneTree,
-        SceneTreeVirtual,
+        load, try_load, utilities, AudioStreamPlayer, Camera2D, Camera3D, IAudioStreamPlayer,
+        ICamera2D, ICamera3D, INode, INode2D, INode3D, IObject, IPackedScene, IRefCounted,
+        IResource, ISceneTree, Input, Node, Node2D, Node3D, Object, PackedScene, PackedSceneExt,
+        RefCounted, Resource, SceneTree,
     };
     pub use super::init::{gdextension, ExtensionLibrary, InitLevel};
     pub use super::log::*;

--- a/itest/rust/src/engine_tests/codegen_test.rs
+++ b/itest/rust/src/engine_tests/codegen_test.rs
@@ -9,7 +9,7 @@
 
 use crate::framework::itest;
 use godot::builtin::inner::{InnerColor, InnerString};
-use godot::engine::{FileAccess, HttpRequest, HttpRequestVirtual, Image};
+use godot::engine::{FileAccess, HttpRequest, IHttpRequest, Image};
 use godot::prelude::*;
 
 #[itest]
@@ -86,7 +86,7 @@ impl TestBaseRenamed {
 }
 
 #[godot_api]
-impl HttpRequestVirtual for TestBaseRenamed {
+impl IHttpRequest for TestBaseRenamed {
     fn init(base: Base<HttpRequest>) -> Self {
         TestBaseRenamed { _base: base }
     }

--- a/itest/rust/src/engine_tests/native_structures_test.rs
+++ b/itest/rust/src/engine_tests/native_structures_test.rs
@@ -7,7 +7,7 @@
 use crate::framework::itest;
 use godot::engine::native::{AudioFrame, CaretInfo, Glyph};
 use godot::engine::text_server::Direction;
-use godot::engine::{TextServer, TextServerExtension, TextServerExtensionVirtual};
+use godot::engine::{ITextServerExtension, TextServer, TextServerExtension};
 use godot::prelude::{godot_api, Base, Gd, GodotClass, Rect2, Rid, Variant};
 
 use std::cell::Cell;
@@ -37,7 +37,7 @@ fn sample_glyph(start: i32) -> Glyph {
 }
 
 #[godot_api]
-impl TextServerExtensionVirtual for TestTextServer {
+impl ITextServerExtension for TestTextServer {
     fn init(_base: Base<TextServerExtension>) -> Self {
         TestTextServer {
             glyphs: [sample_glyph(99), sample_glyph(700)],

--- a/itest/rust/src/object_tests/object_test.rs
+++ b/itest/rust/src/object_tests/object_test.rs
@@ -11,7 +11,7 @@ use godot::bind::{godot_api, GodotClass};
 use godot::builtin::meta::{FromGodot, ToGodot};
 use godot::builtin::{GodotString, StringName, Variant, VariantConversionError, Vector3};
 use godot::engine::{
-    file_access, Area2D, Camera3D, FileAccess, Node, Node3D, Object, RefCounted, RefCountedVirtual,
+    file_access, Area2D, Camera3D, FileAccess, IRefCounted, Node, Node3D, Object, RefCounted,
 };
 use godot::obj::{Base, Gd, Inherits, InstanceId, RawGd};
 use godot::prelude::meta::GodotType;
@@ -811,7 +811,7 @@ pub struct RefcPayload {
 }
 
 #[godot_api]
-impl RefCountedVirtual for RefcPayload {
+impl IRefCounted for RefcPayload {
     fn init(_base: Base<Self::Base>) -> Self {
         Self { value: 111 }
     }

--- a/itest/rust/src/object_tests/property_test.rs
+++ b/itest/rust/src/object_tests/property_test.rs
@@ -128,7 +128,7 @@ impl HasProperty {
 }
 
 #[godot_api]
-impl NodeVirtual for HasProperty {
+impl INode for HasProperty {
     fn init(_base: Base<Node>) -> Self {
         HasProperty {
             int_val: 0,
@@ -336,7 +336,7 @@ pub struct DeriveExport {
 impl DeriveExport {}
 
 #[godot_api]
-impl RefCountedVirtual for DeriveExport {
+impl IRefCounted for DeriveExport {
     fn init(base: godot::obj::Base<Self::Base>) -> Self {
         Self {
             foo: TestEnum::B,
@@ -374,7 +374,7 @@ pub struct CustomResource {}
 impl CustomResource {}
 
 #[godot_api]
-impl ResourceVirtual for CustomResource {}
+impl IResource for CustomResource {}
 
 #[derive(GodotClass)]
 #[class(init, base=Resource, rename=NewNameCustomResource)]
@@ -384,7 +384,7 @@ pub struct RenamedCustomResource {}
 impl RenamedCustomResource {}
 
 #[godot_api]
-impl ResourceVirtual for RenamedCustomResource {}
+impl IResource for RenamedCustomResource {}
 
 #[derive(GodotClass)]
 #[class(init, base=Node)]
@@ -401,7 +401,7 @@ pub struct ExportResource {
 impl ExportResource {}
 
 #[godot_api]
-impl NodeVirtual for ExportResource {}
+impl INode for ExportResource {}
 
 #[itest]
 fn export_resource() {

--- a/itest/rust/src/register_tests/func_test.rs
+++ b/itest/rust/src/register_tests/func_test.rs
@@ -210,7 +210,7 @@ impl GdSelfReference {
 }
 
 #[godot_api]
-impl RefCountedVirtual for GdSelfReference {
+impl IRefCounted for GdSelfReference {
     fn init(base: Base<Self::Base>) -> Self {
         Self {
             internal_value: 0,


### PR DESCRIPTION
The traits do not just contain virtual functions, but also constructors and in the future registration functions. The name is thus not very accurate anymore, and it's also quite long to type.

The `I` stands for "interface" and is more general. For example, `Area2DVirtual` becomes `IArea2D`.

See also [Discord thread](https://discord.com/channels/723850269347283004/1146006896906600549).