### PR TITLE
Fix question mark lint.

### DIFF
--- a/godot-macros/src/class/godot_api.rs
+++ b/godot-macros/src/class/godot_api.rs
@@ -56,7 +56,7 @@ enum BoundAttrType {
         has_gd_self: bool,
     },
     Signal(AttributeValue),
-    Const(AttributeValue),
+    Const(#[allow(dead_code)] AttributeValue),
 }
 
 struct BoundAttr {


### PR DESCRIPTION
Along with a warning about unused field here https://github.com/godot-rust/gdext/blob/c006a09c0fc1d748e5de6e244a3c0694945dd96b/godot-macros/src/class/godot_api.rs#L59 CI failed when I ran it locally on everything. I don't know where I should put the annotation, or if the field should be removed, so I left that out for now.

As for the other, after fixing the `?` lint on the check, I felt that the bindings and extra lines in the changed functions were redundant and didn't really help readability, so I changed both to be what I thought was a little clearer. I thought about including this in my last one but it felt unrelated enough. Sorry if I'm spamming them.

I also got a lot of warnings suggesting `addr_of!` instead of a mutable static, but I think that will be covered by #581