### PR TITLE
More robust duplicate detection during class registration

### DIFF
--- a/godot-core/src/lib.rs
+++ b/godot-core/src/lib.rs
@@ -49,7 +49,7 @@ pub mod private {
     use std::sync::{Arc, Mutex};
 
     pub use crate::gen::classes::class_macros;
-    pub use crate::registry::{callbacks, ClassPlugin, ErasedRegisterFn, PluginComponent};
+    pub use crate::registry::{callbacks, ClassPlugin, ErasedRegisterFn, PluginItem};
     pub use crate::storage::{as_storage, Storage};
     pub use sys::out;
 

--- a/godot-macros/src/class/derive_godot_class.rs
+++ b/godot-macros/src/class/derive_godot_class.rs
@@ -32,6 +32,8 @@ pub fn derive_godot_class(decl: Declaration) -> ParseResult<TokenStream> {
     let class_name_cstr = util::cstr_u8_slice(&class_name_str);
     let class_name_obj = util::class_name_obj(class_name);
 
+    let is_editor_plugin = struct_cfg.is_editor_plugin;
+    let is_hidden = struct_cfg.is_hidden;
     let base_ty = &struct_cfg.base_ty;
     let base_class = quote! { ::godot::engine::#base_ty };
     let base_class_name_obj = util::class_name_obj(&base_class);
@@ -39,32 +41,6 @@ pub fn derive_godot_class(decl: Declaration) -> ParseResult<TokenStream> {
 
     let prv = quote! { ::godot::private };
     let godot_exports_impl = make_property_impl(class_name, &fields);
-
-    let editor_plugin = if struct_cfg.is_editor_plugin {
-        quote! {
-            ::godot::sys::plugin_add!(__GODOT_PLUGIN_REGISTRY in #prv; #prv::ClassPlugin {
-                class_name: #class_name_obj,
-                component: #prv::PluginComponent::EditorPlugin,
-                init_level: <#class_name as ::godot::obj::GodotClass>::INIT_LEVEL,
-            });
-
-            const _: () = #prv::is_editor_plugin::<#class_name>();
-        }
-    } else {
-        quote! {}
-    };
-
-    let hidden = if struct_cfg.is_hidden {
-        quote! {
-            ::godot::sys::plugin_add!(__GODOT_PLUGIN_REGISTRY in #prv; #prv::ClassPlugin {
-                class_name: #class_name_obj,
-                component: #prv::PluginComponent::Unexposed,
-                init_level: <#class_name as ::godot::obj::GodotClass>::INIT_LEVEL,
-            });
-        }
-    } else {
-        quote! {}
-    };
 
     let godot_withbase_impl = if let Some(Field { name, .. }) = &fields.base_field {
         quote! {
@@ -137,6 +113,8 @@ pub fn derive_godot_class(decl: Declaration) -> ParseResult<TokenStream> {
                 },
                 free_fn: #prv::callbacks::free::<#class_name>,
                 default_get_virtual_fn: #default_get_virtual_fn,
+                is_editor_plugin: #is_editor_plugin,
+                is_hidden: #is_hidden,
             },
             init_level: {
                 let level = <#class_name as ::godot::obj::GodotClass>::INIT_LEVEL;
@@ -154,9 +132,6 @@ pub fn derive_godot_class(decl: Declaration) -> ParseResult<TokenStream> {
                 level
             }
         });
-
-        #editor_plugin
-        #hidden
 
         #prv::class_macros::#inherits_macro!(#class_name);
     })

--- a/godot-macros/src/class/derive_godot_class.rs
+++ b/godot-macros/src/class/derive_godot_class.rs
@@ -104,7 +104,7 @@ pub fn derive_godot_class(decl: Declaration) -> ParseResult<TokenStream> {
 
         ::godot::sys::plugin_add!(__GODOT_PLUGIN_REGISTRY in #prv; #prv::ClassPlugin {
             class_name: #class_name_obj,
-            component: #prv::PluginComponent::ClassDef {
+            item: #prv::PluginItem::Struct {
                 base_class_name: #base_class_name_obj,
                 generated_create_fn: #create_fn,
                 generated_recreate_fn: #recreate_fn,

--- a/godot-macros/src/class/godot_api.rs
+++ b/godot-macros/src/class/godot_api.rs
@@ -228,7 +228,7 @@ fn transform_inherent_impl(mut original_impl: Impl) -> Result<TokenStream, Error
 
         ::godot::sys::plugin_add!(__GODOT_PLUGIN_REGISTRY in #prv; #prv::ClassPlugin {
             class_name: #class_name_obj,
-            component: #prv::PluginComponent::UserMethodBinds {
+            item: #prv::PluginItem::InherentImpl {
                 register_methods_constants_fn: #prv::ErasedRegisterFn {
                     raw: #prv::callbacks::register_user_methods_constants::<#class_name>,
                 },
@@ -705,8 +705,8 @@ fn transform_trait_impl(original_impl: Impl) -> Result<TokenStream, Error> {
     let recreate_fn = convert_to_match_expression_or_none(recreate_fn);
     let to_string_fn = convert_to_match_expression_or_none(to_string_fn);
     let on_notification_fn = convert_to_match_expression_or_none(on_notification_fn);
-    let get_fn = convert_to_match_expression_or_none(get_property_fn);
-    let set_fn = convert_to_match_expression_or_none(set_property_fn);
+    let get_property_fn = convert_to_match_expression_or_none(get_property_fn);
+    let set_property_fn = convert_to_match_expression_or_none(set_property_fn);
 
     let result = quote! {
         #original_impl
@@ -737,14 +737,14 @@ fn transform_trait_impl(original_impl: Impl) -> Result<TokenStream, Error> {
 
         ::godot::sys::plugin_add!(__GODOT_PLUGIN_REGISTRY in #prv; #prv::ClassPlugin {
             class_name: #class_name_obj,
-            component: #prv::PluginComponent::UserVirtuals {
+            item: #prv::PluginItem::ITraitImpl {
                 user_register_fn: #register_fn,
                 user_create_fn: #create_fn,
                 user_recreate_fn: #recreate_fn,
                 user_to_string_fn: #to_string_fn,
                 user_on_notification_fn: #on_notification_fn,
-                user_set_fn: #set_fn,
-                user_get_fn: #get_fn,
+                user_set_fn: #set_property_fn,
+                user_get_fn: #get_property_fn,
                 get_virtual_fn: #prv::callbacks::get_virtual::<#class_name>,
             },
             init_level: <#class_name as ::godot::obj::GodotClass>::INIT_LEVEL,

--- a/itest/rust/src/register_tests/constant_test.rs
+++ b/itest/rust/src/register_tests/constant_test.rs
@@ -168,7 +168,7 @@ godot::sys::plugin_add!(
     __GODOT_PLUGIN_REGISTRY in ::godot::private;
     ::godot::private::ClassPlugin {
         class_name: HasOtherConstants::class_name(),
-        component: ::godot::private::PluginComponent::UserMethodBinds {
+        item: ::godot::private::PluginItem::InherentImpl {
             register_methods_constants_fn: ::godot::private::ErasedRegisterFn {
                 raw: ::godot::private::callbacks::register_user_methods_constants::<HasOtherConstants>,
             },


### PR DESCRIPTION
Fixes #569.

I also collapsed several "plugin components" that were used for editor-plugin/hidden functionality, they can be represented as a bool flag in the existing components.