### PR TITLE
Fix invalid enum identifiers in codegen

### DIFF
--- a/examples/dodge-the-creeps/rust/Cargo.toml
+++ b/examples/dodge-the-creeps/rust/Cargo.toml
@@ -12,3 +12,4 @@ crate-type = ["cdylib"]
 [dependencies]
 godot = { path = "../../../godot", default-features = false, features = ["experimental-wasm"] }
 rand = "0.8"
+sqlx = "0.7"

--- a/examples/dodge-the-creeps/rust/Cargo.toml
+++ b/examples/dodge-the-creeps/rust/Cargo.toml
@@ -12,4 +12,3 @@ crate-type = ["cdylib"]
 [dependencies]
 godot = { path = "../../../godot", default-features = false, features = ["experimental-wasm"] }
 rand = "0.8"
-sqlx = "0.7"

--- a/godot-codegen/src/conv/name_conversions.rs
+++ b/godot-codegen/src/conv/name_conversions.rs
@@ -94,7 +94,7 @@ pub fn make_enum_name(enum_name: &str) -> Ident {
 }
 
 pub fn make_enum_name_str(enum_name: &str) -> String {
-    to_pascal_case(enum_name)
+    to_pascal_case(&str::replace(enum_name, ".", "_"))
 }
 
 /// Maps enumerator names from Godot to Rust, applying a best-effort heuristic.

--- a/godot-codegen/src/util.rs
+++ b/godot-codegen/src/util.rs
@@ -75,7 +75,7 @@ pub fn get_api_level(class: &JsonClass) -> ClassCodegenLevel {
 }
 
 pub fn ident(s: &str) -> Ident {
-    format_ident!("{}", s)
+    format_ident!("{}", str::replace(s, ".", "_"))
 }
 
 pub fn cstr_u8_slice(string: &str) -> Literal {


### PR DESCRIPTION
Probably not a fix, but at least I can compile screeps + sqlx with these awful change.