### PR TITLE
More robust case conversion; prevent invalid identifiers in codegen

### DIFF
--- a/godot-codegen/src/context.rs
+++ b/godot-codegen/src/context.rs
@@ -80,6 +80,7 @@ impl<'a> Context<'a> {
                 option_as_slice(&class.constants),
                 &mut ctx,
             );
+
             Self::populate_class_table_indices(
                 class,
                 &class_name,
@@ -165,9 +166,7 @@ impl<'a> Context<'a> {
         methods: &[JsonClassMethod],
         ctx: &mut Context,
     ) {
-        if special_cases::is_class_deleted(class_name) {
-            return;
-        }
+        // Note: already checked for class excluded/deleted.
 
         for method in methods.iter() {
             if special_cases::is_class_method_deleted(class_name, method, ctx) || method.is_virtual

--- a/godot-codegen/src/context.rs
+++ b/godot-codegen/src/context.rs
@@ -19,7 +19,6 @@ use std::collections::{HashMap, HashSet};
 
 #[derive(Default)]
 pub struct Context<'a> {
-    engine_classes: HashMap<TyName, &'a JsonClass>,
     builtin_types: HashSet<&'a str>,
     native_structures_types: HashSet<&'a str>,
     singletons: HashSet<&'a str>,
@@ -56,6 +55,7 @@ impl<'a> Context<'a> {
             ctx.native_structures_types.insert(ty_name);
         }
 
+        let mut engine_classes = HashMap::new();
         for class in api.classes.iter() {
             let class_name = TyName::from_godot(&class.name);
 
@@ -65,7 +65,7 @@ impl<'a> Context<'a> {
 
             // Populate class lookup by name
             println!("-- add engine class {}", class_name.description());
-            ctx.engine_classes.insert(class_name.clone(), class);
+            engine_classes.insert(class_name.clone(), class);
 
             // Populate derived-to-base relations
             if let Some(base) = class.inherits.as_ref() {
@@ -91,7 +91,7 @@ impl<'a> Context<'a> {
         // Populate remaining notification enum names, by copying the one to nearest base class that has at least 1 notification.
         // At this point all classes with notifications are registered.
         // (Used to avoid re-generating the same notification enum for multiple base classes).
-        for class_name in ctx.engine_classes.keys() {
+        for class_name in engine_classes.keys() {
             if ctx
                 .notification_enum_names_by_class
                 .contains_key(class_name)
@@ -207,10 +207,6 @@ impl<'a> Context<'a> {
 
             ctx.register_table_index(key);
         }
-    }
-
-    pub fn get_engine_class(&self, class_name: &TyName) -> &JsonClass {
-        self.engine_classes.get(class_name).unwrap()
     }
 
     // Private, because initialized in constructor. Ensures deterministic assignment.

--- a/godot-codegen/src/conv/name_conversions.rs
+++ b/godot-codegen/src/conv/name_conversions.rs
@@ -31,6 +31,11 @@ fn to_snake_special_case(class_name: &str) -> Option<&'static str> {
 pub fn to_snake_case(ty_name: &str) -> String {
     use heck::ToSnakeCase;
 
+    assert!(
+        is_valid_ident(ty_name),
+        "invalid identifier for snake_case conversion: {ty_name}"
+    );
+
     // Special cases
     if let Some(special_case) = to_snake_special_case(ty_name) {
         return special_case.to_string();
@@ -72,6 +77,11 @@ pub fn to_pascal_case(ty_name: &str) -> String {
 
 pub fn shout_to_pascal(shout_case: &str) -> String {
     // TODO use heck?
+
+    assert!(
+        is_valid_shout_ident(shout_case),
+        "invalid identifier for SHOUT_CASE -> PascalCase conversion: {shout_case}"
+    );
 
     let mut result = String::with_capacity(shout_case.len());
     let mut next_upper = true;
@@ -270,6 +280,12 @@ fn try_strip_prefixes<'e>(enumerator: &'e str, prefixes: &[&str]) -> &'e str {
 /// Check if input is a valid identifier; ie. no special characters except '_' and not starting with a digit.
 fn is_valid_ident(s: &str) -> bool {
     !starts_with_invalid_char(s) && s.chars().all(|c| c == '_' || c.is_ascii_alphanumeric())
+}
+
+fn is_valid_shout_ident(s: &str) -> bool {
+    !starts_with_invalid_char(s)
+        && s.chars()
+            .all(|c| c == '_' || c.is_ascii_digit() || c.is_ascii_uppercase())
 }
 
 fn starts_with_invalid_char(s: &str) -> bool {

--- a/godot-codegen/src/generator/classes.rs
+++ b/godot-codegen/src/generator/classes.rs
@@ -10,8 +10,8 @@ use crate::generator::functions_common::{FnCode, FnDefinition, FnDefinitions};
 use crate::generator::method_tables::MethodTableKey;
 use crate::generator::{constants, docs, enums, functions_common, notifications, virtual_traits};
 use crate::models::domain::{
-    Class, ClassLike, ClassMethod, ExtensionApi, FnDirection, FnQualifier, Function, ModName,
-    TyName,
+    ApiView, Class, ClassLike, ClassMethod, ExtensionApi, FnDirection, FnQualifier, Function,
+    ModName, TyName,
 };
 use crate::util::{ident, make_string_name};
 use crate::{conv, util, SubmitFn};
@@ -22,6 +22,7 @@ use std::path::Path;
 pub fn generate_class_files(
     api: &ExtensionApi,
     ctx: &mut Context,
+    view: &ApiView,
     gen_path: &Path,
     submit_fn: &mut SubmitFn,
 ) {
@@ -30,7 +31,7 @@ pub fn generate_class_files(
 
     let mut modules = vec![];
     for class in api.classes.iter() {
-        let generated_class = make_class(class, ctx);
+        let generated_class = make_class(class, ctx, view);
         let file_contents = generated_class.code;
 
         let out_path = gen_path.join(format!("{}.rs", class.mod_name().rust_mod));
@@ -71,7 +72,7 @@ struct GeneratedClassModule {
     is_pub_sidecar: bool,
 }
 
-fn make_class(class: &Class, ctx: &mut Context) -> GeneratedClass {
+fn make_class(class: &Class, ctx: &mut Context, view: &ApiView) -> GeneratedClass {
     let class_name = class.name();
 
     // Strings
@@ -124,7 +125,7 @@ fn make_class(class: &Class, ctx: &mut Context) -> GeneratedClass {
         &all_bases,
         &virtual_trait_str,
         &notification_enum_name,
-        ctx,
+        view,
     );
 
     // notify() and notify_reversed() are added after other methods, to list others first in docs.

--- a/godot-codegen/src/lib.rs
+++ b/godot-codegen/src/lib.rs
@@ -5,6 +5,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+// Codegen has no FFI and thus no reason to use unsafe code.
+#![forbid(unsafe_code)]
+
 mod context;
 mod conv;
 mod generator;
@@ -26,7 +29,7 @@ use crate::generator::{
     generate_sys_builtin_methods_file, generate_sys_central_file, generate_sys_classes_file,
     generate_sys_utilities_file,
 };
-use crate::models::domain::ExtensionApi;
+use crate::models::domain::{ApiView, ExtensionApi};
 use crate::models::json::{load_extension_api, JsonExtensionApi};
 
 use proc_macro2::TokenStream;
@@ -99,6 +102,7 @@ pub fn generate_core_files(core_gen_path: &Path) {
     watch.record("build_context");
 
     let api = ExtensionApi::from_json(&json_api, &mut ctx);
+    let view = ApiView::new(&api);
     watch.record("map_domain_models");
 
     // TODO if ctx is no longer needed for below functions:
@@ -116,6 +120,7 @@ pub fn generate_core_files(core_gen_path: &Path) {
     generate_class_files(
         &api,
         &mut ctx,
+        &view,
         &core_gen_path.join("classes"),
         &mut submit_fn,
     );

--- a/godot-codegen/src/models/domain.rs
+++ b/godot-codegen/src/models/domain.rs
@@ -17,6 +17,7 @@ use crate::util::{ident, option_as_slice, safe_ident};
 
 use proc_macro2::{Ident, Literal, TokenStream};
 use quote::{format_ident, quote, ToTokens};
+use std::collections::HashMap;
 use std::fmt;
 
 pub struct ExtensionApi {
@@ -39,6 +40,27 @@ impl ExtensionApi {
             .iter()
             .find(|b| b.godot_original_name() == name)
             .unwrap_or_else(|| panic!("builtin_by_name: invalid `{}`", name))
+    }
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// View and indexing over existing ExtensionApi
+
+pub struct ApiView<'a> {
+    class_by_ty: HashMap<TyName, &'a Class>,
+}
+
+impl<'a> ApiView<'a> {
+    pub fn new(api: &'a ExtensionApi) -> ApiView<'a> {
+        let class_by_ty = api.classes.iter().map(|c| (c.name().clone(), c)).collect();
+
+        Self { class_by_ty }
+    }
+
+    pub fn get_engine_class(&self, ty: &TyName) -> &'a Class {
+        self.class_by_ty
+            .get(ty)
+            .unwrap_or_else(|| panic!("specified type `{}` is not an engine class", ty.godot_ty))
     }
 }
 

--- a/godot-codegen/src/special_cases/codegen_special_cases.rs
+++ b/godot-codegen/src/special_cases/codegen_special_cases.rs
@@ -10,7 +10,6 @@
 // TODO make this file private and only accessed by special_cases.rs.
 
 use crate::context::Context;
-use crate::models::domain::TyName;
 use crate::models::json::{JsonBuiltinMethod, JsonClassMethod, JsonUtilityFunction};
 use crate::special_cases;
 
@@ -68,7 +67,7 @@ pub(crate) fn is_class_method_excluded(method: &JsonClassMethod, ctx: &mut Conte
     let is_arg_or_return_excluded = |ty: &str, _ctx: &mut Context| {
         // First check if the type is explicitly deleted. In Godot, type names are unique without further categorization,
         // so passing in a class name while checking for any types is fine.
-        let class_deleted = special_cases::is_godot_type_deleted(&TyName::from_godot(ty));
+        let class_deleted = special_cases::is_godot_type_deleted(ty);
 
         // Then also check if the type is excluded from codegen (due to current Cargo feature. RHS is always false in full-codegen.
         class_deleted || is_type_excluded(ty, _ctx)

--- a/godot-codegen/src/tests.rs
+++ b/godot-codegen/src/tests.rs
@@ -128,6 +128,15 @@ fn test_parse_native_structures_format() {
         NativeStructuresField {
             field_type: String::from(ty),
             field_name: String::from(name),
+            array_size: None,
+        }
+    }
+
+    fn native_array(ty: &str, name: &str, array_size: usize) -> NativeStructuresField {
+        NativeStructuresField {
+            field_type: String::from(ty),
+            field_name: String::from(name),
+            array_size: Some(array_size),
         }
     }
 
@@ -147,11 +156,11 @@ fn test_parse_native_structures_format() {
     );
 
     let actual = parse_native_structures_format(
-        "Vector3 position;Vector3 normal;Vector3 collider_velocity;Vector3 collider_angular_velocity;real_t depth;int local_shape;ObjectID collider_id;RID collider;int collider_shape"
+        "Vector3 position;Vector3 normal[5];Vector3 collider_velocity;Vector3 collider_angular_velocity;real_t depth;int local_shape;ObjectID collider_id;RID collider;int collider_shape"
     );
     let expected = vec![
         native("Vector3", "position"),
-        native("Vector3", "normal"),
+        native_array("Vector3", "normal", 5),
         native("Vector3", "collider_velocity"),
         native("Vector3", "collider_angular_velocity"),
         native("real_t", "depth"),


### PR DESCRIPTION
Fixes #472.
Supersedes #579.

The behavior of #472 is very interesting: gdext compiles fine on its own, but its codegen starts to panic when `sqlx` is added as a dependency in the project. How is that possible?

My first thought was that `sqlx` might downgrade a dependency and re-introduce some older bugs through that. But that's not what happened: no packages changed version when adding `sqlx`.

So I tried to investigate where exactly the problem happened. And this turned out to be more difficult than assumed, because I can't run the debugger during codegen (invoked by build.rs), and stacktraces behaved weird. Concretely, `std::backtrace::Backtrace::capture()` caused provably wrong results -- stack traces of functions that never called each other. Clean builds would show correct stacktraces, but another incremental `cargo build` without changing anything would corrupt them again. That's likely some unrelated rustc bug.

Anyway, after long trial&error I could find the faulty `ident()` call -- it was invoked with the `"EnumAesContext.Mode"` string. So it looks like `"enum::AESContext.Mode"` was erroneously interpreted as an identifier. But why does this only happen with `sqlx`?

This is where things get interesting: `sqlx` and `godot-codgen` both depend on the case conversion library `heck`. Yet we get once `"AesContext.Mode"` (with `sqlx` dependency) and once `"AesContextMode"` (without it). But as stated above, both use the same version!

It turned out that `sqlx` used the `heck` with its `unicode` Cargo feature. Due to [a bug in `heck`](https://github.com/withoutboats/heck/issues/42), this feature does not behave additively and instead changes behavior to include the dot here. This discrepancy was also fixed in the meantime, but no stable crate release followed up.

---

Anyway, without the heck bug we wouldn't have found our own bug, where we pass incorrect identifiers to `ident()`. This is only used in a branch that checks exclusion of certain functions based on argument types, so it did not affect actual code generation. But it turns out going through `ident()` isn't even necessary in that context.

Even more, my digging revealed yet another bug: the native structure
```rs
struct PhysicsServer3DExtensionMotionResult {
    ...
    pub collisions_32: PhysicsServer3DExtensionMotionCollision,
    ...
}
```
had a field that was incorrectly converted to snake_case, from `collisions[32]`
It should be an array!

