### PR TITLE
CI: add `cargo-deny` and `cargo-machete`

### DIFF
--- a/.github/other/deny.toml
+++ b/.github/other/deny.toml
@@ -9,6 +9,8 @@
 # The values provided in this template are the default values that will be used
 # when any section or field is not specified in your own configuration
 
+# Root options
+
 # If 1 or more target triples (and optionally, target_features) are specified,
 # only the specified targets will be checked when running `cargo deny check`.
 # This means, if a particular package is only ever used as a target specific
@@ -26,6 +28,30 @@ targets = [
     # the actual valid features supported by the target architecture.
     #{ triple = "wasm32-unknown-unknown", features = ["atomics"] },
 ]
+# When creating the dependency graph used as the source of truth when checks are
+# executed, this field can be used to prune crates from the graph, removing them
+# from the view of cargo-deny. This is an extremely heavy hammer, as if a crate
+# is pruned from the graph, all of its dependencies will also be pruned unless
+# they are connected to another crate in the graph that hasn't been pruned,
+# so it should be used with care. The identifiers are [Package ID Specifications]
+# (https://doc.rust-lang.org/cargo/reference/pkgid-spec.html)
+#exclude = []
+# If true, metadata will be collected with `--all-features`. Note that this can't
+# be toggled off if true, if you want to conditionally enable `--all-features` it
+# is recommended to pass `--all-features` on the cmd line instead
+all-features = false
+# If true, metadata will be collected with `--no-default-features`. The same
+# caveat with `all-features` applies
+no-default-features = false
+# If set, these feature will be enabled when collecting metadata. If `--features`
+# is specified on the cmd line they will take precedence over this option.
+#features = []
+# When outputting inclusion graphs in diagnostics that include features, this
+# option can be used to specify the depth at which feature edges will be added.
+# This option is included since the graphs can be quite large and the addition
+# of features from the crate(s) to all of the graph roots can be far too verbose.
+# This option can be overridden via `--feature-depth` on the cmd line
+feature-depth = 1
 
 # This section is considered when running `cargo deny check advisories`
 # More documentation for the advisories section can be found here:
@@ -48,7 +74,7 @@ notice = "warn"
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = [
-    # "RUSTSEC-0000-0000",
+    #"RUSTSEC-0000-0000",
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories
@@ -59,6 +85,12 @@ ignore = [
 # * High - CVSS Score 7.0 - 8.9
 # * Critical - CVSS Score 9.0 - 10.0
 #severity-threshold =
+
+# If this is true, then cargo deny will use the git executable to fetch advisory database.
+# If this is false, then it uses a built-in git library.
+# Setting this to true can be helpful if you have special authentication requirements that cargo-deny does not support.
+# See Git Authentication for more information about setting up git authentication.
+#git-fetch-with-cli = true
 
 # This section is considered when running `cargo deny check licenses`
 # More documentation for the licenses section can be found here:
@@ -79,16 +111,6 @@ allow = [
     "MPL-2.0",
     #"Apache-2.0 WITH LLVM-exception",
 ]
-# What to do if a license in the above list is not actually used in a dependency
-# We allow this since we don't want to fine-tune deny.toml every time we add/remove
-# a permissive license.
-unused-allowed-license = "allow"
-# Allow 1 or more licenses on a per-crate basis, so that particular licenses
-# aren't accepted for every possible crate as with the normal allow list
-exceptions = [
-    # Each entry is the crate and version constraint, and its specific allow list
-    # { name = "crate", allow = ["License"], version = "*" },
-]
 # List of explicitly disallowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.11 short identifier (+ optional exception)].
@@ -100,8 +122,10 @@ copyleft = "deny"
 # Blanket approval or denial for OSI-approved or FSF Free/Libre licenses
 # * both - The license will be approved if it is both OSI-approved *AND* FSF
 # * either - The license will be approved if it is either OSI-approved *OR* FSF
-# * osi-only - The license will be approved if is OSI-approved *AND NOT* FSF
-# * fsf-only - The license will be approved if is FSF *AND NOT* OSI-approved
+# * osi - The license will be approved if it is OSI approved
+# * fsf - The license will be approved if it is FSF Free
+# * osi-only - The license will be approved if it is OSI-approved *AND NOT* FSF
+# * fsf-only - The license will be approved if it is FSF *AND NOT* OSI-approved
 # * neither - This predicate is ignored and the default lint level is used
 allow-osi-fsf-free = "neither"
 # Lint level used when no other predicates are matched
@@ -114,6 +138,13 @@ default = "deny"
 # canonical license text of a valid SPDX license file.
 # [possible values: any between 0.0 and 1.0].
 confidence-threshold = 0.8
+# Allow 1 or more licenses on a per-crate basis, so that particular licenses
+# aren't accepted for every possible crate as with the normal allow list
+exceptions = [
+    # Each entry is the crate and version constraint, and its specific allow
+    # list
+    #{ allow = ["Zlib"], name = "adler32", version = "*" },
+]
 
 # Some crates don't have (easily) machine readable licensing information,
 # adding a clarification entry for it allows you to manually specify the
@@ -131,8 +162,8 @@ confidence-threshold = 0.8
 # and the crate will be checked normally, which may produce warnings or errors
 # depending on the rest of your configuration
 #license-files = [
-# Each entry is a crate relative path, and the (opaque) hash of its contents
-#{ path = "LICENSE", hash = 0xbd0eed23 }
+    # Each entry is a crate relative path, and the (opaque) hash of its contents
+    #{ path = "LICENSE", hash = 0xbd0eed23 }
 #]
 
 [licenses.private]
@@ -162,6 +193,14 @@ wildcards = "allow"
 # * simplest-path - The path to the version with the fewest edges is highlighted
 # * all - Both lowest-version and simplest-path are used
 highlight = "all"
+# The default lint level for `default` features for crates that are members of
+# the workspace that is being checked. This can be overridden by allowing/denying
+# `default` on a crate-by-crate basis if desired.
+workspace-default-features = "allow"
+# The default lint level for `default` features for external crates that are not
+# members of the workspace. This can be overridden by allowing/denying `default`
+# on a crate-by-crate basis if desired.
+external-default-features = "allow"
 # List of crates that are allowed. Use with care!
 allow = [
     #{ name = "ansi_term", version = "=0.11.0" },
@@ -189,6 +228,30 @@ deny = [
     { name = "syn", wrappers = ["bindgen", "gensym"] },
     { name = "serde", wrappers = ["godot-core", "serde_json"] },
 ]
+
+# List of features to allow/deny
+# Each entry the name of a crate and a version range. If version is
+# not specified, all versions will be matched.
+#[[bans.features]]
+#name = "reqwest"
+# Features to not allow
+#deny = ["json"]
+# Features to allow
+#allow = [
+#    "rustls",
+#    "__rustls",
+#    "__tls",
+#    "hyper-rustls",
+#    "rustls",
+#    "rustls-pemfile",
+#    "rustls-tls-webpki-roots",
+#    "tokio-rustls",
+#    "webpki-roots",
+#]
+# If true, the allowed features must exactly match the enabled feature set. If
+# this is set there is no point setting `deny`
+#exact = true
+
 # Certain crates/versions that will be skipped when doing duplicate detection.
 skip = [
     #{ name = "ansi_term", version = "=0.11.0" },
@@ -196,7 +259,7 @@ skip = [
 # Similarly to `skip` allows you to skip certain crates during duplicate
 # detection. Unlike skip, it also includes the entire tree of transitive
 # dependencies starting at the specified crate, up to a certain depth, which is
-# by default infinite
+# by default infinite.
 skip-tree = [
     #{ name = "ansi_term", version = "=0.11.0", depth = 20 },
 ]
@@ -218,6 +281,7 @@ allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 allow-git = []
 
 [sources.allow-org]
+# 1 or more github.com organizations to allow git sources for
 github = ["godot-rust"]
 # 1 or more gitlab.com organizations to allow git sources for
 #gitlab = [""]

--- a/.github/other/deny.toml
+++ b/.github/other/deny.toml
@@ -1,0 +1,225 @@
+# This template contains all of the possible sections and their default values
+
+# Note that all fields that take a lint level have these possible values:
+# * deny - An error will be produced and the check will fail
+# * warn - A warning will be produced, but the check will not fail
+# * allow - No warning or error will be produced, though in some cases a note
+# will be
+
+# The values provided in this template are the default values that will be used
+# when any section or field is not specified in your own configuration
+
+# If 1 or more target triples (and optionally, target_features) are specified,
+# only the specified targets will be checked when running `cargo deny check`.
+# This means, if a particular package is only ever used as a target specific
+# dependency, such as, for example, the `nix` crate only being used via the
+# `target_family = "unix"` configuration, that only having windows targets in
+# this list would mean the nix crate, as well as any of its exclusive
+# dependencies not shared by any other crates, would be ignored, as the target
+# list here is effectively saying which targets you are building for.
+targets = [
+    # The triple can be any string, but only the target triples built in to
+    # rustc (as of 1.40) can be checked against actual config expressions
+    #{ triple = "x86_64-unknown-linux-musl" },
+    # You can also specify which target_features you promise are enabled for a
+    # particular target. target_features are currently not validated against
+    # the actual valid features supported by the target architecture.
+    #{ triple = "wasm32-unknown-unknown", features = ["atomics"] },
+]
+
+# This section is considered when running `cargo deny check advisories`
+# More documentation for the advisories section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
+[advisories]
+# The path where the advisory database is cloned/fetched into
+db-path = "~/.cargo/advisory-db"
+# The url(s) of the advisory databases to use
+db-urls = ["https://github.com/rustsec/advisory-db"]
+# The lint level for security vulnerabilities
+vulnerability = "deny"
+# The lint level for unmaintained crates
+unmaintained = "deny"
+# The lint level for crates that have been yanked from their source registry
+yanked = "deny"
+# The lint level for crates with security notices. Note that as of
+# 2019-12-17 there are no security notice advisories in
+# https://github.com/rustsec/advisory-db
+notice = "warn"
+# A list of advisory IDs to ignore. Note that ignored advisories will still
+# output a note when they are encountered.
+ignore = [
+    # "RUSTSEC-0000-0000",
+]
+# Threshold for security vulnerabilities, any vulnerability with a CVSS score
+# lower than the range specified will be ignored. Note that ignored advisories
+# will still output a note when they are encountered.
+# * None - CVSS Score 0.0
+# * Low - CVSS Score 0.1 - 3.9
+# * Medium - CVSS Score 4.0 - 6.9
+# * High - CVSS Score 7.0 - 8.9
+# * Critical - CVSS Score 9.0 - 10.0
+#severity-threshold =
+
+# This section is considered when running `cargo deny check licenses`
+# More documentation for the licenses section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
+[licenses]
+# The lint level for crates which do not have a detectable license
+unlicensed = "deny"
+# List of explicitly allowed licenses
+# See https://spdx.org/licenses/ for list of possible licenses
+# [possible values: any SPDX 3.11 short identifier (+ optional exception)].
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Zlib",
+    "BSD-3-Clause",
+    "ISC",
+    "Unicode-DFS-2016",
+    "MPL-2.0",
+    #"Apache-2.0 WITH LLVM-exception",
+]
+# What to do if a license in the above list is not actually used in a dependency
+# We allow this since we don't want to fine-tune deny.toml every time we add/remove
+# a permissive license.
+unused-allowed-license = "allow"
+# Allow 1 or more licenses on a per-crate basis, so that particular licenses
+# aren't accepted for every possible crate as with the normal allow list
+exceptions = [
+    # Each entry is the crate and version constraint, and its specific allow list
+    # { name = "crate", allow = ["License"], version = "*" },
+]
+# List of explicitly disallowed licenses
+# See https://spdx.org/licenses/ for list of possible licenses
+# [possible values: any SPDX 3.11 short identifier (+ optional exception)].
+deny = [
+    #"Nokia",
+]
+# Lint level for licenses considered copyleft
+copyleft = "deny"
+# Blanket approval or denial for OSI-approved or FSF Free/Libre licenses
+# * both - The license will be approved if it is both OSI-approved *AND* FSF
+# * either - The license will be approved if it is either OSI-approved *OR* FSF
+# * osi-only - The license will be approved if is OSI-approved *AND NOT* FSF
+# * fsf-only - The license will be approved if is FSF *AND NOT* OSI-approved
+# * neither - This predicate is ignored and the default lint level is used
+allow-osi-fsf-free = "neither"
+# Lint level used when no other predicates are matched
+# 1. License isn't in the allow or deny lists
+# 2. License isn't copyleft
+# 3. License isn't OSI/FSF, or allow-osi-fsf-free = "neither"
+default = "deny"
+# The confidence threshold for detecting a license from license text.
+# The higher the value, the more closely the license text must be to the
+# canonical license text of a valid SPDX license file.
+# [possible values: any between 0.0 and 1.0].
+confidence-threshold = 0.8
+
+# Some crates don't have (easily) machine readable licensing information,
+# adding a clarification entry for it allows you to manually specify the
+# licensing information
+#[[licenses.clarify]]
+# The name of the crate the clarification applies to
+#name = "ring"
+# The optional version constraint for the crate
+#version = "*"
+# The SPDX expression for the license requirements of the crate
+#expression = "MIT AND ISC AND OpenSSL"
+# One or more files in the crate's source used as the "source of truth" for
+# the license expression. If the contents match, the clarification will be used
+# when running the license check, otherwise the clarification will be ignored
+# and the crate will be checked normally, which may produce warnings or errors
+# depending on the rest of your configuration
+#license-files = [
+# Each entry is a crate relative path, and the (opaque) hash of its contents
+#{ path = "LICENSE", hash = 0xbd0eed23 }
+#]
+
+[licenses.private]
+# If true, ignores workspace crates that aren't published, or are only
+# published to private registries.
+# To see how to mark a crate as unpublished (to the official registry),
+# visit https://doc.rust-lang.org/cargo/reference/manifest.html#the-publish-field.
+ignore = false
+# One or more private registries that you might publish crates to, if a crate
+# is only published to private registries, and ignore is true, the crate will
+# not have its license(s) checked
+registries = [
+    #"https://sekretz.com/registry
+]
+
+# This section is considered when running `cargo deny check bans`.
+# More documentation about the 'bans' section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html
+[bans]
+# Lint level for when multiple versions of the same crate are detected
+multiple-versions = "warn"
+# Lint level for when a crate version requirement is `*`
+wildcards = "allow"
+# The graph highlighting used when creating dotgraphs for crates
+# with multiple versions
+# * lowest-version - The path to the lowest versioned duplicate is highlighted
+# * simplest-path - The path to the version with the fewest edges is highlighted
+# * all - Both lowest-version and simplest-path are used
+highlight = "all"
+# List of crates that are allowed. Use with care!
+allow = [
+    #{ name = "ansi_term", version = "=0.11.0" },
+]
+# List of crates to deny
+# Each entry the name of a crate and a version range. If version is
+# not specified, all versions will be matched.
+#{ name = "ansi_term", version = "=0.11.0" },
+#
+# Wrapper crates can optionally be specified to allow the crate when it
+# is a direct dependency of the otherwise banned crate
+#{ name = "ansi_term", version = "=0.11.0", wrappers = [] },
+#
+# See also: https://togithub.com/RustSec/advisory-db/issues/173
+deny = [
+    # unmaintained since Feb 20 + https://github.com/noamtashma/owning-ref-unsoundness
+    { name = "owning_ref" },
+
+    # unmaintained since Jul 20, RustSec refuses to acknowledge "because author says maintained"
+    # https://togithub.com/rustsec/advisory-db/pull/891
+    { name = "im" },
+    { name = "im-rc" },
+
+    # Too heavy in default setup. Can be included for custom-godot etc.
+    { name = "syn", wrappers = ["bindgen", "gensym"] },
+    { name = "serde", wrappers = ["godot-core", "serde_json"] },
+]
+# Certain crates/versions that will be skipped when doing duplicate detection.
+skip = [
+    #{ name = "ansi_term", version = "=0.11.0" },
+]
+# Similarly to `skip` allows you to skip certain crates during duplicate
+# detection. Unlike skip, it also includes the entire tree of transitive
+# dependencies starting at the specified crate, up to a certain depth, which is
+# by default infinite
+skip-tree = [
+    #{ name = "ansi_term", version = "=0.11.0", depth = 20 },
+]
+
+# This section is considered when running `cargo deny check sources`.
+# More documentation about the 'sources' section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/sources/cfg.html
+[sources]
+# Lint level for what to happen when a crate from a crate registry that is not
+# in the allow list is encountered
+unknown-registry = "deny"
+# Lint level for what to happen when a crate from a git repository that is not
+# in the allow list is encountered
+unknown-git = "deny"
+# List of URLs for allowed crate registries. Defaults to the crates.io index
+# if not specified. If it is specified but empty, no registries are allowed.
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+# List of URLs for allowed Git repositories
+allow-git = []
+
+[sources.allow-org]
+github = ["godot-rust"]
+# 1 or more gitlab.com organizations to allow git sources for
+#gitlab = [""]
+# 1 or more bitbucket.org organizations to allow git sources for
+#bitbucket = [""]

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -188,11 +188,11 @@ jobs:
             godot-binary: godot.macos.editor.dev.x86_64
 #            godot-prebuilt-patch: '4.2.x'
 
-          - name: macos-4.1
-            os: macos-12
-            artifact-name: macos-4.1
-            godot-binary: godot.macos.editor.dev.x86_64
-            godot-prebuilt-patch: '4.1.3'
+#          - name: macos-4.1
+#            os: macos-12
+#            artifact-name: macos-4.1
+#            godot-binary: godot.macos.editor.dev.x86_64
+#            godot-prebuilt-patch: '4.1.3'
 
           # Windows
 
@@ -214,11 +214,11 @@ jobs:
             godot-binary: godot.windows.editor.dev.x86_64.exe
             #godot-prebuilt-patch: '4.2.x'
 
-          - name: windows-4.1
-            os: windows-latest
-            artifact-name: windows-4.1
-            godot-binary: godot.windows.editor.dev.x86_64.exe
-            godot-prebuilt-patch: '4.1.3'
+#          - name: windows-4.1
+#            os: windows-latest
+#            artifact-name: windows-4.1
+#            godot-binary: godot.windows.editor.dev.x86_64.exe
+#            godot-prebuilt-patch: '4.1.3'
 
           # Linux
 
@@ -230,12 +230,12 @@ jobs:
             godot-binary: godot.linuxbsd.editor.dev.x86_64
             rust-extra-args: --features godot/custom-godot
 
-          # Full codegen could also be moved to another job.
-          - name: linux-double-full
+          # Combines now a lot of features, but should be OK. lazy-function-tables doesn't work with experimental-threads.
+          - name: linux-double-full-lazy
             os: ubuntu-20.04
             artifact-name: linux-double-nightly
             godot-binary: godot.linuxbsd.editor.dev.double.x86_64
-            rust-extra-args: --features godot/custom-godot,godot/double-precision,godot/codegen-full
+            rust-extra-args: --features godot/custom-godot,godot/double-precision,godot/codegen-full,godot/lazy-function-tables
 
           - name: linux-features
             os: ubuntu-20.04
@@ -250,14 +250,7 @@ jobs:
             rust-extra-args: --release
             rust-cache-key: release
 
-          # TODO merge with other jobs
-          - name: linux-lazy-fptrs
-            os: ubuntu-20.04
-            artifact-name: linux-nightly
-            godot-binary: godot.linuxbsd.editor.dev.x86_64
-            rust-extra-args: --features godot/lazy-function-tables
-
-          # Linux compat
+          # Linux compat (4.0 and 4.1 disabled, already covered by memcheck)
 
           - name: linux-4.2
             os: ubuntu-20.04
@@ -265,17 +258,17 @@ jobs:
             godot-binary: godot.linuxbsd.editor.dev.x86_64
             #godot-prebuilt-patch: '4.2.x'
 
-          - name: linux-4.1
-            os: ubuntu-20.04
-            artifact-name: linux-4.2
-            godot-binary: godot.linuxbsd.editor.dev.x86_64
-            godot-prebuilt-patch: '4.1.3'
-
-          - name: linux-4.0
-            os: ubuntu-20.04
-            artifact-name: linux-4.0
-            godot-binary: godot.linuxbsd.editor.dev.x86_64
-            godot-prebuilt-patch: '4.0.4'
+#          - name: linux-4.1
+#            os: ubuntu-20.04
+#            artifact-name: linux-4.2
+#            godot-binary: godot.linuxbsd.editor.dev.x86_64
+#            godot-prebuilt-patch: '4.1.3'
+#
+#          - name: linux-4.0
+#            os: ubuntu-20.04
+#            artifact-name: linux-4.0
+#            godot-binary: godot.linuxbsd.editor.dev.x86_64
+#            godot-prebuilt-patch: '4.0.4'
 
 
           # Memory checks: special Godot binaries compiled with AddressSanitizer/LeakSanitizer to detect UB/leaks.

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -16,11 +16,13 @@ env:
 #  GDEXT_FEATURES: '--features godot/serde'
   RETRY: ${{ github.workspace }}/.github/other/retry.sh
 
+  # ASan options: https://github.com/google/sanitizers/wiki/AddressSanitizerFlags
   # LSan options: https://github.com/google/sanitizers/wiki/AddressSanitizerLeakSanitizer
   # * report_objects: list individual leaked objects when running LeakSanitizer
   LSAN_OPTIONS: report_objects=1
 
-  # ASan options: https://github.com/google/sanitizers/wiki/AddressSanitizerFlags
+  CARGO_DENY_VERSION: "0.14.3"
+  CARGO_MACHETE_VERSION: "0.6.0"
 
 defaults:
   run:
@@ -349,6 +351,32 @@ jobs:
         run: ./.github/other/check-example.sh dodge-the-creeps
 
 
+  cargo-deny-machete:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v4
+
+      # Deny
+      # Note: manually downloading is ~30s faster than https://github.com/EmbarkStudios/cargo-deny-action
+      - name: "Install cargo-deny"
+        run: |
+          wget --no-verbose https://github.com/EmbarkStudios/cargo-deny/releases/download/$CARGO_DENY_VERSION/cargo-deny-$CARGO_DENY_VERSION-x86_64-unknown-linux-musl.tar.gz -O cargo-deny.tar.gz
+          tar -zxvf cargo-deny.tar.gz
+          mkdir -p $HOME/.cargo/bin
+          mv cargo-deny-$CARGO_DENY_VERSION-x86_64-unknown-linux-musl/cargo-deny $HOME/.cargo/bin
+      - name: "Deny non-conforming dependencies"
+        run: cargo deny check --config .github/other/deny.toml
+
+      # Machete
+      - name: "Install cargo-machete"
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: cargo-machete
+          version: ${{ env.CARGO_MACHETE_VERSION }}
+      - name: "Use machete to cut down dependencies"
+        run: cargo machete
+
+
   license-guard:
     runs-on: ubuntu-20.04
     steps:
@@ -379,6 +407,7 @@ jobs:
       - unit-test
       - godot-itest
       - run-examples
+      - cargo-deny-machete
       - license-guard
 
     runs-on: ubuntu-20.04

--- a/.github/workflows/minimal-ci.yml
+++ b/.github/workflows/minimal-ci.yml
@@ -117,7 +117,6 @@ jobs:
         run: cargo test $GDEXT_FEATURES
 
 
-
   # For complex matrix workflow, see https://stackoverflow.com/a/65434401
   godot-itest:
     name: godot-itest (${{ matrix.name }})
@@ -157,13 +156,6 @@ jobs:
             artifact-name: linux-nightly
             godot-binary: godot.linuxbsd.editor.dev.x86_64
             rust-extra-args: --features godot/custom-godot,godot/experimental-threads,godot/serde
-
-          # TODO merge with other jobs
-          - name: linux-lazy-fptrs
-            os: ubuntu-20.04
-            artifact-name: linux-nightly
-            godot-binary: godot.linuxbsd.editor.dev.x86_64
-            rust-extra-args: --features godot/lazy-function-tables
 
           # Linux compat
 

--- a/examples/dodge-the-creeps/rust/Cargo.toml
+++ b/examples/dodge-the-creeps/rust/Cargo.toml
@@ -3,6 +3,7 @@ name = "dodge-the-creeps"
 version = "0.1.0"
 edition = "2021"
 rust-version = "1.70"
+license = "MPL-2.0"
 publish = false
 
 [lib]

--- a/godot-ffi/Cargo.toml
+++ b/godot-ffi/Cargo.toml
@@ -14,6 +14,9 @@ codegen-lazy-fptrs = ["godot-codegen/codegen-lazy-fptrs"]
 experimental-godot-api = ["godot-codegen/experimental-godot-api"]
 trace = []
 
+# TODO: get rid of paste and gensym, they are trivially implementable with proc-macros. Update cargo-deny.
+# Especially gensym which pulls in entire syn for 10 LoC. See https://github.com/regiontog/gensym/blob/master/src/lib.rs.
+# Might however require godot-ffi to depend on godot-macro, which is not ideal...
 [dependencies]
 paste = "1"
 

--- a/godot-fmt/Cargo.toml
+++ b/godot-fmt/Cargo.toml
@@ -2,6 +2,7 @@
 name = "godot-fmt"
 version = "0.1.0"
 edition = "2021"
+license = "MPL-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/itest/rust/Cargo.toml
+++ b/itest/rust/Cargo.toml
@@ -3,6 +3,7 @@ name = "itest"
 version = "0.1.0"
 edition = "2021"
 rust-version = "1.70"
+license = "MPL-2.0"
 publish = false
 
 [lib]


### PR DESCRIPTION
Also remove several `godot-itest` CI jobs.

We should plan the removal of dependencies of `paste` and `gensym`. Both are trivially implementable using proc-macros, we just haven't used them out of convenience so far. But especially `gensym` [is ~10 LoC proc-macro code](https://github.com/regiontog/gensym/blob/master/src/lib.rs) and pulls in entire `syn`, that's just unnecessary bloat for no reason.