### PR TITLE
Fix bitfield values being implicitly wrapped to `i32`

### DIFF
--- a/godot-codegen/Cargo.toml
+++ b/godot-codegen/Cargo.toml
@@ -21,7 +21,7 @@ godot-bindings = { path = "../godot-bindings" }
 godot-fmt = { path = "../godot-fmt" }
 
 heck = "0.4"
-nanoserde = "0.1.29"
+nanoserde = "0.1.35"
 
 # Minimum versions compatible with -Zminimal-versions
 proc-macro2 = "1.0.63"

--- a/godot-codegen/src/api_parser.rs
+++ b/godot-codegen/src/api_parser.rs
@@ -116,7 +116,39 @@ impl BuiltinClassEnum {
 #[derive(DeJson, Clone)]
 pub struct EnumConstant {
     pub name: String,
-    pub value: i32,
+
+    // i64 is common denominator for enum, bitfield and constant values.
+    // Note that values > i64::MAX will be implicitly wrapped, see https://github.com/not-fl3/nanoserde/issues/89.
+    pub value: i64,
+}
+
+impl EnumConstant {
+    pub fn to_enum_ord(&self) -> i32 {
+        self.value.try_into().unwrap_or_else(|_| {
+            panic!(
+                "enum value {} = {} is out of range for i32, please report this",
+                self.name, self.value
+            )
+        })
+    }
+
+    pub fn to_bitfield_ord(&self) -> u64 {
+        self.value.try_into().unwrap_or_else(|_| {
+            panic!(
+                "bitfield value {} = {} is negative, please report this",
+                self.name, self.value
+            )
+        })
+    }
+
+    pub fn to_constant(&self) -> i32 {
+        self.value.try_into().unwrap_or_else(|_| {
+            panic!(
+                "constant {} = {} is out of range for i32, please report this",
+                self.name, self.value
+            )
+        })
+    }
 }
 
 pub type ClassConstant = EnumConstant;

--- a/godot-codegen/src/context.rs
+++ b/godot-codegen/src/context.rs
@@ -149,7 +149,7 @@ impl<'a> Context<'a> {
                 ctx.notifications_by_class
                     .get_mut(class_name)
                     .expect("just inserted constants; must be present")
-                    .push((rust_constant, constant.value));
+                    .push((rust_constant, constant.to_enum_ord()));
             }
         }
     }


### PR DESCRIPTION
The original data model for `EnumConstant` assumed that all Godot values would fit, and that deserialization would fail otherwise. Due to a bug in nanoserde (https://github.com/not-fl3/nanoserde/issues/89), these were silently wrapped, creating wrong values.

This commit uses i64 for deserialization and subsequently narrows down the values *safely* to the appropriate integer types:
- `i32` for enums
- `i32` for constants
- `u64` for bitfields (note that a problem still persists for values > `i64::MAX

This also fixes a few cases of Godot's own bitflags, which were previously mapped wrong.