### PR TITLE
map "Self" to class name in functions and signals.

### DIFF
--- a/godot-macros/src/class/data_models/func.rs
+++ b/godot-macros/src/class/data_models/func.rs
@@ -33,8 +33,11 @@ pub fn make_virtual_callback(
     let method_name = &signature_info.method_name;
 
     let wrapped_method = make_forwarding_closure(class_name, &signature_info, before_kind);
-    let sig_tuple =
-        util::make_signature_tuple_type(&signature_info.ret_type, &signature_info.param_types);
+    let sig_tuple = util::make_signature_tuple_type(
+        class_name,
+        &signature_info.ret_type,
+        &signature_info.param_types,
+    );
 
     let invocation = make_ptrcall_invocation(method_name, &sig_tuple, &wrapped_method, true);
 
@@ -60,8 +63,11 @@ pub fn make_method_registration(
     func_definition: FuncDefinition,
 ) -> TokenStream {
     let signature_info = get_signature_info(&func_definition.func, func_definition.has_gd_self);
-    let sig_tuple =
-        util::make_signature_tuple_type(&signature_info.ret_type, &signature_info.param_types);
+    let sig_tuple = util::make_signature_tuple_type(
+        class_name,
+        &signature_info.ret_type,
+        &signature_info.param_types,
+    );
 
     let method_name = &signature_info.method_name;
     let param_idents = &signature_info.param_idents;

--- a/godot-macros/src/class/godot_api.rs
+++ b/godot-macros/src/class/godot_api.rs
@@ -109,7 +109,8 @@ fn transform_inherent_impl(mut original_impl: Impl) -> Result<TokenStream, Error
             };
         }
 
-        let signature_tuple = util::make_signature_tuple_type(&quote! { () }, &param_types);
+        let signature_tuple =
+            util::make_signature_tuple_type(&class_name, &quote! { () }, &param_types);
         let indexes = 0..param_types.len();
         let param_array_decl = quote! {
             [


### PR DESCRIPTION
First pass at mapping `Self` to struct names. I hijacked `make_signature_tuple_type` and changed it for all uses, even though as far as I could tell, it wasn't broken for signals, but I don't believe it broke anything new.

It's certainly a little hacky, but seems to check out when expanded and works on my machine atm.

```#[derive(GodotClass)]
struct SomeCustomClass {
    field: i32,
}

#[godot_api]
impl SomeCustomClass {
    #[func]
    pub fn do_some_stuff(&self) -> Gd<Self> {
        Self::do_other_stuff(Self { field: 42 })
    }

    pub fn do_other_stuff(other: Self) -> Gd<Self> {
        todo!()
    }
}

```


The above compiles with no errors for me, just for a reference on what I've looked at.

Okay I lied, it errors because I didn't copy all the ToGodot and FromGodot impls, but I did test with those.

I could do this in `get_signature_info` instead, it felt a little busy already though. It'd certainly be a little more self-contained overall.

Would close #578 