### PR TITLE
Fix properties not able to clear from editor

### DIFF
--- a/godot-core/src/builtin/meta/godot_convert/impls.rs
+++ b/godot-core/src/builtin/meta/godot_convert/impls.rs
@@ -61,6 +61,12 @@ where
     }
 
     fn try_from_variant(variant: &Variant) -> Result<Self, ConvertError> {
+        // Note: this forwards to T::Via, not Self::Via (= Option<T>::Via).
+        // For Option<T>, there is a blanket impl GodotType, so case differentiations are not possible.
+        if T::Via::qualifies_as_special_none(variant) {
+            return Ok(None);
+        }
+
         if variant.is_nil() {
             return Ok(None);
         }

--- a/godot-core/src/builtin/meta/godot_convert/mod.rs
+++ b/godot-core/src/builtin/meta/godot_convert/mod.rs
@@ -66,7 +66,8 @@ pub trait FromGodot: Sized + GodotConvert {
     /// # Panics
     /// If the conversion fails.
     fn from_godot(via: Self::Via) -> Self {
-        Self::try_from_godot(via).unwrap()
+        Self::try_from_godot(via)
+            .unwrap_or_else(|err| panic!("FromGodot::from_godot() failed: {err}"))
     }
 
     /// Performs the conversion from a [`Variant`].
@@ -82,7 +83,8 @@ pub trait FromGodot: Sized + GodotConvert {
     /// # Panics
     /// If the conversion fails.
     fn from_variant(variant: &Variant) -> Self {
-        Self::try_from_variant(variant).unwrap()
+        Self::try_from_variant(variant)
+            .unwrap_or_else(|err| panic!("FromGodot::from_variant() failed: {err}"))
     }
 }
 

--- a/godot-core/src/builtin/meta/mod.rs
+++ b/godot-core/src/builtin/meta/mod.rs
@@ -171,6 +171,16 @@ pub trait GodotType:
 
     #[doc(hidden)]
     fn godot_type_name() -> String;
+
+    /// Special-casing for `FromVariant` conversions higher up: true if the variant can be interpreted as `Option<Self>::None`.
+    ///
+    /// Returning false only means that this is not a special case, not that it cannot be `None`. Regular checks are expected to run afterwards.
+    ///
+    /// This exists only for varcalls and serves a similar purpose as `GodotNullableFfi::is_null()` (although that handles general cases).
+    #[doc(hidden)]
+    fn qualifies_as_special_none(_from_variant: &Variant) -> bool {
+        false
+    }
 }
 
 impl<T> GodotType for Option<T>

--- a/godot-core/src/builtin/string/node_path.rs
+++ b/godot-core/src/builtin/string/node_path.rs
@@ -26,6 +26,10 @@ impl NodePath {
         Self { opaque }
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.as_inner().is_empty()
+    }
+
     /// Returns a 32-bit integer hash value representing the string.
     pub fn hash(&self) -> u32 {
         self.as_inner()

--- a/itest/rust/src/builtin_tests/containers/variant_test.rs
+++ b/itest/rust/src/builtin_tests/containers/variant_test.rs
@@ -13,8 +13,8 @@ use godot::builtin::{
     dict, varray, GString, NodePath, Signal, StringName, Variant, Vector2, Vector3,
 };
 use godot::builtin::{Basis, Dictionary, VariantArray, VariantOperator, VariantType};
-use godot::engine::Node2D;
-use godot::obj::{InstanceId, NewAlloc};
+use godot::engine::{Node, Node2D};
+use godot::obj::{Gd, InstanceId, NewAlloc};
 use godot::sys::GodotFfi;
 
 use crate::common::roundtrip;
@@ -77,6 +77,14 @@ fn variant_conversions() {
 #[itest]
 fn variant_forbidden_conversions() {
     truncate_bad::<i8>(128);
+}
+
+#[itest]
+fn variant_special_conversions() {
+    // See https://github.com/godot-rust/gdext/pull/598.
+    let variant = NodePath::default().to_variant();
+    let object = variant.try_to::<Option<Gd<Node>>>();
+    assert!(matches!(object, Ok(None)));
 }
 
 #[itest]


### PR DESCRIPTION
This is more a workaround than a fix: it allows a variant conversion from `NodePath("")` to `Option<Gd<T>>::None`.
Also improves panic messages for failed `FromGodot` conversions.

Why?

---

We can export node types (`Gd<T>`) to the editor. For example, in `main_scene.rs` of dodge-the-creeps:
```rs
    #[export]
    music: Option<Gd<AudioStreamPlayer>>,
```

This will show up as follows in the UI:

![Clearing Godot properties](https://github.com/godot-rust/gdext/assets/708488/a030a63b-6eef-4515-b084-aa703ddcdebe)


It's interesting, the 🔁 reset button does reset it as expected.
However, the clear 🧹 one panics.

I've found that there is some very subtle behavior: Godot sends an object null pointer inside the `Variant` (varcall) when pressing _reset_. However, when pressing _clear_, it sends a `NodePath` which is empty.

This PR treats this special case and thus allows clearing objects again.