### PR TITLE
Impl Iterator::size_hint() for builtin::Array::Iter

### DIFF
--- a/godot-core/src/builtin/array.rs
+++ b/godot-core/src/builtin/array.rs
@@ -940,6 +940,11 @@ impl<'a, T: GodotType + FromGodot> Iterator for Iter<'a, T> {
             None
         }
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = self.array.len() - self.next_idx;
+        (remaining, Some(remaining))
+    }
 }
 
 // TODO There's a macro for this, but it doesn't support generics yet; add support and use it

--- a/itest/rust/src/builtin_tests/containers/array_test.rs
+++ b/itest/rust/src/builtin_tests/containers/array_test.rs
@@ -88,8 +88,11 @@ fn array_try_into_vec() {
 fn array_iter_shared() {
     let array = array![1, 2];
     let mut iter = array.iter_shared();
+    assert_eq!(iter.size_hint(), (2, Some(2)));
     assert_eq!(iter.next(), Some(1));
+    assert_eq!(iter.size_hint(), (1, Some(1)));
     assert_eq!(iter.next(), Some(2));
+    assert_eq!(iter.size_hint(), (0, Some(0)));
     assert_eq!(iter.next(), None);
 }
 


### PR DESCRIPTION
Should I add tests as well? Like those:
```diff
--- a/itest/rust/src/builtin_tests/containers/array_test.rs
+++ b/itest/rust/src/builtin_tests/containers/array_test.rs
@@ -87,8 +87,11 @@ fn array_try_into_vec() {
 #[itest]
 fn array_iter_shared() {
     let array = array![1, 2];
     let mut iter = array.iter_shared();
+    assert_eq!(iter.size_hint(), (2, Some(2)));
     assert_eq!(iter.next(), Some(1));
+    assert_eq!(iter.size_hint(), (1, Some(1)));
     assert_eq!(iter.next(), Some(2));
+    assert_eq!(iter.size_hint(), (0, Some(0)));
     assert_eq!(iter.next(), None);
 }
 ```