### PR TITLE
Implementation of `EngineBitfield` trait

### DIFF
--- a/godot-codegen/src/codegen_special_cases.rs
+++ b/godot-codegen/src/codegen_special_cases.rs
@@ -43,6 +43,12 @@ fn is_type_excluded(ty: &str, ctx: &mut Context) -> bool {
                 None => false,
                 Some(class) => is_class_excluded(class.as_str()),
             },
+            RustTy::EngineBitfield {
+                surrounding_class, ..
+            } => match surrounding_class.as_ref() {
+                None => false,
+                Some(class) => is_class_excluded(class.as_str()),
+            },
             RustTy::EngineClass { inner_class, .. } => is_class_excluded(&inner_class.to_string()),
         }
     }

--- a/godot-codegen/src/lib.rs
+++ b/godot-codegen/src/lib.rs
@@ -185,6 +185,14 @@ enum RustTy {
         surrounding_class: Option<String>,
     },
 
+    /// `module::Bitfield`
+    EngineBitfield {
+        tokens: TokenStream,
+        /// `None` for globals
+        #[allow(dead_code)] // only read in minimal config
+        surrounding_class: Option<String>,
+    },
+
     /// `Gd<Node>`
     EngineClass {
         /// Tokens with full `Gd<T>`
@@ -219,6 +227,7 @@ impl ToTokens for RustTy {
             } => quote! { *mut #inner }.to_tokens(tokens),
             RustTy::EngineArray { tokens: path, .. } => path.to_tokens(tokens),
             RustTy::EngineEnum { tokens: path, .. } => path.to_tokens(tokens),
+            RustTy::EngineBitfield { tokens: path, .. } => path.to_tokens(tokens),
             RustTy::EngineClass { tokens: path, .. } => path.to_tokens(tokens),
         }
     }

--- a/godot-codegen/src/util.rs
+++ b/godot-codegen/src/util.rs
@@ -241,8 +241,37 @@ pub fn make_enum_definition(enum_: &Enum) -> TokenStream {
     unique_ords.sort();
     unique_ords.dedup();
 
-    let bitfield_ops = if enum_.is_bitfield {
-        let tokens = quote! {
+    let mut derives = vec!["Copy", "Clone", "Eq", "PartialEq", "Hash", "Debug"];
+
+    if enum_.is_bitfield {
+        derives.push("Default");
+    }
+
+    let derives = derives.into_iter().map(ident);
+
+    let index_enum_impl = if enum_.is_bitfield {
+        // Bitfields don't implement IndexEnum.
+        TokenStream::new()
+    } else {
+        // Enums implement IndexEnum only if they are "index-like" (see docs).
+        if let Some(enum_max) = try_count_index_enum(enum_) {
+            quote! {
+                impl crate::obj::IndexEnum for #enum_name {
+                    const ENUMERATOR_COUNT: usize = #enum_max;
+                }
+            }
+        } else {
+            TokenStream::new()
+        }
+    };
+
+    let bitfield_ops;
+    let self_as_trait;
+    let engine_impl;
+    let enum_ord_type;
+
+    if enum_.is_bitfield {
+        bitfield_ops = quote! {
             // impl #enum_name {
             //     pub const UNSET: Self = Self { ord: 0 };
             // }
@@ -254,97 +283,85 @@ pub fn make_enum_definition(enum_: &Enum) -> TokenStream {
                 }
             }
         };
+        enum_ord_type = quote! { u64 };
+        self_as_trait = quote! { <Self as crate::obj::EngineBitfield> };
+        engine_impl = quote! {
+            impl crate::obj::EngineBitfield for #enum_name {
+                fn try_from_ord(ord: u64) -> Option<Self> {
+                    Some(Self { ord })
+                }
 
-        Some(tokens)
-    } else {
-        None
-    };
-
-    let try_from_ord = if enum_.is_bitfield {
-        quote! {
-            fn try_from_ord(ord: i32) -> Option<Self> {
-                Some(Self { ord })
-            }
-        }
-    } else {
-        quote! {
-            fn try_from_ord(ord: i32) -> Option<Self> {
-                match ord {
-                    #( ord @ #unique_ords )|* => Some(Self { ord }),
-                    _ => None,
+                fn ord(self) -> u64 {
+                    self.ord
                 }
             }
-        }
-    };
-
-    let mut derives = vec!["Copy", "Clone", "Eq", "PartialEq", "Debug", "Hash"];
-
-    if enum_.is_bitfield {
-        derives.push("Default");
-    }
-
-    let index_enum_impl = if let Some(enum_max) = try_count_index_enum(enum_) {
-        quote! {
-            impl crate::obj::IndexEnum for #enum_name {
-                const ENUMERATOR_COUNT: usize = #enum_max;
-            }
-        }
+        };
     } else {
-        TokenStream::new()
-    };
+        bitfield_ops = TokenStream::new();
+        enum_ord_type = quote! { i32 };
+        self_as_trait = quote! { <Self as crate::obj::EngineEnum> };
+        engine_impl = quote! {
+            impl crate::obj::EngineEnum for #enum_name {
+                // fn try_from_ord(ord: i32) -> Option<Self> {
+                //     match ord {
+                //         #(
+                //             #matches
+                //         )*
+                //         _ => None,
+                //     }
+                // }
 
-    let derives = derives.into_iter().map(ident);
+                fn try_from_ord(ord: i32) -> Option<Self> {
+                    match ord {
+                        #( ord @ #unique_ords )|* => Some(Self { ord }),
+                        _ => None,
+                    }
+                }
+
+                fn ord(self) -> i32 {
+                    self.ord
+                }
+            }
+        };
+    };
 
     // Enumerator ordinal stored as i32, since that's enough to hold all current values and the default repr in C++.
     // Public interface is i64 though, for consistency (and possibly forward compatibility?).
-    // TODO maybe generalize GodotFfi over EngineEnum trait
+    // Bitfield ordinals are stored as u64. See also: https://github.com/godotengine/godot-cpp/pull/1320
     quote! {
         #[repr(transparent)]
         #[derive(#( #derives ),*)]
         pub struct #enum_name {
-            ord: i32
+            ord: #enum_ord_type
         }
         impl #enum_name {
             #(
                 #enumerators
             )*
         }
-        impl crate::obj::EngineEnum for #enum_name {
-            // fn try_from_ord(ord: i32) -> Option<Self> {
-            //     match ord {
-            //         #(
-            //             #matches
-            //         )*
-            //         _ => None,
-            //     }
-            // }
 
-            #try_from_ord
+        #engine_impl
 
-            fn ord(self) -> i32 {
-                self.ord
-            }
-        }
+        #bitfield_ops
+
         #index_enum_impl
 
         impl crate::builtin::meta::GodotConvert for #enum_name {
-            type Via = i32;
+            type Via = #enum_ord_type;
         }
 
         impl crate::builtin::meta::ToGodot for #enum_name {
             fn to_godot(&self) -> Self::Via {
-                <Self as crate::obj::EngineEnum>::ord(*self)
+                #self_as_trait::ord(*self)
             }
         }
 
         impl crate::builtin::meta::FromGodot for #enum_name {
             fn try_from_godot(via: Self::Via) -> std::result::Result<Self, crate::builtin::meta::ConvertError> {
-                <Self as crate::obj::EngineEnum>::try_from_ord(via)
+                #self_as_trait::try_from_ord(via)
                     .ok_or_else(|| crate::builtin::meta::FromGodotError::InvalidEnum.into_error(via))
             }
         }
-
-        #bitfield_ops
     }
 }
 
@@ -670,11 +687,28 @@ fn to_rust_type_uncached(full_ty: &GodotTy, ctx: &mut Context) -> RustTy {
         };
     }
 
-    let qualified_enum = ty
-        .strip_prefix("enum::")
-        .or_else(|| ty.strip_prefix("bitfield::"));
+    if let Some(bitfield) = ty.strip_prefix("bitfield::") {
+        return if let Some((class, enum_)) = bitfield.split_once('.') {
+            // Class-local bitfield.
+            let module = ModName::from_godot(class);
+            let bitfield_ty = make_enum_name(enum_);
 
-    if let Some(qualified_enum) = qualified_enum {
+            RustTy::EngineBitfield {
+                tokens: quote! { crate::engine::#module::#bitfield_ty},
+                surrounding_class: Some(class.to_string()),
+            }
+        } else {
+            // Global bitfield.
+            let bitfield_ty = make_enum_name(bitfield);
+
+            RustTy::EngineBitfield {
+                tokens: quote! { crate::engine::global::#bitfield_ty },
+                surrounding_class: None,
+            }
+        };
+    }
+
+    if let Some(qualified_enum) = ty.strip_prefix("enum::") {
         return if let Some((class, enum_)) = qualified_enum.split_once('.') {
             // Class-local enum
             let module = ModName::from_godot(class);
@@ -799,6 +833,7 @@ fn to_rust_expr_inner(expr: &str, ty: &RustTy, is_inner: bool) -> TokenStream {
     if let Ok(num) = expr.parse::<i64>() {
         let lit = Literal::i64_unsuffixed(num);
         return match ty {
+            RustTy::EngineBitfield { .. } => quote! { crate::obj::EngineBitfield::from_ord(#lit) },
             RustTy::EngineEnum { .. } => quote! { crate::obj::EngineEnum::from_ord(#lit) },
             RustTy::BuiltinIdent(ident) if ident == "Variant" => quote! { Variant::from(#lit) },
             RustTy::BuiltinIdent(ident)
@@ -948,6 +983,12 @@ fn gdscript_to_rust_expr() {
     };
     let ty_enum = Some(&ty_enum);
 
+    let ty_bitfield = RustTy::EngineBitfield {
+        tokens: quote! { SomeEnum },
+        surrounding_class: None,
+    };
+    let ty_bitfield = Some(&ty_bitfield);
+
     let ty_variant = RustTy::BuiltinIdent(ident("Variant"));
     let ty_variant = Some(&ty_variant);
 
@@ -996,6 +1037,9 @@ fn gdscript_to_rust_expr() {
 
         // enum (from int)
         ("7",                                              ty_enum,            quote! { crate::obj::EngineEnum::from_ord(7) }),
+
+        // bitfield (from int)
+        ("7",                                              ty_bitfield,        quote! { crate::obj::EngineBitfield::from_ord(7) }),
 
         // Variant (from int)
         ("8",                                              ty_variant,         quote! { Variant::from(8) }),

--- a/godot-core/src/builtin/meta/godot_convert/convert_error.rs
+++ b/godot-core/src/builtin/meta/godot_convert/convert_error.rs
@@ -135,6 +135,7 @@ pub(crate) enum FromGodotError {
         expected: array_inner::TypeInfo,
         got: array_inner::TypeInfo,
     },
+    /// InvalidEnum is also used by bitfields.
     InvalidEnum,
     ZeroInstanceId,
 }

--- a/godot-core/src/builtin/meta/mod.rs
+++ b/godot-core/src/builtin/meta/mod.rs
@@ -248,6 +248,7 @@ pub struct PropertyInfo {
 impl PropertyInfo {
     /// Converts to the FFI type. Keep this object allocated while using that!
     pub fn property_sys(&self) -> sys::GDExtensionPropertyInfo {
+        use crate::obj::EngineBitfield as _;
         use crate::obj::EngineEnum as _;
 
         sys::GDExtensionPropertyInfo {
@@ -261,6 +262,7 @@ impl PropertyInfo {
     }
 
     pub fn empty_sys() -> sys::GDExtensionPropertyInfo {
+        use crate::obj::EngineBitfield as _;
         use crate::obj::EngineEnum as _;
 
         sys::GDExtensionPropertyInfo {

--- a/godot-core/src/builtin/meta/registration/method.rs
+++ b/godot-core/src/builtin/meta/registration/method.rs
@@ -97,7 +97,7 @@ impl ClassMethodInfo {
     }
 
     pub fn register_extension_class_method(&self) {
-        use crate::obj::EngineEnum as _;
+        use crate::obj::EngineBitfield as _;
 
         let (return_value_info, return_value_metadata) = match &self.return_value {
             Some(info) => (Some(&info.info), info.metadata),

--- a/godot-core/src/obj/traits.rs
+++ b/godot-core/src/obj/traits.rs
@@ -182,6 +182,19 @@ pub trait EngineEnum: Copy {
     }
 }
 
+/// Auto-implemented for all engine-provided bitfields.
+pub trait EngineBitfield: Copy {
+    fn try_from_ord(ord: u64) -> Option<Self>;
+
+    /// Ordinal value of the bit flag, as specified in Godot.
+    fn ord(self) -> u64;
+
+    fn from_ord(ord: u64) -> Self {
+        Self::try_from_ord(ord)
+            .unwrap_or_else(|| panic!("ordinal {ord} does not map to any valid bit flag"))
+    }
+}
+
 /// Trait for enums that can be used as indices in arrays.
 ///
 /// The conditions for a Godot enum to be "index-like" are:

--- a/godot/src/lib.rs
+++ b/godot/src/lib.rs
@@ -235,6 +235,7 @@ pub mod prelude {
 
     // Make trait methods available
     pub use super::engine::NodeExt as _;
+    pub use super::obj::EngineBitfield as _;
     pub use super::obj::EngineEnum as _;
     pub use super::obj::UserClass as _; // new_gd(), alloc_gd()
     pub use super::obj::WithBaseField as _; // to_gd()


### PR DESCRIPTION
This PR partially concerns issue #503 and implements decoupling of enums and bitfields in codegen, in a way, where they are split into an already existing `EngineEnum` trait and the newly implemented `EngineBitfield` trait, where bitfield ords use `u64` whereas enum ords use `i32`.

Since this is my first PR on the subject of codegen, there may be logical errors in my assumptions, weird code style, code that doesn't need to be there, or general noob-ish code. Please do tell me about any such issues, so I may learn and improve, and subsequently correct them. :)

Since this PR is splitting off enums and bitfields in a more explicit way, this introduces breaking changes for those that have used a bitfield in their projects prior to this change. Specifically on the importing side of things. Not a huge issue, since the language server should pick up on where the type lives and therefore users can easily fix this.

This implementation can lead to potentially more flexibility to bitfields. We have the bitwise operation `BitOr`. Could `BitAnd`, `BitXor` or `BitNot` be useful to implement in some capacity here?

It is my understanding that methods that use bitfields already use the type, and therefore don't need any refactoring, I may be completely wrong in that assumption. If there are any such instances, we should change them in this PR.

Thanks for the feedback.