### PR TITLE
Make `Var` use `GodotConvert::Via` to align it with `ToGodot` and `FromGodot` 

### DIFF
--- a/godot-core/src/builtin/array.rs
+++ b/godot-core/src/builtin/array.rs
@@ -762,14 +762,12 @@ impl TypeStringHint for VariantArray {
 }
 
 impl<T: GodotType> Var for Array<T> {
-    type Intermediate = Self;
-
-    fn get_property(&self) -> Self::Intermediate {
-        self.clone()
+    fn get_property(&self) -> Self::Via {
+        self.to_godot()
     }
 
-    fn set_property(&mut self, value: Self::Intermediate) {
-        *self = value;
+    fn set_property(&mut self, value: Self::Via) {
+        *self = FromGodot::from_godot(value)
     }
 
     #[cfg(since_api = "4.2")]

--- a/godot-core/src/builtin/dictionary.rs
+++ b/godot-core/src/builtin/dictionary.rs
@@ -341,14 +341,12 @@ impl Clone for Dictionary {
 }
 
 impl Var for Dictionary {
-    type Intermediate = Self;
-
-    fn get_property(&self) -> Self::Intermediate {
-        self.clone()
+    fn get_property(&self) -> Self::Via {
+        self.to_godot()
     }
 
-    fn set_property(&mut self, value: Self::Intermediate) {
-        *self = value;
+    fn set_property(&mut self, value: Self::Via) {
+        *self = FromGodot::from_godot(value)
     }
 }
 

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -656,15 +656,15 @@ impl<T: GodotClass> TypeStringHint for Gd<T> {
     }
 }
 
+// TODO: Do we even want to implement `Var` and `Export` for `Gd<T>`? You basically always want to use `Option<Gd<T>>` because the editor
+// may otherwise try to set the object to a null value.
 impl<T: GodotClass> Var for Gd<T> {
-    type Intermediate = Self;
-
-    fn get_property(&self) -> Self {
-        self.clone()
+    fn get_property(&self) -> Self::Via {
+        self.to_godot()
     }
 
-    fn set_property(&mut self, value: Self) {
-        *self = value;
+    fn set_property(&mut self, value: Self::Via) {
+        *self = FromGodot::from_godot(value)
     }
 }
 

--- a/godot-core/src/obj/onready.rs
+++ b/godot-core/src/obj/onready.rs
@@ -5,6 +5,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+use crate::builtin::meta::GodotConvert;
 use crate::property::{PropertyHintInfo, Var};
 use std::mem;
 
@@ -190,15 +191,17 @@ impl<T> std::ops::DerefMut for OnReady<T> {
     }
 }
 
-impl<T: Var> Var for OnReady<T> {
-    type Intermediate = T::Intermediate;
+impl<T: GodotConvert> GodotConvert for OnReady<T> {
+    type Via = T::Via;
+}
 
-    fn get_property(&self) -> Self::Intermediate {
+impl<T: Var> Var for OnReady<T> {
+    fn get_property(&self) -> Self::Via {
         let deref: &T = self;
         deref.get_property()
     }
 
-    fn set_property(&mut self, value: Self::Intermediate) {
+    fn set_property(&mut self, value: Self::Via) {
         let deref: &mut T = self;
         deref.set_property(value);
     }

--- a/godot-macros/src/class/data_models/field_var.rs
+++ b/godot-macros/src/class/data_models/field_var.rs
@@ -168,7 +168,7 @@ impl GetterSetterImpl {
         match kind {
             GetSet::Get => {
                 signature = quote! {
-                    fn #function_name(&self) -> <#field_type as ::godot::register::property::Var>::Intermediate
+                    fn #function_name(&self) -> <#field_type as ::godot::builtin::meta::GodotConvert>::Via
                 };
                 function_body = quote! {
                     <#field_type as ::godot::register::property::Var>::get_property(&self.#field_name)
@@ -176,7 +176,7 @@ impl GetterSetterImpl {
             }
             GetSet::Set => {
                 signature = quote! {
-                    fn #function_name(&mut self, #field_name: <#field_type as ::godot::register::property::Var>::Intermediate)
+                    fn #function_name(&mut self, #field_name: <#field_type as ::godot::builtin::meta::GodotConvert>::Via)
                 };
                 function_body = quote! {
                     <#field_type as ::godot::register::property::Var>::set_property(&mut self.#field_name, #field_name);

--- a/godot-macros/src/derive/derive_godot_convert.rs
+++ b/godot-macros/src/derive/derive_godot_convert.rs
@@ -9,7 +9,7 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use venial::Declaration;
 
-use crate::util::{decl_get_info, DeclInfo};
+use crate::util::{decl_get_info, via_type, DeclInfo};
 use crate::ParseResult;
 
 pub fn derive_godot_convert(decl: Declaration) -> ParseResult<TokenStream> {
@@ -22,9 +22,11 @@ pub fn derive_godot_convert(decl: Declaration) -> ParseResult<TokenStream> {
 
     let gen = generic_params.as_ref().map(|x| x.as_inline_args());
 
+    let via_type = via_type(&decl)?;
+
     Ok(quote! {
         impl #generic_params ::godot::builtin::meta::GodotConvert for #name #gen #where_ {
-            type Via = ::godot::builtin::Variant;
+            type Via = #via_type;
         }
     })
 }

--- a/godot-macros/src/lib.rs
+++ b/godot-macros/src/lib.rs
@@ -601,6 +601,8 @@ pub fn derive_from_godot(input: TokenStream) -> TokenStream {
 
 /// Derive macro for [`Var`](../register/property/trait.Var.html) on enums.
 ///
+/// This also requires deriving `GodotConvert`.
+///
 /// Currently has some tight requirements which are expected to be softened as implementation expands:
 /// - Only works for enums, structs aren't supported by this derive macro at the moment.
 /// - The enum must have an explicit `#[repr(u*/i*)]` type.
@@ -612,7 +614,7 @@ pub fn derive_from_godot(input: TokenStream) -> TokenStream {
 ///
 /// ```no_run
 /// # use godot::prelude::*;
-/// #[derive(Var)]
+/// #[derive(Var, GodotConvert)]
 /// #[repr(i32)]
 /// # #[derive(Eq, PartialEq, Debug)]
 /// enum MyEnum {

--- a/itest/rust/src/object_tests/property_test.rs
+++ b/itest/rust/src/object_tests/property_test.rs
@@ -5,15 +5,14 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use godot::{
-    engine::{
-        global::{PropertyHint, PropertyUsageFlags},
-        Texture,
-    },
-    prelude::*,
-    register::property::PropertyHintInfo,
-    test::itest,
-};
+use godot::builtin::meta::{GodotConvert, ToGodot};
+use godot::builtin::{dict, Color, Dictionary, GString, Variant, VariantType};
+use godot::engine::global::{PropertyHint, PropertyUsageFlags};
+use godot::engine::{INode, IRefCounted, Node, Object, RefCounted, Texture};
+use godot::obj::{Base, EngineBitfield, EngineEnum, Gd, NewAlloc, NewGd};
+use godot::register::property::{Export, PropertyHintInfo, Var};
+use godot::register::{godot_api, Export, GodotClass, GodotConvert, Var};
+use godot::test::itest;
 
 // No tests currently, tests using these classes are in Godot scripts.
 
@@ -155,14 +154,16 @@ enum SomeCStyleEnum {
     C = 2,
 }
 
-impl Var for SomeCStyleEnum {
-    type Intermediate = i64;
+impl GodotConvert for SomeCStyleEnum {
+    type Via = i64;
+}
 
-    fn get_property(&self) -> Self::Intermediate {
+impl Var for SomeCStyleEnum {
+    fn get_property(&self) -> Self::Via {
         (*self) as i64
     }
 
-    fn set_property(&mut self, value: Self::Intermediate) {
+    fn set_property(&mut self, value: Self::Via) {
         match value {
             0 => *self = Self::A,
             1 => *self = Self::B,
@@ -187,17 +188,19 @@ struct NotExportable {
     b: i64,
 }
 
-impl Var for NotExportable {
-    type Intermediate = Dictionary;
+impl GodotConvert for NotExportable {
+    type Via = Dictionary;
+}
 
-    fn get_property(&self) -> Self::Intermediate {
+impl Var for NotExportable {
+    fn get_property(&self) -> Self::Via {
         dict! {
             "a": self.a,
             "b": self.b
         }
     }
 
-    fn set_property(&mut self, value: Self::Intermediate) {
+    fn set_property(&mut self, value: Self::Via) {
         let a = value.get("a").unwrap().to::<i64>();
         let b = value.get("b").unwrap().to::<i64>();
 
@@ -300,8 +303,8 @@ struct CheckAllExports {
     color_no_alpha: Color,
 }
 
+#[derive(GodotConvert, Var, Export, Eq, PartialEq, Debug)]
 #[repr(i64)]
-#[derive(Var, Export, Eq, PartialEq, Debug)]
 pub enum TestEnum {
     A = 0,
     B = 1,


### PR DESCRIPTION
`Var` now depends on `GodotConvert` and uses `GodotConvert::Via` instead of its own intermediate type

`Var` does not depend on `ToGodot` or `FromGodot` to make it possible to have properties that cannot be used as function arguments/return types. This is currently the case for `OnReady<T>`. The current implementations do however use `ToGodot` and `FromGodot` to perform the conversions.

This also required some changes in the `GodotConvert` and `Var` macros to make sure they agree on the `Via` type to use for structs/enums. 

I didn't change the derive macros much beyond making them compatible with each other, as i think they could do with a bigger rewrite later, see for instance #452.

closes #453 