### PR TITLE
hud-timers

### DIFF
--- a/examples/dodge-the-creeps/rust/src/hud.rs
+++ b/examples/dodge-the-creeps/rust/src/hud.rs
@@ -23,9 +23,15 @@ impl Hud {
         timer.start();
     }
 
-    pub fn show_game_over(&self) {
+    pub fn show_game_over(&mut self) {
         self.show_message("Game Over".into());
 
+        let mut timer = self.base.get_tree().unwrap().create_timer(2.0).unwrap();
+        timer.connect("timeout".into(), self.base.callable("show_start_button"));
+    }
+
+    #[func]
+    fn show_start_button(&mut self) {
         let mut message_label = self.base.get_node_as::<Label>("MessageLabel");
         message_label.set_text("Dodge the\nCreeps!".into());
         message_label.show();


### PR DESCRIPTION
This should work, however I'm getting this error only in the examples project. It is working in [my build](https://github.com/0awful/literate-dodge-the-creeps-rust) with effectively [the same code](https://github.com/0awful/literate-dodge-the-creeps-rust/blob/main/src/rust/src/hud.rs#L28)

```
error[E0599]: no method named `create_timer` found for struct `godot::prelude::Gd<SceneTree>` in the current scope
  --> examples/dodge-the-creeps/rust/src/hud.rs:29:55
   |
29 | ....unwrap().create_timer(2.0).unwrap();
   |              ^^^^^^^^^^^^ method not found in `Gd<SceneTree>`
```