### PR TITLE
Improve function call diagnostics; fix UB on varcall argument mismatch.

### DIFF
--- a/godot-codegen/src/generator/builtins.rs
+++ b/godot-codegen/src/generator/builtins.rs
@@ -173,6 +173,7 @@ fn make_builtin_method_definition(
     };
 
     let builtin_name = builtin_class.name();
+    let builtin_name_str = builtin_name.rust_ty.to_string();
     let method_name_str = method.godot_name();
 
     let fptr_access = if cfg!(feature = "codegen-lazy-fptrs") {
@@ -201,6 +202,7 @@ fn make_builtin_method_definition(
 
         <CallSig as PtrcallSignatureTuple>::out_builtin_ptrcall::<RetMarshal>(
             method_bind,
+            #builtin_name_str,
             #method_name_str,
             #object_ptr,
             args

--- a/godot-codegen/src/generator/classes.rs
+++ b/godot-codegen/src/generator/classes.rs
@@ -431,6 +431,7 @@ fn make_class_method_definition(
         return FnDefinition::none();
     };
 
+    let rust_class_name = class.name().rust_ty.to_string();
     let rust_method_name = method.name();
     let godot_method_name = method.godot_name();
 
@@ -445,10 +446,10 @@ fn make_class_method_definition(
     };
 
     let fptr_access = if cfg!(feature = "codegen-lazy-fptrs") {
-        let class_name_str = &class.name().godot_ty;
+        let godot_class_name = &class.name().godot_ty;
         quote! {
             fptr_by_key(sys::lazy_keys::ClassMethodKey {
-                class_name: #class_name_str,
+                class_name: #godot_class_name,
                 method_name: #godot_method_name,
                 hash: #hash,
             })
@@ -463,6 +464,7 @@ fn make_class_method_definition(
 
         <CallSig as PtrcallSignatureTuple>::out_class_ptrcall::<RetMarshal>(
             method_bind,
+            #rust_class_name,
             #rust_method_name,
             #object_ptr,
             #maybe_instance_id,
@@ -475,6 +477,7 @@ fn make_class_method_definition(
 
         <CallSig as VarcallSignatureTuple>::out_class_varcall(
             method_bind,
+            #rust_class_name,
             #rust_method_name,
             #object_ptr,
             #maybe_instance_id,

--- a/godot-core/src/builtin/meta/mod.rs
+++ b/godot-core/src/builtin/meta/mod.rs
@@ -13,19 +13,19 @@ mod return_marshal;
 mod signature;
 
 pub use class_name::*;
-pub(crate) use godot_convert::convert_error::*;
 pub use godot_convert::*;
 #[doc(hidden)]
 pub use return_marshal::*;
 #[doc(hidden)]
 pub use signature::*;
 
-use godot_ffi as sys;
-use sys::{GodotFfi, GodotNullableFfi};
+pub(crate) use godot_convert::convert_error::*;
 
 use crate::builtin::*;
 use crate::engine::global;
+use godot_ffi as sys;
 use registration::method::MethodParamOrReturnInfo;
+use sys::{GodotFfi, GodotNullableFfi};
 
 /// Conversion of [`GodotFfi`] types to/from [`Variant`].
 #[doc(hidden)]

--- a/godot-core/src/builtin/meta/signature.rs
+++ b/godot-core/src/builtin/meta/signature.rs
@@ -170,6 +170,7 @@ macro_rules! impl_varcall_signature_for_tuple {
                 func: fn(sys::GDExtensionClassInstancePtr, Self::Params) -> Self::Ret,
             ) {
                 //$crate::out!("in_varcall: {call_ctx}");
+                check_arg_count(arg_count, $PARAM_COUNT, call_ctx);
 
                 let args = ($(
                     unsafe { varcall_arg::<$Pn, $n>(args_ptr, call_ctx) },
@@ -614,5 +615,25 @@ impl<'a> CallContext<'a> {
 impl<'a> fmt::Display for CallContext<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}::{}", self.class_name, self.function_name)
+    }
+}
+
+fn check_arg_count(arg_count: i64, param_count: i64, call_ctx: &CallContext) {
+    // This will need to be adjusted once optional parameters are supported in #[func].
+    if arg_count != param_count {
+        let param_plural = plural(param_count);
+        let arg_plural = plural(arg_count);
+        panic!(
+            "{call_ctx} - function has {param_count} parameter{param_plural}, \
+            but received {arg_count} argument{arg_plural}"
+        );
+    }
+}
+
+fn plural(count: i64) -> &'static str {
+    if count == 1 {
+        ""
+    } else {
+        "s"
     }
 }

--- a/godot-core/src/builtin/meta/signature.rs
+++ b/godot-core/src/builtin/meta/signature.rs
@@ -5,18 +5,17 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::fmt::Debug;
-
+use crate::builtin::meta::*;
+use crate::builtin::Variant;
+use crate::obj::{GodotClass, InstanceId};
 use godot_ffi as sys;
+use std::fmt;
+use std::fmt::Debug;
 use sys::{BuiltinMethodBind, ClassMethodBind, UtilityFunctionBind};
 
 // TODO:
 // separate arguments and return values, so that a type can be used in function arguments even if it doesn't
 // implement `ToGodot`, and the other way around for return values.
-
-use crate::builtin::meta::*;
-use crate::builtin::Variant;
-use crate::obj::InstanceId;
 
 #[doc(hidden)]
 pub trait VarcallSignatureTuple: PtrcallSignatureTuple {
@@ -31,8 +30,9 @@ pub trait VarcallSignatureTuple: PtrcallSignatureTuple {
     // ret: sys::GDExtensionUninitializedTypePtr
     unsafe fn in_varcall(
         instance_ptr: sys::GDExtensionClassInstancePtr,
-        method_name: &str,
+        call_ctx: &CallContext,
         args_ptr: *const sys::GDExtensionConstVariantPtr,
+        arg_count: i64,
         ret: sys::GDExtensionVariantPtr,
         err: *mut sys::GDExtensionCallError,
         func: fn(sys::GDExtensionClassInstancePtr, Self::Params) -> Self::Ret,
@@ -40,6 +40,8 @@ pub trait VarcallSignatureTuple: PtrcallSignatureTuple {
 
     unsafe fn out_class_varcall(
         method_bind: ClassMethodBind,
+        // Separate parameters to reduce tokens in generated class API.
+        class_name: &'static str,
         method_name: &'static str,
         object_ptr: sys::GDExtensionObjectPtr,
         maybe_instance_id: Option<InstanceId>, // if not static
@@ -49,7 +51,7 @@ pub trait VarcallSignatureTuple: PtrcallSignatureTuple {
 
     unsafe fn out_utility_ptrcall_varargs(
         utility_fn: UtilityFunctionBind,
-        method_name: &'static str,
+        function_name: &'static str,
         args: Self::Params,
         varargs: &[Variant],
     ) -> Self::Ret;
@@ -66,7 +68,7 @@ pub trait PtrcallSignatureTuple {
     // We could fall back to varcalls in such cases, and not require GodotFfi categorically.
     unsafe fn in_ptrcall(
         instance_ptr: sys::GDExtensionClassInstancePtr,
-        method_name: &'static str,
+        call_ctx: &CallContext<'static>,
         args_ptr: *const sys::GDExtensionConstTypePtr,
         ret: sys::GDExtensionTypePtr,
         func: fn(sys::GDExtensionClassInstancePtr, Self::Params) -> Self::Ret,
@@ -75,6 +77,8 @@ pub trait PtrcallSignatureTuple {
 
     unsafe fn out_class_ptrcall<Rr: PtrcallReturn<Ret = Self::Ret>>(
         method_bind: ClassMethodBind,
+        // Separate parameters to reduce tokens in generated class API.
+        class_name: &'static str,
         method_name: &'static str,
         object_ptr: sys::GDExtensionObjectPtr,
         maybe_instance_id: Option<InstanceId>, // if not static
@@ -83,6 +87,8 @@ pub trait PtrcallSignatureTuple {
 
     unsafe fn out_builtin_ptrcall<Rr: PtrcallReturn<Ret = Self::Ret>>(
         builtin_fn: BuiltinMethodBind,
+        // Separate parameters to reduce tokens in generated class API.
+        class_name: &'static str,
         method_name: &'static str,
         type_ptr: sys::GDExtensionTypePtr,
         args: Self::Params,
@@ -90,7 +96,7 @@ pub trait PtrcallSignatureTuple {
 
     unsafe fn out_utility_ptrcall(
         utility_fn: UtilityFunctionBind,
-        method_name: &'static str,
+        function_name: &'static str,
         args: Self::Params,
     ) -> Self::Ret;
 }
@@ -156,15 +162,17 @@ macro_rules! impl_varcall_signature_for_tuple {
             #[inline]
             unsafe fn in_varcall(
                 instance_ptr: sys::GDExtensionClassInstancePtr,
-                method_name: &str,
+                call_ctx: &CallContext,
                 args_ptr: *const sys::GDExtensionConstVariantPtr,
+                arg_count: i64,
                 ret: sys::GDExtensionVariantPtr,
                 err: *mut sys::GDExtensionCallError,
                 func: fn(sys::GDExtensionClassInstancePtr, Self::Params) -> Self::Ret,
             ) {
-                //$crate::out!("in_varcall: {method_name}");
+                //$crate::out!("in_varcall: {call_ctx}");
+
                 let args = ($(
-                    unsafe { varcall_arg::<$Pn, $n>(args_ptr, method_name) },
+                    unsafe { varcall_arg::<$Pn, $n>(args_ptr, call_ctx) },
                 )*) ;
 
                 let rust_result = func(instance_ptr, args);
@@ -174,17 +182,20 @@ macro_rules! impl_varcall_signature_for_tuple {
             #[inline]
             unsafe fn out_class_varcall(
                 method_bind: ClassMethodBind,
+                // Separate parameters to reduce tokens in generated class API.
+                class_name: &'static str,
                 method_name: &'static str,
                 object_ptr: sys::GDExtensionObjectPtr,
                 maybe_instance_id: Option<InstanceId>, // if not static
                 ($($pn,)*): Self::Params,
                 varargs: &[Variant],
             ) -> Self::Ret {
-                //$crate::out!("out_class_varcall: {method_name}");
+                let call_ctx = CallContext::outbound(class_name, method_name);
+                //$crate::out!("out_class_varcall: {call_ctx}");
 
                 // Note: varcalls are not safe from failing, if they happen through an object pointer -> validity check necessary.
                 if let Some(instance_id) = maybe_instance_id {
-                    crate::engine::ensure_object_alive(instance_id, object_ptr, method_name);
+                    crate::engine::ensure_object_alive(instance_id, object_ptr, &call_ctx);
                 }
 
                 let class_fn = sys::interface_fn!(object_method_bind_call);
@@ -210,22 +221,24 @@ macro_rules! impl_varcall_signature_for_tuple {
                         std::ptr::addr_of_mut!(err),
                     );
 
-                    check_varcall_error(&err, method_name, &explicit_args, varargs);
+                    check_varcall_error(&err, &call_ctx, &explicit_args, varargs);
                 });
 
                 let result = <Self::Ret as FromGodot>::try_from_variant(&variant);
-                result.unwrap_or_else(|err| return_error::<Self::Ret>(method_name, err))
+                result.unwrap_or_else(|err| return_error::<Self::Ret>(&call_ctx, err))
             }
 
             // Note: this is doing a ptrcall, but uses variant conversions for it
             #[inline]
             unsafe fn out_utility_ptrcall_varargs(
                 utility_fn: UtilityFunctionBind,
-                method_name: &str,
+                function_name: &'static str,
                 ($($pn,)*): Self::Params,
                 varargs: &[Variant],
             ) -> Self::Ret {
-                //$crate::out!("out_utility_ptrcall_varargs: {method_name}");
+                let call_ctx = CallContext::outbound("", function_name);
+                //$crate::out!("out_utility_ptrcall_varargs: {call_ctx}");
+
                 let explicit_args: [Variant; $PARAM_COUNT] = [
                     $(
                         GodotFfiVariant::ffi_to_variant(&into_ffi($pn)),
@@ -240,7 +253,7 @@ macro_rules! impl_varcall_signature_for_tuple {
                 let result = PtrcallReturnT::<$R>::call(|return_ptr| {
                     utility_fn(return_ptr, type_ptrs.as_ptr(), type_ptrs.len() as i32);
                 });
-                result.unwrap_or_else(|err| return_error::<Self::Ret>(method_name, err))
+                result.unwrap_or_else(|err| return_error::<Self::Ret>(&call_ctx, err))
             }
 
             #[inline]
@@ -272,34 +285,39 @@ macro_rules! impl_ptrcall_signature_for_tuple {
             #[inline]
             unsafe fn in_ptrcall(
                 instance_ptr: sys::GDExtensionClassInstancePtr,
-                method_name: &str,
+                call_ctx: &CallContext,
                 args_ptr: *const sys::GDExtensionConstTypePtr,
                 ret: sys::GDExtensionTypePtr,
                 func: fn(sys::GDExtensionClassInstancePtr, Self::Params) -> Self::Ret,
                 call_type: sys::PtrcallType,
             ) {
-                // $crate::out!("in_ptrcall: {method_name}");
+                // $crate::out!("in_ptrcall: {call_ctx}");
+
                 let args = ($(
-                    unsafe { ptrcall_arg::<$Pn, $n>(args_ptr, method_name, call_type) },
+                    unsafe { ptrcall_arg::<$Pn, $n>(args_ptr, call_ctx, call_type) },
                 )*) ;
 
                 // SAFETY:
                 // `ret` is always a pointer to an initialized value of type $R
                 // TODO: double-check the above
-                ptrcall_return::<$R>(func(instance_ptr, args), ret, method_name, call_type)
+                ptrcall_return::<$R>(func(instance_ptr, args), ret, call_ctx, call_type)
             }
 
             #[inline]
             unsafe fn out_class_ptrcall<Rr: PtrcallReturn<Ret = Self::Ret>>(
                 method_bind: ClassMethodBind,
+                // Separate parameters to reduce tokens in generated class API.
+                class_name: &'static str,
                 method_name: &'static str,
                 object_ptr: sys::GDExtensionObjectPtr,
                 maybe_instance_id: Option<InstanceId>, // if not static
                 ($($pn,)*): Self::Params,
             ) -> Self::Ret {
-                // $crate::out!("out_class_ptrcall: {method_name}");
+                let call_ctx = CallContext::outbound(class_name, method_name);
+                // $crate::out!("out_class_ptrcall: {call_ctx}");
+
                 if let Some(instance_id) = maybe_instance_id {
-                    crate::engine::ensure_object_alive(instance_id, object_ptr, method_name);
+                    crate::engine::ensure_object_alive(instance_id, object_ptr, &call_ctx);
                 }
 
                 let class_fn = sys::interface_fn!(object_method_bind_ptrcall);
@@ -320,17 +338,21 @@ macro_rules! impl_ptrcall_signature_for_tuple {
                 let result = Rr::call(|return_ptr| {
                     class_fn(method_bind.0, object_ptr, type_ptrs.as_ptr(), return_ptr);
                 });
-                result.unwrap_or_else(|err| return_error::<Self::Ret>(method_name, err))
+                result.unwrap_or_else(|err| return_error::<Self::Ret>(&call_ctx, err))
             }
 
             #[inline]
             unsafe fn out_builtin_ptrcall<Rr: PtrcallReturn<Ret = Self::Ret>>(
                 builtin_fn: BuiltinMethodBind,
+                // Separate parameters to reduce tokens in generated class API.
+                class_name: &'static str,
                 method_name: &'static str,
                 type_ptr: sys::GDExtensionTypePtr,
                 ($($pn,)*): Self::Params,
             ) -> Self::Ret {
-                // $crate::out!("out_builtin_ptrcall: {method_name}");
+                let call_ctx = CallContext::outbound(class_name, method_name);
+                // $crate::out!("out_builtin_ptrcall: {call_ctx}");
+
                 #[allow(clippy::let_unit_value)]
                 let marshalled_args = (
                     $(
@@ -347,16 +369,18 @@ macro_rules! impl_ptrcall_signature_for_tuple {
                 let result = Rr::call(|return_ptr| {
                     builtin_fn(type_ptr, type_ptrs.as_ptr(), return_ptr, type_ptrs.len() as i32);
                 });
-                result.unwrap_or_else(|err| return_error::<Self::Ret>(method_name, err))
+                result.unwrap_or_else(|err| return_error::<Self::Ret>(&call_ctx, err))
             }
 
             #[inline]
             unsafe fn out_utility_ptrcall(
                 utility_fn: UtilityFunctionBind,
-                method_name: &'static str,
+                function_name: &'static str,
                 ($($pn,)*): Self::Params,
             ) -> Self::Ret {
-                // $crate::out!("out_utility_ptrcall: {method_name}");
+                let call_ctx = CallContext::outbound("", function_name);
+                // $crate::out!("out_utility_ptrcall: {call_ctx}");
+
                 #[allow(clippy::let_unit_value)]
                 let marshalled_args = (
                     $(
@@ -373,7 +397,7 @@ macro_rules! impl_ptrcall_signature_for_tuple {
                 let result = PtrcallReturnT::<$R>::call(|return_ptr| {
                     utility_fn(return_ptr, arg_ptrs.as_ptr(), arg_ptrs.len() as i32);
                 });
-                result.unwrap_or_else(|err| return_error::<Self::Ret>(method_name, err))
+                result.unwrap_or_else(|err| return_error::<Self::Ret>(&call_ctx, err))
             }
         }
     };
@@ -385,12 +409,12 @@ macro_rules! impl_ptrcall_signature_for_tuple {
 /// - It must be safe to dereference the pointer at `args_ptr.offset(N)` .
 unsafe fn varcall_arg<P: FromGodot, const N: isize>(
     args_ptr: *const sys::GDExtensionConstVariantPtr,
-    method_name: &str,
+    call_ctx: &CallContext,
 ) -> P {
     let variant_ref = &*Variant::ptr_from_sys(*args_ptr.offset(N));
 
     let result = P::try_from_variant(variant_ref);
-    result.unwrap_or_else(|err| param_error::<P>(method_name, N as i32, err))
+    result.unwrap_or_else(|err| param_error::<P>(call_ctx, N as i32, err))
 }
 
 /// Moves `ret_val` into `ret`.
@@ -435,7 +459,7 @@ pub(crate) unsafe fn varcall_return_checked<R: ToGodot>(
 ///   [`GodotFuncMarshal::try_from_arg`][sys::GodotFuncMarshal::try_from_arg].
 unsafe fn ptrcall_arg<P: FromGodot, const N: isize>(
     args_ptr: *const sys::GDExtensionConstTypePtr,
-    method_name: &str,
+    call_ctx: &CallContext,
     call_type: sys::PtrcallType,
 ) -> P {
     let ffi = <P::Via as GodotType>::Ffi::from_arg_ptr(
@@ -443,7 +467,7 @@ unsafe fn ptrcall_arg<P: FromGodot, const N: isize>(
         call_type,
     );
 
-    try_from_ffi(ffi).unwrap_or_else(|err| param_error::<P>(method_name, N as i32, err))
+    try_from_ffi(ffi).unwrap_or_else(|err| param_error::<P>(call_ctx, N as i32, err))
 }
 
 /// Moves `ret_val` into `ret`.
@@ -454,26 +478,26 @@ unsafe fn ptrcall_arg<P: FromGodot, const N: isize>(
 unsafe fn ptrcall_return<R: ToGodot>(
     ret_val: R,
     ret: sys::GDExtensionTypePtr,
-    _method_name: &str,
+    _call_ctx: &CallContext,
     call_type: sys::PtrcallType,
 ) {
     let val = into_ffi(ret_val);
     val.move_return_ptr(ret, call_type);
 }
 
-fn param_error<P>(method_name: &str, index: i32, err: ConvertError) -> ! {
+fn param_error<P>(call_ctx: &CallContext, index: i32, err: ConvertError) -> ! {
     let param_ty = std::any::type_name::<P>();
-    panic!("in method `{method_name}` at parameter [{index}] of type {param_ty}: {err}",);
+    panic!("in function `{call_ctx}` at parameter [{index}] of type {param_ty}: {err}");
 }
 
-fn return_error<R>(method_name: &str, err: ConvertError) -> ! {
+fn return_error<R>(call_ctx: &CallContext, err: ConvertError) -> ! {
     let return_ty = std::any::type_name::<R>();
-    panic!("in method `{method_name}` at return type {return_ty}: {err}",);
+    panic!("in function `{call_ctx}` at return type {return_ty}: {err}");
 }
 
 fn check_varcall_error<T>(
     err: &sys::GDExtensionCallError,
-    fn_name: &str,
+    call_ctx: &CallContext,
     explicit_args: &[T],
     varargs: &[Variant],
 ) where
@@ -492,7 +516,7 @@ fn check_varcall_error<T>(
     let explicit_args_str = join_to_string(explicit_args);
     let vararg_str = join_to_string(varargs);
 
-    let func_str = format!("{fn_name}({explicit_args_str}; varargs {vararg_str})");
+    let func_str = format!("{call_ctx}({explicit_args_str}; varargs {vararg_str})");
 
     sys::panic_call_error(err, &func_str, &arg_types);
 }
@@ -550,3 +574,45 @@ impl_ptrcall_signature_for_tuple!(R, (p0, 0): P0, (p1, 1): P1, (p2, 2): P2, (p3,
 impl_ptrcall_signature_for_tuple!(R, (p0, 0): P0, (p1, 1): P1, (p2, 2): P2, (p3, 3): P3, (p4, 4): P4, (p5, 5): P5, (p6, 6): P6, (p7, 7): P7, (p8, 8): P8, (p9, 9): P9, (p10, 10): P10, (p11, 11): P11);
 impl_ptrcall_signature_for_tuple!(R, (p0, 0): P0, (p1, 1): P1, (p2, 2): P2, (p3, 3): P3, (p4, 4): P4, (p5, 5): P5, (p6, 6): P6, (p7, 7): P7, (p8, 8): P8, (p9, 9): P9, (p10, 10): P10, (p11, 11): P11, (p12, 12): P12);
 impl_ptrcall_signature_for_tuple!(R, (p0, 0): P0, (p1, 1): P1, (p2, 2): P2, (p3, 3): P3, (p4, 4): P4, (p5, 5): P5, (p6, 6): P6, (p7, 7): P7, (p8, 8): P8, (p9, 9): P9, (p10, 10): P10, (p11, 11): P11, (p12, 12): P12, (p13, 13): P13);
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// Information about function and method calls.
+
+// Lazy Display, so we don't create tens of thousands of extra string literals.
+pub struct CallContext<'a> {
+    pub class_name: &'a str,
+    pub function_name: &'a str,
+}
+
+impl<'a> CallContext<'a> {
+    /// Call from Godot into a user-defined #[func] function.
+    pub const fn func(class_name: &'a str, function_name: &'a str) -> Self {
+        Self {
+            class_name,
+            function_name,
+        }
+    }
+
+    /// Outbound call from Rust into the engine, class/builtin APIs.
+    pub const fn outbound(class_name: &'a str, function_name: &'a str) -> Self {
+        Self {
+            class_name,
+            function_name,
+        }
+    }
+
+    /// Outbound call from Rust into the engine, via Gd methods.
+    pub fn gd<T: GodotClass>(function_name: &'a str) -> Self {
+        let class_name = T::class_name().as_str();
+        Self {
+            class_name,
+            function_name,
+        }
+    }
+}
+
+impl<'a> fmt::Display for CallContext<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}::{}", self.class_name, self.function_name)
+    }
+}

--- a/godot-core/src/engine/mod.rs
+++ b/godot-core/src/engine/mod.rs
@@ -14,15 +14,15 @@ use crate::obj::{bounds, Bounds, Gd, GodotClass, Inherits, InstanceId};
 pub use crate::gen::central::global;
 pub use crate::gen::classes::*;
 pub use crate::gen::utilities;
+pub use io::*;
+pub use script_instance::{create_script_instance, ScriptInstance};
 
+use crate::builtin::meta::CallContext;
 use crate::sys;
 
 mod io;
 mod script_instance;
 pub mod translate;
-
-pub use io::*;
-pub use script_instance::{create_script_instance, ScriptInstance};
 
 #[cfg(debug_assertions)]
 use crate::builtin::meta::ClassName;
@@ -174,20 +174,20 @@ where
 pub(crate) fn ensure_object_alive(
     instance_id: InstanceId,
     old_object_ptr: sys::GDExtensionObjectPtr,
-    method_name: &'static str,
+    call_ctx: &CallContext,
 ) {
     let new_object_ptr = object_ptr_from_id(instance_id);
 
     assert!(
         !new_object_ptr.is_null(),
-        "{method_name}: access to instance with ID {instance_id} after it has been freed"
+        "{call_ctx}: access to instance with ID {instance_id} after it has been freed"
     );
 
     // This should not happen, as reuse of instance IDs was fixed according to https://github.com/godotengine/godot/issues/32383,
     // namely in PR https://github.com/godotengine/godot/pull/36189. Double-check to make sure.
     assert_eq!(
         new_object_ptr, old_object_ptr,
-        "{method_name}: instance ID {instance_id} points to a stale, reused object. Please report this to gdext maintainers."
+        "{call_ctx}: instance ID {instance_id} points to a stale, reused object. Please report this to gdext maintainers."
     );
 }
 

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -13,7 +13,7 @@ use godot_ffi as sys;
 use sys::{static_assert_eq_size, VariantType};
 
 use crate::builtin::meta::{
-    ConvertError, FromFfiError, FromGodot, GodotConvert, GodotType, ToGodot,
+    CallContext, ConvertError, FromFfiError, FromGodot, GodotConvert, GodotType, ToGodot,
 };
 use crate::builtin::{Callable, NodePath, StringName, Variant};
 use crate::obj::raw::RawGd;
@@ -538,7 +538,7 @@ where
         // Skip check during panic unwind; would need to rewrite whole thing to use Result instead. Having BOTH panic-in-panic and bad type is
         // a very unlikely corner case.
         if !is_panic_unwind {
-            self.raw.check_dynamic_type("free");
+            self.raw.check_dynamic_type(&CallContext::gd::<T>("free"));
         }
 
         // SAFETY: object must be alive, which was just checked above. No multithreading here.
@@ -571,12 +571,12 @@ impl<T: GodotClass> GodotConvert for Gd<T> {
 
 impl<T: GodotClass> ToGodot for Gd<T> {
     fn to_godot(&self) -> Self::Via {
-        self.raw.check_rtti("Gd<T>::to_godot");
+        self.raw.check_rtti("to_godot");
         self.clone()
     }
 
     fn into_godot(self) -> Self::Via {
-        self.raw.check_rtti("Gd<T>::into_godot");
+        self.raw.check_rtti("into_godot");
         self
     }
 }

--- a/godot-core/src/private.rs
+++ b/godot-core/src/private.rs
@@ -99,7 +99,7 @@ where
                     //backtrace: Backtrace::capture(),
                 });
             } else {
-                println!("panic occurred but can't get location information...");
+                eprintln!("panic occurred, but can't get location information");
             }
         }));
     }
@@ -118,7 +118,7 @@ where
             let guard = info.lock().unwrap();
             let info = guard.as_ref().expect("no panic info available");
             log::godot_error!(
-                "Rust function panicked in file {} at line {}. Context: {}",
+                "Rust function panicked at {}:{}.\nContext: {}",
                 info.file,
                 info.line,
                 error_context()

--- a/itest/rust/src/builtin_tests/containers/callable_test.rs
+++ b/itest/rust/src/builtin_tests/containers/callable_test.rs
@@ -85,8 +85,11 @@ fn callable_call() {
     assert_eq!(obj.bind().value, 0);
     callable.callv(varray![10]);
     assert_eq!(obj.bind().value, 10);
+
+    // Too many arguments: this call fails, its logic is not applied.
+    // In the future, panic should be propagated to caller.
     callable.callv(varray![20, 30]);
-    assert_eq!(obj.bind().value, 20);
+    assert_eq!(obj.bind().value, 10);
 
     // TODO(bromeon): this causes a Rust panic, but since call() is routed to Godot, the panic is handled at the FFI boundary.
     // Can there be a way to notify the caller about failed calls like that?

--- a/itest/rust/src/object_tests/object_test.rs
+++ b/itest/rust/src/object_tests/object_test.rs
@@ -835,6 +835,38 @@ fn object_call_with_args() {
 }
 
 #[itest]
+fn object_call_with_too_few_args() {
+    let mut obj = ObjPayload::new_alloc();
+
+    expect_panic("call with too few arguments", || {
+        obj.call("take_1_int".into(), &[]);
+    });
+
+    obj.free();
+}
+
+#[itest]
+fn object_call_with_too_many_args() {
+    let mut obj = ObjPayload::new_alloc();
+
+    expect_panic("call with too many arguments", || {
+        obj.call("take_1_int".into(), &[42.to_variant(), 43.to_variant()]);
+    });
+
+    obj.free();
+}
+
+#[itest(skip)] // Not yet implemented.
+fn object_call_panic_is_nil() {
+    let mut obj = ObjPayload::new_alloc();
+
+    let result = obj.call("do_panic".into(), &[]);
+    assert_eq!(result, Variant::nil());
+
+    obj.free();
+}
+
+#[itest]
 fn object_get_scene_tree(ctx: &TestContext) {
     let node = Node3D::new_alloc();
 
@@ -855,6 +887,16 @@ pub(super) struct ObjPayload {}
 impl ObjPayload {
     #[signal]
     fn do_use();
+
+    #[func]
+    fn take_1_int(&self, value: i64) -> i64 {
+        value
+    }
+
+    #[func]
+    fn do_panic(&self) {
+        panic!("panic from Rust");
+    }
 }
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
### Improve diagnostics (new `CallContext` info)

Improves panic messages by including both class + function name in the description. 
Also changes panic messages to have `filename.rs:line` format, allowing IDEs to directly jump to relevant code.

### Fix UB for inbound varcalls, if argument count mismatches

It was possible to create undefined behavior by doing dynamic calls to `#[func]` methods. If the number of passed arguments was less than the number of declared parameters, the varcall handler (which delegates to the user-defined `#[func]`) caused a read past valid boundaries of the argument array.

This now causes a panic instead. In the future, such errors could be delegated to the user via `Result<T, CallError>` return type (maybe under separate `try_*` names).