### PR TITLE
Add `hide` annotation to classes

### DIFF
--- a/godot-core/src/registry.rs
+++ b/godot-core/src/registry.rs
@@ -157,6 +157,8 @@ pub enum PluginComponent {
 
     #[cfg(since_api = "4.1")]
     EditorPlugin,
+    #[cfg(since_api = "4.2")]
+    Unexposed,
 }
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
@@ -393,6 +395,10 @@ fn fill_class_info(component: PluginComponent, c: &mut ClassRegistrationInfo) {
         #[cfg(since_api = "4.1")]
         PluginComponent::EditorPlugin => {
             c.is_editor_plugin = true;
+        }
+        #[cfg(since_api = "4.2")]
+        PluginComponent::Unexposed => {
+            c.godot_params.is_exposed = false as sys::GDExtensionBool;
         }
     }
     // out!("|   reg (after):     {c:?}");
@@ -771,6 +777,6 @@ fn default_creation_info() -> sys::GDExtensionClassCreationInfo2 {
         call_virtual_with_data_func: None,
         get_rid_func: None,
         class_userdata: ptr::null_mut(),
-        is_exposed: true as u8,
+        is_exposed: true as sys::GDExtensionBool,
     }
 }

--- a/godot-macros/src/lib.rs
+++ b/godot-macros/src/lib.rs
@@ -350,6 +350,20 @@ use crate::util::ident;
 /// ```
 ///
 /// These classes will appear in the Godot editor and GDScript as "AnimalToad" or "NpcToad".
+///
+/// # Hiding Classes
+///
+/// If you want to register a class with Godot, but not have it show up in the editor then you can use `#[class(hide)]`.
+///
+/// ```
+/// # use godot::prelude::*;
+/// #[derive(GodotClass)]
+/// #[class(base = Node, init, hide)]
+/// pub struct Foo {}
+/// ```
+///
+/// Even though this class is a `Node` and it has an init function, it still won't show up in the editor as a node you can add to a scene
+/// because we have added a `hide` key to the class. This will also prevent it from showing up in documentation.
 #[proc_macro_derive(GodotClass, attributes(class, base, var, export, init, signal))]
 pub fn derive_godot_class(input: TokenStream) -> TokenStream {
     translate(input, class::derive_godot_class)


### PR DESCRIPTION
Currently i call the annotation `hide` but the plugin `Unexposed`, since `hide` is probably more intuitive to the user but godot uses `exposed` as the terminology internally.

Part of #563