### PR TITLE
Reintroduce `get_` prefixes (revert #477)

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -58,21 +58,25 @@ jobs:
       # Opened/reopened/updated PR: include PR author + title
       - name: "Construct JSON (for PR sync)"
         if: github.event_name == 'pull_request' && github.event.action != 'closed'
-        # Escape double quotes in PR title, as it will be used in a JSON string.
+        # jq escapes backticks, double quotes etc. in PR title.
         run: |
-          escapedPrTitle=$(echo "${{ github.event.pull_request.title }}" | sed 's/"/\\"/g')
-          payload=$(cat <<'HEREDOC'
-          {
+          payload=$(jq -n \
+          --arg repoOwner '${{ github.repository_owner }}' \
+          --arg num '${{ github.event.number }}' \
+          --arg commitSha '${{ github.event.pull_request.head.sha }}' \
+          --arg date '${{ github.event.pull_request.updated_at }}' \
+          --arg prAuthor '${{ github.event.pull_request.user.login }}' \
+          --arg prTitle '${{ github.event.pull_request.title }}' \
+          '{
             "op": "put",
             "repo": "gdext",
-            "repo-owner": "${{ github.repository_owner }}",
-            "num": "${{ github.event.number }}",
-            "commit-sha": "${{ github.event.pull_request.head.sha }}",
-            "date": "${{ github.event.pull_request.updated_at }}",
-            "pr-author": "${{ github.event.pull_request.user.login }}",
-            "pr-title": "$escapedPrTitle"
-          }
-          HEREDOC)
+            "repo-owner": $repoOwner,
+            "num": $num,
+            "commit-sha": $commitSha,
+            "date": $date,
+            "pr-author": $prAuthor,
+            "pr-title": $prTitle
+          }')
           echo "VAR=$payload"
           echo "GDEXT_JSON<<HEREDOC" >> $GITHUB_ENV
           echo "${payload}" >> $GITHUB_ENV

--- a/examples/dodge-the-creeps/rust/src/main_scene.rs
+++ b/examples/dodge-the-creeps/rust/src/main_scene.rs
@@ -45,7 +45,7 @@ impl Main {
 
         self.score = 0;
 
-        player.bind_mut().start(start_position.position());
+        player.bind_mut().start(start_position.get_position());
         start_timer.start();
 
         let mut hud = self.base.get_node_as::<Hud>("Hud");
@@ -84,9 +84,9 @@ impl Main {
         let progress = rng.gen_range(u32::MIN..u32::MAX);
 
         mob_spawn_location.set_progress(progress as f32);
-        mob_scene.set_position(mob_spawn_location.position());
+        mob_scene.set_position(mob_spawn_location.get_position());
 
-        let mut direction = mob_spawn_location.rotation() + PI / 2.0;
+        let mut direction = mob_spawn_location.get_rotation() + PI / 2.0;
         direction += rng.gen_range(-PI / 4.0..PI / 4.0);
 
         mob_scene.set_rotation(direction);
@@ -101,7 +101,7 @@ impl Main {
         };
 
         mob.set_linear_velocity(Vector2::new(range, 0.0));
-        let lin_vel = mob.linear_velocity().rotated(real::from_f32(direction));
+        let lin_vel = mob.get_linear_velocity().rotated(real::from_f32(direction));
         mob.set_linear_velocity(lin_vel);
 
         let mut hud = self.base.get_node_as::<Hud>("Hud");

--- a/examples/dodge-the-creeps/rust/src/mob.rs
+++ b/examples/dodge-the-creeps/rust/src/mob.rs
@@ -41,7 +41,7 @@ impl IRigidBody2D for Mob {
             .get_node_as::<AnimatedSprite2D>("AnimatedSprite2D");
 
         sprite.play();
-        let anim_names = sprite.sprite_frames().unwrap().animation_names();
+        let anim_names = sprite.get_sprite_frames().unwrap().get_animation_names();
 
         // TODO use pick_random() once implemented
         let anim_names = anim_names.to_vec();

--- a/examples/dodge-the-creeps/rust/src/player.rs
+++ b/examples/dodge-the-creeps/rust/src/player.rs
@@ -52,7 +52,7 @@ impl IArea2D for Player {
     }
 
     fn ready(&mut self) {
-        let viewport = self.base.viewport_rect();
+        let viewport = self.base.get_viewport_rect();
         self.screen_size = viewport.size;
         self.base.hide();
     }
@@ -101,7 +101,7 @@ impl IArea2D for Player {
         }
 
         let change = velocity * real::from_f64(delta);
-        let position = self.base.global_position() + change;
+        let position = self.base.get_global_position() + change;
         let position = Vector2::new(
             position.x.clamp(0.0, self.screen_size.x),
             position.y.clamp(0.0, self.screen_size.y),

--- a/godot-codegen/src/api_parser.rs
+++ b/godot-codegen/src/api_parser.rs
@@ -200,15 +200,6 @@ pub struct ClassMethod {
     pub arguments: Option<Vec<MethodArg>>,
 }
 
-impl ClassMethod {
-    pub fn map_args<R>(&self, f: impl FnOnce(&Vec<MethodArg>) -> R) -> R {
-        match self.arguments.as_ref() {
-            Some(args) => f(args),
-            None => f(&vec![]),
-        }
-    }
-}
-
 // Example: set_point_weight_scale ->
 // [ {name: "id", type: "int", meta: "int64"},
 //   {name: "weight_scale", type: "float", meta: "float"},

--- a/godot-core/src/obj/traits.rs
+++ b/godot-core/src/obj/traits.rs
@@ -106,7 +106,7 @@ pub trait Share {
 ///     T: Inherits<Node>,
 /// {
 ///     let up = node.upcast(); // type Gd<Node> inferred
-///     println!("Node #{} with name {}", up.instance_id(), up.name());
+///     println!("Node #{} with name {}", up.instance_id(), up.get_name());
 ///     up.free();
 /// }
 ///

--- a/itest/godot/SpecialTests.gd
+++ b/itest/godot/SpecialTests.gd
@@ -33,7 +33,7 @@ func test_collision_object_2d_input_event():
 	window.add_child(collision_object)
 
 	assert_that(not collision_object.input_event_called())
-	assert_eq(collision_object.viewport(), null)
+	assert_eq(collision_object.get_viewport(), null)
 
 	var event := InputEventMouseMotion.new()
 	event.global_position = Vector2.ZERO
@@ -43,7 +43,7 @@ func test_collision_object_2d_input_event():
 	await root.get_tree().physics_frame
 
 	assert_that(collision_object.input_event_called())
-	assert_eq(collision_object.viewport(), window)
+	assert_eq(collision_object.get_viewport(), window)
 
 	window.queue_free()
 

--- a/itest/rust/src/builtin_tests/containers/array_test.rs
+++ b/itest/rust/src/builtin_tests/containers/array_test.rs
@@ -398,7 +398,7 @@ fn typed_array_pass_to_godot_func() {
     let error = texture.create_from_images(images);
 
     assert_eq!(error, Error::OK);
-    assert_eq!((texture.width(), texture.height()), (2, 4));
+    assert_eq!((texture.get_width(), texture.get_height()), (2, 4));
 }
 
 #[itest]

--- a/itest/rust/src/builtin_tests/containers/callable_test.rs
+++ b/itest/rust/src/builtin_tests/containers/callable_test.rs
@@ -120,7 +120,7 @@ fn callable_call_engine() {
     // TODO once varargs is available
     // let pos = Vector2::new(5.0, 7.0);
     // inner.call(&[pos.to_variant()]);
-    // assert_eq!(obj.position(), pos);
+    // assert_eq!(obj.get_position(), pos);
     //
     // inner.bindv(array);
 

--- a/itest/rust/src/engine_tests/node_test.rs
+++ b/itest/rust/src/engine_tests/node_test.rs
@@ -52,7 +52,7 @@ fn node_get_node_fail() {
 fn node_path_from_str(ctx: &TestContext) {
     let child = ctx.scene_tree.clone();
     assert_eq!(
-        child.path().to_string(),
+        child.get_path().to_string(),
         NodePath::from_str("/root/TestRunner").unwrap().to_string()
     );
 }
@@ -84,7 +84,7 @@ fn node_scene_tree() {
 #[itest]
 fn node_call_group(ctx: &TestContext) {
     let mut node = ctx.scene_tree.clone();
-    let mut tree = node.tree().unwrap();
+    let mut tree = node.get_tree().unwrap();
 
     node.add_to_group("group".into());
     tree.call_group("group".into(), "set_name".into(), &[Variant::from("name")]);

--- a/itest/rust/src/object_tests/base_test.rs
+++ b/itest/rust/src/object_tests/base_test.rs
@@ -29,7 +29,7 @@ fn base_access_unbound() {
 
     let pos = Vector2::new(-5.5, 7.0);
     obj.set_position(pos);
-    assert_eq!(obj.position(), pos);
+    assert_eq!(obj.get_position(), pos);
 
     obj.free();
 }
@@ -41,7 +41,7 @@ fn base_access_unbound_no_field() {
 
     let pos = Vector2::new(-5.5, 7.0);
     obj.set_position(pos);
-    assert_eq!(obj.position(), pos);
+    assert_eq!(obj.get_position(), pos);
 
     obj.free();
 }
@@ -88,7 +88,7 @@ fn base_with_init() {
     {
         let guard = obj.bind();
         assert_eq!(guard.i, 732);
-        assert_eq!(guard.base.rotation(), 11.0);
+        assert_eq!(guard.base.get_rotation(), 11.0);
     }
     obj.free();
 }

--- a/itest/rust/src/object_tests/object_test.rs
+++ b/itest/rust/src/object_tests/object_test.rs
@@ -109,14 +109,14 @@ fn object_engine_roundtrip() {
 
     let mut obj: Gd<Node3D> = Node3D::new_alloc();
     obj.set_position(pos);
-    assert_eq!(obj.position(), pos);
+    assert_eq!(obj.get_position(), pos);
 
     let raw = obj.to_ffi();
     let ptr = raw.sys();
 
     let raw2 = unsafe { RawGd::<Node3D>::from_sys(ptr) };
     let obj2 = Gd::from_ffi(raw2);
-    assert_eq!(obj2.position(), pos);
+    assert_eq!(obj2.get_position(), pos);
     obj.free();
 }
 
@@ -198,7 +198,7 @@ fn object_from_instance_id_inherits_type() {
 
     let node_as_base = Gd::<Node>::from_instance_id(id);
     assert_eq!(node_as_base.instance_id(), id);
-    assert_eq!(node_as_base.editor_description(), descr);
+    assert_eq!(node_as_base.get_editor_description(), descr);
 
     node_as_base.free();
 }
@@ -313,7 +313,7 @@ fn object_engine_use_after_free() {
     node.free();
 
     expect_panic("call method on dead engine object", move || {
-        copy.position();
+        copy.get_position();
     });
 }
 
@@ -404,7 +404,7 @@ fn object_engine_convert_variant() {
     let variant = obj.to_variant();
     let obj2 = Gd::<Node3D>::from_variant(&variant);
 
-    assert_eq!(obj2.position(), pos);
+    assert_eq!(obj2.get_position(), pos);
     obj.free();
 }
 
@@ -424,26 +424,26 @@ fn object_engine_convert_variant_refcount() {
 /// Converts between Object <-> Variant and verifies the reference counter at each stage.
 fn check_convert_variant_refcount(obj: Gd<RefCounted>) {
     // Freshly created -> refcount 1
-    assert_eq!(obj.reference_count(), 1);
+    assert_eq!(obj.get_reference_count(), 1);
 
     {
         // Variant created from object -> increment
         let variant = obj.to_variant();
-        assert_eq!(obj.reference_count(), 2);
+        assert_eq!(obj.get_reference_count(), 2);
 
         {
             // Yet another object created *from* variant -> increment
             let another_object = variant.to::<Gd<RefCounted>>();
-            assert_eq!(obj.reference_count(), 3);
-            assert_eq!(another_object.reference_count(), 3);
+            assert_eq!(obj.get_reference_count(), 3);
+            assert_eq!(another_object.get_reference_count(), 3);
         }
 
         // `another_object` destroyed -> decrement
-        assert_eq!(obj.reference_count(), 2);
+        assert_eq!(obj.get_reference_count(), 2);
     }
 
     // `variant` destroyed -> decrement
-    assert_eq!(obj.reference_count(), 1);
+    assert_eq!(obj.get_reference_count(), 1);
 }
 
 #[itest]
@@ -472,7 +472,7 @@ fn object_engine_returned_refcount() {
     assert!(file.is_open());
 
     // There was a bug which incremented ref-counts of just-returned objects, keep this as regression test.
-    assert_eq!(file.reference_count(), 1);
+    assert_eq!(file.get_reference_count(), 1);
 }
 
 #[itest]
@@ -540,7 +540,7 @@ fn object_engine_downcast() {
     let node3d: Gd<Node3D> = node.try_cast::<Node3D>().expect("try_cast");
 
     assert_eq!(node3d.instance_id(), id);
-    assert_eq!(node3d.position(), pos);
+    assert_eq!(node3d.get_position(), pos);
 
     node3d.free();
 }
@@ -622,7 +622,7 @@ where
     T: Inherits<Node>,
 {
     let up = node.upcast();
-    up.name()
+    up.get_name()
 }
 
 fn accept_refcounted<T>(node: Gd<T>) -> GString

--- a/itest/rust/src/object_tests/singleton_test.rs
+++ b/itest/rust/src/object_tests/singleton_test.rs
@@ -27,7 +27,7 @@ fn singleton_from_instance_id() {
 
     let b: Gd<Os> = Gd::from_instance_id(id);
 
-    assert_eq!(a.executable_path(), b.executable_path());
+    assert_eq!(a.get_executable_path(), b.get_executable_path());
 }
 
 #[itest]

--- a/itest/rust/src/object_tests/virtual_methods_test.rs
+++ b/itest/rust/src/object_tests/virtual_methods_test.rs
@@ -328,7 +328,7 @@ fn test_tree_enters_exits(test_context: &TestContext) {
 #[itest]
 fn test_virtual_method_with_return() {
     let obj = Gd::<IReturnTest>::new_default();
-    let arr = obj.clone().upcast::<PrimitiveMesh>().mesh_arrays();
+    let arr = obj.clone().upcast::<PrimitiveMesh>().get_mesh_arrays();
     let arr_rust = obj.bind().create_mesh_array();
     assert_eq!(arr.len(), arr_rust.len());
     // can't just assert_eq because the values of some floats change slightly
@@ -487,7 +487,7 @@ impl CollisionObject2DTest {
     }
 
     #[func]
-    fn viewport(&self) -> Variant {
+    fn get_viewport(&self) -> Variant {
         self.viewport
             .as_ref()
             .map(ToGodot::to_variant)

--- a/itest/rust/src/register_tests/constant_test.rs
+++ b/itest/rust/src/register_tests/constant_test.rs
@@ -116,12 +116,12 @@ fn cfg_removes_or_keeps_constants() {
 struct HasOtherConstants {}
 
 impl HasOtherConstants {
-    const ENUM_NAME: &str = "SomeEnum";
+    const ENUM_NAME: &'static str = "SomeEnum";
     const ENUM_A: i64 = 0;
     const ENUM_B: i64 = 1;
     const ENUM_C: i64 = 2;
 
-    const BITFIELD_NAME: &str = "SomeBitfield";
+    const BITFIELD_NAME: &'static str = "SomeBitfield";
     const BITFIELD_A: i64 = 1;
     const BITFIELD_B: i64 = 2;
     const BITFIELD_C: i64 = 4;


### PR DESCRIPTION

This reverts commit d36a144108fe7fc7f4cc5055f7523bd1dfec99cc from pull request #477.
Prepares some logic for overriding const-qualification, without yet enabling it.

Rationale:

1. Godot has non-typical APIs for Rust, following tradititional OOP style with lots of getters/setters.

1. My idea was that porting GDScript's property access to Rust might be more natural: `node.position` becomes `node.position()`. However, Godot's naming is much less consistent than I was initially assuming:
    - `size_flags_horizontal` property has `{get/set}_h_size_flags` accessors
    - `Node.get_path()` and `Node.get_parent()` look like they should have properties, but don't; so `.path()` and `.parent()` would be a "wrong mapping".
    - `Node` bool property `unique_name_in_owner` has `{get/is}_unique_name_in_owner`.
      However, `{get/set}_scene_instance_load_placeholder` methods also return bool but have no property. So mapping would yield `is_unique_name_in_owner` and `scene_instance_placeholder`. Stripping the "is_" for consistency would be confusing: `unique_name_in_owner` sounds like it returns the name.
1. Some `get_` methods take parameters.
   - `MeshDataTool` has `get_vertex_count()` and `get_vertex_color(index)` -- the former would lose its prefix but the latter would not since it's not strictly a "getter" in the Rust sense.
   - It could even happen that such parameters have defaults, in which case a single method would act as both getter and getter-with-param. It's unclear how we'd map it under our `_ex` model.
1. Since some verbs are simultaneously nouns, this makes APIs slightly harder to understand in some cases.
   - `scale()`
   - `queue()` (already causing a conflict)
   - `process_delta_time()`
   - `format()`
   - `modulate()`
1. Exceptions and rules that depend on presence of properties make backwards compatibility harder.
   - if a new property is added, it might not map to the way how Rust maps an existing `get_` method
   - if Godot has a method `get_format()` which we map to `format()`, and then Godot adds another method `format()` later, we have a conflict
1. Getters are harder to discover.
   - partly due to issues above (intermixing with "doer" style methods/verbs)
   - there is no more `get_` autocompletion in IDEs
   
TLDR: There needs to be a complex ruleset, with lots of edge cases. In the end we may come up with something that looks nice and somewhat consistent when looking at the Rust part, but it will be too distant from the GDScript API, making porting between the two harder. We should probably embrace imperfections in the Godot API rather than trying to fight them.