### PR TITLE
Fixed some missed aligns for 32-bit support

### DIFF
--- a/godot-core/src/builtin/packed_array.rs
+++ b/godot-core/src/builtin/packed_array.rs
@@ -15,6 +15,10 @@ use sys::{ffi_methods, interface_fn, GodotFfi};
 // FIXME remove dependency on these types
 use sys::{__GdextString, __GdextType};
 
+// TODO(bromeon): ensure and test that all element types can be packed.
+// Many builtin types don't have a #[repr] themselves, but they are used in packed arrays, which assumes certain size and alignment.
+// This is mostly a problem for as_slice(), which reinterprets the FFI representation into the "frontend" type like GString.
+
 /// Defines and implements a single packed array type. This macro is not hygienic and is meant to
 /// be used only in the current module.
 macro_rules! impl_packed_array {

--- a/godot-core/src/builtin/string/gstring.rs
+++ b/godot-core/src/builtin/string/gstring.rs
@@ -53,7 +53,8 @@ pub type GodotString = GString;
 ///
 /// Godot also provides two separate string classes with slightly different semantics: [`StringName`] and [`NodePath`].
 #[doc(alias = "String")]
-#[repr(C, align(8))]
+// #[repr] is needed on GString itself rather than the opaque field, because PackedStringArray::as_slice() relies on a packed representation.
+#[repr(transparent)]
 pub struct GString {
     opaque: OpaqueString,
 }


### PR DESCRIPTION
This gets the dodge-the-creeps example working on at least win32 builds. (i686-pc-windows-msvc) specifically for the `GodotString` but I wasn't sure if should patch for `Callable` / `Variant` as well (their size is constant between 32 and 64 bit targets, so maybe not?) would like feedback on that.  At the very least, I know for sure `GodotString` needs the align patched.  In theory this should close 347

_Edit bromeon: #347 is **not** closed by this alone. For full 32-bit support, CI as well as tests are needed._
_I needed to edit this message because GitHub recognizes "close #ISSUE" text as a relation that cannot be overridden in UI._