### PR TITLE
Added support for parsing i32, u32, i64, and u64 constants

### DIFF
--- a/godot-codegen/src/api_parser.rs
+++ b/godot-codegen/src/api_parser.rs
@@ -122,6 +122,11 @@ pub struct EnumConstant {
     pub value: i64,
 }
 
+pub enum ConstValue {
+    I32(i32),
+    I64(i64),
+}
+
 impl EnumConstant {
     pub fn to_enum_ord(&self) -> i32 {
         self.value.try_into().unwrap_or_else(|_| {
@@ -141,13 +146,12 @@ impl EnumConstant {
         })
     }
 
-    pub fn to_constant(&self) -> i32 {
-        self.value.try_into().unwrap_or_else(|_| {
-            panic!(
-                "constant {} = {} is out of range for i32, please report this",
-                self.name, self.value
-            )
-        })
+    pub fn to_constant(&self) -> ConstValue {
+        if let Ok(value) = i32::try_from(self.value) {
+            ConstValue::I32(value)
+        } else {
+            ConstValue::I64(self.value)
+        }
     }
 }
 


### PR DESCRIPTION
Previously, the code gen would panic if it encountered constants that were out of range of i32.  Now it handles those edge cases and attempts to store the value in increasingly larger data types up to ``u64`` before it panics.

It would be nice to in the future get a report of exactly what data types the constants are.  But that would likely require making changes in the godot codebase to generate us more detailed reports.  For now, this is a nice alternative that prevents the codegen from panicking.

And even in the future if these improvements are made to godot, this would still be a nice fallback for cases if there are problems on godot's side.

Let me know if you want any changes on this PR :)