### PR TITLE
Use nightly godot4-prebuilt for unit-test and clippy

### DIFF
--- a/.github/composite/godot-itest/action.yml
+++ b/.github/composite/godot-itest/action.yml
@@ -86,35 +86,46 @@ runs:
     - name: "Patch prebuilt version ({{ inputs.godot-prebuilt-patch }})"
       if: inputs.godot-prebuilt-patch != ''
       env:
-        VERSION: ${{ inputs.godot-prebuilt-patch }}
+        PATCHED_VERSION: ${{ inputs.godot-prebuilt-patch }}
       # sed -i'' needed for macOS compatibility, see https://stackoverflow.com/q/4247068
       run: |
-        echo "Patch prebuilt version to $VERSION..."
+        # Find the godot4-prebuilt version that gdext currently depends on.
+        defaultVersion=$(grep 'godot4-prebuilt = {' godot-bindings/Cargo.toml | sed -n 's/.*branch = "\([^"]*\)".*/\1/p')
+        if [ -z "$defaultVersion" ]; then
+          echo "::error::prebuilt version not found or format is incorrect."
+          exit 1
+        else
+          echo "Default prebuilt version: $defaultVersion"
+        fi
         
-        # Reduce version to "major.minor" format
-        apiVersion=$(echo $VERSION | sed -E 's/([0-9]+\.[0-9]+)\.[0-9]+/\1/')
+        # Apply [patch] for godot4-prebuilt crate if needed.
+        if [[ "$PATCHED_VERSION" != $defaultVersion ]]; then
+          .github/other/patch-prebuilt.sh "$PATCHED_VERSION"
+        fi
         
-        # For newer versions, update the compatibility_minimum in .gdextension files to the respective version.
-        # Nothing needs to be done for 4.0.x, as compatibility_minimum didn't exist back then.
-        if [[ "$apiVersion" == "4.2" ]]; then
+        # Reduce versions to "major.minor" format.
+        apiVersion=$(echo "$PATCHED_VERSION" | sed -E 's/([0-9]+\.[0-9]+)\.[0-9]+/\1/')
+        apiDefaultVersion=$(echo "$defaultVersion" | sed -E 's/([0-9]+\.[0-9]+)\.[0-9]+/\1/')
+        
+        # For newer versions, update 'compatibility_minimum' in .gdextension files to the respective version.
+        # Nothing needs to be done for 4.0.x, as compatibility_minimum didn't exist back then (we do it due to easier code, anyway).
+        if [[ "$apiVersion" == "$apiDefaultVersion" ]]; then
+          echo "Already has version $version; no need to change compatibility_minimum."
+      
+        else
           echo "Update compatibility_minimum in .gdextension files to '$apiVersion'..."
           dirs=("itest" "examples")
+        
+          # Note that this is still hardcoded to 4.1, the start of GDExtension's compatibility promise. This makes it easier for users
+          # to use gdext with older Godot versions. There is anyway a runtime check in gdext that checks compatibility again.
           for dir in "${dirs[@]}"; do
-              find "$dir" -type f -name "*.gdextension" -exec sed -i'.bak' 's/compatibility_minimum = 4\.1/compatibility_minimum = $apiVersion/' {} +
+              find "$dir" -type f -name "*.gdextension" -exec sed -i'.bak' "s/compatibility_minimum = 4\.1/compatibility_minimum = $apiVersion/" {} +
           done
         
-        # Apply Cargo.toml patch for godot4-prebuilt crate
-        else
-          # Patch only needed if version is not already set
-          if grep -E 'godot4-prebuilt = { .+ branch = "$VERSION" }' godot-bindings/Cargo.toml; then
-            echo "Already has version $version; no need for patch."
-          else
-            cat << HEREDOC >> Cargo.toml
-        [patch."https://github.com/godot-rust/godot4-prebuilt"]
-        godot4-prebuilt = { git = "https://github.com//godot-rust/godot4-prebuilt", branch = "$VERSION" }
-        HEREDOC
-            echo "Patched Cargo.toml for version $version."
-          fi
+          echo "Example output: itest/godot/itest.gdextension"
+          echo "----------------------------------------------------"
+          cat itest/godot/itest.gdextension
+          echo "----------------------------------------------------"
         fi
 
       shell: bash

--- a/.github/other/patch-prebuilt.sh
+++ b/.github/other/patch-prebuilt.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Copyright (c) godot-rust; Bromeon and contributors.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+# Sets up a patch in Cargo.toml to use godot4-prebuilt artifacts.
+# Input: $version
+
+version="$1"
+
+cat << HEREDOC >> Cargo.toml
+[patch."https://github.com/godot-rust/godot4-prebuilt"]
+godot4-prebuilt = { git = "https://github.com//godot-rust/godot4-prebuilt", branch = "$version" }
+HEREDOC
+
+echo "Patched Cargo.toml for version $version."

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -52,6 +52,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - name: "Patch Cargo.toml to use nightly extension API"
+      run: .github/other/patch-prebuilt.sh nightly
+
     - name: "Install Rust"
       uses: ./.github/composite/rust
       with:
@@ -69,6 +72,9 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
+
+      - name: "Patch Cargo.toml to use nightly extension API"
+        run: .github/other/patch-prebuilt.sh nightly
 
       - name: "Install Rust"
         uses: ./.github/composite/rust
@@ -123,6 +129,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+
+      - name: "Patch Cargo.toml to use nightly extension API"
+        # Only on Linux because godot4-prebuilt/nightly branch doesn't have artifacts for other platforms.
+        if: matrix.name == 'linux' && matrix.rust-special == ''
+        run: .github/other/patch-prebuilt.sh nightly
 
       - name: "Install Rust"
         uses: ./.github/composite/rust

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -35,7 +35,7 @@ jobs:
   rustfmt:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: "Install Rust"
         uses: ./.github/composite/rust
@@ -50,7 +50,7 @@ jobs:
   doc-lints:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: "Patch Cargo.toml to use nightly extension API"
       run: .github/other/patch-prebuilt.sh nightly
@@ -71,7 +71,7 @@ jobs:
   clippy:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: "Patch Cargo.toml to use nightly extension API"
         run: .github/other/patch-prebuilt.sh nightly
@@ -128,7 +128,7 @@ jobs:
             rust-special: -msrv
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: "Patch Cargo.toml to use nightly extension API"
         # Only on Linux because godot4-prebuilt/nightly branch doesn't have artifacts for other platforms.
@@ -308,7 +308,7 @@ jobs:
             rust-target: x86_64-unknown-linux-gnu
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: "Run Godot integration test"
         uses: ./.github/composite/godot-itest
@@ -328,10 +328,10 @@ jobs:
   license-guard:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: "Check license headers"
-        uses: apache/skywalking-eyes/header@v0.4.0
+        uses: apache/skywalking-eyes/header@v0.5.0
         with:
           # log: debug # optional: set the log level. The default value is `info`.
           config: .github/other/licenserc.yml

--- a/.github/workflows/minimal-ci.yml
+++ b/.github/workflows/minimal-ci.yml
@@ -77,6 +77,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: "Patch Cargo.toml to use nightly extension API"
+        run: .github/other/patch-prebuilt.sh nightly
+
       - name: "Install Rust"
         uses: ./.github/composite/rust
         with:
@@ -100,6 +103,9 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
+
+      - name: "Patch Cargo.toml to use nightly extension API"
+        run: .github/other/patch-prebuilt.sh nightly
 
       - name: "Install Rust"
         uses: ./.github/composite/rust

--- a/.github/workflows/minimal-ci.yml
+++ b/.github/workflows/minimal-ci.yml
@@ -41,7 +41,7 @@ jobs:
   rustfmt:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: "Install Rust"
         uses: ./.github/composite/rust
@@ -57,7 +57,7 @@ jobs:
   doc-lints:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: "Install Rust"
         uses: ./.github/composite/rust
@@ -75,7 +75,7 @@ jobs:
   clippy:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: "Patch Cargo.toml to use nightly extension API"
         run: .github/other/patch-prebuilt.sh nightly
@@ -102,7 +102,7 @@ jobs:
     name: unit-test
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: "Patch Cargo.toml to use nightly extension API"
         run: .github/other/patch-prebuilt.sh nightly
@@ -202,7 +202,7 @@ jobs:
             rust-target: x86_64-unknown-linux-gnu
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: "Run Godot integration test"
         uses: ./.github/composite/godot-itest
@@ -222,10 +222,10 @@ jobs:
   license-guard:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: "Check and fix license headers"
-        uses: apache/skywalking-eyes/header@v0.4.0
+        uses: apache/skywalking-eyes/header@v0.5.0
         with:
           # log: debug # optional: set the log level. The default value is `info`.
           config: .github/other/licenserc.yml

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       # Checkout is always needed, for the notify step
       - name: "Checkout"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # This is just a sanity check to make sure that the follow-up docs generation doesn't break.
       # So we use the Rust version provided by the GitHub runners, which hopefully is >= MSRV.


### PR DESCRIPTION
This should detect issues that are hidden behind `#[cfg(since_api = "4.x")]` for cases where 4.x is a future (not yet released) version. Until now, clippy and unit tests simply excluded such code.