### PR TITLE
`#[class(no_init)]` to explicitly disable constructor

### DIFF
--- a/godot-core/src/lib.rs
+++ b/godot-core/src/lib.rs
@@ -186,21 +186,20 @@ pub mod private {
     // https://github.com/rust-lang/rust/pull/58994. Fortunately, an extra layer of indirection solves most problems: we generate a declarative
     // macro that itself isn't deprecated, but _its_ expansion is. Since the expansion happens in a later step, the warning is emitted.
 
-    #[doc(hidden)]
     #[inline(always)]
     #[deprecated = "#[base] is no longer needed; Base<T> is recognized directly. \n\
         More information on https://github.com/godot-rust/gdext/pull/577."]
-    pub const fn base_attribute_warning() {}
+    pub const fn base_attribute() {}
 
     #[doc(hidden)]
     #[macro_export]
-    macro_rules! __base_attribute_warning_expand {
-        () => {
-            const _: () = $crate::private::base_attribute_warning();
+    macro_rules! __emit_deprecated_warning {
+        ($warning_fn:ident) => {
+            const _: () = $crate::private::$warning_fn();
         };
     }
 
-    pub use crate::__base_attribute_warning_expand;
+    pub use crate::__emit_deprecated_warning;
 }
 
 macro_rules! generate_gdextension_api_version {

--- a/godot-macros/src/class/derive_godot_class.rs
+++ b/godot-macros/src/class/derive_godot_class.rs
@@ -312,6 +312,20 @@ fn parse_struct_attributes(class: &Struct) -> ParseResult<ClassAttributes> {
             }
 
             is_editor_plugin = true;
+
+            // Requires #[class(tool, base=EditorPlugin)].
+            if !is_tool {
+                return bail!(
+                    attr_key,
+                    "#[class(editor_plugin)] requires additional key `tool`"
+                );
+            }
+            if base_ty != ident("EditorPlugin") {
+                return bail!(
+                    attr_key,
+                    "#[class(editor_plugin)] requires additional key-value `base=EditorPlugin`"
+                );
+            }
         }
 
         // #[class(hide)]

--- a/godot-macros/src/class/derive_godot_class.rs
+++ b/godot-macros/src/class/derive_godot_class.rs
@@ -71,6 +71,7 @@ pub fn derive_godot_class(decl: Declaration) -> ParseResult<TokenStream> {
     let mut godot_init_impl = TokenStream::new();
     let mut create_fn = quote! { None };
     let mut recreate_fn = quote! { None };
+    let mut is_instantiable = true;
 
     match struct_cfg.init_strategy {
         InitStrategy::Generated => {
@@ -93,7 +94,7 @@ pub fn derive_godot_class(decl: Declaration) -> ParseResult<TokenStream> {
             }
         }
         InitStrategy::Absent => {
-            // nothing
+            is_instantiable = false;
         }
     };
 
@@ -137,6 +138,7 @@ pub fn derive_godot_class(decl: Declaration) -> ParseResult<TokenStream> {
                 default_get_virtual_fn: #default_get_virtual_fn,
                 is_editor_plugin: #is_editor_plugin,
                 is_hidden: #is_hidden,
+                is_instantiable: #is_instantiable,
             },
             init_level: {
                 let level = <#class_name as ::godot::obj::GodotClass>::INIT_LEVEL;

--- a/godot-macros/src/class/godot_api.rs
+++ b/godot-macros/src/class/godot_api.rs
@@ -452,7 +452,7 @@ fn convert_to_match_expression_or_none(tokens: Option<TokenStream>) -> TokenStre
 
 /// Codegen for `#[godot_api] impl GodotExt for MyType`
 fn transform_trait_impl(original_impl: Impl) -> Result<TokenStream, Error> {
-    let (class_name, trait_name) = util::validate_trait_impl_virtual(&original_impl, "godot_api")?;
+    let (class_name, trait_path) = util::validate_trait_impl_virtual(&original_impl, "godot_api")?;
     let class_name_obj = util::class_name_obj(&class_name);
 
     let mut godot_init_impl = TokenStream::new();
@@ -505,7 +505,7 @@ fn transform_trait_impl(original_impl: Impl) -> Result<TokenStream, Error> {
                     #(#cfg_attrs)*
                     impl ::godot::obj::cap::GodotRegisterClass for #class_name {
                         fn __godot_register_class(builder: &mut ::godot::builder::GodotBuilder<Self>) {
-                            <Self as #trait_name>::register_class(builder)
+                            <Self as #trait_path>::register_class(builder)
                         }
                     }
                 };
@@ -534,7 +534,7 @@ fn transform_trait_impl(original_impl: Impl) -> Result<TokenStream, Error> {
                     #(#cfg_attrs)*
                     impl ::godot::obj::cap::GodotDefault for #class_name {
                         fn __godot_user_init(base: ::godot::obj::Base<Self::Base>) -> Self {
-                            <Self as #trait_name>::init(base)
+                            <Self as #trait_path>::init(base)
                         }
                     }
                 };
@@ -559,7 +559,7 @@ fn transform_trait_impl(original_impl: Impl) -> Result<TokenStream, Error> {
                     #(#cfg_attrs)*
                     impl ::godot::obj::cap::GodotToString for #class_name {
                         fn __godot_to_string(&self) -> ::godot::builtin::GString {
-                            <Self as #trait_name>::to_string(self)
+                            <Self as #trait_path>::to_string(self)
                         }
                     }
                 };
@@ -583,7 +583,7 @@ fn transform_trait_impl(original_impl: Impl) -> Result<TokenStream, Error> {
                                 return;
                             }
 
-                            <Self as #trait_name>::on_notification(self, what.into())
+                            <Self as #trait_path>::on_notification(self, what.into())
                         }
                     }
                 };
@@ -605,7 +605,7 @@ fn transform_trait_impl(original_impl: Impl) -> Result<TokenStream, Error> {
                                 return None;
                             }
 
-                            <Self as #trait_name>::get_property(self, property)
+                            <Self as #trait_path>::get_property(self, property)
                         }
                     }
                 };
@@ -626,7 +626,7 @@ fn transform_trait_impl(original_impl: Impl) -> Result<TokenStream, Error> {
                                 return false;
                             }
 
-                            <Self as #trait_name>::set_property(self, property, value)
+                            <Self as #trait_path>::set_property(self, property, value)
                         }
                     }
                 };

--- a/godot-macros/src/lib.rs
+++ b/godot-macros/src/lib.rs
@@ -22,7 +22,27 @@ use crate::util::ident;
 // Below intra-doc link to the trait only works as HTML, not as symbol link.
 /// Derive macro for [`GodotClass`](../obj/trait.GodotClass.html) on structs.
 ///
-/// You must use this macro; manual implementations of the `GodotClass` trait are not supported.
+/// You should use this macro; manual implementations of the `GodotClass` trait are not encouraged.
+///
+/// This is typically used in combination with [`#[godot_api]`](attr.godot_api.html), which can implement custom functions and constants,
+/// as well as override virtual methods.
+///
+/// See also [book chapter _Registering classes_](https://godot-rust.github.io/book/register/classes.html).
+///
+/// **Table of contents:**
+/// - [Construction](#construction)
+/// - [Inheritance](#inheritance)
+/// - [Properties and exports](#properties-and-exports)
+///    - [Property registration](#property-registration)
+///    - [Property exports](#property-exports)
+/// - [Signals](#signals)
+/// - [Further class customization](#further-class-customization)
+///    - [Running code in the editor](#running-code-in-the-editor)
+///    - [Editor plugins](#editor-plugins)
+///    - [Class renaming](#class-renaming)
+///    - [Class hiding](#class-hiding)
+/// - [Further field customization](#further-field-customization)
+///    - [Fine-grained inference hints](#fine-grained-inference-hints)
 ///
 ///
 /// # Construction
@@ -117,12 +137,15 @@ use crate::util::ident;
 ///
 /// # Properties and exports
 ///
+/// See also [book chapter _Registering properties_](https://godot-rust.github.io/book/register/properties.html#registering-properties).
+///
 /// In GDScript, there is a distinction between
 /// [properties](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_basics.html#properties-setters-and-getters)
 /// (fields with a `get` or `set` declaration) and
 /// [exports](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_exports.html)
-/// (fields annotated with `@export`). In the GDExtension API, these two concepts are represented with
-/// `#[var]` and `#[export]` attributes respectively.
+/// (fields annotated with `@export`). In the gdext API, these two concepts are represented with `#[var]` and `#[export]` attributes respectively.
+///
+/// ## Property registration
 ///
 /// To create a property, you can use the `#[var]` annotation:
 ///
@@ -189,6 +212,8 @@ use crate::util::ident;
 ///     }
 /// }
 /// ```
+///
+/// ## Property exports
 ///
 /// For exporting properties to the editor, you can use the `#[export]` attribute:
 ///
@@ -314,7 +339,9 @@ use crate::util::ident;
 /// }
 /// ```
 ///
-/// # Running code in the editor
+/// # Further class customization
+///
+/// ## Running code in the editor
 ///
 /// If you annotate a class with `#[class(tool)]`, its lifecycle methods (`ready()`, `process()` etc.) will be invoked in the editor. This
 /// is useful for writing custom editor plugins, as opposed to classes running simply in-game.
@@ -324,7 +351,7 @@ use crate::util::ident;
 ///
 /// This is very similar to [GDScript's `@tool` feature](https://docs.godotengine.org/en/stable/tutorials/plugins/running_code_in_the_editor.html).
 ///
-/// # Editor plugins
+/// ## Editor plugins
 ///
 /// If you annotate a class with `#[class(editor_plugin)]`, it will be turned into an editor plugin. The
 /// class must then inherit from `EditorPlugin`, and an instance of that class will be automatically added
@@ -338,7 +365,7 @@ use crate::util::ident;
 /// This should usually be combined with `#[class(tool)]` so that the code you write will actually run in the
 /// editor.
 ///
-/// # Class renaming
+/// ## Class renaming
 ///
 /// You may want to have structs with the same name. With Rust, this is allowed using `mod`. However in GDScript,
 /// there are no modules, namespaces, or any such disambiguation.  Therefore, you need to change the names before they
@@ -362,7 +389,7 @@ use crate::util::ident;
 ///
 /// These classes will appear in the Godot editor and GDScript as "AnimalToad" or "NpcToad".
 ///
-/// # Hiding classes
+/// ## Class hiding
 ///
 /// If you want to register a class with Godot, but not have it show up in the editor then you can use `#[class(hide)]`.
 ///
@@ -376,7 +403,9 @@ use crate::util::ident;
 /// Even though this class is a `Node` and it has an init function, it still won't show up in the editor as a node you can add to a scene
 /// because we have added a `hide` key to the class. This will also prevent it from showing up in documentation.
 ///
-/// # Fine-grained inference hints
+/// # Further field customization
+///
+/// ## Fine-grained inference hints
 ///
 /// The derive macro is relatively smart about recognizing `Base<T>` and `OnReady<T>` types, and works also if those are qualified.
 ///
@@ -415,6 +444,8 @@ pub fn derive_godot_class(input: TokenStream) -> TokenStream {
 
 /// Proc-macro attribute to be used with `impl` blocks of [`#[derive(GodotClass)]`][GodotClass] structs.
 ///
+/// See also [book chapter _Registering functions_](https://godot-rust.github.io/book/register/functions.html) and following.
+///
 /// Can be used in two ways:
 /// ```no_run
 /// # use godot::prelude::*;
@@ -422,11 +453,11 @@ pub fn derive_godot_class(input: TokenStream) -> TokenStream {
 /// #[class(init, base=Node)]
 /// struct MyClass {}
 ///
-/// // 1) inherent impl block: user-defined, custom API
+/// // 1) inherent impl block: user-defined, custom API.
 /// #[godot_api]
 /// impl MyClass { /* ... */ }
 ///
-/// // 2) trait impl block: implement Godot-specific APIs
+/// // 2) trait impl block: implement Godot-specific APIs.
 /// #[godot_api]
 /// impl INode for MyClass { /* ... */ }
 /// ```
@@ -635,8 +666,7 @@ pub fn bench(meta: TokenStream, input: TokenStream) -> TokenStream {
 
 /// Proc-macro attribute to be used in combination with the [`ExtensionLibrary`] trait.
 ///
-/// [`ExtensionLibrary`]: trait.ExtensionLibrary.html
-// FIXME intra-doc link
+/// [`ExtensionLibrary`]: ../init/trait.ExtensionLibrary.html
 #[proc_macro_attribute]
 pub fn gdextension(meta: TokenStream, input: TokenStream) -> TokenStream {
     translate_meta(

--- a/godot-macros/src/util/kv_parser.rs
+++ b/godot-macros/src/util/kv_parser.rs
@@ -83,12 +83,12 @@ impl KvParser {
     /// Handles a key that can only occur without a value, e.g. `#[attr(toggle)]`. Returns whether
     /// the key is present.
     pub fn handle_alone(&mut self, key: &str) -> ParseResult<bool> {
-        self.handle_alone_ident(key).map(|id| id.is_some())
+        self.handle_alone_with_span(key).map(|id| id.is_some())
     }
 
-    /// Handles a key that can only occur without a value, e.g. `#[attr(toggle)]`. Returns the key if it is
-    /// present.
-    pub fn handle_alone_ident(&mut self, key: &str) -> ParseResult<Option<Ident>> {
+    /// Handles a key that can only occur without a value, e.g. `#[attr(toggle)]`. Returns the key (as an ident with a span)
+    /// if it is present.
+    pub fn handle_alone_with_span(&mut self, key: &str) -> ParseResult<Option<Ident>> {
         match self.handle_any_entry(key) {
             None => Ok(None),
             Some((id, value)) => match value {

--- a/itest/godot/ManualFfiTests.gd
+++ b/itest/godot/ManualFfiTests.gd
@@ -6,18 +6,13 @@
 extends TestSuite
 
 func test_missing_init():
-	return # TODO: fix dynamic eval
+	var class_found = ClassDB.class_exists("WithoutInit")
+	var can_instantiate = ClassDB.can_instantiate("WithoutInit")
+	var instance = ClassDB.instantiate("WithoutInit")
 
-	var expr = Expression.new()
-	var error = expr.parse("WithoutInit.new()")
-	if not assert_eq(error, OK, "Failed to parse dynamic expression"):
-		return
-
-	var instance = expr.execute()
-	if not assert_that(!expr.has_execute_failed(), "Failed to evaluate dynamic expression"):
-		return
-
-	print("[GD] WithoutInit is: ", instance)
+	assert_eq(class_found, true, "ClassDB.class_exists() is true")
+	assert_eq(can_instantiate, false, "ClassDB.can_instantiate() is false")
+	assert_eq(instance, null, "ClassDB.instantiate() returns null")
 
 func test_init_defaults():
 	var obj = WithInitDefaults.new()

--- a/itest/godot/TestSuite.gd
+++ b/itest/godot/TestSuite.gd
@@ -29,17 +29,17 @@ func assert_that(what: bool, message: String = "") -> bool:
 		print_error("GDScript assertion failed.")
 	return false
 
-func assert_eq(left, right, message: String = "") -> bool:
-	if left == right:
+func assert_eq(actual, expected, message: String = "") -> bool:
+	if actual == expected:
 		return true
 
 	_assertion_failed = true
 
 	print_newline() # previous line not yet broken
 	if message:
-		print_error("GDScript assertion failed:  %s\n  left: %s\n right: %s" % [message, left, right])
+		print_error("GDScript assertion failed:  %s\n  actual:   %s\n  expected: %s" % [message, actual, expected])
 	else:
-		print_error("GDScript assertion failed:  `(left == right)`\n  left: %s\n right: %s" % [left, right])
+		print_error("GDScript assertion failed:  `(actual == expected)`\n  actual: %s\n expected: %s" % [actual, expected])
 	return false
 
 # Disable error message printing from godot. 

--- a/itest/rust/src/builtin_tests/string/string_name_test.rs
+++ b/itest/rust/src/builtin_tests/string/string_name_test.rs
@@ -138,14 +138,6 @@ fn string_name_from_latin1_with_nul() {
         let a = StringName::from_latin1_with_nul(bytes);
         let b = StringName::from(string);
 
-        println!();
-        println!(
-            "Arrays: a={:?}, b={:?}",
-            a.to_string().as_bytes(),
-            b.to_string().as_bytes()
-        );
-        println!("Hashes: a={:?}, b={:?}", a.hash(), b.hash());
-        println!("Lengths: a={}, b={}", a.len(), b.len());
         assert_eq!(a, b);
     }
 }

--- a/itest/rust/src/object_tests/class_rename_test.rs
+++ b/itest/rust/src/object_tests/class_rename_test.rs
@@ -12,6 +12,7 @@ pub mod dont_rename {
     use super::*;
 
     #[derive(GodotClass)]
+    #[class(no_init)]
     pub struct RepeatMe {}
 }
 
@@ -19,7 +20,7 @@ pub mod rename {
     use super::*;
 
     #[derive(GodotClass)]
-    #[class(rename = NoRepeat)]
+    #[class(rename=NoRepeat, no_init)]
     pub struct RepeatMe {}
 }
 

--- a/itest/rust/src/object_tests/object_test.rs
+++ b/itest/rust/src/object_tests/object_test.rs
@@ -578,9 +578,11 @@ fn object_engine_downcast() {
 }
 
 #[derive(GodotClass)]
+#[class(no_init)]
 struct CustomClassA {}
 
 #[derive(GodotClass)]
+#[class(no_init)]
 struct CustomClassB {}
 
 #[itest]
@@ -883,6 +885,7 @@ impl IRefCounted for RefcPayload {
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 
 #[derive(GodotClass, Eq, PartialEq, Debug)]
+#[class(no_init)]
 pub struct Tracker {
     drop_count: Rc<RefCell<i32>>,
 }
@@ -967,7 +970,7 @@ pub mod object_test_gd {
     // ----------------------------------------------------------------------------------------------------------------------------------------------
 
     #[derive(GodotClass)]
-    #[class(base=Object)]
+    #[class(base=Object, no_init)]
     pub struct CustomConstructor {
         #[var]
         pub val: i64,
@@ -1042,7 +1045,7 @@ fn double_use_reference() {
 // compiles.
 #[cfg(since_api = "4.1")]
 #[derive(GodotClass)]
-#[class(base = EditorPlugin, editor_plugin)]
+#[class(no_init, base = EditorPlugin, editor_plugin, tool)]
 struct CustomEditorPlugin;
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------

--- a/itest/rust/src/object_tests/onready_test.rs
+++ b/itest/rust/src/object_tests/onready_test.rs
@@ -145,7 +145,7 @@ fn onready_property_access() {
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 
 #[derive(GodotClass)]
-#[class(base=Node)]
+#[class(no_init, base=Node)]
 struct OnReadyWithImpl {
     #[var]
     auto: OnReady<i32>,
@@ -182,7 +182,7 @@ impl INode for OnReadyWithImpl {
 
 // Class that doesn't have a #[godot_api] impl. Used to test whether variables are still initialized.
 #[derive(GodotClass)]
-#[class(base=Node)]
+#[class(no_init, base=Node)]
 struct OnReadyWithoutImpl {
     auto: OnReady<i32>,
     // No manual one, since those cannot be initialized without a ready() override.
@@ -206,7 +206,7 @@ type Ordy<T> = OnReady<T>;
 
 // Class that has a #[godot_api] impl, but does not override ready. Used to test whether variables are still initialized.
 #[derive(GodotClass)]
-#[class(base=Node)]
+#[class(no_init, base=Node)]
 struct OnReadyWithImplWithoutReady {
     // Test also #[hint] at the same time.
     #[hint(onready)]

--- a/itest/rust/src/object_tests/property_test.rs
+++ b/itest/rust/src/object_tests/property_test.rs
@@ -231,6 +231,7 @@ impl HasCustomProperty {
 
 // These should all compile, but we can't easily test that they look right at the moment.
 #[derive(GodotClass)]
+#[class(no_init)]
 struct CheckAllExports {
     #[export]
     normal: GString,
@@ -308,6 +309,7 @@ pub enum TestEnum {
 }
 
 #[derive(GodotClass)]
+#[class(no_init)]
 pub struct DeriveProperty {
     #[var]
     pub foo: TestEnum,
@@ -369,7 +371,7 @@ pub struct RenamedCustomResource {}
 #[class(init, base=Node)]
 pub struct ExportResource {
     #[export]
-    #[var(usage_flags=[PROPERTY_USAGE_DEFAULT, PROPERTY_USAGE_EDITOR_INSTANTIATE_OBJECT])]
+    #[var(usage_flags=[DEFAULT, EDITOR_INSTANTIATE_OBJECT])]
     pub foo: Option<Gd<CustomResource>>,
 
     #[export]

--- a/itest/rust/src/object_tests/virtual_methods_test.rs
+++ b/itest/rust/src/object_tests/virtual_methods_test.rs
@@ -28,7 +28,7 @@ use godot::register::{godot_api, GodotClass};
 
 /// Simple class, that deliberately has no constructor accessible from GDScript
 #[derive(GodotClass, Debug)]
-#[class(base=RefCounted)]
+#[class(no_init, base=RefCounted)]
 struct WithoutInit {
     some_base: Base<RefCounted>,
 }

--- a/itest/rust/src/register_tests/constant_test.rs
+++ b/itest/rust/src/register_tests/constant_test.rs
@@ -14,6 +14,7 @@ use godot::prelude::*;
 use godot::sys::static_assert;
 
 #[derive(GodotClass)]
+#[class(no_init)]
 struct HasConstants {}
 
 #[godot_api]
@@ -114,6 +115,7 @@ fn cfg_removes_or_keeps_constants() {
 }
 
 #[derive(GodotClass)]
+#[class(no_init)]
 struct HasOtherConstants {}
 
 impl HasOtherConstants {


### PR DESCRIPTION
Adds `#[class(no_init)]`, which is now **required** to disable constructor. 
This is a breaking change for cases where the constructor was implicitly disabled -- but this didn't work properly anyway, see below.

Forgetting a constructor is no longer possible: if there is no `#[class(init)]` attribute and no overridden `init()` function, then the library will emit a compile error. In many cases, constructors were accidentally disabled due to forgotten `#[class(init)]`, which also broke hot reloading.

In addition, the `no_init` key now registers a class properly as non-instantiable (in Godot terms "abstract", which is confusing). This means that you get a helpful error message in the editor in case you call `MyClass.new()` from GDScript:
```
ERROR: Class 'MyClass' or its base class cannot be instantiated.
```

Fixes #539.

