### PR TITLE
Rename `bind` -> `register`; improve docs

### DIFF
--- a/godot-core/src/builtin/aabb.rs
+++ b/godot-core/src/builtin/aabb.rs
@@ -385,7 +385,7 @@ impl Aabb {
 impl std::fmt::Display for Aabb {
     /// Formats `Aabb` to match godot's display style.
     ///
-    /// Example:
+    /// # Example
     /// ```
     /// use godot::prelude::*;
     /// let aabb = Aabb::new(Vector3::new(0.0, 0.0, 0.0), Vector3::new(1.0, 1.0, 1.0));

--- a/godot-core/src/builtin/array.rs
+++ b/godot-core/src/builtin/array.rs
@@ -8,7 +8,7 @@
 use godot_ffi as sys;
 
 use crate::builtin::*;
-use crate::property::{Export, Property, PropertyHintInfo, TypeStringHint};
+use crate::property::{Export, PropertyHintInfo, TypeStringHint, Var};
 use std::fmt;
 use std::marker::PhantomData;
 use sys::{ffi_methods, interface_fn, GodotFfi};
@@ -729,7 +729,7 @@ impl TypeStringHint for VariantArray {
     }
 }
 
-impl<T: GodotType> Property for Array<T> {
+impl<T: GodotType> Var for Array<T> {
     type Intermediate = Self;
 
     fn get_property(&self) -> Self::Intermediate {

--- a/godot-core/src/builtin/array.rs
+++ b/godot-core/src/builtin/array.rs
@@ -677,7 +677,7 @@ impl<T: GodotType> fmt::Debug for Array<T> {
 impl<T: GodotType + fmt::Display> fmt::Display for Array<T> {
     /// Formats `Array` to match Godot's string representation.
     ///
-    /// Example:
+    /// # Example
     /// ```no_run
     /// # use godot::prelude::*;
     /// let a = array![1,2,3,4];
@@ -985,13 +985,16 @@ impl<T: GodotType> PartialOrd for Array<T> {
 ///
 /// The type of the array is inferred from the arguments.
 ///
-/// Example:
+/// # Example
 /// ```no_run
 /// # use godot::prelude::*;
 /// let arr = array![3, 1, 4];  // Array<i32>
 /// ```
 ///
+/// # See also
 /// To create an `Array` of variants, see the [`varray!`] macro.
+///
+/// For dictionaries, a similar macro [`dict!`] exists.
 #[macro_export]
 macro_rules! array {
     ($($elements:expr),* $(,)?) => {
@@ -1007,15 +1010,18 @@ macro_rules! array {
 
 /// Constructs [`VariantArray`] literals, similar to Rust's standard `vec!` macro.
 ///
-/// The type of the array is always [`Variant`].
+/// The type of the array elements is always [`Variant`].
 ///
-/// Example:
+/// # Example
 /// ```no_run
 /// # use godot::prelude::*;
 /// let arr: VariantArray = varray![42_i64, "hello", true];
 /// ```
 ///
+/// # See also
 /// To create a typed `Array` with a single element type, see the [`array!`] macro.
+///
+/// For dictionaries, a similar macro [`dict!`] exists.
 #[macro_export]
 macro_rules! varray {
     // Note: use to_variant() and not Variant::from(), as that works with both references and values

--- a/godot-core/src/builtin/color.rs
+++ b/godot-core/src/builtin/color.rs
@@ -520,7 +520,7 @@ fn to_be_words(mut u: u64) -> [u16; 4] {
 impl std::fmt::Display for Color {
     /// Formats `Color` to match Godot's string representation.
     ///
-    /// Example:
+    /// # Example
     /// ```
     /// use godot::prelude::*;
     /// let color = Color::from_rgba(1.0,1.0,1.0,1.0);

--- a/godot-core/src/builtin/dictionary.rs
+++ b/godot-core/src/builtin/dictionary.rs
@@ -632,7 +632,7 @@ impl<'a, K: FromGodot> Iterator for TypedKeys<'a, K> {
 /// Any value can be used as a key, but to use an expression you need to surround it
 /// in `()` or `{}`.
 ///
-/// Example:
+/// # Example
 /// ```no_run
 /// use godot::builtin::{dict, Variant};
 ///
@@ -644,6 +644,10 @@ impl<'a, K: FromGodot> Iterator for TypedKeys<'a, K> {
 ///     (1 + 2): "final",
 /// };
 /// ```
+///
+/// # See also
+///
+/// For arrays, similar macros [`array!`][macro@crate::builtin::array] and [`varray!`][macro@crate::builtin::varray] exist.
 #[macro_export]
 macro_rules! dict {
     ($($key:tt: $value:expr),* $(,)?) => {

--- a/godot-core/src/builtin/dictionary.rs
+++ b/godot-core/src/builtin/dictionary.rs
@@ -8,16 +8,14 @@
 use godot_ffi as sys;
 
 use crate::builtin::meta::{FromGodot, ToGodot};
-use crate::builtin::{inner, Variant};
-use crate::property::{Export, Property, PropertyHintInfo, TypeStringHint};
-use std::fmt;
+use crate::builtin::{inner, Variant, VariantArray};
+use crate::property::{Export, PropertyHintInfo, TypeStringHint, Var};
 use std::marker::PhantomData;
-use std::ptr::addr_of_mut;
+use std::{fmt, ptr};
 use sys::types::OpaqueDictionary;
-use sys::{ffi_methods, interface_fn, AsUninit, GodotFfi, VariantType};
+use sys::{ffi_methods, interface_fn, AsUninit, GodotFfi};
 
 use super::meta::impl_godot_as_self;
-use super::VariantArray;
 
 /// Godot's `Dictionary` type.
 ///
@@ -339,7 +337,7 @@ impl Clone for Dictionary {
     }
 }
 
-impl Property for Dictionary {
+impl Var for Dictionary {
     type Intermediate = Self;
 
     fn get_property(&self) -> Self::Intermediate {
@@ -353,7 +351,7 @@ impl Property for Dictionary {
 
 impl TypeStringHint for Dictionary {
     fn type_string() -> String {
-        format!("{}:Dictionary", VariantType::Dictionary as i32)
+        format!("{}:Dictionary", sys::VariantType::Dictionary as i32)
     }
 }
 
@@ -484,7 +482,7 @@ impl<'a> DictionaryIter<'a> {
             iter_fn(
                 dictionary.var_sys(),
                 next_value.var_sys(),
-                addr_of_mut!(valid_u8),
+                ptr::addr_of_mut!(valid_u8),
             )
         };
         let valid = super::u8_to_bool(valid_u8);

--- a/godot-core/src/builtin/plane.rs
+++ b/godot-core/src/builtin/plane.rs
@@ -288,7 +288,7 @@ impl ApproxEq for Plane {
 impl std::fmt::Display for Plane {
     /// Formats `Plane` to match Godot's string representation.
     ///
-    /// Example:
+    /// # Example
     /// ```
     /// use godot::prelude::*;
     /// let plane = Plane::new(Vector3::new(1.0, 0.0, 0.0), 1.0);

--- a/godot-core/src/builtin/projection.rs
+++ b/godot-core/src/builtin/projection.rs
@@ -581,7 +581,7 @@ pub enum ProjectionEye {
 impl std::fmt::Display for Projection {
     /// Formats `Projection` to match Godot's string representation.
     ///
-    /// Example:
+    /// # Example
     /// ```
     /// use godot::prelude::*;
     /// let proj = Projection::new([

--- a/godot-core/src/builtin/real.rs
+++ b/godot-core/src/builtin/real.rs
@@ -5,6 +5,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+/// Convenience conversion between `real` and `f32`/`f64`.
+///
 /// Clippy often complains if you do `f as f64` when `f` is already an `f64`. This trait exists to make it easy to
 /// convert between the different reals and floats without a lot of allowing clippy lints for your code.
 pub trait RealConv {

--- a/godot-core/src/builtin/real.rs
+++ b/godot-core/src/builtin/real.rs
@@ -202,6 +202,8 @@ macro_rules! real {
 
 /// Array of reals.
 ///
+/// The expression has type `[real; N]` where `N` is the number of elements in the array.
+///
 /// # Example
 /// ```
 /// use godot_core::builtin::{real, reals};

--- a/godot-core/src/builtin/rect2.rs
+++ b/godot-core/src/builtin/rect2.rs
@@ -278,7 +278,7 @@ impl ApproxEq for Rect2 {
 impl std::fmt::Display for Rect2 {
     /// Formats `Rect2` to match Godot's string representation.
     ///
-    /// Example:
+    /// # Example
     /// ```
     /// use godot::prelude::*;
     /// let rect = Rect2::new(Vector2::new(0.0, 0.0), Vector2::new(1.0, 1.0));

--- a/godot-core/src/builtin/rect2i.rs
+++ b/godot-core/src/builtin/rect2i.rs
@@ -279,7 +279,7 @@ impl_godot_as_self!(Rect2i);
 impl std::fmt::Display for Rect2i {
     /// Formats `Rect2i` to match Godot's string representation.
     ///
-    /// Example:
+    /// # Example
     /// ```
     /// use godot::prelude::*;
     /// let rect = Rect2i::new(Vector2i::new(0, 0), Vector2i::new(1, 1));

--- a/godot-core/src/builtin/rid.rs
+++ b/godot-core/src/builtin/rid.rs
@@ -101,7 +101,7 @@ impl Rid {
 impl std::fmt::Display for Rid {
     /// Formats `Rid` to match Godot's string representation.
     ///
-    /// Example:
+    /// # Example
     /// ```
     /// use godot::prelude::*;
     /// let id = Rid::new(1);

--- a/godot-core/src/log.rs
+++ b/godot-core/src/log.rs
@@ -5,6 +5,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+//! Printing and logging functionality.
+
 #[macro_export]
 #[doc(hidden)]
 macro_rules! inner_godot_msg {
@@ -33,7 +35,7 @@ macro_rules! inner_godot_msg {
 
 /// Pushes a warning message to Godot's built-in debugger and to the OS terminal.
 ///
-/// _Godot equivalent: @GlobalScope.push_warning()_
+/// _Godot equivalent: [`@GlobalScope.push_warning()`](https://docs.godotengine.org/en/stable/classes/class_@globalscope.html#class-globalscope-method-push-warning)_.
 #[macro_export]
 macro_rules! godot_warn {
     ($fmt:literal $(, $args:expr)* $(,)?) => {
@@ -43,7 +45,7 @@ macro_rules! godot_warn {
 
 /// Pushes an error message to Godot's built-in debugger and to the OS terminal.
 ///
-/// _Godot equivalent: @GlobalScope.push_error()_
+/// _Godot equivalent: [`@GlobalScope.push_error()`](https://docs.godotengine.org/en/stable/classes/class_@globalscope.html#class-globalscope-method-push-error)_.
 #[macro_export]
 macro_rules! godot_error {
     ($fmt:literal $(, $args:expr)* $(,)?) => {
@@ -51,6 +53,7 @@ macro_rules! godot_error {
     };
 }
 
+/// Logs a script error to Godot's built-in debugger and to the OS terminal.
 #[macro_export]
 macro_rules! godot_script_error {
     ($fmt:literal $(, $args:expr)* $(,)?) => {
@@ -60,7 +63,7 @@ macro_rules! godot_script_error {
 
 /// Prints to the Godot console.
 ///
-/// _Godot equivalent: @GlobalScope.print()_
+/// _Godot equivalent: [`@GlobalScope.print()`](https://docs.godotengine.org/en/stable/classes/class_@globalscope.html#class-globalscope-method-print)_.
 #[macro_export]
 macro_rules! godot_print {
     ($fmt:literal $(, $args:expr)* $(,)?) => {
@@ -79,7 +82,7 @@ pub use crate::{godot_error, godot_print, godot_script_error, godot_warn};
 use crate::builtin::{StringName, Variant};
 use crate::sys::{self, GodotFfi};
 
-/// Prints to the Godot console, used by the godot_print! macro.
+/// Prints to the Godot console, used by the [`godot_print!`] macro.
 pub fn print(varargs: &[Variant]) {
     unsafe {
         let method_name = StringName::from("print");

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -19,7 +19,7 @@ use crate::builtin::{Callable, StringName};
 use crate::obj::Bounds;
 use crate::obj::{bounds, cap, EngineEnum, GdDerefTarget, GodotClass, Inherits};
 use crate::obj::{GdMut, GdRef, InstanceId};
-use crate::property::{Export, Property, PropertyHintInfo, TypeStringHint};
+use crate::property::{Export, PropertyHintInfo, TypeStringHint, Var};
 use crate::{callbacks, engine, out};
 
 use super::RawGd;
@@ -615,7 +615,7 @@ impl<T: GodotClass> TypeStringHint for Gd<T> {
     }
 }
 
-impl<T: GodotClass> Property for Gd<T> {
+impl<T: GodotClass> Var for Gd<T> {
     type Intermediate = Self;
 
     fn get_property(&self) -> Self {

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -113,7 +113,7 @@ where
     /// The `init` function provides you with a `Base<T::Base>` object that you can use inside your `T`, which
     /// is then wrapped in a `Gd<T>`.
     ///
-    /// Example:
+    /// # Example
     /// ```no_run
     /// # use godot::prelude::*;
     /// #[derive(GodotClass)]

--- a/godot-core/src/obj/onready.rs
+++ b/godot-core/src/obj/onready.rs
@@ -5,7 +5,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use crate::property::{Export, Property, PropertyHintInfo};
+use crate::property::{Export, PropertyHintInfo, Var};
 use std::mem;
 
 /// Ergonomic late-initialization container with `ready()` support.
@@ -187,7 +187,7 @@ impl<T> std::ops::DerefMut for OnReady<T> {
     }
 }
 
-impl<T: Property> Property for OnReady<T> {
+impl<T: Var> Var for OnReady<T> {
     type Intermediate = T::Intermediate;
 
     fn get_property(&self) -> Self::Intermediate {

--- a/godot-macros/src/class/data_models/field_export.rs
+++ b/godot-macros/src/class/data_models/field_export.rs
@@ -359,7 +359,7 @@ impl FieldExport {
 macro_rules! quote_export_func {
     ($function_name:ident($($tt:tt)*)) => {
         FieldHint::HintFromExportFunction(quote! {
-            ::godot::bind::property::export_info_functions::$function_name($($tt)*)
+            ::godot::register::property::export_info_functions::$function_name($($tt)*)
         })
     }
 }

--- a/godot-macros/src/class/data_models/field_var.rs
+++ b/godot-macros/src/class/data_models/field_var.rs
@@ -168,18 +168,18 @@ impl GetterSetterImpl {
         match kind {
             GetSet::Get => {
                 signature = quote! {
-                    fn #function_name(&self) -> <#field_type as ::godot::register::property::Property>::Intermediate
+                    fn #function_name(&self) -> <#field_type as ::godot::register::property::Var>::Intermediate
                 };
                 function_body = quote! {
-                    <#field_type as ::godot::register::property::Property>::get_property(&self.#field_name)
+                    <#field_type as ::godot::register::property::Var>::get_property(&self.#field_name)
                 };
             }
             GetSet::Set => {
                 signature = quote! {
-                    fn #function_name(&mut self, #field_name: <#field_type as ::godot::register::property::Property>::Intermediate)
+                    fn #function_name(&mut self, #field_name: <#field_type as ::godot::register::property::Var>::Intermediate)
                 };
                 function_body = quote! {
-                    <#field_type as ::godot::register::property::Property>::set_property(&mut self.#field_name, #field_name);
+                    <#field_type as ::godot::register::property::Var>::set_property(&mut self.#field_name, #field_name);
                 };
             }
         }

--- a/godot-macros/src/class/data_models/field_var.rs
+++ b/godot-macros/src/class/data_models/field_var.rs
@@ -168,18 +168,18 @@ impl GetterSetterImpl {
         match kind {
             GetSet::Get => {
                 signature = quote! {
-                    fn #function_name(&self) -> <#field_type as ::godot::bind::property::Property>::Intermediate
+                    fn #function_name(&self) -> <#field_type as ::godot::register::property::Property>::Intermediate
                 };
                 function_body = quote! {
-                    <#field_type as ::godot::bind::property::Property>::get_property(&self.#field_name)
+                    <#field_type as ::godot::register::property::Property>::get_property(&self.#field_name)
                 };
             }
             GetSet::Set => {
                 signature = quote! {
-                    fn #function_name(&mut self, #field_name: <#field_type as ::godot::bind::property::Property>::Intermediate)
+                    fn #function_name(&mut self, #field_name: <#field_type as ::godot::register::property::Property>::Intermediate)
                 };
                 function_body = quote! {
-                    <#field_type as ::godot::bind::property::Property>::set_property(&mut self.#field_name, #field_name);
+                    <#field_type as ::godot::register::property::Property>::set_property(&mut self.#field_name, #field_name);
                 };
             }
         }

--- a/godot-macros/src/class/data_models/property.rs
+++ b/godot-macros/src/class/data_models/property.rs
@@ -114,7 +114,7 @@ pub fn make_property_impl(class_name: &Ident, fields: &Fields) -> TokenStream {
                 } else {
                     quote! {
                         {
-                            let default_export_info = <#field_type as ::godot::register::property::Property>::property_hint();
+                            let default_export_info = <#field_type as ::godot::register::property::Var>::property_hint();
                             (default_export_info.hint, default_export_info.hint_string)
                         }
                     }

--- a/godot-macros/src/class/data_models/property.rs
+++ b/godot-macros/src/class/data_models/property.rs
@@ -107,14 +107,14 @@ pub fn make_property_impl(class_name: &Ident, fields: &Fields) -> TokenStream {
                 if export.is_some() {
                     quote! {
                         {
-                            let default_export_info = <#field_type as ::godot::bind::property::Export>::default_export_info();
+                            let default_export_info = <#field_type as ::godot::register::property::Export>::default_export_info();
                             (default_export_info.hint, default_export_info.hint_string)
                         }
                     }
                 } else {
                     quote! {
                         {
-                            let default_export_info = <#field_type as ::godot::bind::property::Property>::property_hint();
+                            let default_export_info = <#field_type as ::godot::register::property::Property>::property_hint();
                             (default_export_info.hint, default_export_info.hint_string)
                         }
                     }
@@ -134,7 +134,7 @@ pub fn make_property_impl(class_name: &Ident, fields: &Fields) -> TokenStream {
             },
             FieldHint::HintFromExportFunction(expression) => quote! {
                 {
-                    let ::godot::bind::property::PropertyHintInfo { hint, hint_string } = #expression;
+                    let ::godot::register::property::PropertyHintInfo { hint, hint_string } = #expression;
                     (hint, hint_string)
                 }
             },

--- a/godot-macros/src/derive/derive_export.rs
+++ b/godot-macros/src/derive/derive_export.rs
@@ -65,9 +65,9 @@ pub fn derive_export(decl: Declaration) -> ParseResult<TokenStream2> {
 
     let out = quote! {
         #[allow(unused_parens)]
-        impl godot::bind::property::Export for #name {
-            fn default_export_info() -> godot::bind::property::PropertyHintInfo {
-                godot::bind::property::PropertyHintInfo {
+        impl godot::register::property::Export for #name {
+            fn default_export_info() -> godot::register::property::PropertyHintInfo {
+                godot::register::property::PropertyHintInfo {
                     hint: godot::engine::global::PropertyHint::PROPERTY_HINT_ENUM,
                     hint_string: godot::prelude::GString::from(#hint_string),
                 }

--- a/godot-macros/src/derive/derive_property.rs
+++ b/godot-macros/src/derive/derive_property.rs
@@ -106,7 +106,7 @@ pub fn derive_property(decl: Declaration) -> ParseResult<TokenStream2> {
 
     let out = quote! {
         #[allow(unused_parens)]
-        impl godot::bind::property::Property for #name {
+        impl godot::register::property::Property for #name {
             type Intermediate = #intermediate;
 
             fn get_property(&self) -> #intermediate {

--- a/godot-macros/src/derive/derive_var.rs
+++ b/godot-macros/src/derive/derive_var.rs
@@ -12,7 +12,7 @@ use venial::{Declaration, StructFields};
 use crate::util::{bail, decl_get_info, ident, DeclInfo};
 use crate::ParseResult;
 
-pub fn derive_property(decl: Declaration) -> ParseResult<TokenStream2> {
+pub fn derive_var(decl: Declaration) -> ParseResult<TokenStream2> {
     let DeclInfo {
         name, name_string, ..
     } = decl_get_info(&decl);
@@ -106,7 +106,7 @@ pub fn derive_property(decl: Declaration) -> ParseResult<TokenStream2> {
 
     let out = quote! {
         #[allow(unused_parens)]
-        impl godot::register::property::Property for #name {
+        impl godot::register::property::Var for #name {
             type Intermediate = #intermediate;
 
             fn get_property(&self) -> #intermediate {

--- a/godot-macros/src/derive/mod.rs
+++ b/godot-macros/src/derive/mod.rs
@@ -10,11 +10,11 @@
 mod derive_export;
 mod derive_from_variant;
 mod derive_godot_convert;
-mod derive_property;
 mod derive_to_variant;
+mod derive_var;
 
 pub(crate) use derive_export::*;
 pub(crate) use derive_from_variant::*;
 pub(crate) use derive_godot_convert::*;
-pub(crate) use derive_property::*;
 pub(crate) use derive_to_variant::*;
+pub(crate) use derive_var::*;

--- a/godot-macros/src/lib.rs
+++ b/godot-macros/src/lib.rs
@@ -20,7 +20,7 @@ use venial::Declaration;
 use crate::util::ident;
 
 // Below intra-doc link to the trait only works as HTML, not as symbol link.
-/// Derive macro for [the `GodotClass` trait](../obj/trait.GodotClass.html) on structs.
+/// Derive macro for [`GodotClass`](../obj/trait.GodotClass.html) on structs.
 ///
 /// You must use this macro; manual implementations of the `GodotClass` trait are not supported.
 ///
@@ -285,12 +285,23 @@ use crate::util::ident;
 /// }
 /// ```
 ///
-///
 /// # Signals
 ///
-/// The `#[signal]` attribute is accepted, but not yet implemented. See [issue
-/// #8](https://github.com/godot-rust/gdext/issues/8).
+/// The `#[signal]` attribute is quite limited at the moment and can only be used for parameter-less signals.
+/// It will be fundamentally reworked.
 ///
+/// ```no_run
+/// use godot::prelude::*;
+///
+/// #[derive(GodotClass)]
+/// struct MyClass {}
+///
+/// #[godot_api]
+/// impl MyClass {
+///     #[signal]
+///     fn some_signal();
+/// }
+/// ```
 ///
 /// # Running code in the editor
 ///
@@ -344,7 +355,7 @@ pub fn derive_godot_class(input: TokenStream) -> TokenStream {
     translate(input, class::derive_godot_class)
 }
 
-/// Proc-macro attribute to be used with `impl` blocks of `#[derive(GodotClass)]` structs.
+/// Proc-macro attribute to be used with `impl` blocks of [`#[derive(GodotClass)]`][GodotClass] structs.
 ///
 /// Can be used in two ways:
 /// ```no_run
@@ -425,12 +436,13 @@ pub fn godot_api(_meta: TokenStream, input: TokenStream) -> TokenStream {
     translate(input, class::attribute_godot_api)
 }
 
+/// Derive macro for [`GodotConvert`](../builtin/meta/trait.GodotConvert.html) on structs (required by [`ToGodot`] and [`FromGodot`]).
 #[proc_macro_derive(GodotConvert)]
 pub fn derive_godot_convert(input: TokenStream) -> TokenStream {
     translate(input, derive::derive_godot_convert)
 }
 
-/// Derive macro for [ToGodot](../builtin/meta/trait.ToGodot.html) on structs or enums.
+/// Derive macro for [`ToGodot`](../builtin/meta/trait.ToGodot.html) on structs or enums.
 ///
 /// # Example
 ///
@@ -463,7 +475,7 @@ pub fn derive_to_godot(input: TokenStream) -> TokenStream {
     translate(input, derive::derive_to_godot)
 }
 
-/// Derive macro for [FromGodot](../builtin/meta/trait.FromVariant.html) on structs or enums.
+/// Derive macro for [`FromGodot`](../builtin/meta/trait.FromVariant.html) on structs or enums.
 ///
 /// # Example
 ///
@@ -497,7 +509,7 @@ pub fn derive_from_godot(input: TokenStream) -> TokenStream {
     translate(input, derive::derive_from_godot)
 }
 
-/// Derive macro for [Property](../bind/property/trait.Property.html) on enums.
+/// Derive macro for [`Var`](../bind/property/trait.Var.html) on enums.
 ///
 /// Currently has some tight requirements which are expected to be softened as implementation expands:
 /// - Only works for enums, structs aren't supported by this derive macro at the moment.
@@ -510,35 +522,36 @@ pub fn derive_from_godot(input: TokenStream) -> TokenStream {
 ///
 /// ```no_run
 /// # use godot::prelude::*;
+/// #[derive(Var)]
 /// #[repr(i32)]
-/// #[derive(Property)]
 /// # #[derive(Eq, PartialEq, Debug)]
-/// enum TestEnum {
+/// enum MyEnum {
 ///     A = 0,
 ///     B = 1,
 /// }
 ///
 /// #[derive(GodotClass)]
-/// struct TestClass {
+/// struct MyClass {
 ///     #[var]
-///     foo: TestEnum
+///     foo: MyEnum,
 /// }
 ///
-/// # fn main() {
-/// let mut class = TestClass {foo: TestEnum::B};
-/// assert_eq!(class.get_foo(), TestEnum::B as i32);
-/// class.set_foo(TestEnum::A as i32);
-/// assert_eq!(class.foo, TestEnum::A);
-/// # }
+/// fn main() {
+///     let mut class = MyClass { foo: MyEnum::B };
+///     assert_eq!(class.get_foo(), MyEnum::B as i32);
+///
+///     class.set_foo(MyEnum::A as i32);
+///     assert_eq!(class.foo, MyEnum::A);
+/// }
 /// ```
-#[proc_macro_derive(Property)]
+#[proc_macro_derive(Var)]
 pub fn derive_property(input: TokenStream) -> TokenStream {
-    translate(input, derive::derive_property)
+    translate(input, derive::derive_var)
 }
 
-/// Derive macro for [Export](../bind/property/trait.Export.html) on enums.
+/// Derive macro for [`Export`](../bind/property/trait.Export.html) on enums.
 ///
-/// Currently has some tight requirements which are expected to be softened as implementation expands, see requirements for [Property].
+/// Currently has some tight requirements which are expected to be softened as implementation expands, see requirements for [`Var`].
 #[proc_macro_derive(Export)]
 pub fn derive_export(input: TokenStream) -> TokenStream {
     translate(input, derive::derive_export)

--- a/godot-macros/src/util/mod.rs
+++ b/godot-macros/src/util/mod.rs
@@ -35,12 +35,12 @@ pub fn class_name_obj(class: &impl ToTokens) -> TokenStream {
 
 pub fn property_variant_type(property_type: &impl ToTokens) -> TokenStream {
     let property_type = property_type.to_token_stream();
-    quote! { <<<#property_type as ::godot::bind::property::Property>::Intermediate as ::godot::builtin::meta::GodotConvert>::Via as ::godot::builtin::meta::GodotType>::Ffi::variant_type() }
+    quote! { <<<#property_type as ::godot::register::property::Property>::Intermediate as ::godot::builtin::meta::GodotConvert>::Via as ::godot::builtin::meta::GodotType>::Ffi::variant_type() }
 }
 
 pub fn property_variant_class_name(property_type: &impl ToTokens) -> TokenStream {
     let property_type = property_type.to_token_stream();
-    quote! { <<<#property_type as ::godot::bind::property::Property>::Intermediate as ::godot::builtin::meta::GodotConvert>::Via as ::godot::builtin::meta::GodotType>::class_name() }
+    quote! { <<<#property_type as ::godot::register::property::Property>::Intermediate as ::godot::builtin::meta::GodotConvert>::Via as ::godot::builtin::meta::GodotType>::class_name() }
 }
 
 pub fn bail_fn<R, T>(msg: impl AsRef<str>, tokens: T) -> ParseResult<R>

--- a/godot-macros/src/util/mod.rs
+++ b/godot-macros/src/util/mod.rs
@@ -35,12 +35,12 @@ pub fn class_name_obj(class: &impl ToTokens) -> TokenStream {
 
 pub fn property_variant_type(property_type: &impl ToTokens) -> TokenStream {
     let property_type = property_type.to_token_stream();
-    quote! { <<<#property_type as ::godot::register::property::Property>::Intermediate as ::godot::builtin::meta::GodotConvert>::Via as ::godot::builtin::meta::GodotType>::Ffi::variant_type() }
+    quote! { <<<#property_type as ::godot::register::property::Var>::Intermediate as ::godot::builtin::meta::GodotConvert>::Via as ::godot::builtin::meta::GodotType>::Ffi::variant_type() }
 }
 
 pub fn property_variant_class_name(property_type: &impl ToTokens) -> TokenStream {
     let property_type = property_type.to_token_stream();
-    quote! { <<<#property_type as ::godot::register::property::Property>::Intermediate as ::godot::builtin::meta::GodotConvert>::Via as ::godot::builtin::meta::GodotType>::class_name() }
+    quote! { <<<#property_type as ::godot::register::property::Var>::Intermediate as ::godot::builtin::meta::GodotConvert>::Via as ::godot::builtin::meta::GodotType>::class_name() }
 }
 
 pub fn bail_fn<R, T>(msg: impl AsRef<str>, tokens: T) -> ParseResult<R>

--- a/godot/src/lib.rs
+++ b/godot/src/lib.rs
@@ -199,12 +199,18 @@ pub mod init {
     pub use godot_macros::gdextension;
 }
 
-/// Export user-defined classes and methods to be called by the engine.
-pub mod bind {
+/// Register Rust symbols in Godot: classes, methods, enums...
+pub mod register {
     pub use godot_core::property;
     pub use godot_macros::{
         godot_api, Export, FromGodot, GodotClass, GodotConvert, Property, ToGodot,
     };
+}
+
+#[deprecated = "Renamed to `register`."]
+/// Renamed to [`register`] module.
+pub mod bind {
+    pub use super::register::*;
 }
 
 /// Testing facilities (unstable).
@@ -218,8 +224,8 @@ pub use godot_core::private;
 
 /// Often-imported symbols.
 pub mod prelude {
-    pub use super::bind::property::{Export, Property, TypeStringHint};
-    pub use super::bind::{
+    pub use super::register::property::{Export, Property, TypeStringHint};
+    pub use super::register::{
         godot_api, Export, FromGodot, GodotClass, GodotConvert, Property, ToGodot,
     };
 

--- a/godot/src/lib.rs
+++ b/godot/src/lib.rs
@@ -192,6 +192,7 @@ compile_error!("Must opt-in using `experimental-wasm` Cargo feature; keep in min
 #[cfg(all(feature = "double-precision", not(feature = "custom-godot")))]
 compile_error!("The feature `double-precision` currently requires `custom-godot` due to incompatibilities in the GDExtension API JSON.");
 
+/// Entry point and global init/shutdown of the library.
 pub mod init {
     pub use godot_core::init::*;
 
@@ -199,7 +200,7 @@ pub mod init {
     pub use godot_macros::gdextension;
 }
 
-/// Register Rust symbols in Godot: classes, methods, enums...
+/// Register/export Rust symbols to Godot: classes, methods, enums...
 pub mod register {
     pub use godot_core::property;
     pub use godot_macros::{godot_api, Export, FromGodot, GodotClass, GodotConvert, ToGodot, Var};

--- a/godot/src/lib.rs
+++ b/godot/src/lib.rs
@@ -205,8 +205,8 @@ pub mod register {
     pub use godot_macros::{godot_api, Export, FromGodot, GodotClass, GodotConvert, ToGodot, Var};
 }
 
-#[deprecated = "Renamed to `register`."]
 /// Renamed to [`register`] module.
+#[deprecated = "Renamed to `register`."]
 pub mod bind {
     pub use super::register::*;
 }
@@ -221,32 +221,4 @@ pub mod test {
 pub use godot_core::private;
 
 /// Often-imported symbols.
-pub mod prelude {
-    pub use super::register::property::{Export, TypeStringHint, Var};
-    pub use super::register::{
-        godot_api, Export, FromGodot, GodotClass, GodotConvert, ToGodot, Var,
-    };
-
-    pub use super::builtin::math::FloatExt as _;
-    pub use super::builtin::meta::{FromGodot, ToGodot};
-    pub use super::builtin::*;
-    pub use super::builtin::{array, dict, varray}; // Re-export macros.
-    pub use super::engine::{
-        load, try_load, utilities, AudioStreamPlayer, Camera2D, Camera3D, GFile,
-        IAudioStreamPlayer, ICamera2D, ICamera3D, INode, INode2D, INode3D, IObject, IPackedScene,
-        IRefCounted, IResource, ISceneTree, Input, Node, Node2D, Node3D, Object, PackedScene,
-        PackedSceneExt, RefCounted, Resource, SceneTree,
-    };
-    pub use super::init::{gdextension, ExtensionLibrary, InitLevel};
-    pub use super::log::*;
-    pub use super::obj::{Base, Gd, GdMut, GdRef, GodotClass, Inherits, InstanceId, OnReady};
-
-    // Make trait methods available
-    pub use super::engine::NodeExt as _;
-    pub use super::obj::EngineBitfield as _;
-    pub use super::obj::EngineEnum as _;
-    pub use super::obj::NewAlloc as _;
-    pub use super::obj::NewGd as _;
-    pub use super::obj::UserClass as _; // new_gd(), alloc_gd() -- TODO: remove (exposed functions are deprecated)
-    pub use super::obj::WithBaseField as _; // to_gd()
-}
+pub mod prelude;

--- a/godot/src/lib.rs
+++ b/godot/src/lib.rs
@@ -202,9 +202,7 @@ pub mod init {
 /// Register Rust symbols in Godot: classes, methods, enums...
 pub mod register {
     pub use godot_core::property;
-    pub use godot_macros::{
-        godot_api, Export, FromGodot, GodotClass, GodotConvert, Property, ToGodot,
-    };
+    pub use godot_macros::{godot_api, Export, FromGodot, GodotClass, GodotConvert, ToGodot, Var};
 }
 
 #[deprecated = "Renamed to `register`."]
@@ -224,9 +222,9 @@ pub use godot_core::private;
 
 /// Often-imported symbols.
 pub mod prelude {
-    pub use super::register::property::{Export, Property, TypeStringHint};
+    pub use super::register::property::{Export, TypeStringHint, Var};
     pub use super::register::{
-        godot_api, Export, FromGodot, GodotClass, GodotConvert, Property, ToGodot,
+        godot_api, Export, FromGodot, GodotClass, GodotConvert, ToGodot, Var,
     };
 
     pub use super::builtin::math::FloatExt as _;

--- a/godot/src/prelude.rs
+++ b/godot/src/prelude.rs
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+pub use super::register::property::{Export, TypeStringHint, Var};
+
+// Re-export macros.
+pub use super::register::{godot_api, Export, FromGodot, GodotClass, GodotConvert, ToGodot, Var};
+
+pub use super::builtin::math::FloatExt as _;
+pub use super::builtin::meta::{FromGodot, ToGodot};
+pub use super::builtin::*;
+pub use super::builtin::{array, dict, varray};
+
+pub use super::engine::{
+    load, try_load, utilities, AudioStreamPlayer, Camera2D, Camera3D, GFile, IAudioStreamPlayer,
+    ICamera2D, ICamera3D, INode, INode2D, INode3D, IObject, IPackedScene, IRefCounted, IResource,
+    ISceneTree, Input, Node, Node2D, Node3D, Object, PackedScene, PackedSceneExt, RefCounted,
+    Resource, SceneTree,
+};
+pub use super::init::{gdextension, ExtensionLibrary, InitLevel};
+pub use super::log::*;
+pub use super::obj::{Base, Gd, GdMut, GdRef, GodotClass, Inherits, InstanceId, OnReady};
+
+// Make trait methods available.
+pub use super::engine::NodeExt as _;
+pub use super::obj::EngineBitfield as _;
+pub use super::obj::EngineEnum as _;
+pub use super::obj::NewAlloc as _;
+pub use super::obj::NewGd as _;
+pub use super::obj::UserClass as _; // TODO: remove (exposed functions are deprecated)
+pub use super::obj::WithBaseField as _; // base(), base_mut(), to_gd()

--- a/itest/rust/build.rs
+++ b/itest/rust/build.rs
@@ -216,12 +216,12 @@ fn main() {
         use godot::engine::global::Error;
         use godot::engine::{Node, Resource};
 
-        #[derive(godot::bind::GodotClass)]
+        #[derive(godot::register::GodotClass)]
         #[class(init)]
         struct GenFfi {}
 
         #[allow(clippy::bool_comparison)] // i == true
-        #[godot::bind::godot_api]
+        #[godot::register::godot_api]
         impl GenFfi {
             #(#methods)*
         }

--- a/itest/rust/src/benchmarks/mod.rs
+++ b/itest/rust/src/benchmarks/mod.rs
@@ -9,11 +9,11 @@
 
 use std::hint::black_box;
 
-use godot::register::GodotClass;
 use godot::builtin::inner::InnerRect2i;
 use godot::builtin::{GString, Rect2i, StringName, Vector2i};
 use godot::engine::{Node3D, Os, RefCounted};
 use godot::obj::{Gd, InstanceId, NewAlloc, NewGd};
+use godot::register::GodotClass;
 
 use crate::framework::bench;
 

--- a/itest/rust/src/benchmarks/mod.rs
+++ b/itest/rust/src/benchmarks/mod.rs
@@ -9,7 +9,7 @@
 
 use std::hint::black_box;
 
-use godot::bind::GodotClass;
+use godot::register::GodotClass;
 use godot::builtin::inner::InnerRect2i;
 use godot::builtin::{GString, Rect2i, StringName, Vector2i};
 use godot::engine::{Node3D, Os, RefCounted};

--- a/itest/rust/src/builtin_tests/containers/callable_test.rs
+++ b/itest/rust/src/builtin_tests/containers/callable_test.rs
@@ -5,7 +5,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use godot::bind::{godot_api, GodotClass};
+use godot::register::{godot_api, GodotClass};
 use godot::builtin::inner::InnerCallable;
 use godot::builtin::meta::ToGodot;
 use godot::builtin::{varray, Callable, GString, StringName, Variant};

--- a/itest/rust/src/builtin_tests/containers/callable_test.rs
+++ b/itest/rust/src/builtin_tests/containers/callable_test.rs
@@ -5,12 +5,12 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use godot::register::{godot_api, GodotClass};
 use godot::builtin::inner::InnerCallable;
 use godot::builtin::meta::ToGodot;
 use godot::builtin::{varray, Callable, GString, StringName, Variant};
 use godot::engine::{Node2D, Object};
 use godot::obj::{NewAlloc, NewGd};
+use godot::register::{godot_api, GodotClass};
 
 use crate::framework::itest;
 

--- a/itest/rust/src/builtin_tests/containers/signal_test.rs
+++ b/itest/rust/src/builtin_tests/containers/signal_test.rs
@@ -7,7 +7,7 @@
 
 use std::cell::Cell;
 
-use godot::bind::{godot_api, GodotClass};
+use godot::register::{godot_api, GodotClass};
 use godot::builtin::{GString, Variant};
 
 use godot::engine::Object;

--- a/itest/rust/src/builtin_tests/containers/signal_test.rs
+++ b/itest/rust/src/builtin_tests/containers/signal_test.rs
@@ -7,8 +7,8 @@
 
 use std::cell::Cell;
 
-use godot::register::{godot_api, GodotClass};
 use godot::builtin::{GString, Variant};
+use godot::register::{godot_api, GodotClass};
 
 use godot::engine::Object;
 use godot::obj::{Base, Gd, NewAlloc, WithBaseField};

--- a/itest/rust/src/builtin_tests/script/script_instance_tests.rs
+++ b/itest/rust/src/builtin_tests/script/script_instance_tests.rs
@@ -7,7 +7,6 @@
 
 use std::ffi::c_void;
 
-use godot::register::{godot_api, GodotClass};
 use godot::builtin::meta::{ClassName, FromGodot, MethodInfo, PropertyInfo, ToGodot};
 use godot::builtin::{GString, StringName, Variant, VariantType};
 use godot::engine::global::{MethodFlags, PropertyHint, PropertyUsageFlags};
@@ -16,6 +15,7 @@ use godot::engine::{
     ScriptLanguage,
 };
 use godot::obj::{Base, Gd, WithBaseField};
+use godot::register::{godot_api, GodotClass};
 use godot::sys;
 
 #[derive(GodotClass)]

--- a/itest/rust/src/builtin_tests/script/script_instance_tests.rs
+++ b/itest/rust/src/builtin_tests/script/script_instance_tests.rs
@@ -7,7 +7,7 @@
 
 use std::ffi::c_void;
 
-use godot::bind::{godot_api, GodotClass};
+use godot::register::{godot_api, GodotClass};
 use godot::builtin::meta::{ClassName, FromGodot, MethodInfo, PropertyInfo, ToGodot};
 use godot::builtin::{GString, StringName, Variant, VariantType};
 use godot::engine::global::{MethodFlags, PropertyHint, PropertyUsageFlags};

--- a/itest/rust/src/engine_tests/native_structures_test.rs
+++ b/itest/rust/src/engine_tests/native_structures_test.rs
@@ -7,12 +7,12 @@
 
 use crate::framework::itest;
 
-use godot::register::{godot_api, GodotClass};
 use godot::builtin::{Rect2, Rid, Variant};
 use godot::engine::native::{AudioFrame, CaretInfo, Glyph};
 use godot::engine::text_server::Direction;
 use godot::engine::{ITextServerExtension, TextServer, TextServerExtension};
 use godot::obj::{Base, NewGd};
+use godot::register::{godot_api, GodotClass};
 
 use std::cell::Cell;
 

--- a/itest/rust/src/engine_tests/native_structures_test.rs
+++ b/itest/rust/src/engine_tests/native_structures_test.rs
@@ -7,7 +7,7 @@
 
 use crate::framework::itest;
 
-use godot::bind::{godot_api, GodotClass};
+use godot::register::{godot_api, GodotClass};
 use godot::builtin::{Rect2, Rid, Variant};
 use godot::engine::native::{AudioFrame, CaretInfo, Glyph};
 use godot::engine::text_server::Direction;

--- a/itest/rust/src/engine_tests/save_load_test.rs
+++ b/itest/rust/src/engine_tests/save_load_test.rs
@@ -5,7 +5,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use godot::bind::GodotClass;
+use godot::register::GodotClass;
 use godot::engine::{load, save, try_load, try_save};
 use godot::obj::NewGd;
 

--- a/itest/rust/src/engine_tests/save_load_test.rs
+++ b/itest/rust/src/engine_tests/save_load_test.rs
@@ -5,9 +5,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use godot::register::GodotClass;
 use godot::engine::{load, save, try_load, try_save};
 use godot::obj::NewGd;
+use godot::register::GodotClass;
 
 use crate::framework::itest;
 

--- a/itest/rust/src/framework/runner.rs
+++ b/itest/rust/src/framework/runner.rs
@@ -7,7 +7,7 @@
 
 use std::time::{Duration, Instant};
 
-use godot::bind::{godot_api, GodotClass};
+use godot::register::{godot_api, GodotClass};
 use godot::builtin::meta::ToGodot;
 use godot::builtin::{Array, GString, Variant, VariantArray};
 use godot::engine::{Engine, Node, Os};

--- a/itest/rust/src/framework/runner.rs
+++ b/itest/rust/src/framework/runner.rs
@@ -7,12 +7,12 @@
 
 use std::time::{Duration, Instant};
 
-use godot::register::{godot_api, GodotClass};
 use godot::builtin::meta::ToGodot;
 use godot::builtin::{Array, GString, Variant, VariantArray};
 use godot::engine::{Engine, Node, Os};
 use godot::log::godot_error;
 use godot::obj::Gd;
+use godot::register::{godot_api, GodotClass};
 
 use crate::framework::{
     bencher, passes_filter, BenchResult, RustBenchmark, RustTestCase, TestContext,

--- a/itest/rust/src/object_tests/object_swap_test.rs
+++ b/itest/rust/src/object_tests/object_swap_test.rs
@@ -13,7 +13,7 @@
 // Disabled in Release mode, since we don't perform the subtype check there.
 #![cfg(debug_assertions)]
 
-use godot::bind::{godot_api, GodotClass};
+use godot::register::{godot_api, GodotClass};
 use godot::builtin::GString;
 use godot::engine::{Node, Node3D, Object};
 use godot::obj::{Gd, NewAlloc, NewGd};

--- a/itest/rust/src/object_tests/object_swap_test.rs
+++ b/itest/rust/src/object_tests/object_swap_test.rs
@@ -13,10 +13,10 @@
 // Disabled in Release mode, since we don't perform the subtype check there.
 #![cfg(debug_assertions)]
 
-use godot::register::{godot_api, GodotClass};
 use godot::builtin::GString;
 use godot::engine::{Node, Node3D, Object};
 use godot::obj::{Gd, NewAlloc, NewGd};
+use godot::register::{godot_api, GodotClass};
 
 use crate::framework::{expect_panic, itest, TestContext};
 use crate::object_tests::object_test::ObjPayload;

--- a/itest/rust/src/object_tests/object_test.rs
+++ b/itest/rust/src/object_tests/object_test.rs
@@ -8,7 +8,6 @@
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 
-use godot::register::{godot_api, GodotClass};
 use godot::builtin::meta::{FromGodot, ToGodot};
 use godot::builtin::{GString, StringName, Variant, Vector3};
 use godot::engine::{
@@ -17,6 +16,7 @@ use godot::engine::{
 };
 use godot::obj::{Base, Gd, Inherits, InstanceId, NewAlloc, NewGd, RawGd};
 use godot::prelude::meta::GodotType;
+use godot::register::{godot_api, GodotClass};
 use godot::sys::{self, GodotFfi};
 
 use crate::framework::{expect_panic, itest, TestContext};

--- a/itest/rust/src/object_tests/object_test.rs
+++ b/itest/rust/src/object_tests/object_test.rs
@@ -8,7 +8,7 @@
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 
-use godot::bind::{godot_api, GodotClass};
+use godot::register::{godot_api, GodotClass};
 use godot::builtin::meta::{FromGodot, ToGodot};
 use godot::builtin::{GString, StringName, Variant, Vector3};
 use godot::engine::{

--- a/itest/rust/src/object_tests/onready_test.rs
+++ b/itest/rust/src/object_tests/onready_test.rs
@@ -6,9 +6,9 @@
  */
 
 use crate::framework::{expect_panic, itest};
-use godot::register::{godot_api, GodotClass};
 use godot::engine::notify::NodeNotification;
 use godot::engine::INode;
+use godot::register::{godot_api, GodotClass};
 
 use godot::obj::{Gd, OnReady};
 use godot::prelude::ToGodot;

--- a/itest/rust/src/object_tests/onready_test.rs
+++ b/itest/rust/src/object_tests/onready_test.rs
@@ -6,7 +6,7 @@
  */
 
 use crate::framework::{expect_panic, itest};
-use godot::bind::{godot_api, GodotClass};
+use godot::register::{godot_api, GodotClass};
 use godot::engine::notify::NodeNotification;
 use godot::engine::INode;
 

--- a/itest/rust/src/object_tests/property_test.rs
+++ b/itest/rust/src/object_tests/property_test.rs
@@ -6,12 +6,12 @@
  */
 
 use godot::{
-    register::property::PropertyHintInfo,
     engine::{
         global::{PropertyHint, PropertyUsageFlags},
         Texture,
     },
     prelude::*,
+    register::property::PropertyHintInfo,
     test::itest,
 };
 
@@ -155,7 +155,7 @@ enum SomeCStyleEnum {
     C = 2,
 }
 
-impl Property for SomeCStyleEnum {
+impl Var for SomeCStyleEnum {
     type Intermediate = i64;
 
     fn get_property(&self) -> Self::Intermediate {
@@ -187,7 +187,7 @@ struct NotExportable {
     b: i64,
 }
 
-impl Property for NotExportable {
+impl Var for NotExportable {
     type Intermediate = Dictionary;
 
     fn get_property(&self) -> Self::Intermediate {
@@ -300,7 +300,7 @@ struct CheckAllExports {
 }
 
 #[repr(i64)]
-#[derive(Property, Export, Eq, PartialEq, Debug)]
+#[derive(Var, Export, Eq, PartialEq, Debug)]
 pub enum TestEnum {
     A = 0,
     B = 1,

--- a/itest/rust/src/object_tests/property_test.rs
+++ b/itest/rust/src/object_tests/property_test.rs
@@ -6,7 +6,7 @@
  */
 
 use godot::{
-    bind::property::PropertyHintInfo,
+    register::property::PropertyHintInfo,
     engine::{
         global::{PropertyHint, PropertyUsageFlags},
         Texture,

--- a/itest/rust/src/object_tests/virtual_methods_test.rs
+++ b/itest/rust/src/object_tests/virtual_methods_test.rs
@@ -9,7 +9,7 @@
 
 use crate::framework::{itest, TestContext};
 
-use godot::bind::{godot_api, GodotClass};
+use godot::register::{godot_api, GodotClass};
 use godot::builtin::meta::ToGodot;
 use godot::builtin::{
     real, varray, Color, GString, PackedByteArray, PackedColorArray, PackedFloat32Array,

--- a/itest/rust/src/object_tests/virtual_methods_test.rs
+++ b/itest/rust/src/object_tests/virtual_methods_test.rs
@@ -9,7 +9,6 @@
 
 use crate::framework::{itest, TestContext};
 
-use godot::register::{godot_api, GodotClass};
 use godot::builtin::meta::ToGodot;
 use godot::builtin::{
     real, varray, Color, GString, PackedByteArray, PackedColorArray, PackedFloat32Array,
@@ -25,6 +24,7 @@ use godot::engine::{
 };
 use godot::obj::{Base, Gd, NewAlloc, NewGd};
 use godot::private::class_macros::assert_eq_approx;
+use godot::register::{godot_api, GodotClass};
 
 /// Simple class, that deliberately has no constructor accessible from GDScript
 #[derive(GodotClass, Debug)]

--- a/itest/rust/src/register_tests/derive_variant_test.rs
+++ b/itest/rust/src/register_tests/derive_variant_test.rs
@@ -7,7 +7,7 @@
 
 use std::fmt::Debug;
 
-use godot::bind::{FromGodot, GodotConvert, ToGodot};
+use godot::register::{FromGodot, GodotConvert, ToGodot};
 use godot::builtin::meta::{FromGodot, ToGodot};
 use godot::builtin::{dict, varray, Variant};
 

--- a/itest/rust/src/register_tests/derive_variant_test.rs
+++ b/itest/rust/src/register_tests/derive_variant_test.rs
@@ -7,9 +7,9 @@
 
 use std::fmt::Debug;
 
-use godot::register::{FromGodot, GodotConvert, ToGodot};
 use godot::builtin::meta::{FromGodot, ToGodot};
 use godot::builtin::{dict, varray, Variant};
+use godot::register::{FromGodot, GodotConvert, ToGodot};
 
 use crate::common::roundtrip;
 use crate::framework::itest;


### PR DESCRIPTION
Changes:

1. Rename module `godot::bind` -> `godot::register`.
   - Originally intended for "binding", the new term is more expressive and doesn't clash with other meanings of "bind" (notably `Gd::bind()`, `Callable::bind()`).
   - Registration is the term used in the book.
   - In particular, "export" is wrong -- it only refers to editor exports (i.e. `#[export]`), or unrelated, export builds.
2. Rename `Property` -> `Var`
   - Consistent between `#[export]` <-> `Export` traits, and now `#[var]` <-> `Var`.
   - Makes prelude space free for a `Property<T>` placeholder.
3. Extract `prelude` to its own file.
4. Several doc improvements.

Renaming the GitHub label `c: bind` -> `c: registration` as well.