### PR TITLE
Some cleanup and more accurate tracking of safety invariants

### DIFF
--- a/godot-codegen/src/context.rs
+++ b/godot-codegen/src/context.rs
@@ -246,17 +246,6 @@ impl<'a> Context<'a> {
         self.singletons.contains(class_name)
     }
 
-    pub fn is_exportable(&self, class_name: &TyName) -> bool {
-        if class_name.godot_ty == "Resource" || class_name.godot_ty == "Node" {
-            return true;
-        }
-
-        self.inheritance_tree
-            .collect_all_bases(class_name)
-            .iter()
-            .any(|ty| ty.godot_ty == "Resource" || ty.godot_ty == "Node")
-    }
-
     pub fn inheritance_tree(&self) -> &InheritanceTree {
         &self.inheritance_tree
     }

--- a/godot-codegen/src/generator/builtins.rs
+++ b/godot-codegen/src/generator/builtins.rs
@@ -163,6 +163,21 @@ fn make_special_builtin_methods(class_name: &TyName, _ctx: &Context) -> TokenStr
     }
 }
 
+/// Get the safety docs of a method if it should be unsafe
+fn method_safety_doc(class_name: &TyName, method: &BuiltinMethod) -> Option<TokenStream> {
+    if class_name.godot_ty == "Array" {
+        if &method.return_value().type_tokens().to_string() == "VariantArray" {
+            return Some(quote! {
+                #[doc = "# Safety"]
+                #[doc = ""]
+                #[doc = "You must ensure that the returned array fulfils the safety invariants of [`Array`](crate::builtin::Array)"]
+            });
+        }
+    }
+
+    None
+}
+
 fn make_builtin_method_definition(
     builtin_class: &BuiltinClass,
     method: &BuiltinMethod,
@@ -220,6 +235,8 @@ fn make_builtin_method_definition(
         )*/
     };
 
+    let safety_doc = method_safety_doc(builtin_class.name(), method);
+
     functions_common::make_function_definition(
         method,
         &FnCode {
@@ -227,5 +244,6 @@ fn make_builtin_method_definition(
             varcall_invocation,
             ptrcall_invocation,
         },
+        safety_doc,
     )
 }

--- a/godot-codegen/src/generator/builtins.rs
+++ b/godot-codegen/src/generator/builtins.rs
@@ -163,16 +163,16 @@ fn make_special_builtin_methods(class_name: &TyName, _ctx: &Context) -> TokenStr
     }
 }
 
-/// Get the safety docs of a method if it should be unsafe
+/// Get the safety docs of an unsafe method, or `None` if it is safe.
 fn method_safety_doc(class_name: &TyName, method: &BuiltinMethod) -> Option<TokenStream> {
-    if class_name.godot_ty == "Array" {
-        if &method.return_value().type_tokens().to_string() == "VariantArray" {
-            return Some(quote! {
-                #[doc = "# Safety"]
-                #[doc = ""]
-                #[doc = "You must ensure that the returned array fulfils the safety invariants of [`Array`](crate::builtin::Array)"]
-            });
-        }
+    if class_name.godot_ty == "Array"
+        && &method.return_value().type_tokens().to_string() == "VariantArray"
+    {
+        return Some(quote! {
+            /// # Safety
+            ///
+            /// You must ensure that the returned array fulfils the safety invariants of [`Array`](crate::builtin::Array).
+        });
     }
 
     None

--- a/godot-codegen/src/generator/classes.rs
+++ b/godot-codegen/src/generator/classes.rs
@@ -469,5 +469,6 @@ fn make_class_method_definition(
             varcall_invocation,
             ptrcall_invocation,
         },
+        None,
     )
 }

--- a/godot-codegen/src/generator/classes.rs
+++ b/godot-codegen/src/generator/classes.rs
@@ -139,7 +139,17 @@ fn make_class(class: &Class, ctx: &mut Context, view: &ApiView) -> GeneratedClas
             let instance_id = rtti.check_type::<Self>();
             Some(instance_id)
         }
+
+        #[doc(hidden)]
+        pub fn __object_ptr(&self) -> sys::GDExtensionObjectPtr {
+            self.object_ptr
+        }
     };
+
+    let inherits_macro_safety_doc = format!(
+        "The provided class must be a subclass of all the superclasses of [`{}`]",
+        class_name.rust_ty
+    );
 
     // mod re_export needed, because class should not appear inside the file module, and we can't re-export private struct as pub.
     let imports = util::make_imports();
@@ -197,7 +207,7 @@ fn make_class(class: &Class, ctx: &mut Context, view: &ApiView) -> GeneratedClas
 
             /// # Safety
             ///
-            #[doc = concat!("The provided class must be a subclass of all the superclasses of ", stringify!(#class_name))]
+            #[doc = #inherits_macro_safety_doc]
             #[macro_export]
             #[allow(non_snake_case)]
             macro_rules! #inherits_macro {

--- a/godot-codegen/src/generator/functions_common.rs
+++ b/godot-codegen/src/generator/functions_common.rs
@@ -82,7 +82,11 @@ impl FnDefinitions {
     }
 }
 
-pub fn make_function_definition(sig: &dyn Function, code: &FnCode) -> FnDefinition {
+pub fn make_function_definition(
+    sig: &dyn Function,
+    code: &FnCode,
+    safety_doc: Option<TokenStream>,
+) -> FnDefinition {
     let has_default_params = default_parameters::function_uses_default_params(sig);
     let vis = if has_default_params {
         // Public API mapped by separate function.
@@ -92,7 +96,9 @@ pub fn make_function_definition(sig: &dyn Function, code: &FnCode) -> FnDefiniti
         make_vis(sig.is_private())
     };
 
-    let (maybe_unsafe, safety_doc) = if function_uses_pointers(sig) {
+    let (maybe_unsafe, safety_doc) = if let Some(safety_doc) = safety_doc {
+        (quote! { unsafe }, safety_doc)
+    } else if function_uses_pointers(sig) {
         (
             quote! { unsafe },
             quote! {

--- a/godot-codegen/src/generator/utility_functions.rs
+++ b/godot-codegen/src/generator/utility_functions.rs
@@ -78,6 +78,7 @@ pub(crate) fn make_utility_function_definition(function: &UtilityFunction) -> To
             varcall_invocation,
             ptrcall_invocation,
         },
+        None,
     );
 
     // Utility functions have no builders.

--- a/godot-codegen/src/generator/virtual_traits.rs
+++ b/godot-codegen/src/generator/virtual_traits.rs
@@ -124,6 +124,7 @@ fn make_virtual_method(method: &ClassMethod) -> Option<TokenStream> {
             varcall_invocation: TokenStream::new(),
             ptrcall_invocation: TokenStream::new(),
         },
+        None,
     );
 
     // Virtual methods have no builders.

--- a/godot-core/src/builtin/array.rs
+++ b/godot-core/src/builtin/array.rs
@@ -56,8 +56,22 @@ use super::meta::{
 // GodotType`. Whew. This could be fixed by splitting up `GodotFfi` if desired.
 #[repr(C)]
 pub struct Array<T: GodotType> {
+    // Safety Invariant: The type of all values in `opaque` matches the type `T`.
     opaque: sys::types::OpaqueArray,
     _phantom: PhantomData<T>,
+}
+
+/// Guard that can only call immutable methods on the array.
+struct InnerArrayRef<'a> {
+    inner: inner::InnerArray<'a>,
+}
+
+impl<'a> std::ops::Deref for InnerArrayRef<'a> {
+    type Target = inner::InnerArray<'a>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
 }
 
 /// A Godot `Array` without an assigned type.
@@ -91,7 +105,7 @@ impl<T: GodotType> Array<T> {
     /// it in a variable. For loops, prefer iterators.
     #[doc(alias = "size")]
     pub fn len(&self) -> usize {
-        to_usize(self.as_inner().size())
+        to_usize(self.as_inner_ref().size())
     }
 
     /// Returns `true` if the array is empty.
@@ -99,7 +113,7 @@ impl<T: GodotType> Array<T> {
     /// Checking for emptiness incurs an FFI call. If you know the size hasn't changed, you may consider storing
     /// it in a variable. For loops, prefer iterators.
     pub fn is_empty(&self) -> bool {
-        self.as_inner().is_empty()
+        self.as_inner_ref().is_empty()
     }
 
     /// Returns a 32-bit integer hash value representing the array and its contents.
@@ -110,24 +124,19 @@ impl<T: GodotType> Array<T> {
     pub fn hash(&self) -> u32 {
         // The GDExtension interface only deals in `i64`, but the engine's own `hash()` function
         // actually returns `uint32_t`.
-        self.as_inner().hash().try_into().unwrap()
+        self.as_inner_ref().hash().try_into().unwrap()
     }
 
     /// Clears the array, removing all elements.
     pub fn clear(&mut self) {
-        self.as_inner().clear();
-    }
-
-    /// Resizes the array to contain a different number of elements. If the new size is smaller,
-    /// elements are removed from the end. If the new size is larger, new elements are set to
-    /// [`Variant::nil()`].
-    pub fn resize(&mut self, size: usize) {
-        self.as_inner().resize(to_i64(size));
+        // SAFETY: No new values are written to the array, we only remove values from the array.
+        unsafe { self.as_inner() }.clear();
     }
 
     /// Reverses the order of the elements in the array.
     pub fn reverse(&mut self) {
-        self.as_inner().reverse();
+        // SAFETY: We do not write any values that dont already exist in the array, so all values have the correct type.
+        unsafe { self.as_inner() }.reverse();
     }
 
     /// Sorts the array.
@@ -137,7 +146,8 @@ impl<T: GodotType> Array<T> {
     /// considered equal may have their order changed when using `sort_unstable`.
     #[doc(alias = "sort")]
     pub fn sort_unstable(&mut self) {
-        self.as_inner().sort();
+        // SAFETY: We do not write any values that dont already exist in the array, so all values have the correct type.
+        unsafe { self.as_inner() }.sort();
     }
 
     /// Sorts the array.
@@ -149,14 +159,29 @@ impl<T: GodotType> Array<T> {
     /// `sort_unstable`.
     #[doc(alias = "sort_custom")]
     pub fn sort_unstable_custom(&mut self, func: Callable) {
-        self.as_inner().sort_custom(func);
+        // SAFETY: We do not write any values that dont already exist in the array, so all values have the correct type.
+        unsafe { self.as_inner() }.sort_custom(func);
     }
 
     /// Shuffles the array such that the items will have a random order. This method uses the
     /// global random number generator common to methods such as `randi`. Call `randomize` to
     /// ensure that a new seed will be used each time if you want non-reproducible shuffling.
     pub fn shuffle(&mut self) {
-        self.as_inner().shuffle();
+        // SAFETY: We do not write any values that dont already exist in the array, so all values have the correct type.
+        unsafe { self.as_inner() }.shuffle();
+    }
+
+    /// Shrinks the array down to `new_size`.
+    ///
+    /// If you want to increase the size of the array, use [`resize_with`](Array::resize_with) instead.
+    #[doc(alias = "resize")]
+    pub fn shrink(&mut self, new_size: usize) {
+        if new_size >= self.len() {
+            return;
+        }
+
+        // SAFETY: Since `new_size` is less than the current size, we'll only be removing elements from the array.
+        unsafe { self.as_inner() }.resize(to_i64(new_size));
     }
 
     /// Asserts that the given index refers to an existing element.
@@ -226,26 +251,41 @@ impl<T: GodotType> Array<T> {
         Variant::ptr_from_sys_mut(variant_ptr)
     }
 
+    /// # Safety
+    ///
+    /// This has the same safety issues as doing `self.assume_type::<Variant>()` and so the relevant safety invariants from
+    /// [`assume_type`](Self::assume_type) must be upheld.
+    ///
+    /// In particular this means that all reads are fine, since all values can be converted to `Variant`. However writes are only ok
+    /// if they match the type `T`.
     #[doc(hidden)]
-    pub fn as_inner(&self) -> inner::InnerArray {
-        // SAFETY: The memory layout of `Array<T>` does not depend on `T`.
+    pub unsafe fn as_inner(&self) -> inner::InnerArray {
+        // The memory layout of `Array<T>` does not depend on `T`.
         inner::InnerArray::from_outer_typed(self)
+    }
+
+    fn as_inner_ref(&self) -> InnerArrayRef {
+        InnerArrayRef {
+            // SAFETY: We can only read from the array.
+            inner: unsafe { self.as_inner() },
+        }
     }
 
     /// Changes the generic type on this array, without changing its contents. Needed for API
     /// functions that return a variant array even though we know its type, and for API functions
     /// that take a variant array even though we want to pass a typed one.
     ///
-    /// This is marked `unsafe` since it can be used to break the invariant that a `Array<T>`
-    /// always holds a Godot array whose runtime type is `T`.
-    ///
     /// # Safety
     ///
-    /// In and of itself, calling this does not result in undefined behavior. However:
-    /// - If `T` is not `Variant`, the returned array should not be written to, because the runtime
-    ///   type check may fail.
-    /// - If `U` is not `Variant`, the returned array should not be read from, because conversion
-    ///   from variants may fail.
+    /// - Any values written to the array must match the runtime type of the array.
+    /// - Any values read from the array must be convertible to the type `U`.
+    ///
+    /// If the safety invariant of `Array` is intact, which it must be for any publicly accessible arrays, then `U` must match
+    /// the runtime type of the array. This then implies that both of the conditions above hold. This means that you only need
+    /// to keep the above conditions in mind if you are intentionally violating the safety invariant of `Array`.
+    ///
+    /// Note also that any `GodotType` can be written to a `Variant` array.
+    ///
     /// In the current implementation, both cases will produce a panic rather than undefined
     /// behavior, but this should not be relied upon.
     unsafe fn assume_type<U: GodotType>(self) -> Array<U> {
@@ -266,8 +306,9 @@ impl<T: GodotType> Array<T> {
     /// To create a deep copy, use [`duplicate_deep()`][Self::duplicate_deep] instead.
     /// To create a new reference to the same array data, use [`clone()`][Clone::clone].
     pub fn duplicate_shallow(&self) -> Self {
-        let duplicate: VariantArray = self.as_inner().duplicate(false);
-        // SAFETY: duplicate() returns a typed array with the same type as Self
+        // SAFETY: We never write to the duplicated array, and all values read are read as `Variant`.
+        let duplicate: VariantArray = unsafe { self.as_inner_ref().duplicate(false) };
+        // SAFETY: duplicate() returns a typed array with the same type as Self, and all values are taken from `self` so have the right type.
         unsafe { duplicate.assume_type() }
     }
 
@@ -278,8 +319,9 @@ impl<T: GodotType> Array<T> {
     /// To create a shallow copy, use [`duplicate_shallow()`][Self::duplicate_shallow] instead.
     /// To create a new reference to the same array data, use [`clone()`][Clone::clone].
     pub fn duplicate_deep(&self) -> Self {
-        let duplicate: VariantArray = self.as_inner().duplicate(true);
-        // SAFETY: duplicate() returns a typed array with the same type as Self
+        // SAFETY: We never write to the duplicated array, and all values read are read as `Variant`.
+        let duplicate: VariantArray = unsafe { self.as_inner_ref().duplicate(true) };
+        // SAFETY: duplicate() returns a typed array with the same type as Self, and all values are taken from `self` so have the right type.
         unsafe { duplicate.assume_type() }
     }
 
@@ -323,9 +365,11 @@ impl<T: GodotType> Array<T> {
         let end = end.min(len);
         let step = step.unwrap_or(1);
 
-        let subarray: VariantArray =
-            self.as_inner()
-                .slice(to_i64(begin), to_i64(end), step.try_into().unwrap(), deep);
+        // SAFETY: The type of the array is `T` and we convert the returned array to an `Array<T>` immediately.
+        let subarray: VariantArray = unsafe {
+            self.as_inner_ref()
+                .slice(to_i64(begin), to_i64(end), step.try_into().unwrap(), deep)
+        };
 
         // SAFETY: slice() returns a typed array with the same type as Self
         unsafe { subarray.assume_type() }
@@ -333,18 +377,20 @@ impl<T: GodotType> Array<T> {
 
     /// Appends another array at the end of this array. Equivalent of `append_array` in GDScript.
     pub fn extend_array(&mut self, other: Array<T>) {
-        // SAFETY: Read-only arrays are covariant: conversion to a variant array is fine as long as
-        // we don't insert values into it afterwards, and `append_array()` doesn't do that.
+        // SAFETY: `append_array` will only read values from `other`, and all types can be converted to `Variant`.
         let other: VariantArray = unsafe { other.assume_type::<Variant>() };
-        self.as_inner().append_array(other);
+        // SAFETY: `append_array` will only write values gotten from `other` into `self`, and all values in `other` are guaranteed
+        // to be of type `T`.
+        let mut inner_self = unsafe { self.as_inner() };
+        inner_self.append_array(other);
     }
 
     /// Returns the runtime type info of this array.
     fn type_info(&self) -> TypeInfo {
         let variant_type = VariantType::from_sys(
-            self.as_inner().get_typed_builtin() as sys::GDExtensionVariantType
+            self.as_inner_ref().get_typed_builtin() as sys::GDExtensionVariantType
         );
-        let class_name = self.as_inner().get_typed_class_name();
+        let class_name = self.as_inner_ref().get_typed_class_name();
 
         TypeInfo {
             variant_type,
@@ -368,14 +414,19 @@ impl<T: GodotType> Array<T> {
         }
     }
 
-    /// Sets the type of the inner array. Can only be called once, directly after creation.
-    fn init_inner_type(&mut self) {
+    /// Sets the type of the inner array.
+    ///
+    /// # Safety
+    ///
+    /// Must only be called once, directly after creation.
+    unsafe fn init_inner_type(&mut self) {
         debug_assert!(self.is_empty());
         debug_assert!(!self.type_info().is_typed());
 
         let type_info = TypeInfo::of::<T>();
         if type_info.is_typed() {
             let script = Variant::nil();
+            // SAFETY: The array is a newly created empty untyped array.
             unsafe {
                 interface_fn!(array_set_typed)(
                     self.sys(),
@@ -433,7 +484,7 @@ impl<T: GodotType + FromGodot> Array<T> {
     /// `front()` in GDScript.
     pub fn first(&self) -> Option<T> {
         (!self.is_empty()).then(|| {
-            let variant = self.as_inner().front();
+            let variant = self.as_inner_ref().front();
             T::from_variant(&variant)
         })
     }
@@ -442,7 +493,7 @@ impl<T: GodotType + FromGodot> Array<T> {
     /// `back()` in GDScript.
     pub fn last(&self) -> Option<T> {
         (!self.is_empty()).then(|| {
-            let variant = self.as_inner().back();
+            let variant = self.as_inner_ref().back();
             T::from_variant(&variant)
         })
     }
@@ -450,21 +501,21 @@ impl<T: GodotType + FromGodot> Array<T> {
     /// Returns the minimum value contained in the array if all elements are of comparable types.
     /// If the elements can't be compared or the array is empty, `None` is returned.
     pub fn min(&self) -> Option<T> {
-        let min = self.as_inner().min();
+        let min = self.as_inner_ref().min();
         (!min.is_nil()).then(|| T::from_variant(&min))
     }
 
     /// Returns the maximum value contained in the array if all elements are of comparable types.
     /// If the elements can't be compared or the array is empty, `None` is returned.
     pub fn max(&self) -> Option<T> {
-        let max = self.as_inner().max();
+        let max = self.as_inner_ref().max();
         (!max.is_nil()).then(|| T::from_variant(&max))
     }
 
     /// Returns a random element from the array, or `None` if it is empty.
     pub fn pick_random(&self) -> Option<T> {
         (!self.is_empty()).then(|| {
-            let variant = self.as_inner().pick_random();
+            let variant = self.as_inner_ref().pick_random();
             T::from_variant(&variant)
         })
     }
@@ -473,7 +524,8 @@ impl<T: GodotType + FromGodot> Array<T> {
     /// Equivalent of `pop_back` in GDScript.
     pub fn pop(&mut self) -> Option<T> {
         (!self.is_empty()).then(|| {
-            let variant = self.as_inner().pop_back();
+            // SAFETY: We do not write any values to the array, we just remove one.
+            let variant = unsafe { self.as_inner() }.pop_back();
             T::from_variant(&variant)
         })
     }
@@ -484,7 +536,8 @@ impl<T: GodotType + FromGodot> Array<T> {
     /// array's elements. The larger the array, the slower `pop_front` will be.
     pub fn pop_front(&mut self) -> Option<T> {
         (!self.is_empty()).then(|| {
-            let variant = self.as_inner().pop_front();
+            // SAFETY: We do not write any values to the array, we just remove one.
+            let variant = unsafe { self.as_inner() }.pop_front();
             T::from_variant(&variant)
         })
     }
@@ -499,7 +552,8 @@ impl<T: GodotType + FromGodot> Array<T> {
     /// If `index` is out of bounds.
     pub fn remove(&mut self, index: usize) -> T {
         self.check_bounds(index);
-        let variant = self.as_inner().pop_at(to_i64(index));
+        // SAFETY: We do not write any values to the array, we just remove one.
+        let variant = unsafe { self.as_inner() }.pop_at(to_i64(index));
         T::from_variant(&variant)
     }
 }
@@ -513,7 +567,7 @@ impl<T: GodotType + ToGodot> Array<T> {
     ///
     /// Calling `bsearch` on an unsorted array results in unspecified behavior.
     pub fn bsearch(&self, value: &T) -> usize {
-        to_usize(self.as_inner().bsearch(value.to_variant(), true))
+        to_usize(self.as_inner_ref().bsearch(value.to_variant(), true))
     }
 
     /// Finds the index of an existing value in a sorted array using binary search.
@@ -530,26 +584,26 @@ impl<T: GodotType + ToGodot> Array<T> {
     /// your callable's ordering
     pub fn bsearch_custom(&self, value: &T, func: Callable) -> usize {
         to_usize(
-            self.as_inner()
+            self.as_inner_ref()
                 .bsearch_custom(value.to_variant(), func, true),
         )
     }
 
     /// Returns the number of times a value is in the array.
     pub fn count(&self, value: &T) -> usize {
-        to_usize(self.as_inner().count(value.to_variant()))
+        to_usize(self.as_inner_ref().count(value.to_variant()))
     }
 
     /// Returns `true` if the array contains the given value. Equivalent of `has` in GDScript.
     pub fn contains(&self, value: &T) -> bool {
-        self.as_inner().has(value.to_variant())
+        self.as_inner_ref().has(value.to_variant())
     }
 
     /// Searches the array for the first occurrence of a value and returns its index, or `None` if
     /// not found. Starts searching at index `from`; pass `None` to search the entire array.
     pub fn find(&self, value: &T, from: Option<usize>) -> Option<usize> {
         let from = to_i64(from.unwrap_or(0));
-        let index = self.as_inner().find(value.to_variant(), from);
+        let index = self.as_inner_ref().find(value.to_variant(), from);
         if index >= 0 {
             Some(index.try_into().unwrap())
         } else {
@@ -562,7 +616,7 @@ impl<T: GodotType + ToGodot> Array<T> {
     /// array.
     pub fn rfind(&self, value: &T, from: Option<usize>) -> Option<usize> {
         let from = from.map(to_i64).unwrap_or(-1);
-        let index = self.as_inner().rfind(value.to_variant(), from);
+        let index = self.as_inner_ref().rfind(value.to_variant(), from);
         // It's not documented, but `rfind` returns -1 if not found.
         if index >= 0 {
             Some(to_usize(index))
@@ -587,7 +641,8 @@ impl<T: GodotType + ToGodot> Array<T> {
     /// Appends an element to the end of the array. Equivalent of `append` and `push_back` in
     /// GDScript.
     pub fn push(&mut self, value: T) {
-        self.as_inner().push_back(value.to_variant());
+        // SAFETY: The array has type `T` and we're writing a value of type `T` to it.
+        unsafe { self.as_inner() }.push_back(value.to_variant());
     }
 
     /// Adds an element at the beginning of the array. See also `push`.
@@ -595,7 +650,8 @@ impl<T: GodotType + ToGodot> Array<T> {
     /// Note: On large arrays, this method is much slower than `push` as it will move all the
     /// array's elements. The larger the array, the slower `push_front` will be.
     pub fn push_front(&mut self, value: T) {
-        self.as_inner().push_front(value.to_variant());
+        // SAFETY: The array has type `T` and we're writing a value of type `T` to it.
+        unsafe { self.as_inner() }.push_front(value.to_variant());
     }
 
     /// Inserts a new element at a given index in the array. The index must be valid, or at the end
@@ -610,7 +666,8 @@ impl<T: GodotType + ToGodot> Array<T> {
             index <= len,
             "Array insertion index {index} is out of bounds: length is {len}",
         );
-        self.as_inner().insert(to_i64(index), value.to_variant());
+        // SAFETY: The array has type `T` and we're writing a value of type `T` to it.
+        unsafe { self.as_inner() }.insert(to_i64(index), value.to_variant());
     }
 
     /// Removes the first occurrence of a value from the array. If the value does not exist in the
@@ -619,13 +676,35 @@ impl<T: GodotType + ToGodot> Array<T> {
     /// On large arrays, this method is much slower than `pop_back` as it will move all the array's
     /// elements after the removed element. The larger the array, the slower `remove` will be.
     pub fn erase(&mut self, value: &T) {
-        self.as_inner().erase(value.to_variant());
+        // SAFETY: We don't write anything to the array.
+        unsafe { self.as_inner() }.erase(value.to_variant());
     }
 
     /// Assigns the given value to all elements in the array. This can be used together with
     /// `resize` to create an array with a given size and initialized elements.
     pub fn fill(&mut self, value: &T) {
-        self.as_inner().fill(value.to_variant());
+        // SAFETY: The array has type `T` and we're writing values of type `T` to it.
+        unsafe { self.as_inner() }.fill(value.to_variant());
+    }
+
+    /// Resizes the array to contain a different number of elements.
+    ///
+    /// If the new size is smaller than the current size, then it removes elements from the end. If the new size is bigger than the current one
+    /// then the new elements are set to `value`.
+    ///
+    /// If you know that the new size is smaller, then consider using [`shrink`](Array::shrink) instead.
+    #[doc(alias = "resize")]
+    pub fn resize_with(&mut self, new_size: usize, value: &T) {
+        let original_size = self.len();
+        // SAFETY: While we do insert `Variant::nil()` if the new size is larger, we then fill it with `value` ensuring that all values in the
+        // array are of type `T` still.
+        unsafe { self.as_inner() }.resize(to_i64(new_size));
+
+        if new_size > original_size {
+            for i in original_size..new_size {
+                self.set(i, value.to_godot());
+            }
+        }
     }
 }
 
@@ -807,7 +886,8 @@ impl<T: GodotType> Default for Array<T> {
                 ctor(self_ptr, std::ptr::null_mut())
             })
         };
-        array.init_inner_type();
+        // SAFETY: We just created this array, and haven't called `init_inner_type` before.
+        unsafe { array.init_inner_type() };
         array
     }
 }
@@ -886,12 +966,14 @@ impl<T: GodotType + ToGodot, const N: usize> From<&[T; N]> for Array<T> {
 /// Creates a `Array` from the given slice.
 impl<T: GodotType + ToGodot> From<&[T]> for Array<T> {
     fn from(slice: &[T]) -> Self {
-        let mut array = Self::new();
+        let array = Self::new();
         let len = slice.len();
         if len == 0 {
             return array;
         }
-        array.resize(len);
+        // SAFETY: We fill the array with `Variant::nil()`, however since we're resizing to the size of the slice we'll end up rewriting all
+        // the nulls with values of type `T`.
+        unsafe { array.as_inner() }.resize(to_i64(len));
 
         let ptr = array.ptr_mut_or_null(0);
         for (i, element) in slice.iter().enumerate() {

--- a/godot-core/src/obj/traits.rs
+++ b/godot-core/src/obj/traits.rs
@@ -46,7 +46,7 @@ where
     fn inherits<U: GodotClass>() -> bool {
         if Self::class_name() == U::class_name() {
             true
-        } else if Self::Base::class_name() == <()>::class_name() {
+        } else if Self::Base::class_name() == <NoBase>::class_name() {
             false
         } else {
             Self::Base::inherits::<U>()
@@ -54,9 +54,13 @@ where
     }
 }
 
-/// Unit impl only exists to represent "no base", and is used for exactly one class: `Object`.
-impl GodotClass for () {
-    type Base = ();
+/// Type representing an object without a base. It is used as the base class for exactly one class: `Object`.
+///
+/// This is an enum without any variants as we should never construct an instance of this class.
+pub enum NoBase {}
+
+impl GodotClass for NoBase {
+    type Base = NoBase;
 
     fn class_name() -> ClassName {
         ClassName::none()
@@ -65,8 +69,7 @@ impl GodotClass for () {
     const INIT_LEVEL: InitLevel = InitLevel::Core; // arbitrary; never read.
 }
 
-/// Unit impl only exists to represent "no base", and is used for exactly one class: `Object`.
-unsafe impl Bounds for () {
+unsafe impl Bounds for NoBase {
     type Memory = bounds::MemManual;
     type DynMemory = bounds::MemManual;
     type Declarer = bounds::DeclEngine;
@@ -116,14 +119,15 @@ unsafe impl Bounds for () {
 /// print_node(Node3D::new_alloc().upcast());
 /// ```
 ///
-pub trait Inherits<Base: GodotClass>: GodotClass {}
-
-impl<T: GodotClass> Inherits<T> for T {}
-
-/// Trait implemented for all objects that inherit from `Resource` or `Node`.
+/// # Safety
 ///
-/// Those are the only objects you can export to the editor.
-pub trait ExportableObject: GodotClass {}
+/// This trait must only be implemented for subclasses of `Base`.
+///
+/// Importantly, this means it is always safe to upcast a value of type `Gd<Self>` to `Gd<Base>`.
+pub unsafe trait Inherits<Base: GodotClass>: GodotClass {}
+
+// SAFETY: Every class is a subclass of itself.
+unsafe impl<T: GodotClass> Inherits<T> for T {}
 
 /// Implemented for all user-defined classes, providing extensions on the raw object to interact with `Gd`.
 // #[deprecated = "Use `NewGd` and `NewAlloc` traits instead."]
@@ -150,12 +154,6 @@ pub trait UserClass: Bounds<Declarer = bounds::DeclUser> {
     fn __default_virtual_call(_method_name: &str) -> sys::GDExtensionClassCallVirtual {
         None
     }
-}
-
-/// Auto-implemented for all engine-provided classes.
-pub trait EngineClass: GodotClass {
-    fn as_object_ptr(&self) -> sys::GDExtensionObjectPtr;
-    fn as_type_ptr(&self) -> sys::GDExtensionTypePtr;
 }
 
 /// Auto-implemented for all engine-provided enums.

--- a/godot-core/src/obj/traits.rs
+++ b/godot-core/src/obj/traits.rs
@@ -54,9 +54,11 @@ where
     }
 }
 
-/// Type representing an object without a base. It is used as the base class for exactly one class: `Object`.
+/// Type representing the absence of a base class, at the root of the hierarchy.
 ///
-/// This is an enum without any variants as we should never construct an instance of this class.
+/// `NoBase` is used as the base class for exactly one class: [`Object`][crate::engine::Object].
+///
+/// This is an enum without any variants, as we should never construct an instance of this class.
 pub enum NoBase {}
 
 impl GodotClass for NoBase {

--- a/godot-macros/src/class/derive_godot_class.rs
+++ b/godot-macros/src/class/derive_godot_class.rs
@@ -37,7 +37,7 @@ pub fn derive_godot_class(decl: Declaration) -> ParseResult<TokenStream> {
     let base_ty = &struct_cfg.base_ty;
     let base_class = quote! { ::godot::engine::#base_ty };
     let base_class_name_obj = util::class_name_obj(&base_class);
-    let inherits_macro = format_ident!("inherits_transitive_{}", base_ty);
+    let inherits_macro = format_ident!("unsafe_inherits_transitive_{}", base_ty);
 
     let prv = quote! { ::godot::private };
     let godot_exports_impl = make_property_impl(class_name, &fields);

--- a/itest/rust/src/builtin_tests/containers/array_test.rs
+++ b/itest/rust/src/builtin_tests/containers/array_test.rs
@@ -497,6 +497,53 @@ fn array_binary_search_custom() {
     assert_eq!(a.bsearch_custom(&3, func), 2);
 }
 
+#[itest]
+fn array_shrink() {
+    let mut a = array![1, 5, 4, 3, 8];
+
+    assert!(!a.shrink(10));
+    assert_eq!(a.len(), 5);
+
+    assert!(a.shrink(3));
+    assert_eq!(a.len(), 3);
+    assert_eq!(a, array![1, 5, 4]);
+}
+
+#[itest]
+fn array_resize() {
+    let mut a = array![
+        GString::from("hello"),
+        GString::from("bar"),
+        GString::from("mixed"),
+        GString::from("baz"),
+        GString::from("meow")
+    ];
+
+    let new = GString::from("new!");
+
+    a.resize(10, &new);
+    assert_eq!(a.len(), 10);
+    assert_eq!(
+        a,
+        array![
+            GString::from("hello"),
+            GString::from("bar"),
+            GString::from("mixed"),
+            GString::from("baz"),
+            GString::from("meow"),
+            new.clone(),
+            new.clone(),
+            new.clone(),
+            new.clone(),
+            new.clone(),
+        ]
+    );
+
+    a.resize(2, &new);
+
+    assert_eq!(a, array![GString::from("hello"), GString::from("bar"),]);
+}
+
 #[derive(GodotClass, Debug)]
 #[class(init, base=RefCounted)]
 struct ArrayTest;

--- a/itest/rust/src/object_tests/object_test.rs
+++ b/itest/rust/src/object_tests/object_test.rs
@@ -18,7 +18,6 @@ use godot::engine::{
 use godot::obj::{Base, Gd, Inherits, InstanceId, NewAlloc, NewGd, RawGd};
 use godot::register::{godot_api, GodotClass};
 use godot::sys::{self, interface_fn, GodotFfi};
-use sys::GDExtensionObjectPtr;
 
 use crate::framework::{expect_panic, itest, TestContext};
 
@@ -528,9 +527,7 @@ fn object_engine_upcast() {
 }
 
 fn ref_instance_id(obj: &Object) -> InstanceId {
-    // SAFETY: `Object` is a `#[repr(C)]` struct with its first field being the object pointer.
-    let obj_ptr = unsafe { *(obj as *const Object as *const GDExtensionObjectPtr) };
-
+    let obj_ptr = obj.__object_ptr();
     // SAFETY: raw FFI call since we can't access get_instance_id() of a raw Object anymore, and call() needs &mut.
     let raw_id = unsafe { interface_fn!(object_get_instance_id)(obj_ptr) };
     InstanceId::try_from_i64(raw_id as i64).unwrap()

--- a/itest/rust/src/object_tests/object_test.rs
+++ b/itest/rust/src/object_tests/object_test.rs
@@ -18,6 +18,7 @@ use godot::engine::{
 use godot::obj::{Base, Gd, Inherits, InstanceId, NewAlloc, NewGd, RawGd};
 use godot::register::{godot_api, GodotClass};
 use godot::sys::{self, interface_fn, GodotFfi};
+use sys::GDExtensionObjectPtr;
 
 use crate::framework::{expect_panic, itest, TestContext};
 
@@ -527,11 +528,10 @@ fn object_engine_upcast() {
 }
 
 fn ref_instance_id(obj: &Object) -> InstanceId {
+    // SAFETY: `Object` is a `#[repr(C)]` struct with its first field being the object pointer.
+    let obj_ptr = unsafe { *(obj as *const Object as *const GDExtensionObjectPtr) };
+
     // SAFETY: raw FFI call since we can't access get_instance_id() of a raw Object anymore, and call() needs &mut.
-    use godot::obj::EngineClass as _;
-
-    let obj_ptr = obj.as_object_ptr();
-
     let raw_id = unsafe { interface_fn!(object_get_instance_id)(obj_ptr) };
     InstanceId::try_from_i64(raw_id as i64).unwrap()
 }


### PR DESCRIPTION
Probably gonna split this PR up later since the `Array`-related changes ended up being a lot bigger than i expected. So leaving it as a draft until i do that at least.

# Removes some unused traits
From what i can tell, `EngineClass` and `ExportableObject` are now actually unused (beyond a test using a method from `EngineClass`). So i removed them.

# Makes `Inherits` unsafe
We rely on `Inherits` being implemented correctly for `upcast` to be safe.

# Replace `()` with `NoBase`
It seemed weird to use `()` in this situation, so i made it a dedicated unconstructable type instead.

# More accurately track `Array`'s safety invariant
Array's safety invariant is that it only containts values matching its type, but that could very easily be circumvented internally in our code. You could simply call `self.as_inner().duplicate()`. This PR treats `self.as_inner()` as equivalent to doing `self.assume_type::<Variant>()`. This revealed the fact that we actually violated the safety invariant with `resize`, as it inserts `Variant::nil()` when increasing the size.

To support this properly i made it possible to mark arbitrary methods in the codegen as unsafe with safety docs, and currently just added all array methods that return `VariantArray` to that, since they can just bypass safety checks by coercing the array to a `VariantArray.

I removed `resize` since it can be used to circumvent the safety invariant, instead there's now `shrink` and `resize_with`.