### PR TITLE
Strip `get_` prefixes from engine getters

### DIFF
--- a/examples/dodge-the-creeps/rust/src/hud.rs
+++ b/examples/dodge-the-creeps/rust/src/hud.rs
@@ -1,4 +1,4 @@
-use godot::engine::{Button, CanvasLayer, CanvasLayerVirtual, Label, Timer};
+use godot::engine::{Button, CanvasLayer, ICanvasLayer, Label, Timer};
 use godot::prelude::*;
 
 #[derive(GodotClass)]
@@ -61,7 +61,7 @@ impl Hud {
 }
 
 #[godot_api]
-impl CanvasLayerVirtual for Hud {
+impl ICanvasLayer for Hud {
     fn init(base: Base<Self::Base>) -> Self {
         Self { base }
     }

--- a/examples/dodge-the-creeps/rust/src/main_scene.rs
+++ b/examples/dodge-the-creeps/rust/src/main_scene.rs
@@ -45,7 +45,7 @@ impl Main {
 
         self.score = 0;
 
-        player.bind_mut().start(start_position.get_position());
+        player.bind_mut().start(start_position.position());
         start_timer.start();
 
         let mut hud = self.base.get_node_as::<Hud>("Hud");
@@ -84,9 +84,9 @@ impl Main {
         let progress = rng.gen_range(u32::MIN..u32::MAX);
 
         mob_spawn_location.set_progress(progress as f32);
-        mob_scene.set_position(mob_spawn_location.get_position());
+        mob_scene.set_position(mob_spawn_location.position());
 
-        let mut direction = mob_spawn_location.get_rotation() + PI / 2.0;
+        let mut direction = mob_spawn_location.rotation() + PI / 2.0;
         direction += rng.gen_range(-PI / 4.0..PI / 4.0);
 
         mob_scene.set_rotation(direction);
@@ -101,7 +101,7 @@ impl Main {
         };
 
         mob.set_linear_velocity(Vector2::new(range, 0.0));
-        let lin_vel = mob.get_linear_velocity().rotated(real::from_f32(direction));
+        let lin_vel = mob.linear_velocity().rotated(real::from_f32(direction));
         mob.set_linear_velocity(lin_vel);
 
         let mut hud = self.base.get_node_as::<Hud>("Hud");

--- a/examples/dodge-the-creeps/rust/src/main_scene.rs
+++ b/examples/dodge-the-creeps/rust/src/main_scene.rs
@@ -121,7 +121,7 @@ impl Main {
 }
 
 #[godot_api]
-impl NodeVirtual for Main {
+impl INode for Main {
     fn init(base: Base<Node>) -> Self {
         Main {
             mob_scene: PackedScene::new(),

--- a/examples/dodge-the-creeps/rust/src/mob.rs
+++ b/examples/dodge-the-creeps/rust/src/mob.rs
@@ -41,7 +41,7 @@ impl IRigidBody2D for Mob {
             .get_node_as::<AnimatedSprite2D>("AnimatedSprite2D");
 
         sprite.play();
-        let anim_names = sprite.get_sprite_frames().unwrap().get_animation_names();
+        let anim_names = sprite.sprite_frames().unwrap().animation_names();
 
         // TODO use pick_random() once implemented
         let anim_names = anim_names.to_vec();

--- a/examples/dodge-the-creeps/rust/src/mob.rs
+++ b/examples/dodge-the-creeps/rust/src/mob.rs
@@ -1,4 +1,4 @@
-use godot::engine::{AnimatedSprite2D, RigidBody2D, RigidBody2DVirtual};
+use godot::engine::{AnimatedSprite2D, IRigidBody2D, RigidBody2D};
 use godot::prelude::*;
 use rand::seq::SliceRandom;
 
@@ -26,7 +26,7 @@ impl Mob {
 }
 
 #[godot_api]
-impl RigidBody2DVirtual for Mob {
+impl IRigidBody2D for Mob {
     fn init(base: Base<RigidBody2D>) -> Self {
         Mob {
             min_speed: 150.0,

--- a/examples/dodge-the-creeps/rust/src/player.rs
+++ b/examples/dodge-the-creeps/rust/src/player.rs
@@ -52,7 +52,7 @@ impl IArea2D for Player {
     }
 
     fn ready(&mut self) {
-        let viewport = self.base.get_viewport_rect();
+        let viewport = self.base.viewport_rect();
         self.screen_size = viewport.size;
         self.base.hide();
     }
@@ -101,7 +101,7 @@ impl IArea2D for Player {
         }
 
         let change = velocity * real::from_f64(delta);
-        let position = self.base.get_global_position() + change;
+        let position = self.base.global_position() + change;
         let position = Vector2::new(
             position.x.clamp(0.0, self.screen_size.x),
             position.y.clamp(0.0, self.screen_size.y),

--- a/examples/dodge-the-creeps/rust/src/player.rs
+++ b/examples/dodge-the-creeps/rust/src/player.rs
@@ -1,4 +1,4 @@
-use godot::engine::{AnimatedSprite2D, Area2D, Area2DVirtual, CollisionShape2D, PhysicsBody2D};
+use godot::engine::{AnimatedSprite2D, Area2D, CollisionShape2D, IArea2D, PhysicsBody2D};
 use godot::prelude::*;
 
 #[derive(GodotClass)]
@@ -42,7 +42,7 @@ impl Player {
 }
 
 #[godot_api]
-impl Area2DVirtual for Player {
+impl IArea2D for Player {
     fn init(base: Base<Area2D>) -> Self {
         Player {
             speed: 400.0,

--- a/godot-codegen/src/class_generator.rs
+++ b/godot-codegen/src/class_generator.rs
@@ -391,6 +391,8 @@ fn make_class_doc(
         godot_ty.to_ascii_lowercase()
     );
 
+    let trait_name = class_name.virtual_trait_name();
+
     format!(
         "Godot class `{godot_ty}.`\n\n\
         \
@@ -398,7 +400,7 @@ fn make_class_doc(
         \
         Related symbols:\n\n\
         {sidecar_line}\
-        * [`{rust_ty}Virtual`][crate::engine::{rust_ty}Virtual]: virtual methods\n\
+        * [`{trait_name}`][crate::engine::{trait_name}]: virtual methods\n\
         {notify_line}\
         \n\n\
         See also [Godot docs for `{godot_ty}`]({online_link}).\n\n",

--- a/godot-codegen/src/lib.rs
+++ b/godot-codegen/src/lib.rs
@@ -250,7 +250,7 @@ impl TyName {
     }
 
     fn virtual_trait_name(&self) -> String {
-        format!("{}Virtual", self.rust_ty)
+        format!("I{}", self.rust_ty)
     }
 }
 

--- a/godot-codegen/src/special_cases.rs
+++ b/godot-codegen/src/special_cases.rs
@@ -176,6 +176,69 @@ pub(crate) fn is_excluded_from_default_params(class_name: Option<&TyName>, godot
     }
 }
 
+#[rustfmt::skip]
+pub(crate) fn keeps_get_prefix(class_name: &TyName, method: &ClassMethod) -> bool {
+    // Also list those which have default parameters and can be called with 0 arguments. Those are anyway
+    // excluded at the moment, but this is more robust if the outer logic changes.
+
+    match (class_name.godot_ty.as_str(), method.name.as_str()) {
+        // For Object
+        // https://docs.godotengine.org/en/stable/classes/class_object.html#methods
+        | ("Object", "get_class")
+        | ("Object", "get_instance_id") // currently removed, but would be shadowed by Gd::instance_id().
+        | ("Object", "get_script")
+        | ("Object", "get_script_instance")
+        // The following ones often have slight variations with parameters, so it's more consistent to have get_signal_list() and
+        // get_signal_connection_list(signal). This may change in the future.
+        | ("Object", "get_incoming_connections")
+        | ("Object", "get_meta_list")
+        | ("Object", "get_method_list")
+        | ("Object", "get_property_list")
+        | ("Object", "get_signal_list")
+
+        // For Node
+        // https://docs.godotengine.org/en/stable/classes/class_node.html#methods
+        // TODO get_child_count?
+
+        // https://docs.godotengine.org/en/stable/classes/class_fileaccess.html#methods
+        | ("FileAccess", "get_16")
+        | ("FileAccess", "get_32")
+        | ("FileAccess", "get_64")
+        | ("FileAccess", "get_8")
+        | ("FileAccess", "get_as_text")
+        | ("FileAccess", "get_csv_line")
+        | ("FileAccess", "get_double")
+        | ("FileAccess", "get_error") // If this has side effects, should definitely keep prefix. Not clear.
+        | ("FileAccess", "get_float")
+        | ("FileAccess", "get_line")
+        | ("FileAccess", "get_open_error")
+        | ("FileAccess", "get_pascal_string")
+        | ("FileAccess", "get_real")
+        | ("FileAccess", "get_var")
+
+        // https://docs.godotengine.org/en/stable/classes/class_streampeer.html#methods
+        // do for 8,16,32,64 and u*
+        | ("StreamPeer", "get_16")
+        | ("StreamPeer", "get_32")
+        | ("StreamPeer", "get_64")
+        | ("StreamPeer", "get_8")
+        | ("StreamPeer", "get_double")
+        | ("StreamPeer", "get_float")
+        | ("StreamPeer", "get_string")
+        | ("StreamPeer", "get_u16")
+        | ("StreamPeer", "get_u32")
+        | ("StreamPeer", "get_u64")
+        | ("StreamPeer", "get_u8")
+        | ("StreamPeer", "get_utf8_string")
+        | ("StreamPeer", "get_var")
+
+        // Others that conflict with a verb:
+        | ("AnimationPlayer", "get_queue")
+
+        => true, _ => false,
+    }
+}
+
 /// True if builtin method is excluded. Does NOT check for type exclusion; use [`is_builtin_type_deleted`] for that.
 pub(crate) fn is_builtin_deleted(_class_name: &TyName, method: &BuiltinClassMethod) -> bool {
     // Currently only deleted if codegen.

--- a/godot-core/src/lib.rs
+++ b/godot-core/src/lib.rs
@@ -23,7 +23,7 @@ pub use registry::*;
 ///
 /// This module contains the following symbols:
 /// * Classes: `CanvasItem`, etc.
-/// * Virtual traits: `CanvasItemVirtual`, etc.
+/// * Virtual traits: `ICanvasItem`, etc.
 /// * Enum/flag modules: `canvas_item`, etc.
 ///
 /// Noteworthy sub-modules are:

--- a/godot-core/src/obj/traits.rs
+++ b/godot-core/src/obj/traits.rs
@@ -106,7 +106,7 @@ pub trait Share {
 ///     T: Inherits<Node>,
 /// {
 ///     let up = node.upcast(); // type Gd<Node> inferred
-///     println!("Node #{} with name {}", up.instance_id(), up.get_name());
+///     println!("Node #{} with name {}", up.instance_id(), up.name());
 ///     up.free();
 /// }
 ///

--- a/godot-core/src/registry.rs
+++ b/godot-core/src/registry.rs
@@ -353,8 +353,8 @@ fn fill_class_info(component: PluginComponent, c: &mut ClassRegistrationInfo) {
         } => {
             c.user_register_fn = user_register_fn;
 
-            // following unwraps of fill_into shouldn't panic since rustc will error if there's
-            // multiple `impl {Class}Virtual for Thing` definitions
+            // The following unwraps of fill_into() shouldn't panic, since rustc will error if there are
+            // multiple `impl I{Class} for Thing` definitions.
 
             fill_into(&mut c.godot_params.create_instance_func, user_create_fn).unwrap();
 

--- a/godot-macros/src/lib.rs
+++ b/godot-macros/src/lib.rs
@@ -376,11 +376,11 @@ pub fn derive_godot_class(input: TokenStream) -> TokenStream {
 ///
 /// // 2) trait impl block: implement Godot-specific APIs
 /// #[godot_api]
-/// impl NodeVirtual for MyClass { /* ... */ }
+/// impl INode for MyClass { /* ... */ }
 /// ```
 ///
-/// The second case works by implementing the corresponding trait `<Base>Virtual` for the base class of your class
-/// (for example `RefCountedVirtual` or `Node3DVirtual`). Then, you can add functionality such as:
+/// The second case works by implementing the corresponding trait `I<Base>` for the base class of your class
+/// (for example `IRefCounted` or `INode3D`). Then, you can add functionality such as:
 /// * `init` constructors
 /// * lifecycle methods like `ready` or `process`
 /// * `on_notification` method
@@ -408,7 +408,7 @@ pub fn derive_godot_class(input: TokenStream) -> TokenStream {
 /// }
 ///
 /// #[godot_api]
-/// impl RefCountedVirtual for MyStruct {
+/// impl IRefCounted for MyStruct {
 ///     fn init(_base: Base<RefCounted>) -> Self {
 ///         MyStruct
 ///     }
@@ -431,7 +431,7 @@ pub fn derive_godot_class(input: TokenStream) -> TokenStream {
 /// }
 ///
 /// #[godot_api]
-/// impl NodeVirtual for MyNode {
+/// impl INode for MyNode {
 ///     fn ready(&mut self) {
 ///         godot_print!("Hello World!");
 ///     }

--- a/godot-macros/src/util/mod.rs
+++ b/godot-macros/src/util/mod.rs
@@ -173,11 +173,11 @@ pub(crate) fn validate_trait_impl_virtual(
     // Validate trait
     if !typename
         .as_ref()
-        .map_or(false, |seg| seg.ident.to_string().ends_with("Virtual"))
+        .map_or(false, |seg| seg.ident.to_string().starts_with('I'))
     {
         return bail!(
             original_impl,
-            "#[{attr}] for trait impls requires a virtual method trait (trait name should end in 'Virtual')",
+            "#[{attr}] for trait impls requires a virtual method trait (trait name should start with 'I')",
         );
     }
 

--- a/godot/src/lib.rs
+++ b/godot/src/lib.rs
@@ -214,11 +214,10 @@ pub mod prelude {
     pub use super::builtin::*;
     pub use super::builtin::{array, dict, varray}; // Re-export macros.
     pub use super::engine::{
-        load, try_load, utilities, AudioStreamPlayer, AudioStreamPlayerVirtual, Camera2D,
-        Camera2DVirtual, Camera3D, Camera3DVirtual, Input, Node, Node2D, Node2DVirtual, Node3D,
-        Node3DVirtual, NodeVirtual, Object, ObjectVirtual, PackedScene, PackedSceneExt,
-        PackedSceneVirtual, RefCounted, RefCountedVirtual, Resource, ResourceVirtual, SceneTree,
-        SceneTreeVirtual,
+        load, try_load, utilities, AudioStreamPlayer, Camera2D, Camera3D, IAudioStreamPlayer,
+        ICamera2D, ICamera3D, INode, INode2D, INode3D, IObject, IPackedScene, IRefCounted,
+        IResource, ISceneTree, Input, Node, Node2D, Node3D, Object, PackedScene, PackedSceneExt,
+        RefCounted, Resource, SceneTree,
     };
     pub use super::init::{gdextension, ExtensionLibrary, InitLevel};
     pub use super::log::*;

--- a/itest/godot/SpecialTests.gd
+++ b/itest/godot/SpecialTests.gd
@@ -33,7 +33,7 @@ func test_collision_object_2d_input_event():
 	window.add_child(collision_object)
 
 	assert_that(not collision_object.input_event_called())
-	assert_eq(collision_object.get_viewport(), null)
+	assert_eq(collision_object.viewport(), null)
 
 	var event := InputEventMouseMotion.new()
 	event.global_position = Vector2.ZERO
@@ -43,7 +43,7 @@ func test_collision_object_2d_input_event():
 	await root.get_tree().physics_frame
 
 	assert_that(collision_object.input_event_called())
-	assert_eq(collision_object.get_viewport(), window)
+	assert_eq(collision_object.viewport(), window)
 
 	window.queue_free()
 

--- a/itest/rust/src/builtin_tests/containers/array_test.rs
+++ b/itest/rust/src/builtin_tests/containers/array_test.rs
@@ -401,7 +401,7 @@ fn typed_array_pass_to_godot_func() {
     let error = texture.create_from_images(images);
 
     assert_eq!(error, Error::OK);
-    assert_eq!((texture.get_width(), texture.get_height()), (2, 4));
+    assert_eq!((texture.width(), texture.height()), (2, 4));
 }
 
 #[itest]

--- a/itest/rust/src/builtin_tests/containers/callable_test.rs
+++ b/itest/rust/src/builtin_tests/containers/callable_test.rs
@@ -120,7 +120,7 @@ fn callable_call_engine() {
     // TODO once varargs is available
     // let pos = Vector2::new(5.0, 7.0);
     // inner.call(&[pos.to_variant()]);
-    // assert_eq!(obj.get_position(), pos);
+    // assert_eq!(obj.position(), pos);
     //
     // inner.bindv(array);
 

--- a/itest/rust/src/engine_tests/codegen_test.rs
+++ b/itest/rust/src/engine_tests/codegen_test.rs
@@ -9,7 +9,7 @@
 
 use crate::framework::itest;
 use godot::builtin::inner::{InnerColor, InnerString};
-use godot::engine::{FileAccess, HttpRequest, HttpRequestVirtual, Image};
+use godot::engine::{FileAccess, HttpRequest, IHttpRequest, Image};
 use godot::prelude::*;
 
 #[itest]
@@ -86,7 +86,7 @@ impl TestBaseRenamed {
 }
 
 #[godot_api]
-impl HttpRequestVirtual for TestBaseRenamed {
+impl IHttpRequest for TestBaseRenamed {
     fn init(base: Base<HttpRequest>) -> Self {
         TestBaseRenamed { _base: base }
     }

--- a/itest/rust/src/engine_tests/native_structures_test.rs
+++ b/itest/rust/src/engine_tests/native_structures_test.rs
@@ -7,7 +7,7 @@
 use crate::framework::itest;
 use godot::engine::native::{AudioFrame, CaretInfo, Glyph};
 use godot::engine::text_server::Direction;
-use godot::engine::{TextServer, TextServerExtension, TextServerExtensionVirtual};
+use godot::engine::{ITextServerExtension, TextServer, TextServerExtension};
 use godot::prelude::{godot_api, Base, Gd, GodotClass, Rect2, Rid, Variant};
 
 use std::cell::Cell;
@@ -37,7 +37,7 @@ fn sample_glyph(start: i32) -> Glyph {
 }
 
 #[godot_api]
-impl TextServerExtensionVirtual for TestTextServer {
+impl ITextServerExtension for TestTextServer {
     fn init(_base: Base<TextServerExtension>) -> Self {
         TestTextServer {
             glyphs: [sample_glyph(99), sample_glyph(700)],

--- a/itest/rust/src/engine_tests/node_test.rs
+++ b/itest/rust/src/engine_tests/node_test.rs
@@ -52,7 +52,7 @@ fn node_get_node_fail() {
 fn node_path_from_str(ctx: &TestContext) {
     let child = ctx.scene_tree.clone();
     assert_eq!(
-        child.get_path().to_string(),
+        child.path().to_string(),
         NodePath::from_str("/root/TestRunner").unwrap().to_string()
     );
 }
@@ -84,7 +84,7 @@ fn node_scene_tree() {
 #[itest]
 fn node_call_group(ctx: &TestContext) {
     let mut node = ctx.scene_tree.clone();
-    let mut tree = node.get_tree().unwrap();
+    let mut tree = node.tree().unwrap();
 
     node.add_to_group("group".into());
     tree.call_group("group".into(), "set_name".into(), &[Variant::from("name")]);

--- a/itest/rust/src/object_tests/base_test.rs
+++ b/itest/rust/src/object_tests/base_test.rs
@@ -29,7 +29,7 @@ fn base_access_unbound() {
 
     let pos = Vector2::new(-5.5, 7.0);
     obj.set_position(pos);
-    assert_eq!(obj.get_position(), pos);
+    assert_eq!(obj.position(), pos);
 
     obj.free();
 }
@@ -41,7 +41,7 @@ fn base_access_unbound_no_field() {
 
     let pos = Vector2::new(-5.5, 7.0);
     obj.set_position(pos);
-    assert_eq!(obj.get_position(), pos);
+    assert_eq!(obj.position(), pos);
 
     obj.free();
 }
@@ -88,7 +88,7 @@ fn base_with_init() {
     {
         let guard = obj.bind();
         assert_eq!(guard.i, 732);
-        assert_eq!(guard.base.get_rotation(), 11.0);
+        assert_eq!(guard.base.rotation(), 11.0);
     }
     obj.free();
 }

--- a/itest/rust/src/object_tests/object_test.rs
+++ b/itest/rust/src/object_tests/object_test.rs
@@ -109,14 +109,14 @@ fn object_engine_roundtrip() {
 
     let mut obj: Gd<Node3D> = Node3D::new_alloc();
     obj.set_position(pos);
-    assert_eq!(obj.get_position(), pos);
+    assert_eq!(obj.position(), pos);
 
     let raw = obj.to_ffi();
     let ptr = raw.sys();
 
     let raw2 = unsafe { RawGd::<Node3D>::from_sys(ptr) };
     let obj2 = Gd::from_ffi(raw2);
-    assert_eq!(obj2.get_position(), pos);
+    assert_eq!(obj2.position(), pos);
     obj.free();
 }
 
@@ -198,7 +198,7 @@ fn object_from_instance_id_inherits_type() {
 
     let node_as_base = Gd::<Node>::from_instance_id(id);
     assert_eq!(node_as_base.instance_id(), id);
-    assert_eq!(node_as_base.get_editor_description(), descr);
+    assert_eq!(node_as_base.editor_description(), descr);
 
     node_as_base.free();
 }
@@ -313,7 +313,7 @@ fn object_engine_use_after_free() {
     node.free();
 
     expect_panic("call method on dead engine object", move || {
-        copy.get_position();
+        copy.position();
     });
 }
 
@@ -404,7 +404,7 @@ fn object_engine_convert_variant() {
     let variant = obj.to_variant();
     let obj2 = Gd::<Node3D>::from_variant(&variant);
 
-    assert_eq!(obj2.get_position(), pos);
+    assert_eq!(obj2.position(), pos);
     obj.free();
 }
 
@@ -424,26 +424,26 @@ fn object_engine_convert_variant_refcount() {
 /// Converts between Object <-> Variant and verifies the reference counter at each stage.
 fn check_convert_variant_refcount(obj: Gd<RefCounted>) {
     // Freshly created -> refcount 1
-    assert_eq!(obj.get_reference_count(), 1);
+    assert_eq!(obj.reference_count(), 1);
 
     {
         // Variant created from object -> increment
         let variant = obj.to_variant();
-        assert_eq!(obj.get_reference_count(), 2);
+        assert_eq!(obj.reference_count(), 2);
 
         {
             // Yet another object created *from* variant -> increment
             let another_object = variant.to::<Gd<RefCounted>>();
-            assert_eq!(obj.get_reference_count(), 3);
-            assert_eq!(another_object.get_reference_count(), 3);
+            assert_eq!(obj.reference_count(), 3);
+            assert_eq!(another_object.reference_count(), 3);
         }
 
         // `another_object` destroyed -> decrement
-        assert_eq!(obj.get_reference_count(), 2);
+        assert_eq!(obj.reference_count(), 2);
     }
 
     // `variant` destroyed -> decrement
-    assert_eq!(obj.get_reference_count(), 1);
+    assert_eq!(obj.reference_count(), 1);
 }
 
 #[itest]
@@ -472,7 +472,7 @@ fn object_engine_returned_refcount() {
     assert!(file.is_open());
 
     // There was a bug which incremented ref-counts of just-returned objects, keep this as regression test.
-    assert_eq!(file.get_reference_count(), 1);
+    assert_eq!(file.reference_count(), 1);
 }
 
 #[itest]
@@ -540,7 +540,7 @@ fn object_engine_downcast() {
     let node3d: Gd<Node3D> = node.try_cast::<Node3D>().expect("try_cast");
 
     assert_eq!(node3d.instance_id(), id);
-    assert_eq!(node3d.get_position(), pos);
+    assert_eq!(node3d.position(), pos);
 
     node3d.free();
 }
@@ -622,7 +622,7 @@ where
     T: Inherits<Node>,
 {
     let up = node.upcast();
-    up.get_name()
+    up.name()
 }
 
 fn accept_refcounted<T>(node: Gd<T>) -> GodotString

--- a/itest/rust/src/object_tests/object_test.rs
+++ b/itest/rust/src/object_tests/object_test.rs
@@ -11,7 +11,7 @@ use godot::bind::{godot_api, GodotClass};
 use godot::builtin::meta::{FromGodot, ToGodot};
 use godot::builtin::{GodotString, StringName, Variant, VariantConversionError, Vector3};
 use godot::engine::{
-    file_access, Area2D, Camera3D, FileAccess, Node, Node3D, Object, RefCounted, RefCountedVirtual,
+    file_access, Area2D, Camera3D, FileAccess, IRefCounted, Node, Node3D, Object, RefCounted,
 };
 use godot::obj::{Base, Gd, Inherits, InstanceId, RawGd};
 use godot::prelude::meta::GodotType;
@@ -811,7 +811,7 @@ pub struct RefcPayload {
 }
 
 #[godot_api]
-impl RefCountedVirtual for RefcPayload {
+impl IRefCounted for RefcPayload {
     fn init(_base: Base<Self::Base>) -> Self {
         Self { value: 111 }
     }

--- a/itest/rust/src/object_tests/property_test.rs
+++ b/itest/rust/src/object_tests/property_test.rs
@@ -128,7 +128,7 @@ impl HasProperty {
 }
 
 #[godot_api]
-impl NodeVirtual for HasProperty {
+impl INode for HasProperty {
     fn init(_base: Base<Node>) -> Self {
         HasProperty {
             int_val: 0,
@@ -336,7 +336,7 @@ pub struct DeriveExport {
 impl DeriveExport {}
 
 #[godot_api]
-impl RefCountedVirtual for DeriveExport {
+impl IRefCounted for DeriveExport {
     fn init(base: godot::obj::Base<Self::Base>) -> Self {
         Self {
             foo: TestEnum::B,
@@ -374,7 +374,7 @@ pub struct CustomResource {}
 impl CustomResource {}
 
 #[godot_api]
-impl ResourceVirtual for CustomResource {}
+impl IResource for CustomResource {}
 
 #[derive(GodotClass)]
 #[class(init, base=Resource, rename=NewNameCustomResource)]
@@ -384,7 +384,7 @@ pub struct RenamedCustomResource {}
 impl RenamedCustomResource {}
 
 #[godot_api]
-impl ResourceVirtual for RenamedCustomResource {}
+impl IResource for RenamedCustomResource {}
 
 #[derive(GodotClass)]
 #[class(init, base=Node)]
@@ -401,7 +401,7 @@ pub struct ExportResource {
 impl ExportResource {}
 
 #[godot_api]
-impl NodeVirtual for ExportResource {}
+impl INode for ExportResource {}
 
 #[itest]
 fn export_resource() {

--- a/itest/rust/src/object_tests/singleton_test.rs
+++ b/itest/rust/src/object_tests/singleton_test.rs
@@ -27,7 +27,7 @@ fn singleton_from_instance_id() {
 
     let b: Gd<Os> = Gd::from_instance_id(id);
 
-    assert_eq!(a.get_executable_path(), b.get_executable_path());
+    assert_eq!(a.executable_path(), b.executable_path());
 }
 
 #[itest]

--- a/itest/rust/src/object_tests/virtual_methods_test.rs
+++ b/itest/rust/src/object_tests/virtual_methods_test.rs
@@ -328,7 +328,7 @@ fn test_tree_enters_exits(test_context: &TestContext) {
 #[itest]
 fn test_virtual_method_with_return() {
     let obj = Gd::<IReturnTest>::new_default();
-    let arr = obj.clone().upcast::<PrimitiveMesh>().get_mesh_arrays();
+    let arr = obj.clone().upcast::<PrimitiveMesh>().mesh_arrays();
     let arr_rust = obj.bind().create_mesh_array();
     assert_eq!(arr.len(), arr_rust.len());
     // can't just assert_eq because the values of some floats change slightly
@@ -487,7 +487,7 @@ impl CollisionObject2DTest {
     }
 
     #[func]
-    fn get_viewport(&self) -> Variant {
+    fn viewport(&self) -> Variant {
         self.viewport
             .as_ref()
             .map(ToGodot::to_variant)

--- a/itest/rust/src/register_tests/func_test.rs
+++ b/itest/rust/src/register_tests/func_test.rs
@@ -210,7 +210,7 @@ impl GdSelfReference {
 }
 
 #[godot_api]
-impl RefCountedVirtual for GdSelfReference {
+impl IRefCounted for GdSelfReference {
     fn init(base: Base<Self::Base>) -> Self {
         Self {
             internal_value: 0,


### PR DESCRIPTION
Follows Rust style and makes code slightly more concise, especially since we don't have properties. Some exceptions are necessary, as Godot sometimes names non-getters (`get_8`, `get_u8` for reading), and some nouns collide with verbs (`queue`/`get_queue`).

These methods still retain the `get_` prefix for now:
* Custom getters for `#[var]` properties.
    * It's unclear whether such methods should be made automatically accessible in Rust at all, and if so, whether having a name different from the field is worthwhile.
* Virtual functions to be overridden.
     * `IObject::get_property_list()` (not yet supported).
* Cases where there is a direct naming conflict.
     * E.g. `AnimationPlayer::get_queue()`, because there is also `AnimationPlayer::queue()`.
* Some `Object` ones like `get_property_list()`, `get_meta_list()` etc.
     * Partly because `get_meta()` taking parameters is still a thing.
     * May be changed in light of virtual functions with the same name.

A lot of the details are still subject to change, based on naming collisions and consistency considerations.

This PR is based on #476.