### PR TITLE
`Gd::upcast_ref()` + `Gd::upcast_mut()`

### DIFF
--- a/godot-codegen/src/class_generator.rs
+++ b/godot-codegen/src/class_generator.rs
@@ -1167,12 +1167,13 @@ fn make_class_method_definition(
     let rust_method_name = special_cases::maybe_rename_class_method(class_name, godot_method_name);
 
     // Override const-qualification for known special cases (FileAccess::get_16, StreamPeer::get_u16, etc.).
-    /* TODO enable this once JSON/domain models are separated. Remove #[allow] above.
-    let mut override_is_const = None;
-    if let Some(override_const) = special_cases::is_class_method_const(class_name, &method) {
-        override_is_const = Some(override_const);
+    let mut is_actually_const = method.is_const;
+    if let Some(override_const) = special_cases::is_class_method_const(class_name, method) {
+        is_actually_const = override_const;
     }
 
+    /*
+    // TODO re-enable this once JSON/domain models are separated.
     // Getters in particular are re-qualified as const (if there isn't already an override).
     if override_is_const.is_none() && option_as_slice(&method.arguments).is_empty() {
         if rust_method_name.starts_with("get_") {
@@ -1185,7 +1186,7 @@ fn make_class_method_definition(
     let receiver = make_receiver(
         method.is_static,
         //override_is_const.unwrap_or(method.is_const),
-        method.is_const,
+        is_actually_const,
         quote! { self.object_ptr },
     );
 

--- a/godot-codegen/src/special_cases.rs
+++ b/godot-codegen/src/special_cases.rs
@@ -195,10 +195,15 @@ pub(crate) fn is_method_excluded_from_default_params(class_name: Option<&TyName>
 /// should be returned to take precedence over general rules. Example: `FileAccess::get_pascal_string()` is mut, but would be const-qualified
 /// since it looks like a getter.
 #[rustfmt::skip]
-#[cfg(FALSE)] // TODO enable this once JSON/domain models are separated.
 pub(crate) fn is_class_method_const(class_name: &TyName, godot_method: &ClassMethod) -> Option<bool> {
     match (class_name.godot_ty.as_str(), godot_method.name.as_str()) {
+        // Changed to const.
+        | ("Object", "to_string")
+        => Some(true),
+
         // Changed to mut.
+        // Needs some fixes to make sure _ex() builders have consistent signature, e.g. FileAccess::get_csv_line_full().
+        /*
         | ("FileAccess", "get_16")
         | ("FileAccess", "get_32")
         | ("FileAccess", "get_64")
@@ -217,6 +222,7 @@ pub(crate) fn is_class_method_const(class_name: &TyName, godot_method: &ClassMet
         | ("StreamPeer", "get_float")
         | ("StreamPeer", "get_double")
         => Some(false),
+        */
 
         _ => None,
     }

--- a/godot-core/src/builtin/callable.rs
+++ b/godot-core/src/builtin/callable.rs
@@ -202,8 +202,8 @@ impl Callable {
     pub fn object(&self) -> Option<Gd<Object>> {
         // Increment refcount because we're getting a reference, and `InnerCallable::get_object` doesn't
         // increment the refcount.
-        self.as_inner().get_object().map(|object| {
-            <Object as Bounds>::DynMemory::maybe_inc_ref(&object.raw);
+        self.as_inner().get_object().map(|mut object| {
+            <Object as Bounds>::DynMemory::maybe_inc_ref(&mut object.raw);
             object
         })
     }

--- a/godot-core/src/engine/mod.rs
+++ b/godot-core/src/engine/mod.rs
@@ -140,7 +140,7 @@ pub(crate) fn debug_string<T: GodotClass>(
     ty: &str,
 ) -> std::fmt::Result {
     if let Some(id) = obj.instance_id_or_none() {
-        let class: GString = obj.raw.as_object(|obj| Object::get_class(obj));
+        let class: GString = obj.raw.as_object().get_class();
         write!(f, "{ty} {{ id: {id}, class: {class} }}")
     } else {
         write!(f, "{ty} {{ freed obj }}")
@@ -151,7 +151,7 @@ pub(crate) fn display_string<T: GodotClass>(
     obj: &Gd<T>,
     f: &mut std::fmt::Formatter<'_>,
 ) -> std::fmt::Result {
-    let string: GString = obj.raw.as_object(Object::to_string);
+    let string: GString = obj.raw.as_object().to_string();
     <GString as std::fmt::Display>::fmt(&string, f)
 }
 

--- a/godot-core/src/obj/bounds.rs
+++ b/godot-core/src/obj/bounds.rs
@@ -146,11 +146,11 @@ pub trait Memory: Sealed {}
 pub trait DynMemory: Sealed {
     /// Initialize reference counter
     #[doc(hidden)]
-    fn maybe_init_ref<T: GodotClass>(obj: &RawGd<T>);
+    fn maybe_init_ref<T: GodotClass>(obj: &mut RawGd<T>);
 
     /// If ref-counted, then increment count
     #[doc(hidden)]
-    fn maybe_inc_ref<T: GodotClass>(obj: &RawGd<T>);
+    fn maybe_inc_ref<T: GodotClass>(obj: &mut RawGd<T>);
 
     /// If ref-counted, then decrement count. Returns `true` if the count hit 0 and the object can be
     /// safely freed.
@@ -166,7 +166,7 @@ pub trait DynMemory: Sealed {
     /// then the reference count must either be incremented before it hits 0, or some [`Gd`] referencing
     /// this object must be forgotten.
     #[doc(hidden)]
-    unsafe fn maybe_dec_ref<T: GodotClass>(obj: &RawGd<T>) -> bool;
+    unsafe fn maybe_dec_ref<T: GodotClass>(obj: &mut RawGd<T>) -> bool;
 
     /// Check if ref-counted, return `None` if information is not available (dynamic and obj dead)
     #[doc(hidden)]
@@ -188,34 +188,41 @@ pub struct MemRefCounted {}
 impl Sealed for MemRefCounted {}
 impl Memory for MemRefCounted {}
 impl DynMemory for MemRefCounted {
-    fn maybe_init_ref<T: GodotClass>(obj: &RawGd<T>) {
-        out!("  Stat::init  <{}>", std::any::type_name::<T>());
+    fn maybe_init_ref<T: GodotClass>(obj: &mut RawGd<T>) {
+        out!("  MemRefc::init  <{}>", std::any::type_name::<T>());
         if obj.is_null() {
             return;
         }
-        obj.as_ref_counted(|refc| {
+        obj.with_ref_counted(|refc| {
             let success = refc.init_ref();
             assert!(success, "init_ref() failed");
         });
+
+        /*
+        // SAFETY: DynMemory=MemRefCounted statically guarantees that the object inherits from RefCounted.
+        let refc = unsafe { obj.as_ref_counted_unchecked() };
+
+        let success = refc.init_ref();
+        assert!(success, "init_ref() failed");*/
     }
 
-    fn maybe_inc_ref<T: GodotClass>(obj: &RawGd<T>) {
-        out!("  Stat::inc   <{}>", std::any::type_name::<T>());
+    fn maybe_inc_ref<T: GodotClass>(obj: &mut RawGd<T>) {
+        out!("  MemRefc::inc   <{}>", std::any::type_name::<T>());
         if obj.is_null() {
             return;
         }
-        obj.as_ref_counted(|refc| {
+        obj.with_ref_counted(|refc| {
             let success = refc.reference();
             assert!(success, "reference() failed");
         });
     }
 
-    unsafe fn maybe_dec_ref<T: GodotClass>(obj: &RawGd<T>) -> bool {
-        out!("  Stat::dec   <{}>", std::any::type_name::<T>());
+    unsafe fn maybe_dec_ref<T: GodotClass>(obj: &mut RawGd<T>) -> bool {
+        out!("  MemRefc::dec   <{}>", std::any::type_name::<T>());
         if obj.is_null() {
             return false;
         }
-        obj.as_ref_counted(|refc| {
+        obj.with_ref_counted(|refc| {
             let is_last = refc.unreference();
             out!("  +-- was last={is_last}");
             is_last
@@ -236,20 +243,23 @@ impl DynMemory for MemRefCounted {
 pub struct MemDynamic {}
 impl Sealed for MemDynamic {}
 impl DynMemory for MemDynamic {
-    fn maybe_init_ref<T: GodotClass>(obj: &RawGd<T>) {
-        out!("  Dyn::init  <{}>", std::any::type_name::<T>());
+    fn maybe_init_ref<T: GodotClass>(obj: &mut RawGd<T>) {
+        out!("  MemDyn::init  <{}>", std::any::type_name::<T>());
         if obj
             .instance_id_unchecked()
             .map(|id| id.is_ref_counted())
             .unwrap_or(false)
         {
             // Will call `RefCounted::init_ref()` which checks for liveness.
+            out!("MemDyn -> MemRefc");
             MemRefCounted::maybe_init_ref(obj)
+        } else {
+            out!("MemDyn -> MemManu");
         }
     }
 
-    fn maybe_inc_ref<T: GodotClass>(obj: &RawGd<T>) {
-        out!("  Dyn::inc   <{}>", std::any::type_name::<T>());
+    fn maybe_inc_ref<T: GodotClass>(obj: &mut RawGd<T>) {
+        out!("  MemDyn::inc   <{}>", std::any::type_name::<T>());
         if obj
             .instance_id_unchecked()
             .map(|id| id.is_ref_counted())
@@ -260,8 +270,8 @@ impl DynMemory for MemDynamic {
         }
     }
 
-    unsafe fn maybe_dec_ref<T: GodotClass>(obj: &RawGd<T>) -> bool {
-        out!("  Dyn::dec   <{}>", std::any::type_name::<T>());
+    unsafe fn maybe_dec_ref<T: GodotClass>(obj: &mut RawGd<T>) -> bool {
+        out!("  MemDyn::dec   <{}>", std::any::type_name::<T>());
         if obj
             .instance_id_unchecked()
             .map(|id| id.is_ref_counted())
@@ -286,9 +296,9 @@ pub struct MemManual {}
 impl Sealed for MemManual {}
 impl Memory for MemManual {}
 impl DynMemory for MemManual {
-    fn maybe_init_ref<T: GodotClass>(_obj: &RawGd<T>) {}
-    fn maybe_inc_ref<T: GodotClass>(_obj: &RawGd<T>) {}
-    unsafe fn maybe_dec_ref<T: GodotClass>(_obj: &RawGd<T>) -> bool {
+    fn maybe_init_ref<T: GodotClass>(_obj: &mut RawGd<T>) {}
+    fn maybe_inc_ref<T: GodotClass>(_obj: &mut RawGd<T>) {}
+    unsafe fn maybe_dec_ref<T: GodotClass>(_obj: &mut RawGd<T>) -> bool {
         false
     }
     fn is_ref_counted<T: GodotClass>(_obj: &RawGd<T>) -> Option<bool> {
@@ -302,12 +312,6 @@ impl DynMemory for MemManual {
 /// Trait that specifies who declares a given `GodotClass`.
 pub trait Declarer: Sealed {
     type DerefTarget<T: GodotClass>: GodotClass;
-
-    #[doc(hidden)]
-    fn scoped_mut<T, F, R>(obj: &mut RawGd<T>, closure: F) -> R
-    where
-        T: GodotClass + Bounds<Declarer = Self>,
-        F: FnOnce(&mut T) -> R;
 
     /// Check if the object is a user object *and* currently locked by a `bind()` or `bind_mut()` guard.
     ///
@@ -329,14 +333,6 @@ pub enum DeclEngine {}
 impl Sealed for DeclEngine {}
 impl Declarer for DeclEngine {
     type DerefTarget<T: GodotClass> = T;
-
-    fn scoped_mut<T, F, R>(obj: &mut RawGd<T>, closure: F) -> R
-    where
-        T: GodotClass + Bounds<Declarer = DeclEngine>,
-        F: FnOnce(&mut T) -> R,
-    {
-        closure(obj.as_target_mut())
-    }
 
     unsafe fn is_currently_bound<T>(_obj: &RawGd<T>) -> bool
     where
@@ -362,15 +358,6 @@ pub enum DeclUser {}
 impl Sealed for DeclUser {}
 impl Declarer for DeclUser {
     type DerefTarget<T: GodotClass> = T::Base;
-
-    fn scoped_mut<T, F, R>(obj: &mut RawGd<T>, closure: F) -> R
-    where
-        T: GodotClass + Bounds<Declarer = Self>,
-        F: FnOnce(&mut T) -> R,
-    {
-        let mut guard = obj.bind_mut();
-        closure(&mut *guard)
-    }
 
     unsafe fn is_currently_bound<T>(obj: &RawGd<T>) -> bool
     where

--- a/godot-core/src/obj/bounds.rs
+++ b/godot-core/src/obj/bounds.rs
@@ -301,7 +301,7 @@ impl DynMemory for MemManual {
 
 /// Trait that specifies who declares a given `GodotClass`.
 pub trait Declarer: Sealed {
-    type DerefTarget<T: GodotClass>;
+    type DerefTarget<T: GodotClass>: GodotClass;
 
     #[doc(hidden)]
     fn scoped_mut<T, F, R>(obj: &mut RawGd<T>, closure: F) -> R
@@ -335,10 +335,7 @@ impl Declarer for DeclEngine {
         T: GodotClass + Bounds<Declarer = DeclEngine>,
         F: FnOnce(&mut T) -> R,
     {
-        closure(
-            obj.as_target_mut()
-                .expect("scoped mut should not be called on a null object"),
-        )
+        closure(obj.as_target_mut())
     }
 
     unsafe fn is_currently_bound<T>(_obj: &RawGd<T>) -> bool

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -290,7 +290,7 @@ impl<T: GodotClass> Gd<T> {
     /// #[class(init, base=Node2D)]
     /// struct MyClass {}
     ///
-    /// let obj: Gd<MyClass> = MyClass::alloc_gd();
+    /// let obj: Gd<MyClass> = MyClass::new_alloc();
     /// let base = obj.clone().upcast::<Node>();
     /// ```
     pub fn upcast<Base>(self) -> Gd<Base>
@@ -583,7 +583,7 @@ where
     ///
     /// This trait is only implemented for reference-counted classes. Classes with manually-managed memory (e.g. `Node`) are not covered,
     /// because they need explicit memory management, and deriving `Default` has a high chance of the user forgetting to call `free()` on those.
-    /// `T::alloc_gd()` should be used for those instead.
+    /// `T::new_alloc()` should be used for those instead.
     fn default() -> Self {
         T::__godot_default()
     }

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -302,6 +302,48 @@ impl<T: GodotClass> Gd<T> {
             .expect("Upcast failed. This is a bug; please report it.")
     }
 
+    /// **Upcast shared-ref:** access this object as a shared reference to a base class.
+    ///
+    /// This is semantically equivalent to multiple applications of [`Self::deref()`]. Not really useful on its own, but combined with
+    /// generic programming:
+    /// ```no_run
+    /// # use godot::prelude::*;
+    /// fn print_node_name<T>(node: &Gd<T>)
+    /// where
+    ///     T: Inherits<Node>,
+    /// {
+    ///     println!("Node name: {}", node.upcast_ref().get_name());
+    /// }
+    /// ```
+    pub fn upcast_ref<Base>(&self) -> &Base
+    where
+        Base: GodotClass,
+        T: Inherits<Base>,
+    {
+        self.raw.as_upcast_ref::<Base>()
+    }
+
+    /// **Upcast exclusive-ref:** access this object as an exclusive reference to a base class.
+    ///
+    /// This is semantically equivalent to multiple applications of [`Self::deref_mut()`]. Not really useful on its own, but combined with
+    /// generic programming:
+    /// ```no_run
+    /// # use godot::prelude::*;
+    /// fn set_node_name<T>(node: &mut Gd<T>, name: &str)
+    /// where
+    ///     T: Inherits<Node>,
+    /// {
+    ///     node.upcast_mut().set_name(name.into());
+    /// }
+    /// ```
+    pub fn upcast_mut<Base>(&mut self) -> &mut Base
+    where
+        Base: GodotClass,
+        T: Inherits<Base>,
+    {
+        self.raw.as_upcast_mut::<Base>()
+    }
+
     /// **Downcast:** try to convert into a smart pointer to a derived class.
     ///
     /// If `T`'s dynamic type is not `Derived` or one of its subclasses, `None` is returned

--- a/godot-core/src/obj/rtti.rs
+++ b/godot-core/src/obj/rtti.rs
@@ -18,11 +18,15 @@ use crate::obj::{GodotClass, InstanceId};
 #[derive(Debug)]
 pub struct ObjectRtti {
     /// Cached instance ID. May point to dead objects.
-    pub instance_id: InstanceId,
+    instance_id: InstanceId,
 
     /// Only in Debug mode: dynamic class.
     #[cfg(debug_assertions)]
-    pub class_name: crate::builtin::meta::ClassName,
+    class_name: crate::builtin::meta::ClassName,
+    //
+    // TODO(bromeon): class_name is not always most-derived class; ObjectRtti is sometimes constructed from a base class, via RawGd::from_obj_sys_weak().
+    // Examples: after upcast, when receiving Gd<Base> from Godot, etc.
+    // Thus, dynamic lookup via Godot get_class() is needed. However, this returns a String, and ClassName is 'static + Copy right now.
 }
 
 impl ObjectRtti {
@@ -46,6 +50,11 @@ impl ObjectRtti {
         #[cfg(debug_assertions)]
         crate::engine::ensure_object_inherits(self.class_name, T::class_name(), self.instance_id);
 
+        self.instance_id
+    }
+
+    #[inline]
+    pub fn instance_id(&self) -> InstanceId {
         self.instance_id
     }
 }

--- a/godot-core/src/obj/traits.rs
+++ b/godot-core/src/obj/traits.rs
@@ -114,7 +114,7 @@ unsafe impl Bounds for () {
 /// print_node(Node3D::new_alloc().upcast());
 /// ```
 ///
-pub trait Inherits<Base>: GodotClass {}
+pub trait Inherits<Base: GodotClass>: GodotClass {}
 
 impl<T: GodotClass> Inherits<T> for T {}
 

--- a/godot-core/src/registry.rs
+++ b/godot-core/src/registry.rs
@@ -224,7 +224,7 @@ pub fn register_class<
     };
 
     assert!(
-        !T::class_name().as_str().is_empty(),
+        !T::class_name().is_empty(),
         "cannot register () or unnamed class"
     );
 

--- a/godot-ffi/src/toolbox.rs
+++ b/godot-ffi/src/toolbox.rs
@@ -138,6 +138,16 @@ pub fn hash_value<T: std::hash::Hash>(t: &T) -> u64 {
     hasher.finish()
 }
 
+/// Check whether contents of `lhs` and `rhs` are bitwise equal.
+///
+/// # Safety
+/// Requires valid pointers, properly aligned.
+pub unsafe fn bitwise_equal<T>(lhs: *const T, rhs: *const T) -> bool {
+    // Convert to raw parts
+    std::slice::from_raw_parts(lhs as *const u8, std::mem::size_of::<T>())
+        == std::slice::from_raw_parts(rhs as *const u8, std::mem::size_of::<T>())
+}
+
 /*
 pub fn unqualified_type_name<T>() -> &'static str {
     let type_name = std::any::type_name::<T>();

--- a/itest/rust/src/builtin_tests/containers/array_test.rs
+++ b/itest/rust/src/builtin_tests/containers/array_test.rs
@@ -323,7 +323,8 @@ fn array_mixed_values() {
     let typed_array = array![1, 2];
     let object = Object::new_alloc();
     let node = Node::new_alloc();
-    let ref_counted = RefCounted::new_gd();
+    let engine_refc = RefCounted::new_gd();
+    let user_refc = ArrayTest::new_gd(); // user RefCounted type
 
     let array = varray![
         int,
@@ -332,7 +333,8 @@ fn array_mixed_values() {
         typed_array,
         object,
         node,
-        ref_counted,
+        engine_refc,
+        user_refc,
     ];
 
     assert_eq!(i64::try_from_variant(&array.get(0)).unwrap(), int);
@@ -354,11 +356,18 @@ fn array_mixed_values() {
             .instance_id(),
         node.instance_id()
     );
+
     assert_eq!(
         Gd::<RefCounted>::try_from_variant(&array.get(6))
             .unwrap()
             .instance_id(),
-        ref_counted.instance_id()
+        engine_refc.instance_id()
+    );
+    assert_eq!(
+        Gd::<ArrayTest>::try_from_variant(&array.get(7))
+            .unwrap()
+            .instance_id(),
+        user_refc.instance_id()
     );
 
     object.free();

--- a/itest/rust/src/object_tests/object_test.rs
+++ b/itest/rust/src/object_tests/object_test.rs
@@ -703,7 +703,10 @@ fn object_user_upcast_mut() {
     let object = obj.upcast_mut::<Object>();
     assert_eq!(ref_instance_id(object), id);
     assert_eq!(object.get_class(), GString::from("RefcPayload"));
-    assert_eq!(object.call("to_string".into(), &[]), "value=17943".to_variant());
+    assert_eq!(
+        object.call("to_string".into(), &[]),
+        "value=17943".to_variant()
+    );
 }
 
 #[itest]

--- a/itest/rust/src/object_tests/object_test.rs
+++ b/itest/rust/src/object_tests/object_test.rs
@@ -14,10 +14,11 @@ use godot::engine::{
     file_access, Area2D, Camera3D, Engine, FileAccess, IRefCounted, Node, Node3D, Object,
     RefCounted,
 };
+use godot::obj;
 use godot::obj::{Base, Gd, Inherits, InstanceId, NewAlloc, NewGd, RawGd};
 use godot::prelude::meta::GodotType;
 use godot::register::{godot_api, GodotClass};
-use godot::sys::{self, GodotFfi};
+use godot::sys::{self, interface_fn, GodotFfi};
 
 use crate::framework::{expect_panic, itest, TestContext};
 
@@ -522,8 +523,30 @@ fn object_engine_upcast() {
     assert_eq!(object.instance_id(), id);
     assert_eq!(object.get_class(), GString::from("Node3D"));
 
-    // Deliberate free on upcast object
+    // Deliberate free on upcast object.
     object.free();
+}
+
+fn ref_instance_id(obj: &Object) -> InstanceId {
+    // SAFETY: raw FFI call since we can't access get_instance_id() of a raw Object anymore, and call() needs &mut.
+    use obj::EngineClass as _;
+
+    let obj_ptr = obj.as_object_ptr();
+
+    let raw_id = unsafe { interface_fn!(object_get_instance_id)(obj_ptr) };
+    InstanceId::try_from_i64(raw_id as i64).unwrap()
+}
+
+#[itest]
+fn object_engine_upcast_ref() {
+    let node3d: Gd<Node3D> = Node3D::new_alloc();
+    let id = node3d.instance_id();
+
+    let object = node3d.upcast_ref::<Object>();
+    assert_eq!(ref_instance_id(object), id);
+    assert_eq!(object.get_class(), GString::from("Node3D"));
+
+    node3d.free();
 }
 
 #[itest]
@@ -660,6 +683,27 @@ fn object_user_upcast() {
     let object = obj.upcast::<Object>();
     assert_eq!(object.instance_id(), id);
     assert_eq!(object.get_class(), GString::from("RefcPayload"));
+}
+
+#[itest]
+fn object_user_upcast_ref() {
+    let obj = user_refc_instance();
+    let id = obj.instance_id();
+
+    let object = obj.upcast_ref::<Object>();
+    assert_eq!(ref_instance_id(object), id);
+    assert_eq!(object.get_class(), GString::from("RefcPayload"));
+}
+
+#[itest]
+fn object_user_upcast_mut() {
+    let mut obj = user_refc_instance();
+    let id = obj.instance_id();
+
+    let object = obj.upcast_mut::<Object>();
+    assert_eq!(ref_instance_id(object), id);
+    assert_eq!(object.get_class(), GString::from("RefcPayload"));
+    assert_eq!(object.call("to_string".into(), &[]), "value=17943".to_variant());
 }
 
 #[itest]

--- a/itest/rust/src/object_tests/reentrant_test.rs
+++ b/itest/rust/src/object_tests/reentrant_test.rs
@@ -10,7 +10,7 @@ use godot::prelude::*;
 
 #[derive(GodotClass)]
 #[class(init, base = Object)]
-pub struct MyClass {
+pub struct ReentrantClass {
     #[base]
     base: Base<Object>,
 
@@ -20,7 +20,7 @@ pub struct MyClass {
 }
 
 #[godot_api]
-impl MyClass {
+impl ReentrantClass {
     #[signal]
     fn some_signal();
 
@@ -46,7 +46,7 @@ impl MyClass {
 
 #[itest]
 fn reentrant_call_succeeds() {
-    let mut class = MyClass::new_alloc();
+    let mut class = ReentrantClass::new_alloc();
 
     assert!(!class.bind().first_called_pre);
     assert!(!class.bind().first_called_post);
@@ -63,7 +63,7 @@ fn reentrant_call_succeeds() {
 
 #[itest]
 fn reentrant_emit_succeeds() {
-    let mut class = MyClass::new_alloc();
+    let mut class = ReentrantClass::new_alloc();
 
     let callable = class.callable("second");
     class.connect("some_signal".into(), callable);


### PR DESCRIPTION
Adds `Gd::upcast_ref()` and `Gd::upcast_mut()`. They have no direct use due to `Deref` trait, but can be useful in generic programming:
```rs
fn print_node_name<T>(node: &Gd<T>)
where
    T: Inherits<Node>,
{
    println!("Node name: {}", node.upcast_ref().get_name());
}
```

Also took the opportunity to clean up quite a few things around `Deref` and casting, which were handled entirely separately in the past. Most of the work is done -- there's still `RawGd::with_ref_counted()` which I'd like to align with `as_object()`, but I can't spend more time on this right now.

As a side effect, some of the object-swap checks (#23) now got even stricter. You can basically not do anything useful anymore, indicating that this is a bug that must _always_ be fixed.

More details in commit messages.