### PR TITLE
`MethodInfo` (`GDExtensionClassMethodInfo`) collides with `GDExtensionMethodInfo`

### DIFF
--- a/godot-core/src/builtin/meta/registration/method.rs
+++ b/godot-core/src/builtin/meta/registration/method.rs
@@ -24,7 +24,7 @@ impl MethodParamOrReturnInfo {
 }
 
 /// All info needed to register a method for a class with Godot.
-pub struct MethodInfo {
+pub struct ClassMethodInfo {
     class_name: ClassName,
     method_name: StringName,
     call_func: sys::GDExtensionClassMethodCall,
@@ -35,7 +35,7 @@ pub struct MethodInfo {
     default_arguments: Vec<Variant>,
 }
 
-impl MethodInfo {
+impl ClassMethodInfo {
     /// # Safety
     ///
     /// `ptrcall_func`, if provided, must:

--- a/godot-macros/src/class/data_models/func.rs
+++ b/godot-macros/src/class/data_models/func.rs
@@ -90,7 +90,7 @@ pub fn make_method_registration(
         #(#cfg_attrs)*
         {
             use ::godot::obj::GodotClass;
-            use ::godot::builtin::meta::registration::method::MethodInfo;
+            use ::godot::builtin::meta::registration::method::ClassMethodInfo;
             use ::godot::builtin::{StringName, Variant};
             use ::godot::sys;
 
@@ -105,7 +105,7 @@ pub fn make_method_registration(
             // `get_varcall_func` upholds all the requirements for `call_func`.
             // `get_ptrcall_func` upholds all the requirements for `ptrcall_func`
             let method_info = unsafe {
-                MethodInfo::from_signature::<Sig>(
+                ClassMethodInfo::from_signature::<Sig>(
                 #class_name::class_name(),
                 method_name,
                 Some(varcall_func),


### PR DESCRIPTION
As discussed in https://github.com/godot-rust/gdext/pull/492#discussion_r1405475717 the existing `MethodInfo` struct name collides a bit with the newly introduced `MethodInfo` from #492. The current `MethodInfo` actually relates to the `GDExtensionClassMethodInfo` and should therefore be called `ClassMethodInfo` which will resolve the naming confusion.