### PR TITLE
`Global<T>` to store global variables ergonomically

### DIFF
--- a/godot-core/src/builtin/meta/registration/constant.rs
+++ b/godot-core/src/builtin/meta/registration/constant.rs
@@ -27,7 +27,7 @@ impl IntegerConstant {
         }
     }
 
-    fn register(&self, class_name: &ClassName, enum_name: &StringName, is_bitfield: bool) {
+    fn register(&self, class_name: ClassName, enum_name: &StringName, is_bitfield: bool) {
         unsafe {
             interface_fn!(classdb_register_extension_class_integer_constant)(
                 sys::get_library(),
@@ -56,7 +56,7 @@ pub enum ConstantKind {
 }
 
 impl ConstantKind {
-    fn register(&self, class_name: &ClassName) {
+    fn register(&self, class_name: ClassName) {
         match self {
             ConstantKind::Integer(integer) => {
                 integer.register(class_name, &StringName::default(), false)
@@ -87,6 +87,6 @@ impl ExportConstant {
     }
 
     pub fn register(&self) {
-        self.kind.register(&self.class_name)
+        self.kind.register(self.class_name)
     }
 }

--- a/godot-core/src/lib.rs
+++ b/godot-core/src/lib.rs
@@ -51,7 +51,7 @@ pub mod private {
     pub use crate::gen::classes::class_macros;
     pub use crate::registry::{callbacks, ClassPlugin, ErasedRegisterFn, PluginComponent};
     pub use crate::storage::as_storage;
-    pub use godot_ffi::out;
+    pub use sys::out;
 
     use crate::{log, sys};
 

--- a/godot-core/src/obj/rtti.rs
+++ b/godot-core/src/obj/rtti.rs
@@ -44,7 +44,7 @@ impl ObjectRtti {
     #[inline]
     pub fn check_type<T: GodotClass>(&self) -> InstanceId {
         #[cfg(debug_assertions)]
-        crate::engine::ensure_object_inherits(&self.class_name, &T::class_name(), self.instance_id);
+        crate::engine::ensure_object_inherits(self.class_name, T::class_name(), self.instance_id);
 
         self.instance_id
     }

--- a/godot-ffi/src/global.rs
+++ b/godot-ffi/src/global.rs
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use std::ops::{Deref, DerefMut};
+use std::sync::{Mutex, MutexGuard};
+
+/// Ergonomic global variables.
+///
+/// No more `Mutex<Option<...>>` shenanigans with lazy initialization on each use site, or `OnceLock` which limits to immutable access.
+///
+/// This type is very similar to [`once_cell::Lazy`](https://docs.rs/once_cell/latest/once_cell/sync/struct.Lazy.html) in its nature,
+/// with a minimalistic implementation. It features:
+/// - A `const` constructor, allowing to be used in `static` variables without `Option`.
+/// - Initialization function provided in constructor, not in each use site separately.
+/// - Ergonomic access through guards to both `&T` and `&mut T`.
+/// - Completely safe usage. Almost completely safe implementation (besides `unreachable_unchecked`).
+///
+/// There are two main methods: [`new()`](Self::new) and [`lock()`](Self::lock). Additionally, [`default()`](Self::default) is provided
+/// for convenience.
+pub struct Global<T> {
+    // When needed, this could be changed to use RwLock and separate read/write guards.
+    value: Mutex<InitState<T>>,
+}
+
+impl<T> Global<T> {
+    /// Create `Global<T>`, providing a lazy initialization function.
+    ///
+    /// The initialization function is only called once, when the global is first accessed through [`lock()`](Self::lock).
+    pub const fn new(init_fn: fn() -> T) -> Self {
+        // Note: could be generalized to F: FnOnce() -> T + Send. See also once_cell::Lazy<T, F>.
+        Self {
+            value: Mutex::new(InitState::Pending(init_fn)),
+        }
+    }
+
+    /// Create `Global<T>` with `T::default()` as initialization function.
+    ///
+    /// This is inherent rather than implementing the `Default` trait, because the latter is not `const` and thus useless in static contexts.
+    pub const fn default() -> Self
+    where
+        T: Default,
+    {
+        Self::new(T::default)
+    }
+
+    /// Returns a guard that gives shared or mutable access to the value.
+    ///
+    /// Blocks until the internal mutex is available.
+    ///
+    /// # Panics
+    /// If the initialization function panics. Once that happens, the global is considered poisoned and all future calls to `lock()` will panic.
+    /// This can currently not be recovered from.
+    pub fn lock(&self) -> GlobalGuard<'_, T> {
+        let guard = self.ensure_init();
+        debug_assert!(matches!(*guard, InitState::Initialized(_)));
+
+        GlobalGuard { guard }
+    }
+
+    fn ensure_init(&self) -> MutexGuard<'_, InitState<T>> {
+        let mut guard = self.value.lock().expect("lock poisoned");
+        let pending_state = match &mut *guard {
+            InitState::Initialized(_) => {
+                return guard;
+            }
+            InitState::TransientInitializing => {
+                // SAFETY: only set inside this function and all paths (panic + return) leave the enum in a different state.
+                unsafe { std::hint::unreachable_unchecked() };
+            }
+            InitState::Failed => {
+                panic!("previous Global<T> initialization failed due to panic")
+            }
+            state @ InitState::Pending(_) => {
+                std::mem::replace(state, InitState::TransientInitializing)
+            }
+        };
+
+        let InitState::Pending(init_fn) = pending_state else {
+            // SAFETY: all other paths leave the function, see above.
+            unsafe { std::hint::unreachable_unchecked() }
+        };
+
+        // Unwinding should be safe here, as there is no unsafe code relying on it.
+        let init_fn = std::panic::AssertUnwindSafe(init_fn);
+        match std::panic::catch_unwind(init_fn) {
+            Ok(value) => *guard = InitState::Initialized(value),
+            Err(e) => {
+                eprintln!("panic during Global<T> initialization");
+                *guard = InitState::Failed;
+                std::panic::resume_unwind(e);
+            }
+        };
+
+        guard
+    }
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// Guards
+
+/// Guard that temporarily gives access to a `Global<T>`'s inner value.
+pub struct GlobalGuard<'a, T> {
+    guard: MutexGuard<'a, InitState<T>>,
+}
+
+impl<T> Deref for GlobalGuard<'_, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        self.guard.unwrap_ref()
+    }
+}
+
+impl<T> DerefMut for GlobalGuard<'_, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.guard.unwrap_mut()
+    }
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// Internals
+
+enum InitState<T> {
+    Initialized(T),
+    Pending(fn() -> T),
+    TransientInitializing,
+    Failed,
+}
+
+impl<T> InitState<T> {
+    fn unwrap_ref(&self) -> &T {
+        match self {
+            InitState::Initialized(t) => t,
+            _ => {
+                // SAFETY: This method is only called from a guard, which can only be obtained in Initialized state.
+                unsafe { std::hint::unreachable_unchecked() }
+            }
+        }
+    }
+
+    fn unwrap_mut(&mut self) -> &mut T {
+        match self {
+            InitState::Initialized(t) => t,
+            _ => {
+                // SAFETY: This method is only called from a guard, which can only be obtained in Initialized state.
+                unsafe { std::hint::unreachable_unchecked() }
+            }
+        }
+    }
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// Tests
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    static MAP: Global<HashMap<i32, &'static str>> = Global::default();
+    static VEC: Global<Vec<i32>> = Global::new(|| vec![1, 2, 3]);
+
+    #[test]
+    fn test_global_map() {
+        {
+            let mut map = MAP.lock();
+            map.insert(2, "two");
+            map.insert(3, "three");
+        }
+
+        {
+            let mut map = MAP.lock();
+            map.insert(1, "one");
+        }
+
+        let map = MAP.lock();
+        assert_eq!(map.len(), 3);
+        assert_eq!(map.get(&1), Some(&"one"));
+        assert_eq!(map.get(&2), Some(&"two"));
+        assert_eq!(map.get(&3), Some(&"three"));
+    }
+
+    #[test]
+    fn test_global_vec() {
+        {
+            let mut vec = VEC.lock();
+            vec.push(4);
+        }
+
+        let vec = VEC.lock();
+        assert_eq!(*vec, &[1, 2, 3, 4]);
+    }
+}

--- a/godot-ffi/src/lib.rs
+++ b/godot-ffi/src/lib.rs
@@ -33,6 +33,7 @@ pub(crate) mod gen {
 
 mod compat;
 mod extras;
+mod global;
 mod godot_ffi;
 mod opaque;
 mod plugins;
@@ -69,6 +70,7 @@ pub use extras::*;
 pub use gen::central::*;
 pub use gen::gdextension_interface::*;
 pub use gen::interface::*;
+pub use global::*;
 pub use string_cache::StringCache;
 pub use toolbox::*;
 


### PR DESCRIPTION
Similar to `once_cell::Lazy`, this type allows lazy initialization in `static` variables, without `Option` or other workarounds. The implementation was initially very simple (just 100 LoC), but got a bit more involved once `try_lock()` was added. An older commit contains the simpler implementation. Depending on needs, we might also consider `RwLock` instead of `Mutex` internally, but I think it's not necessary right now, and it would add quite a bit of further complexity in both implementation and usage (e.g. for caches).

I replaced two occurrences of `Mutex<Option<T>>` in gdext with `Global<T>` and added a new one. 

`Global<T>` is currently not part of the public API, but we may consider exposing it if there is demand.

At some point, we should also consider what to do with the `static mut` in godot-ffi that gives access to the entire `BINDING`. We need to see if concurrent access is needed. And if yes, how to provide it without compromising performance for every single Godot API call.