### PR TITLE
Rework `Gd` constructors, add `default()` to engine classes

### DIFF
--- a/godot-core/src/builtin/string/gstring.rs
+++ b/godot-core/src/builtin/string/gstring.rs
@@ -84,14 +84,6 @@ impl GString {
             .expect("Godot hashes are uint32_t")
     }
 
-    /// Move `self` into a system pointer. This transfers ownership and thus does not call the destructor.
-    ///
-    /// # Safety
-    /// `dst` must be a pointer to a `GString` which is suitable for ffi with Godot.
-    pub unsafe fn move_string_ptr(self, dst: sys::GDExtensionStringPtr) {
-        self.move_return_ptr(dst as *mut _, sys::PtrcallType::Standard);
-    }
-
     /// Gets the internal chars slice from a [`GString`].
     ///
     /// Note: This operation is *O*(*n*). Consider using [`chars_unchecked`][Self::chars_unchecked]
@@ -137,6 +129,14 @@ impl GString {
         fn from_string_sys = from_sys;
         fn from_string_sys_init = from_sys_init;
         fn string_sys = sys;
+    }
+
+    /// Move `self` into a system pointer. This transfers ownership and thus does not call the destructor.
+    ///
+    /// # Safety
+    /// `dst` must be a pointer to a `GString` which is suitable for ffi with Godot.
+    pub(crate) unsafe fn move_string_ptr(self, dst: sys::GDExtensionStringPtr) {
+        self.move_return_ptr(dst as *mut _, sys::PtrcallType::Standard);
     }
 
     #[doc(hidden)]

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -134,15 +134,6 @@ where
         unsafe { Gd::from_obj_sys(object_ptr) }
     }
 
-    /// Construct default instance for manually managed pointer.
-    pub fn new_alloc<ManualMem>() -> Self
-    where
-        T: GodotClass<Mem = ManualMem> + cap::GodotDefault,
-        ManualMem: mem::PossiblyManual,
-    {
-        Self::default_instance()
-    }
-
     /// Moves a user-created object into this smart pointer, submitting ownership to the Godot engine.
     ///
     /// This is only useful for types `T` which do not store their base objects (if they have a base,

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -6,7 +6,6 @@
 
 use std::fmt::{Debug, Display, Formatter, Result as FmtResult};
 use std::ops::{Deref, DerefMut};
-use std::ptr;
 
 use godot_ffi as sys;
 use godot_ffi::VariantType;
@@ -23,28 +22,65 @@ use super::RawGd;
 
 /// Smart pointer to objects owned by the Godot engine.
 ///
+/// See also [chapter about objects][book] in the book.
+///
 /// This smart pointer can only hold _objects_ in the Godot sense: instances of Godot classes (`Node`, `RefCounted`, etc.)
-/// or user-declared structs (`#[derive(GodotClass)]`). It does **not** hold built-in types (`Vector3`, `Color`, `i32`).
+/// or user-declared structs (declared with `#[derive(GodotClass)]`). It does **not** hold built-in types (`Vector3`, `Color`, `i32`).
 ///
 /// `Gd<T>` never holds null objects. If you need nullability, use `Option<Gd<T>>`.
+///
+/// # Memory management
 ///
 /// This smart pointer behaves differently depending on `T`'s associated types, see [`GodotClass`] for their documentation.
 /// In particular, the memory management strategy is fully dependent on `T`:
 ///
-/// * Objects of type [`RefCounted`] or inherited from it are **reference-counted**. This means that every time a smart pointer is
+/// - **Reference-counted**<br>
+///   Objects of type [`RefCounted`] or inherited from it are **reference-counted**. This means that every time a smart pointer is
 ///   shared using [`Clone::clone()`], the reference counter is incremented, and every time one is dropped, it is decremented.
-///   This ensures that the last reference (either in Rust or Godot) will deallocate the object and call `T`'s destructor.
+///   This ensures that the last reference (either in Rust or Godot) will deallocate the object and call `T`'s destructor.<br><br>
 ///
-/// * Objects inheriting from [`Object`] which are not `RefCounted` (or inherited) are **manually-managed**.
+/// - **Manual**<br>
+///   Objects inheriting from [`Object`] which are not `RefCounted` (or inherited) are **manually-managed**.
 ///   Their destructor is not automatically called (unless they are part of the scene tree). Creating a `Gd<T>` means that
-///   you are responsible of explicitly deallocating such objects using [`Gd::free()`].
+///   you are responsible of explicitly deallocating such objects using [`free()`][Self::free].<br><br>
 ///
-/// * For `T=Object`, the memory strategy is determined **dynamically**. Due to polymorphism, a `Gd<T>` can point to either
+/// - **Dynamic**<br>
+///   For `T=Object`, the memory strategy is determined **dynamically**. Due to polymorphism, a `Gd<Object>` can point to either
 ///   reference-counted or manually-managed types at runtime. The behavior corresponds to one of the two previous points.
 ///   Note that if the dynamic type is also `Object`, the memory is manually-managed.
 ///
-/// [`Object`]: crate::engine::Object
-/// [`RefCounted`]: crate::engine::RefCounted
+/// # Construction
+///
+/// To construct default instances of various `Gd<T>` types, there are extension methods on the type `T` itself:
+///
+/// | Type \ Memory Strategy | Ref-counted          | Manually managed      | Singleton               |
+/// |------------------------|----------------------|-----------------------|-------------------------|
+/// | **Engine type**        | `Resource::new()`    | `Node::new_alloc()`   | `Os::singleton()`       |
+/// | **User type**          | `MyClass::new_gd()`  | `MyClass::alloc_gd()` | _(not yet implemented)_ |
+///
+/// In addition, the smart pointer can be constructed in multiple ways:
+///
+/// * [`Gd::default()`] for reference-counted types that are constructible. For user types, this means they must expose an `init` function
+///   or have a generated one. `Gd::<T>::default()` is equivalent to the shorter `T::new_gd()` and primarily useful for derives or generics.
+/// * [`Gd::from_init_fn(function)`][Gd::from_init_fn] for Rust objects with `#[base]` field, which are constructed inside the smart pointer.
+///   This is a very handy function if you want to pass extra parameters to your object upon construction.
+/// * [`Gd::from_object(rust_obj)`][Gd::from_object] for existing Rust objects without a `#[base]` field that are moved _into_ the smart pointer.
+/// * [`Gd::from_instance_id(id)`][Gd::from_instance_id] and [`Gd::try_from_instance_id(id)`][Gd::try_from_instance_id]
+///   to obtain a pointer to an object which is already alive in the engine.
+///
+/// # Binds
+///
+/// The [`bind()`][Self::bind] and [`bind_mut()`][Self::bind_mut] methods allow you to obtain a shared or exclusive guard to the user instance.
+/// These provide interior mutability similar to [`RefCell`][std::cell::RefCell], with the addition that `Gd` simultaneously handles reference
+/// counting (for some types `T`).
+///
+/// When you declare a `#[func]` method on your own class and it accepts `&self` or `&mut self`, an implicit `bind()` or `bind_mut()` call
+/// on the owning `Gd<T>` is performed. This is important to keep in mind, as you can get into situations that violate dynamic borrow rules; for
+/// example if you are inside a `&mut self` method, make a call to GDScript and indirectly call another method on the same object (re-entrancy).
+///
+/// [book]: https://godot-rust.github.io/book/intro/objects.html
+/// [`Object`]: engine::Object
+/// [`RefCounted`]: engine::RefCounted
 #[repr(C)] // must be layout compatible with engine classes
 pub struct Gd<T: GodotClass> {
     // Note: `opaque` has the same layout as GDExtensionObjectPtr == Object* in C++, i.e. the bytes represent a pointer
@@ -68,27 +104,6 @@ impl<T> Gd<T>
 where
     T: GodotClass<Declarer = dom::UserDomain>,
 {
-    /// Moves a user-created object into this smart pointer, submitting ownership to the Godot engine.
-    ///
-    /// This is only useful for types `T` which do not store their base objects (if they have a base,
-    /// you cannot construct them standalone).
-    pub fn new(user_object: T) -> Self {
-        Self::with_base(move |_base| user_object)
-    }
-
-    /// Creates a default-constructed instance of `T` inside a smart pointer.
-    ///
-    /// This is equivalent to the GDScript expression `T.new()`.
-    pub fn new_default() -> Self
-    where
-        T: cap::GodotInit,
-    {
-        unsafe {
-            let object_ptr = callbacks::create::<T>(ptr::null_mut());
-            Gd::from_obj_sys(object_ptr)
-        }
-    }
-
     /// Creates a `Gd<T>` using a function that constructs a `T` from a provided base.
     ///
     /// Imagine you have a type `T`, which has a `#[base]` field that you cannot default-initialize.
@@ -106,17 +121,55 @@ where
     ///     other_field: i32,
     /// }
     ///
-    /// let obj = Gd::<MyClass>::with_base(|my_base| {
+    /// let obj = Gd::from_init_fn(|my_base| {
     ///     // accepts the base and returns a constructed object containing it
     ///     MyClass { my_base, other_field: 732 }
     /// });
     /// ```
-    pub fn with_base<F>(init: F) -> Self
+    pub fn from_init_fn<F>(init: F) -> Self
     where
         F: FnOnce(crate::obj::Base<T::Base>) -> T,
     {
         let object_ptr = callbacks::create_custom(init);
         unsafe { Gd::from_obj_sys(object_ptr) }
+    }
+
+    /// Construct default instance for manually managed pointer.
+    pub fn new_alloc<ManualMem>() -> Self
+    where
+        T: GodotClass<Mem = ManualMem> + cap::GodotDefault,
+        ManualMem: mem::PossiblyManual,
+    {
+        Self::default_instance()
+    }
+
+    /// Moves a user-created object into this smart pointer, submitting ownership to the Godot engine.
+    ///
+    /// This is only useful for types `T` which do not store their base objects (if they have a base,
+    /// you cannot construct them standalone).
+    pub fn from_object(user_object: T) -> Self {
+        Self::from_init_fn(move |_base| user_object)
+    }
+
+    #[deprecated = "Use `Gd::from_object()` instead."]
+    pub fn new(user_object: T) -> Self {
+        Self::from_object(user_object)
+    }
+
+    #[deprecated = "Use `Gd::default()` or the short-hands `T::new_gd()` and `T::alloc_gd()` instead."]
+    pub fn new_default() -> Self
+    where
+        T: cap::GodotDefault,
+    {
+        Self::default_instance()
+    }
+
+    #[deprecated = "Use `Gd::from_init_fn()` instead."]
+    pub fn with_base<F>(init: F) -> Self
+    where
+        F: FnOnce(crate::obj::Base<T::Base>) -> T,
+    {
+        Self::from_init_fn(init)
     }
 
     /// Hands out a guard for a shared borrow, through which the user instance can be read.
@@ -242,7 +295,7 @@ impl<T: GodotClass> Gd<T> {
     /// #[class(init, base=Node2D)]
     /// struct MyClass {}
     ///
-    /// let obj: Gd<MyClass> = Gd::new_default();
+    /// let obj: Gd<MyClass> = MyClass::alloc_gd();
     /// let base = obj.clone().upcast::<Node>();
     /// ```
     pub fn upcast<Base>(self) -> Gd<Base>
@@ -295,7 +348,19 @@ impl<T: GodotClass> Gd<T> {
             .map_err(Self::from_ffi)
     }
 
-    #[doc(hidden)]
+    /// Create default instance for all types that have `GodotDefault`.
+    ///
+    /// Deliberately more loose than `Gd::default()`, does not require ref-counted memory strategy for user types.
+    pub(crate) fn default_instance() -> Self
+    where
+        T: cap::GodotDefault,
+    {
+        unsafe {
+            let object_ptr = crate::callbacks::create::<T>(std::ptr::null_mut());
+            Gd::from_obj_sys(object_ptr)
+        }
+    }
+
     pub(crate) unsafe fn from_obj_sys_or_none(ptr: sys::GDExtensionObjectPtr) -> Option<Self> {
         Self::try_from_ffi(RawGd::from_obj_sys(ptr))
     }
@@ -305,26 +370,21 @@ impl<T: GodotClass> Gd<T> {
     ///
     /// This is the default for most initializations from FFI. In cases where reference counter
     /// should explicitly **not** be updated, [`Self::from_obj_sys_weak`] is available.
-    #[doc(hidden)]
     pub(crate) unsafe fn from_obj_sys(ptr: sys::GDExtensionObjectPtr) -> Self {
         Self::from_obj_sys_or_none(ptr).unwrap()
     }
 
-    #[doc(hidden)]
     pub(crate) unsafe fn from_obj_sys_weak_or_none(ptr: sys::GDExtensionObjectPtr) -> Option<Self> {
         Self::try_from_ffi(RawGd::from_obj_sys_weak(ptr))
     }
 
-    #[doc(hidden)]
     pub(crate) unsafe fn from_obj_sys_weak(ptr: sys::GDExtensionObjectPtr) -> Self {
         Self::from_obj_sys_weak_or_none(ptr).unwrap()
     }
 
-    #[doc(hidden)]
     pub(crate) fn obj_sys(&self) -> sys::GDExtensionObjectPtr {
         self.raw.obj_sys()
     }
-
     /// Returns a callable referencing a method from this object named `method_name`.
     pub fn callable<S: Into<StringName>>(&self, method_name: S) -> Callable {
         Callable::from_object_method(self.clone(), method_name)
@@ -483,6 +543,22 @@ impl<T: GodotClass> GodotType for Gd<T> {
 
     fn godot_type_name() -> String {
         T::class_name().to_string()
+    }
+}
+
+impl<T> Default for Gd<T>
+where
+    T: cap::GodotDefault + GodotClass<Mem = mem::StaticRefCount>,
+{
+    /// Creates a default-constructed `T` inside a smart pointer.
+    ///
+    /// This is equivalent to the GDScript expression `T.new()`, and to the shorter Rust expression `T::new_gd()`.
+    ///
+    /// This trait is only implemented for reference-counted classes. Classes with manually-managed memory (e.g. `Node`) are not covered,
+    /// because they need explicit memory management, and deriving `Default` has a high chance of the user forgetting to call `free()` on those.
+    /// `T::alloc_gd()` should be used for those instead.
+    fn default() -> Self {
+        T::__godot_default()
     }
 }
 

--- a/godot-macros/src/class/derive_godot_class.rs
+++ b/godot-macros/src/class/derive_godot_class.rs
@@ -78,6 +78,9 @@ pub fn derive_godot_class(decl: Declaration) -> ParseResult<TokenStream> {
                 ::godot::builtin::meta::ClassName::from_ascii_cstr(#class_name_cstr)
             }
         }
+        impl ::godot::obj::UserClass for #class_name {
+
+        }
 
         #godot_init_impl
         #godot_exports_impl
@@ -249,8 +252,8 @@ fn make_godot_init_impl(class_name: &Ident, fields: Fields) -> TokenStream {
     });
 
     quote! {
-        impl ::godot::obj::cap::GodotInit for #class_name {
-            fn __godot_init(base: ::godot::obj::Base<Self::Base>) -> Self {
+        impl ::godot::obj::cap::GodotDefault for #class_name {
+            fn __godot_user_init(base: ::godot::obj::Base<Self::Base>) -> Self {
                 Self {
                     #( #rest_init )*
                     #base_init

--- a/godot-macros/src/class/godot_api.rs
+++ b/godot-macros/src/class/godot_api.rs
@@ -526,8 +526,8 @@ fn transform_trait_impl(original_impl: Impl) -> Result<TokenStream, Error> {
                     #godot_init_impl
 
                     #(#cfg_attrs)*
-                    impl ::godot::obj::cap::GodotInit for #class_name {
-                        fn __godot_init(base: ::godot::obj::Base<Self::Base>) -> Self {
+                    impl ::godot::obj::cap::GodotDefault for #class_name {
+                        fn __godot_user_init(base: ::godot::obj::Base<Self::Base>) -> Self {
                             <Self as #trait_name>::init(base)
                         }
                     }

--- a/godot/src/lib.rs
+++ b/godot/src/lib.rs
@@ -226,4 +226,5 @@ pub mod prelude {
     // Make trait methods available
     pub use super::engine::NodeExt as _;
     pub use super::obj::EngineEnum as _;
+    pub use super::obj::UserClass as _; // new_gd(), self_gd()
 }

--- a/itest/rust/src/benchmarks/mod.rs
+++ b/itest/rust/src/benchmarks/mod.rs
@@ -61,7 +61,7 @@ fn class_refcounted_life() -> Gd<RefCounted> {
 
 #[bench(repeat = 25)]
 fn class_user_refc_life() -> Gd<MyBenchType> {
-    Gd::<MyBenchType>::new_default()
+    Gd::default()
 }
 
 #[bench]

--- a/itest/rust/src/builtin_tests/containers/callable_test.rs
+++ b/itest/rust/src/builtin_tests/containers/callable_test.rs
@@ -9,7 +9,7 @@ use godot::builtin::inner::InnerCallable;
 use godot::builtin::meta::ToGodot;
 use godot::builtin::{varray, Callable, GString, StringName, Variant};
 use godot::engine::{Node2D, Object};
-use godot::obj::Gd;
+use godot::obj::UserClass;
 
 use crate::framework::itest;
 
@@ -34,7 +34,7 @@ impl CallableTestObj {
 
 #[itest]
 fn callable_validity() {
-    let obj = Gd::<CallableTestObj>::new_default();
+    let obj = CallableTestObj::new_gd();
 
     // non-null object, valid method
     assert!(obj.callable("foo").is_valid());
@@ -57,14 +57,14 @@ fn callable_validity() {
 
 #[itest]
 fn callable_hash() {
-    let obj = Gd::<CallableTestObj>::new_default();
+    let obj = CallableTestObj::new_gd();
     assert_eq!(obj.callable("foo").hash(), obj.callable("foo").hash());
     assert_ne!(obj.callable("foo").hash(), obj.callable("bar").hash());
 }
 
 #[itest]
 fn callable_object_method() {
-    let obj = Gd::<CallableTestObj>::new_default();
+    let obj = CallableTestObj::new_gd();
     let callable = obj.callable("foo");
 
     assert_eq!(callable.object(), Some(obj.clone().upcast::<Object>()));
@@ -78,7 +78,7 @@ fn callable_object_method() {
 
 #[itest]
 fn callable_call() {
-    let obj = Gd::<CallableTestObj>::new_default();
+    let obj = CallableTestObj::new_gd();
     let callable = obj.callable("foo");
 
     assert_eq!(obj.bind().value, 0);
@@ -96,7 +96,7 @@ fn callable_call() {
 
 #[itest]
 fn callable_call_return() {
-    let obj = Gd::<CallableTestObj>::new_default();
+    let obj = CallableTestObj::new_gd();
     let callable = obj.callable("bar");
 
     assert_eq!(

--- a/itest/rust/src/builtin_tests/containers/signal_test.rs
+++ b/itest/rust/src/builtin_tests/containers/signal_test.rs
@@ -10,7 +10,7 @@ use godot::bind::{godot_api, GodotClass};
 use godot::builtin::{GString, Variant};
 
 use godot::engine::Object;
-use godot::obj::{Base, Gd};
+use godot::obj::{Base, Gd, UserClass};
 use godot::sys;
 
 use crate::framework::itest;
@@ -62,8 +62,8 @@ const SIGNAL_ARG_STRING: &str = "Signal string arg";
 #[itest]
 /// Test that godot can call a method that is connect with a signal
 fn signals() {
-    let mut emitter = Gd::<Emitter>::new_default();
-    let receiver = Gd::<Receiver>::new_default();
+    let mut emitter = Emitter::alloc_gd();
+    let receiver = Receiver::alloc_gd();
 
     let args = [
         vec![],

--- a/itest/rust/src/engine_tests/codegen_test.rs
+++ b/itest/rust/src/engine_tests/codegen_test.rs
@@ -24,7 +24,7 @@ fn codegen_base_renamed() {
     // The registration is done at startup time, so it may already fail during GDExtension init.
     // Nevertheless, try to instantiate an object with base HttpRequest here.
 
-    let obj = Gd::with_base(|base| TestBaseRenamed { _base: base });
+    let obj = Gd::new(|base| TestBaseRenamed { _base: base });
     let _id = obj.instance_id();
 
     obj.free();

--- a/itest/rust/src/engine_tests/native_structures_test.rs
+++ b/itest/rust/src/engine_tests/native_structures_test.rs
@@ -5,10 +5,13 @@
  */
 
 use crate::framework::itest;
+
+use godot::bind::{godot_api, GodotClass};
+use godot::builtin::{Rect2, Rid, Variant};
 use godot::engine::native::{AudioFrame, CaretInfo, Glyph};
 use godot::engine::text_server::Direction;
 use godot::engine::{ITextServerExtension, TextServer, TextServerExtension};
-use godot::prelude::{godot_api, Base, Gd, GodotClass, Rect2, Rid, Variant};
+use godot::obj::{Base, UserClass};
 
 use std::cell::Cell;
 
@@ -92,7 +95,7 @@ fn test_native_structures_codegen() {
 fn test_native_structure_out_parameter() {
     // Instantiate a TextServerExtension and then have Godot call a
     // function which uses an 'out' pointer parameter.
-    let mut ext: Gd<TestTextServer> = Gd::new_default();
+    let mut ext = TestTextServer::new_gd();
     let result = ext
         .clone()
         .upcast::<TextServer>()
@@ -125,7 +128,7 @@ fn test_native_structure_out_parameter() {
 #[itest]
 fn test_native_structure_pointer_to_array_parameter() {
     // Instantiate a TextServerExtension.
-    let ext: Gd<TestTextServer> = Gd::new_default();
+    let ext = TestTextServer::new_gd();
     let result = ext
         .clone()
         .upcast::<TextServer>()

--- a/itest/rust/src/object_tests/base_test.rs
+++ b/itest/rust/src/object_tests/base_test.rs
@@ -15,7 +15,7 @@ fn base_test_is_weak() {
 
 #[itest]
 fn base_instance_id() {
-    let obj = Gd::<Based>::new_default();
+    let obj = Based::alloc_gd();
     let obj_id = obj.instance_id();
     let base_id = obj.bind().base.instance_id();
 
@@ -25,7 +25,7 @@ fn base_instance_id() {
 
 #[itest]
 fn base_access_unbound() {
-    let mut obj = Gd::<Based>::new_default();
+    let mut obj = Based::alloc_gd();
 
     let pos = Vector2::new(-5.5, 7.0);
     obj.set_position(pos);
@@ -37,7 +37,7 @@ fn base_access_unbound() {
 // Tests whether access to base is possible from outside the Gd<T>, even if there is no `#[base]` field.
 #[itest]
 fn base_access_unbound_no_field() {
-    let mut obj = Gd::<Baseless>::new_default();
+    let mut obj = Baseless::alloc_gd();
 
     let pos = Vector2::new(-5.5, 7.0);
     obj.set_position(pos);
@@ -48,7 +48,7 @@ fn base_access_unbound_no_field() {
 
 #[itest]
 fn base_display() {
-    let obj = Gd::<Based>::new_default();
+    let obj = Based::alloc_gd();
     {
         let guard = obj.bind();
         let id = guard.base.instance_id();
@@ -64,7 +64,7 @@ fn base_display() {
 
 #[itest]
 fn base_debug() {
-    let obj = Gd::<Based>::new_default();
+    let obj = Based::alloc_gd();
     {
         let guard = obj.bind();
         let id = guard.base.instance_id();
@@ -80,7 +80,7 @@ fn base_debug() {
 
 #[itest]
 fn base_with_init() {
-    let obj = Gd::<Based>::with_base(|mut base| {
+    let obj = Gd::<Based>::from_init_fn(|mut base| {
         base.set_rotation(11.0);
         Based { base, i: 732 }
     });

--- a/itest/rust/src/object_tests/property_template_test.rs
+++ b/itest/rust/src/object_tests/property_template_test.rs
@@ -21,7 +21,7 @@ use crate::register_tests::gen_ffi::PropertyTestsRust;
 
 #[itest]
 fn property_template_test(ctx: &TestContext) {
-    let rust_properties = Gd::<PropertyTestsRust>::new_default();
+    let rust_properties = PropertyTestsRust::alloc_gd();
     let gdscript_properties = ctx.property_tests.clone();
 
     // Accumulate errors so we can catch all of them in one go.

--- a/itest/rust/src/object_tests/property_test.rs
+++ b/itest/rust/src/object_tests/property_test.rs
@@ -347,7 +347,7 @@ impl IRefCounted for DeriveExport {
 
 #[itest]
 fn derive_export() {
-    let class: Gd<DeriveExport> = Gd::new_default();
+    let class = DeriveExport::new_gd();
 
     let property = class
         .get_property_list()
@@ -405,7 +405,7 @@ impl INode for ExportResource {}
 
 #[itest]
 fn export_resource() {
-    let class: Gd<ExportResource> = Gd::new_default();
+    let class = ExportResource::alloc_gd();
 
     let property = class
         .get_property_list()

--- a/itest/rust/src/register_tests/func_test.rs
+++ b/itest/rust/src/register_tests/func_test.rs
@@ -265,7 +265,7 @@ fn class_has_signal<T: GodotClass>(name: &str) -> bool {
 #[itest]
 fn cfg_doesnt_interfere_with_valid_method_impls() {
     // If we re-implement this method but the re-implementation is removed, that should keep the non-removed implementation.
-    let object = Gd::new(FuncRename);
+    let object = Gd::from_object(FuncRename);
     assert_eq!(
         object.bind().returns_hello_world(),
         GString::from("Hello world!")


### PR DESCRIPTION
Changes:
- Rename `new_default` -> `default`
- Rename `new` -> `from_object`
- Rename `with_base` -> `from_init_fn`
- Extend `impl Default` from user types to engine types that have a new() constructor (i.e. ref-counted ones)
- Rename `GodotInit` -> `GodotDefault` to reflect new meaning
- Enable `Gd::default()` and `Gd::new_alloc()` constructors depending on memory strategy

Old names remain deprecated where possible.

Add extension methods `T::new_gd()` and `T::alloc_gd()` as shortcut for `Gd::<T>::default()` and `Gd::<T>::new_alloc()`.
These are provided via extension trait `UserClass` (part of prelude) and likely almost always the preferred way of constructing.

---

### New API overview:

| Type \ Memory Strategy | Ref-counted          | Manually managed             | Singleton               |
|------------------------|----------------------|------------------------------|-------------------------|
| **Engine type**        | `Resource::new()`    | `Node::new_alloc()`          | `Os::singleton()`       |
| **User type**          | `MyClass::new_gd()`  | `MyClass::alloc_gd()`        | _(not yet implemented)_ |
| **Gd<T>** (rarely used constructors)             | `Gd::<T>::default()` | _(not available)_ | _(not available)_       | 

| Other `Gd<T>` constructors      | Usage                               |
|-------------------------------|-------------------------------------|
| from existing Rust object     | `Gd::<T>::from_object(obj)`         |
| from closure accepting `base` | `Gd::<T>::from_init_fn(closure)`    |
| from instance ID              | `Gd::<T>::from_instance_id(id)`     |
| from instance ID (fallible)   | `Gd::<T>::try_from_instance_id(id)` |

As you see, the naming is not very consistent, unfortunately. There are some constraints:
1. I cannot use `MyClass::new()`, since it's very likely that a user already provides such a constructor.
2. I _could_ use `Resource::new_gd()` to have `new_gd()` everywhere, but it would mean all engine types are now harder to construct. Unlike with user types, there is no other `new` or so that could collide.
3. I _could_ use `Gd::new()` to mean `Gd::default()`, but:
    * This constructor is very rarely useful, since we now have extensions on the inner types that are more concise, making `new` not a great choice of name (as this indicates the most commonly used one).
    * I was actually considering `from_init_fn()` to be named `new()` just because of how useful it is, and since it's a bit hard to discover otherwise. Lots of people didn't know you could create custom `Gd<T>` instances where `T` would receive a base.

This may need a bit more thought, feedback is welcome.
