### PR TITLE
Enable `#[var]` and `#[export]` for `OnReady<T>` fields

### DIFF
--- a/godot-core/src/obj/onready.rs
+++ b/godot-core/src/obj/onready.rs
@@ -5,6 +5,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+use crate::property::{Export, Property, PropertyHintInfo};
 use std::mem;
 
 /// Ergonomic late-initialization container with `ready()` support.
@@ -186,7 +187,32 @@ impl<T> std::ops::DerefMut for OnReady<T> {
     }
 }
 
+impl<T: Property> Property for OnReady<T> {
+    type Intermediate = T::Intermediate;
+
+    fn get_property(&self) -> Self::Intermediate {
+        let deref: &T = self;
+        deref.get_property()
+    }
+
+    fn set_property(&mut self, value: Self::Intermediate) {
+        let deref: &mut T = self;
+        deref.set_property(value);
+    }
+
+    fn property_hint() -> PropertyHintInfo {
+        T::property_hint()
+    }
+}
+
+impl<T: Export> Export for OnReady<T> {
+    fn default_export_info() -> PropertyHintInfo {
+        T::default_export_info()
+    }
+}
+
 // ----------------------------------------------------------------------------------------------------------------------------------------------
+// Implementation
 
 enum InitState<T> {
     ManualUninitialized,

--- a/itest/rust/src/object_tests/onready_test.rs
+++ b/itest/rust/src/object_tests/onready_test.rs
@@ -11,6 +11,7 @@ use godot::engine::notify::NodeNotification;
 use godot::engine::INode;
 
 use godot::obj::{Gd, OnReady};
+use godot::prelude::ToGodot;
 
 #[itest]
 fn onready_deref() {
@@ -116,12 +117,36 @@ fn onready_lifecycle_with_impl_without_ready() {
     obj.free();
 }
 
+#[itest]
+fn onready_property_access() {
+    let mut obj = OnReadyWithImpl::create(true);
+    obj.notify(NodeNotification::Ready);
+
+    obj.set("auto".into(), 33.to_variant());
+    obj.set("manual".into(), 44.to_variant());
+
+    {
+        let obj = obj.bind();
+        assert_eq!(*obj.auto, 33);
+        assert_eq!(*obj.manual, 44);
+    }
+
+    let auto = obj.get("auto".into()).to::<i32>();
+    let manual = obj.get("manual".into()).to::<i64>();
+    assert_eq!(auto, 33);
+    assert_eq!(manual, 44);
+
+    obj.free();
+}
+
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 
 #[derive(GodotClass)]
 #[class(base=Node)]
 struct OnReadyWithImpl {
+    #[export]
     auto: OnReady<i32>,
+    #[var]
     manual: OnReady<i32>,
     runs_manual_init: bool,
 }


### PR DESCRIPTION
Done by implementing `Property` and `Export` traits for `OnReady<T>`, delegating the implementation to underlying `T`.
