### PR TITLE
Add serde support for GString, StringName, NodePath and Array

### DIFF
--- a/check.sh
+++ b/check.sh
@@ -171,6 +171,9 @@ for arg in "$@"; do
             echo "$HELP_TEXT"
             exit 0
             ;;
+        --use-serde)
+            extraCargoArgs+=("--features" "serde")
+            ;;
         --double)
             extraCargoArgs+=("--features" "godot/double-precision")
             ;;

--- a/godot-core/Cargo.toml
+++ b/godot-core/Cargo.toml
@@ -31,6 +31,7 @@ serde = { version = "1", features = ["derive"], optional = true }
 # Reverse dev dependencies so doctests can use `godot::` prefix
 [dev-dependencies]
 godot = { path = "../godot" }
+serde_json = { version = "1.0" }
 
 [build-dependencies]
 godot-bindings = { path = "../godot-bindings" }

--- a/godot-core/src/builtin/string/string_name.rs
+++ b/godot-core/src/builtin/string/string_name.rs
@@ -245,3 +245,50 @@ impl From<NodePath> for StringName {
         Self::from(GString::from(path))
     }
 }
+
+#[cfg(feature = "serde")]
+mod serialize {
+    use super::*;
+    use serde::de::{Error, Visitor};
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+    use std::fmt::Formatter;
+
+    impl Serialize for StringName {
+        #[inline]
+        fn serialize<S>(
+            &self,
+            serializer: S,
+        ) -> Result<<S as Serializer>::Ok, <S as Serializer>::Error>
+        where
+            S: Serializer,
+        {
+            serializer.serialize_str(&self.to_string())
+        }
+    }
+
+    impl<'de> serialize::Deserialize<'de> for StringName {
+        #[inline]
+        fn deserialize<D>(deserializer: D) -> Result<Self, <D as Deserializer<'de>>::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            struct StringNameVisitor;
+            impl<'de> Visitor<'de> for StringNameVisitor {
+                type Value = StringName;
+
+                fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
+                    formatter.write_str("a StringName")
+                }
+
+                fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
+                where
+                    E: Error,
+                {
+                    Ok(StringName::from(s))
+                }
+            }
+
+            deserializer.deserialize_str(StringNameVisitor)
+        }
+    }
+}

--- a/itest/rust/Cargo.toml
+++ b/itest/rust/Cargo.toml
@@ -10,11 +10,14 @@ crate-type = ["cdylib"]
 
 [features]
 default = []
+serde = ["dep:serde", "dep:serde_json", "godot/serde"]
 # Do not add features here that are 1:1 forwarded to the `godot` crate.
 # Instead, compile itest with `--features godot/my-feature`.
 
 [dependencies]
 godot = { path = "../../godot", default-features = false }
+serde = { version = "1", features = ["derive"], optional = true }
+serde_json = { version = "1.0", optional = true }
 
 [build-dependencies]
 godot-bindings = { path = "../../godot-bindings" } # emit_godot_version_cfg

--- a/itest/rust/src/builtin_tests/mod.rs
+++ b/itest/rust/src/builtin_tests/mod.rs
@@ -35,3 +35,6 @@ mod string {
 mod color_test;
 
 mod convert_test;
+
+#[cfg(feature = "serde")]
+mod serde_test;

--- a/itest/rust/src/builtin_tests/serde_test.rs
+++ b/itest/rust/src/builtin_tests/serde_test.rs
@@ -1,0 +1,79 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use crate::framework::itest;
+use godot::builtin::{array, Array, GString, NodePath, StringName, Vector2i};
+use serde::{Deserialize, Serialize};
+
+fn serde_roundtrip<T>(value: &T, expected_json: &str)
+where
+    T: for<'a> Deserialize<'a> + Serialize + PartialEq + std::fmt::Debug,
+{
+    let json: String = serde_json::to_string(value).unwrap();
+    let back: T = serde_json::from_str(json.as_str()).unwrap();
+
+    assert_eq!(back, *value, "serde round-trip changes value");
+    assert_eq!(
+        json, expected_json,
+        "value does not conform to expected JSON"
+    );
+}
+
+#[itest]
+fn serde_gstring() {
+    let value = GString::from("hello world");
+
+    let expected_json = "\"hello world\"";
+
+    serde_roundtrip(&value, expected_json);
+}
+
+#[itest]
+fn serde_node_path() {
+    let value = NodePath::from("res://icon.png");
+    let expected_json = "\"res://icon.png\"";
+
+    serde_roundtrip(&value, expected_json);
+}
+
+#[itest]
+fn serde_string_name() {
+    let value = StringName::from("hello world");
+    let expected_json = "\"hello world\"";
+
+    serde_roundtrip(&value, expected_json);
+}
+
+#[itest]
+fn serde_array_rust_native_type() {
+    let value: Array<i32> = array![1, 2, 3, 4, 5, 6];
+
+    let expected_json = r#"[1,2,3,4,5,6]"#;
+
+    serde_roundtrip(&value, expected_json)
+}
+
+#[itest]
+fn serde_array_godot_builtin_type() {
+    let value: Array<GString> = array!["Godot".into(), "Rust".into(), "Rocks".into()];
+
+    let expected_json = r#"["Godot","Rust","Rocks"]"#;
+
+    serde_roundtrip(&value, expected_json)
+}
+
+#[itest]
+fn serde_array_godot_type() {
+    let value: Array<Vector2i> = array![
+        Vector2i::new(1, 1),
+        Vector2i::new(2, 2),
+        Vector2i::new(3, 3)
+    ];
+
+    let expected_json = r#"[{"x":1,"y":1},{"x":2,"y":2},{"x":3,"y":3}]"#;
+
+    serde_roundtrip(&value, expected_json)
+}


### PR DESCRIPTION
I used https://github.com/godot-rust/gdnative/pull/743 as a base PR, so thanks @lilizoey 

I created some `itest` for testing these types.

You can use locally with:
```bash
./check.sh itest --use-serde -f serde_roundtrip
```

For executing tests, the CI needs to add the `serde` (not `godot/serde`) to the features on the `itest` crate. If there is a better solution for this, please, let me know.