### PR TITLE
Map "Self" to class name in functions.

### DIFF
--- a/godot-macros/src/class/godot_api.rs
+++ b/godot-macros/src/class/godot_api.rs
@@ -14,7 +14,7 @@ use venial::{
 };
 
 use crate::class::{
-    get_signature_info, make_method_registration, make_virtual_callback, BeforeKind,
+    into_signature_info, make_method_registration, make_virtual_callback, BeforeKind,
     FuncDefinition, SignatureInfo,
 };
 use crate::util;
@@ -654,7 +654,7 @@ fn transform_trait_impl(original_impl: Impl) -> Result<TokenStream, Error> {
                     format!("_{method_name}")
                 };
 
-                let signature_info = get_signature_info(&method, false);
+                let signature_info = into_signature_info(method, &class_name, false);
 
                 // Overridden ready() methods additionally have an additional `__before_ready()` call (for OnReady inits).
                 let before_kind = if method_name == "ready" {

--- a/godot-macros/src/util/mod.rs
+++ b/godot-macros/src/util/mod.rs
@@ -105,7 +105,7 @@ pub fn parse_signature(mut signature: TokenStream) -> Function {
 /// Returns a type expression that can be used as a `VarcallSignatureTuple`.
 pub fn make_signature_tuple_type(
     ret_type: &TokenStream,
-    param_types: &Vec<venial::TyExpr>,
+    param_types: &[venial::TyExpr],
 ) -> TokenStream {
     quote::quote! {
         (#ret_type, #(#param_types),*)

--- a/itest/rust/src/object_tests/object_test.rs
+++ b/itest/rust/src/object_tests/object_test.rs
@@ -911,12 +911,16 @@ pub mod object_test_gd {
         i: i64,
     }
 
-    #[derive(GodotClass, Debug)]
-    #[class(init, base=RefCounted)]
-    struct ObjectTest;
+    mod nested {
+        use godot::prelude::*;
+        #[derive(GodotClass, Debug)]
+        #[class(init, base=RefCounted)]
+        pub(super) struct ObjectTest;
+    }
+    use nested::ObjectTest;
 
     #[godot_api]
-    impl ObjectTest {
+    impl nested::ObjectTest {
         #[func]
         fn pass_object(&self, object: Gd<Object>) -> i64 {
             let i = object.get("i".into()).to();
@@ -947,6 +951,16 @@ pub mod object_test_gd {
         #[func]
         fn return_refcounted_as_object(&self) -> Gd<Object> {
             Gd::from_object(MockRefCountedRust { i: 42 }).upcast()
+        }
+
+        #[func]
+        fn return_self() -> Gd<Self> {
+            Gd::from_object(Self)
+        }
+
+        #[func]
+        fn return_nested_self() -> Array<Gd<<Self as GodotClass>::Base>> {
+            array![Self::return_self().upcast()]
         }
     }
 


### PR DESCRIPTION
Alternative, probably better implementation of #590. Keeps the utils clean, and uses the cloning of the tokens that's happening anyway to make the swap instead. I did address the lint on `&Vec<_>` vs `&[_]` that Clippy caught in utils the first time around, though.

This doesn't affect Signals as far as I can tell at the moment, since I don't think those generate nested functions.

Fixes #578 