### PR TITLE
`save` and `try_save` functions and IO-utilites refactor in godot_core::engine refactor

### DIFF
--- a/godot-codegen/src/codegen_special_cases.rs
+++ b/godot-codegen/src/codegen_special_cases.rs
@@ -162,6 +162,7 @@ const SELECTED_CLASSES: &[&str] = &[
     "Resource",
     "ResourceFormatLoader",
     "ResourceLoader",
+    "ResourceSaver",
     "RigidBody2D",
     "SceneTree",
     "SceneTreeTimer",

--- a/godot-core/src/engine/io/gfile.rs
+++ b/godot-core/src/engine/io/gfile.rs
@@ -9,14 +9,12 @@ use crate::builtin::{real, GString, PackedByteArray, PackedStringArray, Variant}
 use crate::engine::file_access::{CompressionMode, ModeFlags};
 use crate::gen::central::global::Error;
 use crate::gen::classes::FileAccess;
-use crate::obj::{Gd, Inherits};
+use crate::obj::{Gd, NotUniqueError};
 
 use std::cmp;
 use std::io::{
     BufRead, Error as IoError, ErrorKind, Read, Result as IoResult, Seek, SeekFrom, Write,
 };
-
-use super::RefCounted;
 
 /// Open a file for reading or writing.
 ///
@@ -830,87 +828,5 @@ impl BufRead for GFile {
         let pos = SeekFrom::Current(-offset);
 
         self.seek(pos).expect("failed to consume bytes during read");
-    }
-}
-
-// ----------------------------------------------------------------------------------------------------------------------------------------------
-// Errors.
-
-/// Error stemming from the non-uniqueness of the [`Gd`] instance.
-///
-/// Keeping track of the uniqueness of references can be crucial in many applications, especially if we want to ensure
-/// that the passed [`Gd`] reference will be possessed by only one different object instance or function in its lifetime.
-///
-/// Only applicable to [`GodotClass`](crate::obj::GodotClass) objects that inherit from [`RefCounted`]. To check the
-/// uniqueness, call the `check()` associated method.
-///
-/// ## Example
-///
-/// ```no_run
-/// use godot::engine::RefCounted;
-/// use godot::engine::NotUniqueError;
-///
-/// let shared = RefCounted::new();
-/// let cloned = shared.clone();
-/// let result = NotUniqueError::check(shared);
-///
-/// assert!(result.is_err());
-///
-/// if let Err(error) = result {
-///     assert_eq!(error.get_reference_count(), 2)
-/// }
-/// ```
-#[derive(Debug)]
-pub struct NotUniqueError {
-    reference_count: i32,
-}
-
-impl NotUniqueError {
-    /// check [`Gd`] reference uniqueness.
-    ///
-    /// Checks the [`Gd`] of the [`GodotClass`](crate::obj::GodotClass) that inherits from [`RefCounted`] if it is unique
-    /// reference to the object.
-    ///
-    /// ## Example
-    ///
-    /// ```no_run
-    /// use godot::engine::RefCounted;
-    /// use godot::engine::NotUniqueError;
-    ///
-    /// let unique = RefCounted::new();
-    /// assert!(NotUniqueError::check(unique).is_ok());
-    ///
-    /// let shared = RefCounted::new();
-    /// let cloned = shared.clone();
-    /// assert!(NotUniqueError::check(shared).is_err());
-    /// assert!(NotUniqueError::check(cloned).is_err());
-    /// ```
-    pub fn check<T>(rc: Gd<T>) -> Result<Gd<T>, Self>
-    where
-        T: Inherits<RefCounted>,
-    {
-        let rc = rc.upcast::<RefCounted>();
-        let reference_count = rc.get_reference_count();
-
-        if reference_count != 1 {
-            Err(Self { reference_count })
-        } else {
-            Ok(rc.cast::<T>())
-        }
-    }
-
-    /// Get the detected reference count
-    pub fn get_reference_count(&self) -> i32 {
-        self.reference_count
-    }
-}
-
-impl std::fmt::Display for NotUniqueError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "pointer is not unique, current reference count: {}",
-            self.reference_count
-        )
     }
 }

--- a/godot-core/src/engine/io/io_error.rs
+++ b/godot-core/src/engine/io/io_error.rs
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use std::error::Error;
+
+use crate::engine::global::Error as GodotError;
+use crate::gen::classes::FileAccess;
+use crate::obj::{Gd, NotUniqueError};
+
+/// Error that can occur while using `gdext` IO utilities.
+#[derive(Debug)]
+pub struct IoError {
+    data: ErrorData,
+}
+
+impl std::fmt::Display for IoError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.data {
+            ErrorData::Load(err) => err.fmt(f),
+            ErrorData::Save(err) => err.fmt(f),
+            ErrorData::GFile(err) => err.fmt(f),
+        }
+    }
+}
+
+impl Error for IoError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        if let ErrorData::GFile(GFileError {
+            kind: GFileErrorKind::NotUniqueRef(err),
+            ..
+        }) = &self.data
+        {
+            return Some(err);
+        }
+        None
+    }
+}
+
+impl IoError {
+    pub(crate) fn saving(error: GodotError, class: String, path: String) -> Self {
+        Self {
+            data: ErrorData::Save(SaverError {
+                class,
+                path,
+                godot_error: error,
+            }),
+        }
+    }
+
+    pub(crate) fn loading(class: String, path: String) -> Self {
+        Self {
+            data: ErrorData::Load(LoaderError {
+                kind: LoaderErrorKind::Load,
+                class,
+                path,
+            }),
+        }
+    }
+
+    pub(crate) fn loading_cast(class: String, path: String) -> Self {
+        Self {
+            data: ErrorData::Load(LoaderError {
+                kind: LoaderErrorKind::Cast,
+                class,
+                path,
+            }),
+        }
+    }
+
+    pub(crate) fn check_unique_open_file_access(
+        file_access: Gd<FileAccess>,
+    ) -> Result<Gd<FileAccess>, Self> {
+        let path = file_access.get_path();
+
+        if !file_access.is_open() {
+            return Err(Self {
+                data: ErrorData::GFile(GFileError {
+                    kind: GFileErrorKind::NotOpen,
+                    path: path.to_string(),
+                }),
+            });
+        }
+
+        match NotUniqueError::check(file_access) {
+            Ok(gd) => Ok(gd),
+            Err(err) => Err(Self {
+                data: ErrorData::GFile(GFileError {
+                    kind: GFileErrorKind::NotUniqueRef(err),
+                    path: path.to_string(),
+                }),
+            }),
+        }
+    }
+}
+
+#[derive(Debug)]
+enum ErrorData {
+    Load(LoaderError),
+    Save(SaverError),
+    GFile(GFileError),
+}
+
+#[derive(Debug)]
+struct LoaderError {
+    kind: LoaderErrorKind,
+    class: String,
+    path: String,
+}
+
+#[derive(Debug)]
+enum LoaderErrorKind {
+    Load,
+    Cast,
+}
+
+impl std::fmt::Display for LoaderError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let class = &self.class;
+        let path = &self.path;
+
+        match &self.kind {
+            LoaderErrorKind::Load => write!(
+                f,
+                "can't load resource of class: '{class}' from path: '{path}'"
+            ),
+            LoaderErrorKind::Cast => write!(
+                f,
+                "can't cast loaded resource to class: '{class}' from path: '{path}'"
+            ),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct SaverError {
+    class: String,
+    path: String,
+    godot_error: GodotError,
+}
+
+impl std::fmt::Display for SaverError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let class = &self.class;
+        let path = &self.path;
+        let godot_error = &self.godot_error;
+
+        write!(f, "can't save resource of class: '{class}' to path: '{path}'; Godot error: {godot_error:?}")
+    }
+}
+
+#[derive(Debug)]
+struct GFileError {
+    kind: GFileErrorKind,
+    path: String,
+}
+
+#[derive(Debug)]
+enum GFileErrorKind {
+    NotUniqueRef(NotUniqueError),
+    NotOpen,
+}
+
+impl std::fmt::Display for GFileError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let path = &self.path;
+
+        match &self.kind {
+            GFileErrorKind::NotUniqueRef(err) => {
+                write!(f, "access to file '{path}' is not unique: '{err}'")
+            }
+            GFileErrorKind::NotOpen => write!(f, "access to file '{path}' is not open"),
+        }
+    }
+}

--- a/godot-core/src/engine/io/mod.rs
+++ b/godot-core/src/engine/io/mod.rs
@@ -6,7 +6,9 @@
  */
 
 mod gfile;
+mod io_error;
 mod resources;
 
 pub use gfile::GFile;
-pub use resources::{load, try_load};
+pub use io_error::*;
+pub use resources::{load, save, try_load, try_save};

--- a/godot-core/src/engine/io/mod.rs
+++ b/godot-core/src/engine/io/mod.rs
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+mod gfile;
+mod resources;
+
+pub use gfile::GFile;
+pub use resources::{load, try_load};

--- a/godot-core/src/engine/io/resources.rs
+++ b/godot-core/src/engine/io/resources.rs
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use crate::builtin::GString;
+use crate::gen::classes::{Resource, ResourceLoader};
+use crate::obj::{Gd, GodotClass, Inherits};
+
+/// Loads a resource from the filesystem located at `path`, panicking on error.
+///
+/// See [`try_load`] for more information.
+///
+/// # Example
+///
+/// ```no_run
+/// use godot::prelude::*;
+///
+/// let scene = load::<PackedScene>("res://path/to/Main.tscn");
+/// ```
+///
+/// # Panics
+/// If the resource cannot be loaded, or is not of type `T` or inherited.
+#[inline]
+pub fn load<T>(path: impl Into<GString>) -> Gd<T>
+where
+    T: GodotClass + Inherits<Resource>,
+{
+    let path = path.into();
+    load_impl(&path).unwrap_or_else(|| panic!("failed to load node at path `{path}`"))
+}
+
+/// Loads a resource from the filesystem located at `path`.
+///
+/// The resource is loaded on the method call (unless it's referenced already elsewhere, e.g. in another script or in the scene),
+/// which might cause slight delay, especially when loading scenes.
+///
+/// If the resource cannot be loaded, or is not of type `T` or inherited, this method returns `None`.
+///
+/// This method is a simplified version of [`ResourceLoader::load()`][crate::engine::ResourceLoader::load],
+/// which can be used for more advanced scenarios.
+///
+/// # Note:
+/// Resource paths can be obtained by right-clicking on a resource in the Godot editor (_FileSystem_ dock) and choosing "Copy Path",
+/// or by dragging the file from the _FileSystem_ dock into the script.
+///
+/// The path must be absolute (typically starting with `res://`), a local path will fail.
+///
+/// # Example
+/// Loads a scene called `Main` located in the `path/to` subdirectory of the Godot project and caches it in a variable.
+/// The resource is directly stored with type `PackedScene`.
+///
+/// ```no_run
+/// use godot::prelude::*;
+///
+/// if let Some(scene) = try_load::<PackedScene>("res://path/to/Main.tscn") {
+///     // all good
+/// } else {
+///     // handle error
+/// }
+/// ```
+// TODO Result to differentiate 2 errors
+#[inline]
+pub fn try_load<T>(path: impl Into<GString>) -> Option<Gd<T>>
+where
+    T: GodotClass + Inherits<Resource>,
+{
+    load_impl(&path.into())
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// Implementation of this file
+
+// Separate function, to avoid constructing string twice
+// Note that more optimizations than that likely make no sense, as loading is quite expensive
+fn load_impl<T>(path: &GString) -> Option<Gd<T>>
+where
+    T: GodotClass + Inherits<Resource>,
+{
+    ResourceLoader::singleton()
+        .load_ex(path.clone())
+        .type_hint(T::class_name().to_godot_string())
+        .done() // TODO unclone
+        .and_then(|res| res.try_cast::<T>().ok())
+}

--- a/godot-core/src/engine/io/resources.rs
+++ b/godot-core/src/engine/io/resources.rs
@@ -6,8 +6,11 @@
  */
 
 use crate::builtin::GString;
-use crate::gen::classes::{Resource, ResourceLoader};
+use crate::engine::global::Error as GodotError;
+use crate::gen::classes::{Resource, ResourceLoader, ResourceSaver};
 use crate::obj::{Gd, GodotClass, Inherits};
+
+use super::IoError;
 
 /// Loads a resource from the filesystem located at `path`, panicking on error.
 ///
@@ -29,7 +32,7 @@ where
     T: GodotClass + Inherits<Resource>,
 {
     let path = path.into();
-    load_impl(&path).unwrap_or_else(|| panic!("failed to load node at path `{path}`"))
+    load_impl(&path).unwrap_or_else(|err| panic!("failed: {err}"))
 }
 
 /// Loads a resource from the filesystem located at `path`.
@@ -37,7 +40,7 @@ where
 /// The resource is loaded on the method call (unless it's referenced already elsewhere, e.g. in another script or in the scene),
 /// which might cause slight delay, especially when loading scenes.
 ///
-/// If the resource cannot be loaded, or is not of type `T` or inherited, this method returns `None`.
+/// This function can fail if resource can't be loaded by [`ResourceLoader`] or if the subsequent cast into `T` fails.
 ///
 /// This method is a simplified version of [`ResourceLoader::load()`][crate::engine::ResourceLoader::load],
 /// which can be used for more advanced scenarios.
@@ -55,19 +58,78 @@ where
 /// ```no_run
 /// use godot::prelude::*;
 ///
-/// if let Some(scene) = try_load::<PackedScene>("res://path/to/Main.tscn") {
+/// if let Ok(scene) = try_load::<PackedScene>("res://path/to/Main.tscn") {
 ///     // all good
 /// } else {
 ///     // handle error
 /// }
 /// ```
-// TODO Result to differentiate 2 errors
 #[inline]
-pub fn try_load<T>(path: impl Into<GString>) -> Option<Gd<T>>
+pub fn try_load<T>(path: impl Into<GString>) -> Result<Gd<T>, IoError>
 where
     T: GodotClass + Inherits<Resource>,
 {
     load_impl(&path.into())
+}
+
+/// Saves a [`Resource`]-inheriting [`GodotClass`] `obj` into file located at `path`.
+///
+/// See [`try_save`] for more information.
+///
+/// # Panics
+/// If the resouce cannot be saved.
+///
+/// # Example
+/// ```no_run
+/// use godot::prelude::*;
+/// use godot::engine::save;
+///
+/// save(Resource::new(), "res://base_resource.tres")
+/// ```
+/// use godot::
+#[inline]
+pub fn save<T>(obj: Gd<T>, path: impl Into<GString>)
+where
+    T: GodotClass + Inherits<Resource>,
+{
+    let path = path.into();
+    save_impl(obj, &path)
+        .unwrap_or_else(|err| panic!("failed to save resource at path '{}': {}", &path, err));
+}
+
+/// Saves a [Resource]-inheriting [GodotClass] `obj` into file located at `path`.
+///
+/// This function can fail if [`ResourceSaver`] can't save the resource to file, as it is a simplified version of
+/// [`ResourceSaver::save()`][crate::engine::ResourceSaver::save]. The underlying method can be used for more advances scenarios.
+///
+/// # Note
+/// Target path must be presented in Godot-recognized format, mainly the ones beginning with `res://` and `user://`. Saving
+/// to `res://` is possible only when working with unexported project - after its export only `user://` is viable.
+///
+/// # Example
+/// ```no_run
+/// use godot::prelude::*;
+/// use godot::engine::try_save;
+///
+/// #[derive(GodotClass)]
+/// #[class(base=Resource, init)]
+/// struct SavedGame {
+///   // Exported properties are saved in `.tres` files.
+///   #[export]
+///   level: u32
+/// };
+///
+/// let save_state = SavedGame::new_gd();
+/// let res = try_save(save_state, "user://save.tres");
+///
+/// assert!(res.is_ok());
+/// ```
+#[inline]
+pub fn try_save<T>(obj: Gd<T>, path: impl Into<GString>) -> Result<(), IoError>
+where
+    T: GodotClass + Inherits<Resource>,
+{
+    save_impl(obj, &path.into())
 }
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
@@ -75,13 +137,46 @@ where
 
 // Separate function, to avoid constructing string twice
 // Note that more optimizations than that likely make no sense, as loading is quite expensive
-fn load_impl<T>(path: &GString) -> Option<Gd<T>>
+fn load_impl<T>(path: &GString) -> Result<Gd<T>, IoError>
 where
     T: GodotClass + Inherits<Resource>,
 {
-    ResourceLoader::singleton()
+    // TODO unclone GString
+    match ResourceLoader::singleton()
         .load_ex(path.clone())
-        .type_hint(T::class_name().to_godot_string())
-        .done() // TODO unclone
-        .and_then(|res| res.try_cast::<T>().ok())
+        .type_hint(T::class_name().to_gstring())
+        .done()
+    {
+        Some(res) => match res.try_cast::<T>() {
+            Ok(obj) => Ok(obj),
+            Err(_) => Err(IoError::loading_cast(
+                T::class_name().to_string(),
+                path.to_string(),
+            )),
+        },
+        None => Err(IoError::loading(
+            T::class_name().to_string(),
+            path.to_string(),
+        )),
+    }
+}
+
+fn save_impl<T>(obj: Gd<T>, path: &GString) -> Result<(), IoError>
+where
+    T: GodotClass + Inherits<Resource>,
+{
+    // TODO unclone GString
+    let res = ResourceSaver::singleton()
+        .save_ex(obj.upcast())
+        .path(path.clone())
+        .done();
+
+    if res == GodotError::OK {
+        return Ok(());
+    }
+    Err(IoError::saving(
+        res,
+        T::class_name().to_string(),
+        path.to_string(),
+    ))
 }

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -762,6 +762,8 @@ impl NotUniqueError {
     }
 }
 
+impl std::error::Error for NotUniqueError {}
+
 impl std::fmt::Display for NotUniqueError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(

--- a/itest/rust/src/engine_tests/gfile_test.rs
+++ b/itest/rust/src/engine_tests/gfile_test.rs
@@ -24,22 +24,6 @@ fn remove_test_file() {
 }
 
 #[itest]
-fn non_unique_error_works() {
-    use godot::engine::NotUniqueError;
-    use godot::engine::RefCounted;
-
-    let unique = RefCounted::new();
-    assert!(NotUniqueError::check(unique).is_ok());
-
-    let shared = RefCounted::new();
-    let cloned = shared.clone();
-    match NotUniqueError::check(cloned) {
-        Err(error) => assert_eq!(error.get_reference_count(), 2),
-        Ok(_) => panic!("NotUniqueError::check must not succeed"),
-    }
-}
-
-#[itest]
 fn basic_read_write_works() {
     let mut file = GFile::open(TEST_FULL_PATH, ModeFlags::WRITE).unwrap();
     let line_to_store = GString::from("TESTING1");

--- a/itest/rust/src/engine_tests/mod.rs
+++ b/itest/rust/src/engine_tests/mod.rs
@@ -8,4 +8,5 @@
 mod gfile_test;
 mod native_structures_test;
 mod node_test;
+mod save_load_test;
 mod utilities_test;

--- a/itest/rust/src/engine_tests/save_load_test.rs
+++ b/itest/rust/src/engine_tests/save_load_test.rs
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use godot::bind::GodotClass;
+use godot::engine::{load, save, try_load, try_save};
+use godot::obj::UserClass;
+
+use crate::framework::itest;
+
+fn remove_test_file(file_name: &str) {
+    let godot_path = std::path::Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/../godot/"));
+    let file_path = godot_path.join(file_name);
+    std::fs::remove_file(&file_path)
+        .unwrap_or_else(|_| panic!("couldn't remove test file: {}", file_path.display()));
+}
+
+#[derive(GodotClass)]
+#[class(base=Resource, init)]
+struct SavedGame {
+    #[export]
+    level: u32,
+}
+
+const RESOURCE_NAME: &str = "test_resource.tres";
+const FAULTY_PATH: &str = "no_such_path";
+
+#[itest]
+fn save_test() {
+    let res_path = format!("res://{}", RESOURCE_NAME);
+
+    let resource = SavedGame::new_gd();
+
+    let res = try_save(resource.clone(), FAULTY_PATH);
+    assert!(res.is_err());
+
+    let res = try_save(resource.clone(), &res_path);
+    assert!(res.is_ok());
+
+    save(resource.clone(), &res_path);
+
+    remove_test_file(RESOURCE_NAME);
+}
+
+#[itest]
+fn load_test() {
+    let level = 2317;
+    let res_path = format!("res://{}", RESOURCE_NAME);
+
+    let mut resource = SavedGame::new_gd();
+    resource.bind_mut().set_level(level);
+
+    save(resource.clone(), &res_path);
+
+    let res = try_load::<SavedGame>(FAULTY_PATH);
+    assert!(res.is_err());
+
+    let res = try_load::<SavedGame>(&res_path);
+    assert!(res.is_ok());
+
+    let loaded = res.unwrap();
+    assert_eq!(loaded.bind().get_level(), level);
+
+    let loaded = load::<SavedGame>(&res_path);
+    assert_eq!(loaded.bind().get_level(), level);
+
+    remove_test_file(RESOURCE_NAME);
+}

--- a/itest/rust/src/object_tests/object_test.rs
+++ b/itest/rust/src/object_tests/object_test.rs
@@ -989,8 +989,8 @@ struct CustomEditorPlugin;
 
 #[itest]
 fn non_unique_error_works() {
-    use godot::obj::NotUniqueError;
     use godot::engine::RefCounted;
+    use godot::obj::NotUniqueError;
 
     let unique = RefCounted::new();
     assert!(NotUniqueError::check(unique).is_ok());

--- a/itest/rust/src/object_tests/object_test.rs
+++ b/itest/rust/src/object_tests/object_test.rs
@@ -984,3 +984,21 @@ fn double_use_reference() {
 #[derive(GodotClass)]
 #[class(base = EditorPlugin, editor_plugin)]
 struct CustomEditorPlugin;
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+
+#[itest]
+fn non_unique_error_works() {
+    use godot::obj::NotUniqueError;
+    use godot::engine::RefCounted;
+
+    let unique = RefCounted::new();
+    assert!(NotUniqueError::check(unique).is_ok());
+
+    let shared = RefCounted::new();
+    let cloned = shared.clone();
+    match NotUniqueError::check(cloned) {
+        Err(error) => assert_eq!(error.get_reference_count(), 2),
+        Ok(_) => panic!("NotUniqueError::check must not succeed"),
+    }
+}


### PR DESCRIPTION
Initially addressing only #532, but after checking out TODOs and general structure some more proposed changes requiring opinions from maintainers:

- internal `godot_core::engine::io` module, containing all utility functions and structs regarding general I-O: loading, saving and file read/write,
- `try_load` returning `Result` instead of `Option`, allowing for distinguishing between _load failure_ and _casting failure_ (for the second possible recover, as the `Gd<Resource>` is encapsulated,
- `GFile::try_from_unique` returning `Error` if built from `Gd<FileAccess>` not in open state.

My main question would be about `GdIoError` - thematically it seems fitting to gather all errors stemming from `try_load`, `try_save` and `GFile::try_from_unique` under one enum (as in this draft). Functionally I have some doubts, as it could be limiting if we would like in future to extend the errors: `GdIoError::ResourceSave` would be a prime candidate, as we could potentially try to match Godot's `Error` to help user distinguish between the cases without requiring them to match it themselves.

On the other hand I don't know if introducing three new error types regarding each of these functionalities: `GdLoadError`, `GdSaveError` and `GFileError` wouldn't be considered a bloat.

Additionally, the currently used `IoResult` in `GFile` operations could be also put into `GdIoError`/`GFileError`, passing additional information about underlying Godot's `Error`.