### PR TITLE
impl Hash for Gd<T> per instance ID

### DIFF
--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -654,6 +654,16 @@ impl<T: GodotClass> Debug for Gd<T> {
     }
 }
 
+impl<T: GodotClass> std::hash::Hash for Gd<T> {
+    /// ⚠️ Hashes this object based on its instance ID.
+    ///
+    /// # Panics
+    /// When `self` is dead.
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.instance_id().hash(state);
+    }
+}
+
 // Gd unwinding across panics does not invalidate any invariants;
 // its mutability is anyway present, in the Godot engine.
 impl<T: GodotClass> std::panic::UnwindSafe for Gd<T> {}


### PR DESCRIPTION
I try to `Hash` `Gd`'s a ton in my development, but end up working around not having this by hashing `GString` and calling `get_node()`, so this would be a nice convenience to have. Also [others](https://discord.com/channels/723850269347283004/1043514894198255737/1178539885536223292) have inquired

If this isn't desired though feel to ignore.


Minor progress on #297 
