### PR TITLE
Fix `ResourceImporter*` methods not found in Release mode; add Release CI

### DIFF
--- a/.github/composite/godot-itest/action.yml
+++ b/.github/composite/godot-itest/action.yml
@@ -51,6 +51,11 @@ inputs:
     default: ''
     description: "If provided, acts as an argument for '--target', and results in output files written to ./target/{target}"
 
+  rust-cache-key:
+    required: false
+    default: ''
+    description: "Extra key to resolve Rust cache"
+
   with-llvm:
     required: false
     default: ''
@@ -82,6 +87,7 @@ runs:
       with:
         rust: ${{ inputs.rust-toolchain }}
         with-llvm: ${{ inputs.with-llvm }}
+        cache-key: ${{ inputs.rust-cache-key }}
 
     - name: "Patch prebuilt version ({{ inputs.godot-prebuilt-patch }})"
       if: inputs.godot-prebuilt-patch != ''

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -230,17 +230,25 @@ jobs:
             godot-binary: godot.linuxbsd.editor.dev.x86_64
             rust-extra-args: --features godot/custom-godot
 
-          - name: linux-double
+          # Full codegen could also be moved to another job.
+          - name: linux-double-full
             os: ubuntu-20.04
             artifact-name: linux-double-nightly
             godot-binary: godot.linuxbsd.editor.dev.double.x86_64
-            rust-extra-args: --features godot/custom-godot,godot/double-precision
+            rust-extra-args: --features godot/custom-godot,godot/double-precision,godot/codegen-full
 
           - name: linux-features
             os: ubuntu-20.04
             artifact-name: linux-nightly
             godot-binary: godot.linuxbsd.editor.dev.x86_64
             rust-extra-args: --features godot/custom-godot,godot/experimental-threads,godot/serde
+
+          - name: linux-release
+            os: ubuntu-20.04
+            artifact-name: linux-release-nightly
+            godot-binary: godot.linuxbsd.template_release.x86_64
+            rust-extra-args: --release
+            rust-cache-key: release
 
           # TODO merge with other jobs
           - name: linux-lazy-fptrs
@@ -321,6 +329,7 @@ jobs:
           rust-toolchain: ${{ matrix.rust-toolchain || 'stable' }}
           rust-env-rustflags: ${{ matrix.rust-env-rustflags }}
           rust-target: ${{ matrix.rust-target }}
+          rust-cache-key: ${{ matrix.rust-cache-key }}
           with-llvm: ${{ contains(matrix.name, 'macos') && contains(matrix.rust-extra-args, 'custom-godot') }}
           godot-check-header: ${{ matrix.godot-check-header }}
 

--- a/godot-codegen/src/central_generator.rs
+++ b/godot-codegen/src/central_generator.rs
@@ -1021,7 +1021,7 @@ fn populate_class_methods(
     let mut method_inits = vec![];
 
     for method in option_as_slice(&class.methods) {
-        if special_cases::is_deleted(class_ty, method, ctx) {
+        if special_cases::is_class_method_deleted(class_ty, method, ctx) {
             continue;
         }
 
@@ -1084,7 +1084,7 @@ fn populate_builtin_methods(
 
     for method in option_as_slice(&builtin_class.methods) {
         let builtin_ty = TyName::from_godot(&builtin_class.name);
-        if special_cases::is_builtin_deleted(&builtin_ty, method) {
+        if special_cases::is_builtin_method_deleted(&builtin_ty, method) {
             continue;
         }
 

--- a/godot-codegen/src/codegen_special_cases.rs
+++ b/godot-codegen/src/codegen_special_cases.rs
@@ -55,7 +55,7 @@ fn is_type_excluded(ty: &str, ctx: &mut Context) -> bool {
     is_rust_type_excluded(&util::to_rust_type(ty, None, ctx))
 }
 
-pub(crate) fn is_method_excluded(
+pub(crate) fn is_class_method_excluded(
     method: &ClassMethod,
     is_virtual_impl: bool,
     ctx: &mut Context,

--- a/godot-codegen/src/context.rs
+++ b/godot-codegen/src/context.rs
@@ -165,7 +165,7 @@ impl<'a> Context<'a> {
         }
 
         for method in methods.iter() {
-            if special_cases::is_deleted(class_name, method, ctx) {
+            if special_cases::is_class_method_deleted(class_name, method, ctx) {
                 continue;
             }
 
@@ -190,7 +190,7 @@ impl<'a> Context<'a> {
         }
 
         for method in methods.iter() {
-            if special_cases::is_builtin_deleted(&builtin_ty, method) {
+            if special_cases::is_builtin_method_deleted(&builtin_ty, method) {
                 continue;
             }
 

--- a/godot-codegen/src/util.rs
+++ b/godot-codegen/src/util.rs
@@ -8,7 +8,7 @@
 use crate::api_parser::{
     BuiltinClassMethod, Class, ClassConstant, ClassMethod, ConstValue, Enum, UtilityFunction,
 };
-use crate::special_cases::is_builtin_scalar;
+use crate::special_cases::is_builtin_type_scalar;
 use crate::{Context, GodotTy, ModName, RustTy, TyName};
 
 use proc_macro2::{Ident, Literal, TokenStream};
@@ -640,7 +640,7 @@ fn to_rust_type_uncached(full_ty: &GodotTy, ctx: &mut Context) -> RustTy {
 
     /// Transforms a Godot class/builtin/enum IDENT (without `::` or other syntax) to a Rust one
     fn rustify_ty(ty: &str) -> Ident {
-        if is_builtin_scalar(ty) {
+        if is_builtin_type_scalar(ty) {
             ident(ty)
         } else {
             TyName::from_godot(ty).rust_ty

--- a/itest/godot/ManualFfiTests.gd
+++ b/itest/godot/ManualFfiTests.gd
@@ -253,6 +253,9 @@ func test_custom_property():
 	assert_eq(d.b, 33)
 
 func test_custom_property_wrong_values_1():
+	if runs_release():
+		return
+
 	var has_property: HasCustomProperty = HasCustomProperty.new()
 	disable_error_messages()
 	has_property.some_c_style_enum = 10 # Should fail.
@@ -260,6 +263,9 @@ func test_custom_property_wrong_values_1():
 	assert_fail("HasCustomProperty.some_c_style_enum should only accept integers in the range `(0 ..= 2)`")
 
 func test_custom_property_wrong_values_2():
+	if runs_release():
+		return
+
 	var has_property: HasCustomProperty = HasCustomProperty.new()
 	disable_error_messages()
 	has_property.not_exportable = {"a": "hello", "b": Callable()}  # Should fail.

--- a/itest/godot/TestSuite.gd
+++ b/itest/godot/TestSuite.gd
@@ -66,3 +66,8 @@ func assert_fail(message: String = "") -> bool:
 		print_error("Test execution should have failed")
 
 	return false
+
+## Some tests are disabled, as they rely on Godot checks which are only available in Debug builds.
+## See https://github.com/godotengine/godot/issues/86264.
+static func runs_release() -> bool:
+	return !OS.is_debug_build()

--- a/itest/rust/src/builtin_tests/containers/variant_test.rs
+++ b/itest/rust/src/builtin_tests/containers/variant_test.rs
@@ -16,7 +16,7 @@ use godot::obj::InstanceId;
 use godot::sys::GodotFfi;
 
 use crate::common::roundtrip;
-use crate::framework::{expect_panic, itest};
+use crate::framework::{expect_panic, itest, runs_release};
 
 const TEST_BASIS: Basis = Basis::from_rows(
     Vector3::new(1.0, 2.0, 3.0),
@@ -146,16 +146,18 @@ fn variant_call() {
     let result = vector.to_variant().call("dot", &[vector_rhs.to_variant()]);
     assert_eq!(result, 2.0.to_variant());
 
-    // Error cases
-    expect_panic("Variant::call on non-existent method", || {
-        variant.call("gut_position", &[]);
-    });
-    expect_panic("Variant::call with bad signature", || {
-        variant.call("set_position", &[]);
-    });
-    expect_panic("Variant::call with non-object variant (int)", || {
-        Variant::from(77).call("to_string", &[]);
-    });
+    // Dynamic checks are only available in Debug builds.
+    if !runs_release() {
+        expect_panic("Variant::call on non-existent method", || {
+            variant.call("gut_position", &[]);
+        });
+        expect_panic("Variant::call with bad signature", || {
+            variant.call("set_position", &[]);
+        });
+        expect_panic("Variant::call with non-object variant (int)", || {
+            Variant::from(77).call("to_string", &[]);
+        });
+    }
 
     node2d.free();
 }

--- a/itest/rust/src/framework/mod.rs
+++ b/itest/rust/src/framework/mod.rs
@@ -5,7 +5,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use godot::engine::{Engine, Node};
+use godot::engine::{Engine, Node, Os};
 use godot::obj::Gd;
 use godot::sys;
 use std::collections::HashSet;
@@ -127,4 +127,10 @@ pub fn suppress_godot_print(mut f: impl FnMut()) {
     Engine::singleton().set_print_error_messages(false);
     f();
     Engine::singleton().set_print_error_messages(true);
+}
+
+/// Some tests are disabled, as they rely on Godot checks which are only available in Debug builds.
+/// See https://github.com/godotengine/godot/issues/86264.
+pub fn runs_release() -> bool {
+    !Os::singleton().is_debug_build()
 }


### PR DESCRIPTION
Fixes https://github.com/godot-rust/gdext/issues/489. Corresponding upstream fix: https://github.com/godotengine/godot/pull/86209.
I still worked around the problem in gdext, as it is present in already-released Godot 4.2.0 and 4.2.1.

Adds a full-ci job to run integration tests with a release Godot version. This necessitated some changes in our nightly pipeline. 

The new release CI also revealed another upstream issue: https://github.com/godotengine/godot/issues/86264. In short, dynamic calls like `Object::call` or `Variant::call` are unchecked in Release mode. Integration tests relying on those checks have thus been disabled in Release builds.