### PR TITLE
Make ConvertError: Send + Sync

### DIFF
--- a/godot-core/src/builtin/array.rs
+++ b/godot-core/src/builtin/array.rs
@@ -815,7 +815,7 @@ impl<T: GodotType> GodotFfiVariant for Array<T> {
                 expected: Self::variant_type(),
                 got: variant.get_type(),
             }
-            .into_error(variant.clone()));
+            .into_error(variant));
         }
 
         let array = unsafe {

--- a/godot-core/src/builtin/meta/godot_convert/convert_error.rs
+++ b/godot-core/src/builtin/meta/godot_convert/convert_error.rs
@@ -19,7 +19,7 @@ type Cause = Box<dyn Error + Send + Sync>;
 pub struct ConvertError {
     kind: ErrorKind,
     cause: Option<Cause>,
-    value: Option<Box<dyn fmt::Debug>>,
+    value: Option<String>,
 }
 
 impl ConvertError {
@@ -41,14 +41,20 @@ impl ConvertError {
     }
 
     /// Create a new custom error for a conversion with the value that failed to convert.
-    pub fn with_value<V: fmt::Debug + 'static>(value: V) -> Self {
+    pub fn with_value<V>(value: V) -> Self
+    where
+        V: fmt::Debug,
+    {
         let mut err = Self::custom();
-        err.value = Some(Box::new(value));
+        err.value = Some(format!("{value:?}"));
         err
     }
 
     /// Create a new custom error with a rust-error as an underlying cause for the conversion error.
-    pub fn with_cause<C: Into<Cause>>(cause: C) -> Self {
+    pub fn with_cause<C>(cause: C) -> Self
+    where
+        C: Into<Cause>,
+    {
         let mut err = Self::custom();
         err.cause = Some(cause.into());
         err
@@ -56,10 +62,14 @@ impl ConvertError {
 
     /// Create a new custom error with a rust-error as an underlying cause for the conversion error, and the
     /// value that failed to convert.
-    pub fn with_cause_value<C: Into<Cause>, V: fmt::Debug + 'static>(cause: C, value: V) -> Self {
+    pub fn with_cause_value<C, V>(cause: C, value: V) -> Self
+    where
+        C: Into<Cause>,
+        V: fmt::Debug,
+    {
         let mut err = Self::custom();
         err.cause = Some(cause.into());
-        err.value = Some(Box::new(value));
+        err.value = Some(format!("{value:?}"));
         err
     }
 
@@ -68,8 +78,8 @@ impl ConvertError {
         self.cause.as_deref()
     }
 
-    /// Returns the value that failed to convert, if one exists.
-    pub fn value(&self) -> Option<&(dyn fmt::Debug)> {
+    /// Returns a string representation of the value that failed to convert, if one exists.
+    pub fn value_str(&self) -> Option<&str> {
         self.value.as_deref()
     }
 
@@ -140,11 +150,14 @@ pub(crate) enum FromGodotError {
 }
 
 impl FromGodotError {
-    pub fn into_error<V: fmt::Debug + 'static>(self, value: V) -> ConvertError {
+    pub fn into_error<V>(self, value: V) -> ConvertError
+    where
+        V: fmt::Debug,
+    {
         ConvertError {
             kind: ErrorKind::FromGodot(self),
             cause: None,
-            value: Some(Box::new(value)),
+            value: Some(format!("{value:?}")),
         }
     }
 
@@ -199,11 +212,14 @@ pub(crate) enum FromFfiError {
 }
 
 impl FromFfiError {
-    pub fn into_error<V: fmt::Debug + 'static>(self, value: V) -> ConvertError {
+    pub fn into_error<V>(self, value: V) -> ConvertError
+    where
+        V: fmt::Debug,
+    {
         ConvertError {
             kind: ErrorKind::FromFfi(self),
             cause: None,
-            value: Some(Box::new(value)),
+            value: Some(format!("{value:?}")),
         }
     }
 
@@ -237,11 +253,14 @@ pub(crate) enum FromVariantError {
 }
 
 impl FromVariantError {
-    pub fn into_error<V: fmt::Debug + 'static>(self, value: V) -> ConvertError {
+    pub fn into_error<V>(self, value: V) -> ConvertError
+    where
+        V: fmt::Debug,
+    {
         ConvertError {
             kind: ErrorKind::FromVariant(self),
             cause: None,
-            value: Some(Box::new(value)),
+            value: Some(format!("{value:?}")),
         }
     }
 
@@ -255,4 +274,9 @@ impl FromVariantError {
             }
         }
     }
+}
+
+fn __ensure_send_sync() {
+    fn check<T: Send + Sync>() {}
+    check::<ConvertError>();
 }

--- a/godot-core/src/builtin/variant/impls.rs
+++ b/godot-core/src/builtin/variant/impls.rs
@@ -42,7 +42,7 @@ macro_rules! impl_ffi_variant {
                         expected: Self::variant_type(),
                         got: variant.get_type(),
                     }
-                    .into_error(variant.clone()));
+                    .into_error(variant));
                 }
 
                 // For 4.0:
@@ -160,7 +160,7 @@ impl GodotFfiVariant for () {
             expected: VariantType::Nil,
             got: variant.get_type(),
         }
-        .into_error(variant.clone()))
+        .into_error(variant))
     }
 }
 

--- a/godot-macros/src/derive/derive_from_variant.rs
+++ b/godot-macros/src/derive/derive_from_variant.rs
@@ -262,7 +262,7 @@ fn make_enum_tuple(
         } else {
             quote! {
                 let #ident = variant.pop_front()
-                    .ok_or(ConvertError::with_cause_value("missing expected value", variant.clone()))?
+                    .ok_or(ConvertError::with_cause_value("missing expected value", &variant))?
                     .try_to::<#field_type>()?;
             }
         };
@@ -298,7 +298,7 @@ fn make_enum_named(
             let err = format!("missing expected value {field_name_string}");
             quote! {
                 let #field_name = variant.get(#field_name_string)
-                    .ok_or(ConvertError::with_cause_value(#err, variant.clone()))?
+                    .ok_or(ConvertError::with_cause_value(#err, &variant))?
                     .try_to::<#field_type>()?;
             }
         };


### PR DESCRIPTION
Instead of a value in a `Box<dyn Debug>`, which cannot really be used except for debug printing,
ConvertError now stores a string containing the Debug repr. `value()` method is now `value_str()`.

Adjusted call-sites to use reference where clones were previously necessary.

Also adds static test for `Send`/`Sync`.

Closes #523.