### PR TITLE
bash is not always in /bin/bash

### DIFF
--- a/check.sh
+++ b/check.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) godot-rust; Bromeon and contributors.
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this


### PR DESCRIPTION
Bash is not always in `/bin/bash`. E.g., on macOS an up-to-date version is rather in `/opt/homebrew/bin/bash`. It could also be in `/usr/local/bin/bash`.