### PR TITLE
Fix build warnings

### DIFF
--- a/godot-core/src/engine/mod.rs
+++ b/godot-core/src/engine/mod.rs
@@ -9,7 +9,6 @@
 
 use crate::builtin::{GString, NodePath};
 use crate::obj::{bounds, Bounds, Gd, GodotClass, Inherits, InstanceId};
-use std::collections::HashSet;
 
 // Re-exports of generated symbols
 pub use crate::gen::central::global;
@@ -216,6 +215,7 @@ pub(crate) fn ensure_object_inherits(
 /// Checks if `derived` inherits from `base`, using a cache for _successful_ queries.
 #[cfg(debug_assertions)]
 fn is_derived_base_cached(derived: ClassName, base: ClassName) -> bool {
+    use std::collections::HashSet;
     use sys::Global;
     static CACHE: Global<HashSet<(ClassName, ClassName)>> = Global::default();
 

--- a/godot-core/src/obj/raw.rs
+++ b/godot-core/src/obj/raw.rs
@@ -292,6 +292,8 @@ impl<T: GodotClass> RawGd<T> {
         unsafe { self.as_upcast_mut::<GdDerefTarget<T>>() }
     }
 
+    // Clippy believes the type parameters are not used, however they are used in the `.ffi_cast::<Base>` call.
+    #[allow(clippy::extra_unused_type_parameters)]
     fn ensure_valid_upcast<Base>(&self)
     where
         Base: GodotClass,


### PR DESCRIPTION
There were two warnings that would happen when you attempted to build the crate. 

The first was an `unused import` warning. The import could be moved so clippy would understand it was not unused.

The second was a, `unused type parameters` warning. This occurred because clippy did not peer into a child scope and observe its use. This warning was silenced directly.