### PR TITLE
Harden safety around dead and badly typed `Gd<T>` instances

### DIFF
--- a/godot-core/src/builtin/meta/class_name.rs
+++ b/godot-core/src/builtin/meta/class_name.rs
@@ -61,18 +61,18 @@ impl ClassName {
         self.c_str.to_str().unwrap()
     }
 
-    /// Converts the class name to a GString.
-    pub fn to_godot_string(&self) -> GString {
+    /// Converts the class name to a `GString`.
+    pub fn to_gstring(&self) -> GString {
         self.with_string_name(|s| s.into())
     }
 
-    /// Converts the class name to a StringName.
+    /// Converts the class name to a `StringName`.
     pub fn to_string_name(&self) -> StringName {
         self.with_string_name(|s| s.clone())
     }
 
     /// The returned pointer is valid indefinitely, as entries are never deleted from the cache.
-    /// Since we use Box<StringName>, HashMap reallocations don't affect the validity of the StringName.
+    /// Since we use `Box<StringName>`, `HashMap` reallocations don't affect the validity of the StringName.
     #[doc(hidden)]
     pub fn string_sys(&self) -> sys::GDExtensionStringNamePtr {
         self.with_string_name(|s| s.string_sys())

--- a/godot-core/src/builtin/meta/signature.rs
+++ b/godot-core/src/builtin/meta/signature.rs
@@ -167,7 +167,8 @@ macro_rules! impl_varcall_signature_for_tuple {
                     unsafe { varcall_arg::<$Pn, $n>(args_ptr, method_name) },
                 )*) ;
 
-                varcall_return::<$R>(func(instance_ptr, args), ret, err)
+                let rust_result = func(instance_ptr, args);
+                varcall_return::<$R>(rust_result, ret, err)
             }
 
             #[inline]
@@ -181,9 +182,9 @@ macro_rules! impl_varcall_signature_for_tuple {
             ) -> Self::Ret {
                 //$crate::out!("out_class_varcall: {method_name}");
 
-                // Note: varcalls are not safe from failing, if the happen through an object pointer -> validity check necessary.
+                // Note: varcalls are not safe from failing, if they happen through an object pointer -> validity check necessary.
                 if let Some(instance_id) = maybe_instance_id {
-                    crate::engine::ensure_object_alive(Some(instance_id), object_ptr, method_name);
+                    crate::engine::ensure_object_alive(instance_id, object_ptr, method_name);
                 }
 
                 let class_fn = sys::interface_fn!(object_method_bind_call);
@@ -298,7 +299,7 @@ macro_rules! impl_ptrcall_signature_for_tuple {
             ) -> Self::Ret {
                 // $crate::out!("out_class_ptrcall: {method_name}");
                 if let Some(instance_id) = maybe_instance_id {
-                    crate::engine::ensure_object_alive(Some(instance_id), object_ptr, method_name);
+                    crate::engine::ensure_object_alive(instance_id, object_ptr, method_name);
                 }
 
                 let class_fn = sys::interface_fn!(object_method_bind_ptrcall);

--- a/godot-core/src/lib.rs
+++ b/godot-core/src/lib.rs
@@ -65,6 +65,8 @@ pub mod private {
         sys::plugin_foreach!(__GODOT_PLUGIN_REGISTRY; visitor);
     }
 
+    pub use crate::obj::rtti::ObjectRtti;
+
     pub struct ClassConfig {
         pub is_tool: bool,
     }

--- a/godot-core/src/obj/mod.rs
+++ b/godot-core/src/obj/mod.rs
@@ -19,6 +19,8 @@ mod onready;
 mod raw;
 mod traits;
 
+pub(crate) mod rtti;
+
 pub use base::*;
 pub use gd::*;
 pub use guards::*;
@@ -26,5 +28,7 @@ pub use instance_id::*;
 pub use onready::*;
 pub use raw::*;
 pub use traits::*;
+
+// Do not re-export rtti here.
 
 type GdDerefTarget<T> = <<T as GodotClass>::Declarer as dom::Domain>::DerefTarget<T>;

--- a/godot-core/src/obj/rtti.rs
+++ b/godot-core/src/obj/rtti.rs
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use crate::obj::{GodotClass, InstanceId};
+
+// This is private; despite `pub` here it is re-exported in `crate::private` module.
+
+/// Object runtime type information, obtained at creation time.
+///
+/// Stores how a Godot-managed object has been created, for debug info and runtime checks.
+/// This is persisted independently of the static type system (e.g. `T` in `Gd<T>`) and can be used to perform sanity checks at runtime.
+///
+/// See also <https://github.com/godot-rust/gdext/issues/23>.
+#[derive(Debug)]
+pub struct ObjectRtti {
+    /// Cached instance ID. May point to dead objects.
+    pub instance_id: InstanceId,
+
+    /// Only in Debug mode: dynamic class.
+    #[cfg(debug_assertions)]
+    pub class_name: crate::builtin::meta::ClassName,
+}
+
+impl ObjectRtti {
+    /// Creates a new instance of `ObjectRtti`.
+    #[inline]
+    pub fn of<T: GodotClass>(instance_id: InstanceId) -> Self {
+        Self {
+            instance_id,
+
+            #[cfg(debug_assertions)]
+            class_name: T::class_name(),
+        }
+    }
+
+    /// Checks that the object is of type `T` or derived. Returns instance ID.
+    ///
+    /// # Panics
+    /// In Debug mode, if the object is not of type `T` or derived.
+    #[inline]
+    pub fn check_type<T: GodotClass>(&self) -> InstanceId {
+        #[cfg(debug_assertions)]
+        crate::engine::ensure_object_inherits(&self.class_name, &T::class_name(), self.instance_id);
+
+        self.instance_id
+    }
+}

--- a/godot-core/src/storage.rs
+++ b/godot-core/src/storage.rs
@@ -373,7 +373,7 @@ pub unsafe fn destroy_storage<T: GodotClass>(instance_ptr: sys::GDExtensionClass
         );
 
         // In Debug mode, crash which may trigger breakpoint.
-        // In release mode, leak player object (Godot philosophy: don't crash if somehow avoidable). Likely leads to follow-up issues.
+        // In Release mode, leak player object (Godot philosophy: don't crash if somehow avoidable). Likely leads to follow-up issues.
         if cfg!(debug_assertions) {
             crate::engine::Os::singleton().crash(error.into());
         } else {

--- a/godot-macros/src/class/data_models/func.rs
+++ b/godot-macros/src/class/data_models/func.rs
@@ -365,6 +365,7 @@ fn make_ptrcall_func(
     wrapped_method: &TokenStream,
 ) -> TokenStream {
     let invocation = make_ptrcall_invocation(method_name, sig_tuple, wrapped_method, false);
+    let method_name_str = method_name.to_string();
 
     quote! {
         {
@@ -375,7 +376,7 @@ fn make_ptrcall_func(
                 ret: sys::GDExtensionTypePtr,
             ) {
                 let success = ::godot::private::handle_panic(
-                    || stringify!(#method_name),
+                    || #method_name_str,
                     || #invocation
                 );
 

--- a/itest/rust/src/builtin_tests/string/gstring_test.rs
+++ b/itest/rust/src/builtin_tests/string/gstring_test.rs
@@ -76,10 +76,10 @@ fn empty_string_chars() {
 fn string_chars() {
     let string = String::from("some_string");
     let string_chars: Vec<char> = string.chars().collect();
-    let godot_string = GString::from(string);
-    let godot_string_chars: Vec<char> = godot_string.chars_checked().to_vec();
+    let gstring = GString::from(string);
+    let gstring_chars: Vec<char> = gstring.chars_checked().to_vec();
 
-    assert_eq!(godot_string_chars, string_chars);
+    assert_eq!(gstring_chars, string_chars);
 }
 
 #[itest]

--- a/itest/rust/src/framework/mod.rs
+++ b/itest/rust/src/framework/mod.rs
@@ -103,12 +103,15 @@ pub fn passes_filter(filters: &[String], test_name: &str) -> bool {
     filters.is_empty() || filters.iter().any(|x| test_name.contains(x))
 }
 
-pub fn expect_panic(context: &str, code: impl FnOnce() + std::panic::UnwindSafe) {
+pub fn expect_panic(context: &str, code: impl FnOnce()) {
     use std::panic;
 
     // Exchange panic hook, to disable printing during expected panics
     let prev_hook = panic::take_hook();
     panic::set_hook(Box::new(|_panic_info| {}));
+
+    // Generally, types should be unwind safe, and this helps ergonomics in testing (especially around &mut in expect_panic closures).
+    let code = panic::AssertUnwindSafe(code);
 
     // Run code that should panic, restore hook
     let panic = panic::catch_unwind(code);

--- a/itest/rust/src/object_tests/mod.rs
+++ b/itest/rust/src/object_tests/mod.rs
@@ -7,6 +7,7 @@
 
 mod base_test;
 mod class_rename_test;
+mod object_swap_test;
 mod object_test;
 mod onready_test;
 mod property_template_test;

--- a/itest/rust/src/object_tests/object_swap_test.rs
+++ b/itest/rust/src/object_tests/object_swap_test.rs
@@ -1,0 +1,227 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+// Tests that revolve particularly around https://github.com/godot-rust/gdext/issues/23.
+
+// A lot these tests also exist in the `object_test` module, where they test object lifetime rather than type swapping.
+// TODO consolidate them, so that it's less likely to forget edge cases.
+
+// Disabled in Release mode, since we don't perform the subtype check there.
+#![cfg(debug_assertions)]
+
+use godot::bind::{godot_api, GodotClass};
+use godot::builtin::GString;
+use godot::engine::{Node, Node3D, Object};
+use godot::obj::{Gd, UserClass};
+
+use crate::framework::{expect_panic, itest, TestContext};
+use crate::object_tests::object_test::ObjPayload;
+
+/// Swaps `lhs` and `rhs`, then frees both.
+///
+/// Needed because freeing a `Gd<T>` with wrong runtime type panics, and otherwise we get a memory leak.
+///
+/// This is a macro because a function needs excessive bounds, e.g.
+/// `T: GodotClass<Mem = Mt>, Mt: godot::obj::mem::Memory + godot::obj::mem::PossiblyManual` and then even more for `DerefMut`...
+/// Maybe something to improve in the future, as generic programming is quite hard like this...
+macro_rules! swapped_free {
+    ($lhs:ident, $rhs:ident) => {{
+        let mut lhs = $lhs;
+        let mut rhs = $rhs;
+        std::mem::swap(&mut *lhs, &mut *rhs);
+
+        lhs.free();
+        rhs.free();
+    }};
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+
+#[itest]
+fn object_subtype_swap_method() {
+    let mut node: Gd<Node> = Node::new_alloc();
+    let mut node_3d: Gd<Node3D> = Node3D::new_alloc();
+
+    let n_id = node.instance_id();
+    let n3_id = node_3d.instance_id();
+
+    std::mem::swap(&mut *node, &mut *node_3d);
+
+    assert_eq!(node.instance_id(), n3_id);
+    assert_eq!(node_3d.instance_id(), n_id);
+
+    // Explicitly allowed to call get_class() because it's on Object and every class inherits that.
+    assert_eq!(node.get_class(), GString::from("Node3D"));
+    assert_eq!(node_3d.get_class(), GString::from("Node"));
+
+    expect_panic("method call on Gd<T> with invalid runtime type", || {
+        node_3d.get_position(); // only Node3D has this method
+    });
+
+    swapped_free!(node, node_3d);
+}
+
+#[itest]
+fn object_subtype_swap_clone() {
+    let mut obj: Gd<Object> = Object::new_alloc();
+    let mut node: Gd<Node> = Node::new_alloc();
+
+    std::mem::swap(&mut *obj, &mut *node);
+
+    expect_panic("clone badly typed Gd<T>", || {
+        let _ = node.clone();
+    });
+
+    swapped_free!(obj, node);
+}
+
+#[itest]
+fn object_subtype_swap_free() {
+    let mut obj: Gd<Object> = Object::new_alloc();
+    let mut node: Gd<Node> = Node::new_alloc();
+
+    let obj_copy = obj.clone();
+    let node_copy = node.clone();
+
+    std::mem::swap(&mut *obj, &mut *node);
+
+    expect_panic("free badly typed Gd<T>", || {
+        node.free();
+    });
+    // Do not check obj, because Gd<Object>::free() always works.
+
+    // Free with original type.
+    obj_copy.free();
+    node_copy.free();
+}
+
+#[itest]
+fn object_subtype_swap_argument_passing(ctx: &TestContext) {
+    let mut obj: Gd<Object> = Object::new_alloc();
+    let mut node: Gd<Node> = Node::new_alloc();
+    let node2 = obj.clone();
+
+    std::mem::swap(&mut *obj, &mut *node);
+
+    let mut tree = ctx.scene_tree.clone();
+    expect_panic("pass badly typed Gd<T> to Godot engine API", || {
+        tree.add_child(node);
+    });
+
+    swapped_free!(obj, node2);
+}
+
+#[itest]
+fn object_subtype_swap_bind() {
+    let mut obj: Gd<Object> = Object::new_alloc();
+    let mut user: Gd<ObjPayload> = ObjPayload::alloc_gd();
+
+    let obj_id = obj.instance_id();
+    let user_id = user.instance_id();
+
+    std::mem::swap(&mut *obj, &mut *user);
+
+    assert_eq!(obj.instance_id(), user_id);
+    assert_eq!(user.instance_id(), obj_id);
+    assert_eq!(obj.get_class(), GString::from("ObjPayload"));
+    assert_eq!(user.get_class(), GString::from("Object"));
+
+    expect_panic("access badly typed Gd<T> using bind()", || {
+        let _ = user.bind();
+    });
+    expect_panic("access badly typed Gd<T> using bind_mut()", || {
+        let _ = user.bind_mut();
+    });
+
+    swapped_free!(obj, user);
+}
+
+#[itest]
+fn object_subtype_swap_casts() {
+    let mut obj: Gd<Object> = Object::new_alloc();
+    let mut node3d: Gd<Node3D> = Node3D::new_alloc();
+    let mut obj_v2: Gd<Object> = obj.clone();
+    let mut node3d_v2: Gd<Node3D> = node3d.clone();
+    let mut obj_v3: Gd<Object> = obj.clone();
+    let mut node3d_v3: Gd<Node3D> = node3d.clone();
+
+    // let obj_id = obj.instance_id();
+    let node3d_id = node3d.instance_id();
+
+    std::mem::swap(&mut *obj, &mut *node3d);
+    std::mem::swap(&mut *obj_v2, &mut *node3d_v2);
+    std::mem::swap(&mut *obj_v3, &mut *node3d_v3);
+    drop(node3d_v3); // not needed, just existed as a swap partner for obj_v3.
+
+    // Current design: ALL casts fail if self is badly typed, even with correct target type. See RawGd::ffi_cast() for details.
+
+    // Upcasting itself should not fail as long as the target type is matching the runtime type.
+    expect_panic("upcast() on Gd<T> with invalid runtime type", || {
+        let _upcast_obj = node3d_v2.upcast::<Object>();
+        // assert_eq!(upcast_obj.instance_id(), obj_id);
+    });
+
+    // Upcasting to itself works, as long as self's type info is correct _before_ the cast.
+    let upcast_node3d = obj_v2.upcast::<Object>();
+    assert_eq!(upcast_node3d.instance_id(), node3d_id);
+
+    // Downcasting should work if the actual dynamic type matches.
+    let downcast_node = obj_v3.cast::<Node3D>();
+    assert_eq!(downcast_node.instance_id(), node3d_id);
+
+    // Downcasting does not work if the dynamic type is wrong.
+    expect_panic("cast() on Gd<T> with invalid runtime type", || {
+        let _ = node3d.clone().cast::<Node3D>();
+    });
+
+    swapped_free!(obj, node3d);
+}
+
+#[itest(focus)]
+fn object_subtype_swap_func_return() {
+    let mut swapped = SwapHolder::new_gd();
+
+    // Call through Godot.
+    let result = swapped.call("return_swapped_node".into(), &[]);
+    dbg!(result);
+}
+
+//----------------------------------------------------------------------------------------------------------------------------------------------
+
+#[derive(GodotClass)]
+#[class(init)]
+struct SwapHolder {
+    gc: Vec<Gd<Object>>,
+}
+
+#[godot_api]
+impl SwapHolder {
+    #[func]
+    fn return_swapped_node(&mut self) -> Gd<Node> {
+        let mut object: Gd<Object> = Object::new_alloc();
+        let mut node: Gd<Node> = Node::new_alloc();
+        self.gc.push(object.clone());
+        self.gc.push(node.clone().upcast());
+
+        std::mem::swap(&mut *object, &mut *node);
+
+        // Dynamic free which is unchecked
+        object.call("free".into(), &[]);
+
+        node
+    }
+}
+
+impl Drop for SwapHolder {
+    fn drop(&mut self) {
+        for obj in self.gc.drain(..) {
+            println!("sw free");
+            obj.free();
+            println!("after free");
+        }
+    }
+}

--- a/itest/rust/src/object_tests/object_test.rs
+++ b/itest/rust/src/object_tests/object_test.rs
@@ -12,7 +12,8 @@ use godot::bind::{godot_api, GodotClass};
 use godot::builtin::meta::{FromGodot, ToGodot};
 use godot::builtin::{GString, StringName, Variant, Vector3};
 use godot::engine::{
-    file_access, Area2D, Camera3D, FileAccess, IRefCounted, Node, Node3D, Object, RefCounted,
+    file_access, Area2D, Camera3D, Engine, FileAccess, IRefCounted, Node, Node3D, Object,
+    RefCounted,
 };
 use godot::obj::{Base, Gd, Inherits, InstanceId, RawGd, UserClass};
 use godot::prelude::meta::GodotType;
@@ -40,39 +41,6 @@ fn object_construct_new_gd() {
 fn object_construct_value() {
     let obj = Gd::from_object(RefcPayload { value: 222 });
     assert_eq!(obj.bind().value, 222);
-}
-
-// TODO(#23): DerefMut on Gd pointer may be used to break subtyping relations
-#[itest(skip)]
-fn object_subtype_swap() {
-    let mut a: Gd<Node> = Node::new_alloc();
-    let mut b: Gd<Node3D> = Node3D::new_alloc();
-
-    /*
-    let a_id = a.instance_id();
-    let b_id = b.instance_id();
-    let a_class = a.get_class();
-    let b_class = b.get_class();
-
-    dbg!(a_id);
-    dbg!(b_id);
-    dbg!(&a_class);
-    dbg!(&b_class);
-    println!("..swap..");
-    */
-
-    std::mem::swap(&mut *a, &mut *b);
-
-    /*
-    dbg!(a_id);
-    dbg!(b_id);
-    dbg!(&a_class);
-    dbg!(&b_class);
-    */
-
-    // This should not panic
-    a.free();
-    b.free();
 }
 
 #[itest]
@@ -788,7 +756,7 @@ fn object_get_scene_tree(ctx: &TestContext) {
 
 #[derive(GodotClass)]
 #[class(init, base=Object)]
-struct ObjPayload {}
+pub(super) struct ObjPayload {}
 
 #[godot_api]
 impl ObjPayload {


### PR DESCRIPTION
Fixes a wide range of UB in scenarios when interacting with `Gd<T>` instances that are either dead or wrongly typed due to the #23 `DerefMut` exploit. The latter is done by tracking the runtime type in each `Gd<T>` object as debug information. 

Release mode has the type check disabled, but the object validity one enabled. This might be worth a separate discussion in the future, maybe if performance impact is measured.

Scenarios covered:
- passing `Gd<T>` to `godot::engine` APIs
- returning `Gd<T>` from `#[func]`
- converting via `ToGodot` trait
- `upcast()` and `cast()`
- `bind()` and `bind_mut()`
- `clone()`
- `free()` on wrong type
- `free()` that panics when there is already a panic unwind in progress

There might be more, but this significantly improves safety when working with objects, to the point that it catches even deliberate abuse.
