### PR TITLE
Empty `#[godot_api] impl` blocks are no longer needed

### DIFF
--- a/godot-core/src/lib.rs
+++ b/godot-core/src/lib.rs
@@ -45,11 +45,6 @@ mod gen;
 
 #[doc(hidden)]
 pub mod private {
-    // If someone forgets #[godot_api], this causes a compile error, rather than virtual functions not being called at runtime.
-    #[allow(non_camel_case_types)]
-    pub trait You_forgot_the_attribute__godot_api {}
-    pub use crate::property::Cannot_export_without_godot_api_impl;
-
     use std::sync::{Arc, Mutex};
 
     pub use crate::gen::classes::class_macros;
@@ -58,6 +53,10 @@ pub mod private {
     pub use godot_ffi::out;
 
     use crate::{log, sys};
+
+    // If someone forgets #[godot_api], this causes a compile error, rather than virtual functions not being called at runtime.
+    #[allow(non_camel_case_types)]
+    pub trait You_forgot_the_attribute__godot_api {}
 
     sys::plugin_registry!(pub __GODOT_PLUGIN_REGISTRY: ClassPlugin);
 

--- a/godot-core/src/obj/traits.rs
+++ b/godot-core/src/obj/traits.rs
@@ -38,7 +38,7 @@ where
     /// During which initialization level this class is available/should be initialized with Godot.
     ///
     /// Is `None` if the class has complicated initialization requirements, and generally cannot be inherited
-    /// from.
+    /// from (currently only for `()`, the "base" of `Object`).
     const INIT_LEVEL: Option<InitLevel>;
 
     /// The name of the class, under which it is registered in Godot.

--- a/godot-core/src/property.rs
+++ b/godot-core/src/property.rs
@@ -106,23 +106,6 @@ impl PropertyHintInfo {
     }
 }
 
-/// To export properties to Godot, you must have an impl-block with the `#[godot_api]` attribute, even if
-/// it is empty.
-///
-/// This trait is automatically implemented when such an impl-block is present. If Rust complains that it is
-/// not implemented, then you can usually fix this by adding:
-///
-/// ```ignore
-/// #[godot_api]
-/// impl MyClass {}
-/// ```
-///
-/// Where you replace `MyClass` with the name of your class.
-#[allow(non_camel_case_types)]
-pub trait Cannot_export_without_godot_api_impl {
-    const EXISTS: () = ();
-}
-
 /// Functions used to translate user-provided arguments into export hints.
 pub mod export_info_functions {
     use crate::builtin::GString;

--- a/godot-macros/src/class/data_models/property.rs
+++ b/godot-macros/src/class/data_models/property.rs
@@ -203,18 +203,8 @@ pub fn make_property_impl(class_name: &Ident, fields: &Fields) -> TokenStream {
         });
     }
 
-    let enforce_godot_api_impl = if !export_tokens.is_empty() {
-        quote! {
-            const MUST_HAVE_GODOT_API_IMPL: () = <#class_name as ::godot::private::Cannot_export_without_godot_api_impl>::EXISTS;
-        }
-    } else {
-        TokenStream::new()
-    };
-
     quote! {
         impl #class_name {
-            #enforce_godot_api_impl
-
             #(#getter_setter_impls)*
         }
 

--- a/godot-macros/src/class/derive_godot_class.rs
+++ b/godot-macros/src/class/derive_godot_class.rs
@@ -103,6 +103,9 @@ pub fn derive_godot_class(decl: Declaration) -> ParseResult<TokenStream> {
                 base_class_name: #base_class_name_obj,
                 generated_create_fn: #create_fn,
                 generated_recreate_fn: #recreate_fn,
+                register_properties_fn: #prv::ErasedRegisterFn {
+                    raw: #prv::callbacks::register_user_properties::<#class_name>,
+                },
                 free_fn: #prv::callbacks::free::<#class_name>,
             },
             init_level: <#class_name as ::godot::obj::GodotClass>::INIT_LEVEL,

--- a/godot-macros/src/class/godot_api.rs
+++ b/godot-macros/src/class/godot_api.rs
@@ -222,8 +222,6 @@ fn transform_inherent_impl(mut original_impl: Impl) -> Result<TokenStream, Error
             }
         }
 
-        impl ::godot::private::Cannot_export_without_godot_api_impl for #class_name {}
-
         ::godot::sys::plugin_add!(__GODOT_PLUGIN_REGISTRY in #prv; #prv::ClassPlugin {
             class_name: #class_name_obj,
             component: #prv::PluginComponent::UserMethodBinds {

--- a/godot-macros/src/lib.rs
+++ b/godot-macros/src/lib.rs
@@ -124,17 +124,11 @@ use crate::util::ident;
 ///     #[var]
 ///     my_field: i64,
 /// }
-///
-/// #[godot_api]
-/// impl MyStruct {}
 /// ```
 ///
 /// This makes the field accessible in GDScript using `my_struct.my_field` syntax. Additionally, it
 /// generates a trivial getter and setter named `get_my_field` and `set_my_field`, respectively.
 /// These are `pub` in Rust, since they're exposed from GDScript anyway.
-///
-/// For technical reasons, an impl-block with the `#[godot_api]` attribute is required for properties to
-/// work. Failing to include one will cause a compile error if you try to create any properties.
 ///
 /// If you want to implement your own getter and/or setter, write those as a function on your Rust
 /// type, expose it using `#[func]`, and annotate the field with
@@ -196,9 +190,6 @@ use crate::util::ident;
 ///     #[export]
 ///     my_field: i64,
 /// }
-///
-/// #[godot_api]
-/// impl MyStruct {}
 /// ```
 ///
 /// If you dont also include a `#[var]` attribute, then a default one will be generated.
@@ -252,9 +243,6 @@ use crate::util::ident;
 ///     #[export(flags = (A = 1, B = 2, AB = 3))]
 ///     flags: u32,
 /// }
-///
-/// #[godot_api]
-/// impl MyStruct {}
 /// ```
 ///
 /// Most values in expressions like `key = value`, can be an arbitrary expression that evaluates to the
@@ -274,9 +262,6 @@ use crate::util::ident;
 ///     #[export(flags = (A = 0b0001, B = 0b0010, C = 0b0100, D = 0b1000))]
 ///     flags: u32,
 /// }
-///
-/// #[godot_api]
-/// impl MyStruct {}
 /// ```
 ///
 /// You can specify custom property hints, hint strings, and usage flags in a `#[var]` attribute using the
@@ -297,9 +282,6 @@ use crate::util::ident;
 ///     )]
 ///     my_field: i64,
 /// }
-///
-/// #[godot_api]
-/// impl MyStruct {}
 /// ```
 ///
 ///
@@ -540,10 +522,6 @@ pub fn derive_from_godot(input: TokenStream) -> TokenStream {
 ///     #[var]
 ///     foo: TestEnum
 /// }
-///
-/// # //TODO: remove this when https://github.com/godot-rust/gdext/issues/187 is truly addressed
-/// # #[godot_api]
-/// # impl TestClass {}
 ///
 /// # fn main() {
 /// let mut class = TestClass {foo: TestEnum::B};

--- a/itest/rust/build.rs
+++ b/itest/rust/build.rs
@@ -457,9 +457,6 @@ fn generate_property_template(inputs: &[Input]) -> PropertyTests {
             #[export(enum = (Rebecca, Mary, Leah))]
             export_enum_string_rebecca_mary_leah: GString,
         }
-
-        #[godot_api]
-        impl PropertyTestsRust {}
     };
 
     let gdscript = format!(

--- a/itest/rust/src/object_tests/object_test.rs
+++ b/itest/rust/src/object_tests/object_test.rs
@@ -844,18 +844,12 @@ pub mod object_test_gd {
         i: i64,
     }
 
-    #[godot_api]
-    impl MockObjRust {}
-
     #[derive(GodotClass)]
     #[class(init, base=RefCounted)]
     struct MockRefCountedRust {
         #[var]
         i: i64,
     }
-
-    #[godot_api]
-    impl MockRefCountedRust {}
 
     #[derive(GodotClass, Debug)]
     #[class(init, base=RefCounted)]

--- a/itest/rust/src/object_tests/property_test.rs
+++ b/itest/rust/src/object_tests/property_test.rs
@@ -298,9 +298,6 @@ struct CheckAllExports {
     color_no_alpha: Color,
 }
 
-#[godot_api]
-impl CheckAllExports {}
-
 #[repr(i64)]
 #[derive(Property, Export, Eq, PartialEq, Debug)]
 pub enum TestEnum {
@@ -314,9 +311,6 @@ pub struct DeriveProperty {
     #[var]
     pub foo: TestEnum,
 }
-
-#[godot_api]
-impl DeriveProperty {}
 
 #[itest]
 fn derive_property() {
@@ -334,9 +328,6 @@ pub struct DeriveExport {
     #[base]
     pub base: Base<RefCounted>,
 }
-
-#[godot_api]
-impl DeriveExport {}
 
 #[godot_api]
 impl IRefCounted for DeriveExport {
@@ -373,21 +364,9 @@ fn derive_export() {
 #[class(init, base=Resource)]
 pub struct CustomResource {}
 
-#[godot_api]
-impl CustomResource {}
-
-#[godot_api]
-impl IResource for CustomResource {}
-
 #[derive(GodotClass)]
 #[class(init, base=Resource, rename=NewNameCustomResource)]
 pub struct RenamedCustomResource {}
-
-#[godot_api]
-impl RenamedCustomResource {}
-
-#[godot_api]
-impl IResource for RenamedCustomResource {}
 
 #[derive(GodotClass)]
 #[class(init, base=Node)]
@@ -399,12 +378,6 @@ pub struct ExportResource {
     #[export]
     pub bar: Option<Gd<RenamedCustomResource>>,
 }
-
-#[godot_api]
-impl ExportResource {}
-
-#[godot_api]
-impl INode for ExportResource {}
 
 #[itest]
 fn export_resource() {

--- a/itest/rust/src/object_tests/virtual_methods_test.rs
+++ b/itest/rust/src/object_tests/virtual_methods_test.rs
@@ -45,9 +45,6 @@ struct VirtualMethodTest {
 }
 
 #[godot_api]
-impl VirtualMethodTest {}
-
-#[godot_api]
 impl IRefCounted for VirtualMethodTest {
     fn to_string(&self) -> GString {
         format!("VirtualMethodTest[integer={}]", self.integer).into()

--- a/itest/rust/src/register_tests/constant_test.rs
+++ b/itest/rust/src/register_tests/constant_test.rs
@@ -168,8 +168,8 @@ godot::sys::plugin_add!(
     ::godot::private::ClassPlugin {
         class_name: HasOtherConstants::class_name(),
         component: ::godot::private::PluginComponent::UserMethodBinds {
-            generated_register_fn: ::godot::private::ErasedRegisterFn {
-                raw: ::godot::private::callbacks::register_user_binds::<HasOtherConstants>,
+            register_methods_constants_fn: ::godot::private::ErasedRegisterFn {
+                raw: ::godot::private::callbacks::register_user_methods_constants::<HasOtherConstants>,
             },
         },
         init_level: HasOtherConstants::INIT_LEVEL,

--- a/itest/rust/src/register_tests/option_ffi_test.rs
+++ b/itest/rust/src/register_tests/option_ffi_test.rs
@@ -103,6 +103,3 @@ struct OptionExportFfiTest {
     #[export]
     optional_export: Option<Gd<Node>>,
 }
-
-#[godot_api]
-impl OptionExportFfiTest {}

--- a/itest/rust/src/register_tests/var_test.rs
+++ b/itest/rust/src/register_tests/var_test.rs
@@ -20,7 +20,3 @@ struct WithInitDefaults {
     #[init(default = -42)]
     expr_int: i64,
 }
-
-// TODO Remove once https://github.com/godot-rust/gdext/issues/187 is fixed
-#[godot_api]
-impl WithInitDefaults {}


### PR DESCRIPTION
Proper fix for #187, makes the workaround unnecessary.