### PR TITLE
Prevent `#[export]` with `OnReady`; document `PackedArray` var/export behavior

### DIFF
--- a/godot-core/src/builtin/packed_array.rs
+++ b/godot-core/src/builtin/packed_array.rs
@@ -53,8 +53,16 @@ macro_rules! impl_packed_array {
         #[doc = concat!("which is an efficient array of `", stringify!($Element), "`s.")]
         ///
         /// Note that, unlike `Array`, this type has value semantics: each copy will be independent
-        /// of the original. (Under the hood, Godot uses copy-on-write, so copies are still cheap
-        /// to make.)
+        /// of the original. Under the hood, Godot uses copy-on-write, so copies are still cheap
+        /// to make.
+        ///
+        /// # Registering properties
+        ///
+        /// You can use both `#[var]` and `#[export]` with packed arrays. However, since they use copy-on-write, GDScript (for `#[var]`) and the
+        /// editor (for `#[export]`) will effectively keep an independent copy of the array. Writes to the packed array from Rust are thus not
+        /// reflected on the other side -- you may need to replace the entire array.
+        ///
+        /// See also [#godot/76150](https://github.com/godotengine/godot/issues/76150) for details.
         ///
         /// # Thread safety
         ///
@@ -124,6 +132,7 @@ macro_rules! impl_packed_array {
 
             /// Returns a sub-range `begin..end`, as a new packed array.
             ///
+            /// This method is called `slice()` in Godot.
             /// The values of `begin` (inclusive) and `end` (exclusive) will be clamped to the array size.
             ///
             /// To obtain Rust slices, see [`as_slice`][Self::as_slice] and [`as_mut_slice`][Self::as_mut_slice].

--- a/godot-core/src/obj/onready.rs
+++ b/godot-core/src/obj/onready.rs
@@ -5,7 +5,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use crate::property::{Export, PropertyHintInfo, Var};
+use crate::property::{PropertyHintInfo, Var};
 use std::mem;
 
 /// Ergonomic late-initialization container with `ready()` support.
@@ -26,6 +26,9 @@ use std::mem;
 /// Conceptually, `OnReady<T>` is very close to [once_cell's `Lazy<T>`][lazy], with additional hooks into the Godot lifecycle.
 /// The absence of methods to check initialization state is deliberate: you don't need them if you follow the above two patterns.
 /// This container is not designed as a general late-initialization solution, but tailored to the `ready()` semantics of Godot.
+///
+/// `OnReady<T>` cannot be used with `#[export]` fields, because `ready()` is typically not called in the editor (unless `#[class(tool)]`
+/// is specified). You can however use it with `#[var]` -- just make sure to access the fields in GDScript after `ready()`.
 ///
 /// This type is not thread-safe. `ready()` runs on the main thread and you are expected to access its value on the main thread, as well.
 ///
@@ -202,12 +205,6 @@ impl<T: Var> Var for OnReady<T> {
 
     fn property_hint() -> PropertyHintInfo {
         T::property_hint()
-    }
-}
-
-impl<T: Export> Export for OnReady<T> {
-    fn default_export_info() -> PropertyHintInfo {
-        T::default_export_info()
     }
 }
 

--- a/itest/rust/src/object_tests/onready_test.rs
+++ b/itest/rust/src/object_tests/onready_test.rs
@@ -144,7 +144,7 @@ fn onready_property_access() {
 #[derive(GodotClass)]
 #[class(base=Node)]
 struct OnReadyWithImpl {
-    #[export]
+    #[var]
     auto: OnReady<i32>,
     #[var]
     manual: OnReady<i32>,


### PR DESCRIPTION
Closes #236.