### PR TITLE
tr! and tr_n! macros

### DIFF
--- a/godot-core/src/engine/mod.rs
+++ b/godot-core/src/engine/mod.rs
@@ -19,6 +19,7 @@ use crate::sys;
 
 mod io;
 mod script_instance;
+pub mod translate;
 
 pub use io::*;
 pub use script_instance::{create_script_instance, ScriptInstance};

--- a/godot-core/src/engine/translate.rs
+++ b/godot-core/src/engine/translate.rs
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+//! Macros for translation.
+
+pub use crate::{tr, tr_n};
+
+/// A convenience macro for using the [`Object::tr()`](crate::engine::Object::tr()) and [`Object::tr_ex()`](crate::engine::Object::tr_ex())
+///  methods.
+///
+/// Takes a format string literal, with optional arguments. Optionally, `context` for potentially ambiguous words can be
+/// added before the format arguments, separated with a `;`.
+///
+/// Using named or positional parameters instead of `{}` may make it easier to use dynamic formatting once gdext supports it:
+/// ```no_run
+/// # #[macro_use] extern crate godot;
+/// # use godot::builtin::Vector2i;
+/// # let a = Vector2i { x: 0, y: 0 };
+/// # let b = Vector2i { x: 0, y: 0 };
+/// # let context = "context";
+/// use godot::engine::translate::tr;
+///
+/// // Good.
+/// tr!(context; "{a} is a {b}"); // inlined, with context
+/// tr!("{0} is a {1}", a, b); // positional, without context
+/// tr!("{c} is a {d}", c = a.x, d = b.y); // named (inlining not possible here)
+///
+/// // Not as good, much more fragile.
+/// tr!("{} is a {}", a, b);
+/// ```
+/// The methods are called from the [`Engine`](crate::engine::Engine) singleton.
+///
+/// See also: [Translation contexts](https://docs.godotengine.org/en/stable/tutorials/i18n/internationalizing_games.html#translation-contexts)
+/// in Godot.
+#[macro_export]
+macro_rules! tr {
+    ($fmt:literal $(, $($args:tt)*)?) => {
+        $crate::engine::Engine::singleton()
+            .tr(format!($fmt $(, $($args)*)?).into())
+    };
+
+    ($context:expr; $fmt:literal $(, $($args:tt)*)?) => {
+        $crate::engine::Engine::singleton()
+            .tr_ex(format!($fmt $(, $($args)*)?).into())
+            .context(format!("{}", $context).into())
+            .done()
+    };
+}
+
+/// A convenience macro for using the [`Object::tr_n()`](crate::engine::Object::tr_n()) and
+/// [`Object::tr_n_ex()`](crate::engine::Object::tr_n_ex()) methods.
+///
+/// Allows for the use of format strings with arbitrary arguments. `n` is given prior to the format string, followed by `;`.
+/// Optionally, `context` for potentially ambiguous words can be added with `,` after `n` and before `;`.
+///
+/// Using named or positional parameters instead of `{}` may make it easier to use dynamic formatting once gdext supports it:
+/// ```no_run
+/// # #[macro_use] extern crate godot;
+/// # use godot::builtin::Vector2i;
+/// # let a = Vector2i { x: 0, y: 0 };
+/// # let b = Vector2i { x: 0, y: 0 };
+/// # let context = "context";
+/// # let n = 2;
+/// use godot::engine::translate::tr_n;
+///
+/// // Good.
+/// tr_n!(n, context; "{a} is a {b}", "{a}s are {b}s"); // inlined, with context
+/// tr_n!(n; "{0} is a {1}", "{0}s are {1}s", a, b); // positional, without context
+/// tr_n!(n; "{c} is a {d}", "{c}s are {d}s", c = a.x, d = b.y); // named (inlining not possible here)
+///
+/// // Not as good, much more fragile.
+/// // Additionally, such syntax requires that BOTH format strings use ALL listed arguments.
+/// tr_n!(n; "{} is a {}", "{}s are {}s", a, b);
+/// ```
+/// The methods are called from the [`Engine`](crate::engine::Engine) singleton.
+///
+/// See also: [Translation contexts](https://docs.godotengine.org/en/stable/tutorials/i18n/internationalizing_games.html#translation-contexts)
+/// in Godot.
+#[macro_export]
+macro_rules! tr_n {
+    ($n:expr; $singular:literal, $plural:literal $(, $($args:tt)*)?) => {
+        $crate::engine::Engine::singleton()
+            .tr_n(
+                format!($singular$(, $($args)*)?).into(),
+                format!($plural$(, $($args)*)?).into(),
+                $n,
+            )
+    };
+
+    ($n:expr, $context:expr; $singular:literal, $plural:literal $(, $($args:tt)*)?) => {
+        $crate::engine::Engine::singleton()
+            .tr_n_ex(
+                format!($singular$(, $($args)*)?).into(),
+                format!($plural$(, $($args)*)?).into(),
+                $n,
+            )
+            .context(format!("{}", $context).into())
+            .done()
+    };
+}

--- a/godot-core/src/lib.rs
+++ b/godot-core/src/lib.rs
@@ -37,6 +37,7 @@ pub use registry::*;
 /// * [`notify`][crate::engine::notify]: all notification types, used when working with the virtual callback to handle lifecycle notifications.
 /// * [`global`][crate::engine::global]: global enums not belonging to a specific class.
 /// * [`utilities`][crate::engine::utilities]: utility methods that are global in Godot.
+/// * [`translate`][crate::engine::translate]: convenience macros for translation.
 pub mod engine;
 
 // Output of generated code. Mimics the file structure, symbols are re-exported.

--- a/itest/rust/src/engine_tests/mod.rs
+++ b/itest/rust/src/engine_tests/mod.rs
@@ -11,4 +11,5 @@ mod gfile_test;
 mod native_structures_test;
 mod node_test;
 mod save_load_test;
+mod translate_test;
 mod utilities_test;

--- a/itest/rust/src/engine_tests/translate_test.rs
+++ b/itest/rust/src/engine_tests/translate_test.rs
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use crate::framework::itest;
+use godot::builtin::Vector2;
+use godot::engine::translate::{tr, tr_n};
+
+#[itest]
+fn tr_macro_format() {
+    // Make sure expressions are parsed correctly, and use positional label to use argument again.
+    let no_context_list_positional = tr!(
+        "List: first: {}, second: {}, first again: {0}",
+        255,
+        "hello!",
+    );
+    assert_eq!(
+        no_context_list_positional.to_string(),
+        "List: first: 255, second: hello!, first again: 255"
+    );
+
+    // Create a Vector2 to test named field-access formatting.
+    let vector2 = Vector2 { x: 1.25, y: 1.5 };
+
+    // Test named (with context).
+    let context_named = tr!(
+        false; "Named: x: {x}, y: {y}",
+        x = vector2.x,
+        y = vector2.y,
+    );
+    assert_eq!(context_named.to_string(), "Named: x: 1.25, y: 1.5");
+}
+
+#[itest]
+fn tr_n_macro_format_plural() {
+    // Test that the first string is chosen and formatted correctly when n == 1.
+    let mut n = 1;
+    let hello = tr_n!(n; "Hello singular {}!", "Hello plural {}s!", "world");
+    assert_eq!(hello.to_string(), "Hello singular world!");
+
+    // Test that the plural string is chosen and formatted correctly with the same invocation when n != 1.
+    n = 3;
+    let hello = tr_n!(n; "Hello singular {}!", "Hello plural {}s!", "world");
+    assert_eq!(hello.to_string(), "Hello plural worlds!");
+}


### PR DESCRIPTION
Added `tr!` and `tr_n!` macros for using the built in translation methods. Figured I'd start the request and hash out details here instead.

Uses the `Engine` singleton to call the methods, and the functions internally call `Engine::get_singleton()` so I think that should be safe.

Looks like only `,` `;` and `=>` are allowed following expressions. Can't have the arguments be `tt` since everything after would be ambiguous, and `=>` doesn't feel right, at least for context. Kind of unfortunate but it's workable I think.

syntax:
```rust
// no context
tr!("I am {} years old", player_age);
// with context
tr!("{} and I are very close", player_name; "friendship");
// One option for pluralization
tr_n!("{} has {n} pen", name; "{} has {n} pens",  name; num_pens; "farm");
// Another option for pluralization
tr_n!("{} has {n} pen" | "{} has {n} pens":  name; num_pens; "writing");
```

I like the second option more, since it only includes the arguments once and the function is specifically based around contextualizing the same things in varying numbers, so including arguments for each feels redundant, but I only thought of it after I had already finished writing the documentation for the first, so I left both in there and will probably remove one.

I'm not sure #392, will be closed by this, but it might if you make sure to do all of your localization-sensitive work in rust (since gdscript's formatting syntax is different). More testing will be required, but the ergonomics are there.