### PR TITLE
Fix packed array tests

### DIFF
--- a/itest/rust/src/builtin_tests/containers/packed_array_test.rs
+++ b/itest/rust/src/builtin_tests/containers/packed_array_test.rs
@@ -38,7 +38,7 @@ fn packed_array_from() {
 #[itest]
 fn packed_array_to_vec() {
     let array = PackedByteArray::new();
-    assert_eq!(array.to_vec(), vec![]);
+    assert_eq!(array.to_vec(), Vec::<u8>::new());
     let array = PackedByteArray::from(&[1, 2]);
     assert_eq!(array.to_vec(), vec![1, 2]);
 }

--- a/itest/rust/src/builtin_tests/mod.rs
+++ b/itest/rust/src/builtin_tests/mod.rs
@@ -20,6 +20,7 @@ mod containers {
     mod array_test;
     mod callable_test;
     mod dictionary_test;
+    mod packed_array_test;
     mod rid_test;
     mod signal_test;
     mod variant_test;


### PR DESCRIPTION
Packed Array Tests were not being executed.

I didn't find a reason for that in the git history. So, it looks like it was a mistake that was not included in the mod.rs.