### PR TITLE
Implement timers called out in #432

### DIFF
--- a/examples/dodge-the-creeps/rust/src/hud.rs
+++ b/examples/dodge-the-creeps/rust/src/hud.rs
@@ -26,6 +26,12 @@ impl Hud {
     pub fn show_game_over(&self) {
         self.show_message("Game Over".into());
 
+        let mut timer = self.base.get_tree().unwrap().create_timer(2.0).unwrap();
+        timer.connect("timeout".into(), self.base.callable("show_start_button"));
+    }
+
+    #[func]
+    fn show_start_button(&mut self) {
         let mut message_label = self.base.get_node_as::<Label>("MessageLabel");
         message_label.set_text("Dodge the\nCreeps!".into());
         message_label.show();

--- a/godot-codegen/src/codegen_special_cases.rs
+++ b/godot-codegen/src/codegen_special_cases.rs
@@ -120,12 +120,12 @@ pub(crate) fn is_function_excluded(function: &UtilityFunction, ctx: &mut Context
 #[cfg(not(feature = "codegen-full"))]
 const SELECTED_CLASSES: &[&str] = &[
     "AnimatedSprite2D",
-    "ArrayMesh",
     "Area2D",
+    "ArrayMesh",
     "AudioStreamPlayer",
     "BaseButton",
-    "Button",
     "BoxMesh",
+    "Button",
     "Camera2D",
     "Camera3D",
     "CanvasItem",
@@ -164,6 +164,7 @@ const SELECTED_CLASSES: &[&str] = &[
     "ResourceLoader",
     "RigidBody2D",
     "SceneTree",
+    "SceneTreeTimer",
     "Script",
     "ScriptExtension",
     "ScriptLanguage",
@@ -176,6 +177,6 @@ const SELECTED_CLASSES: &[&str] = &[
     "TextureLayered",
     "Time",
     "Timer",
-    "Window",
     "Viewport",
+    "Window",
 ];


### PR DESCRIPTION
in #432 a proposed solution was offered. I've implemented it on my machine and it works. Here's that change.

`_show_start_button` was used to make cargo warnings go away.