### PR TITLE
ColorHsv addition

### DIFF
--- a/godot-core/src/builtin/color_hsv.rs
+++ b/godot-core/src/builtin/color_hsv.rs
@@ -1,0 +1,292 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use super::math::{ApproxEq, FloatExt};
+use super::Color;
+
+/// HSVA floating-number Color representation.
+///
+/// Godot's [`Color`] built-in type supports mainly RGBA floating point-based notation. `ColorHsv` supports manipulating its HSVA
+/// representation by introducing conversion methods between itself and `Color`.
+///
+/// `ColorHsv` *is not* a [`GodotType`](crate::builtin::meta::GodotType). To use it in properties expecting `Color`, you need to convert
+/// it back to this type.
+///
+/// A `Color` created by [`ColorHsv::to_rgb()`] is equal to one created by [`Color::from_hsv(h, s, v)`](Color::from_hsv), but the conversion
+/// time is approximately 4 times faster - partly because it avoids calls between Godot and Rust during conversion.
+///
+/// ## Conversions
+///
+/// Both conversions (`Color` to `ColorHsv` and `ColorHsv` to `Color`) will panic if RGBA or HSVA values are not within range `0.0..=1.0`.
+/// To ensure the values are in valid range, methods [`Color::normalized`] and [`ColorHsv::normalized_clamped_h`]
+/// or [`ColorHsv::normalized_wrapped_h`] can be used.
+///
+/// ```
+/// use godot::builtin::{Color, ColorHsv};
+///
+/// let rgb = Color::from_rgb(1.15, 0.0, 0.0);
+/// let hsv = ColorHsv::from_hsv(1.15, 0.0, 0.0);
+/// ```
+///
+/// Such colors can't be converted - below calls will panic, because at least one of the color values are not within `0.0..=1.0` range.
+///
+/// ```should_panic
+/// # use godot::builtin::{Color, ColorHsv};
+/// # let rgb = Color::from_rgb(1.15, 0.0, 0.0);
+/// let hsv_from_rgb = rgb.to_hsv();
+/// ```
+/// ```should_panic
+/// # use godot::builtin::{Color, ColorHsv};
+/// # let hsv = ColorHsv::from_hsv(1.15, 0.0, 0.0);
+/// let rgb_from_hsv = hsv.to_rgb();
+/// ```
+///
+/// After normalization all values are within `0.0..=1.0` range, so the conversions are safe and won't panic.
+///
+/// ```
+/// # use godot::builtin::{Color, ColorHsv};
+/// #
+/// # let rgb = Color::from_rgb(1.15, 0.0, 0.0);
+/// # let hsv = ColorHsv::from_hsv(1.15, 0.0, 0.0);
+/// let hsv_from_rgb = rgb.normalized().to_hsv();
+/// let rgb_from_hsv = hsv.normalized_wrapped_h().to_rgb();
+/// ```
+///
+/// ## Precision warning
+/// Conversions between `f32`-based RGB and HSV representations are not completely lossless. Try to avoid repeatable
+/// `Color` -> `ColorHsv` -> `Color` roundtrips. One way to minimalize possible distortions is to keep `ColorHsv` on the Rust side, apply
+/// all changes to this struct and convert it to `Color` before moving to the Godot side, instead of fetching `Color` from Godot side before
+/// every mutation, though changes should be minimal if color values are mutated either only on `Color` or `ColorHsv` side.
+///
+/// ## Examples
+///
+/// ```
+/// use godot::builtin::{Color, ColorHsv};
+/// use godot::builtin::math::assert_eq_approx;
+///
+/// // ColorHsv can be constructed from only Hue, Saturation and Value.  
+/// let mut c_hsv = ColorHsv::from_hsv(0.74, 0.69, 0.18);
+///
+/// // Or with Alpha value also specified. If not specified, it is set at 1.0.
+/// let mut c_hsv2 = ColorHsv::from_hsva(0.74, 0.69, 0.18, 1.0);
+///
+/// assert_eq!(c_hsv, c_hsv2);
+///
+/// // Two way conversion: Color -> ColorHsv -> Color is not entirely lossless. Such repeatable
+/// // conversions should be avoided, as the data loss could build up to significant values if values
+/// // are mutated both on `Color` and `ColorHsv`.
+/// let color1 = Color::from_rgb(0.74, 0.69, 0.18);
+/// let color2 = color1.to_hsv().to_rgb();
+///
+/// assert_ne!(color1, color2);
+/// assert_eq_approx!(color1.r, color2.r);
+/// assert_eq_approx!(color1.g, color2.g);
+/// assert_eq_approx!(color1.b, color2.b);
+/// ```
+///  
+/// ## Reference
+/// - Smith, Alvy Ray. "Color gamut transform pairs." ACM Siggraph Computer Graphics 12.3 (1978): 12-19.
+#[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ColorHsv {
+    pub h: f32,
+    pub s: f32,
+    pub v: f32,
+    pub a: f32,
+}
+
+impl ApproxEq for ColorHsv {
+    /// Hue values are wrapped before approximate comparison.
+    fn approx_eq(&self, other: &Self) -> bool {
+        (wrap_hue(self.h - other.h).is_zero_approx())
+            && (self.s - other.s).abs().is_zero_approx()
+            && (self.v - other.v).abs().is_zero_approx()
+            && (self.a - other.a).abs().is_zero_approx()
+    }
+}
+
+impl ColorHsv {
+    /// Construct from Hue, Saturation and Value.
+    ///
+    /// Alpha will be set at `1.` by default. To construct with custom Alpha value, use [`ColorHsv::from_hsva`] constructor.
+    pub const fn from_hsv(h: f32, s: f32, v: f32) -> Self {
+        ColorHsv { h, s, v, a: 1.0 }
+    }
+
+    /// Construct from Hue, Saturation, Value and Alpha.
+    ///
+    /// To construct with Alpha set as default `1.`, use [`ColorHsv::from_hsv`] constructor.
+    pub const fn from_hsva(h: f32, s: f32, v: f32, a: f32) -> Self {
+        ColorHsv { h, s, v, a }
+    }
+
+    /// Transforms the `ColorHsv` into one with values clamped to the range valid for transformation into [`Color`].
+    ///
+    /// To normalize with **Hue** value wrapped, not clamped (for continuity around the hue wheel), use [`ColorHsv::normalized_wrapped_h`].
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// use godot::builtin::ColorHsv;
+    /// use godot::builtin::math::assert_eq_approx;
+    ///
+    /// let hsv_c = ColorHsv::from_hsv(1.35, -0.60, 1.15);
+    /// let normalized = hsv_c.normalized_clamped_h();
+    /// assert_eq_approx!(normalized, ColorHsv::from_hsv(1.0, 0.0, 1.0));
+    /// ```
+    #[must_use]
+    pub fn normalized_clamped_h(self) -> Self {
+        ColorHsv {
+            h: self.h.clamp(0.0, 1.0),
+            s: self.s.clamp(0.0, 1.0),
+            v: self.v.clamp(0.0, 1.0),
+            a: self.a.clamp(0.0, 1.0),
+        }
+    }
+
+    /// Transforms the `ColorHsv` into one with **Hue** value wrapped and SVA clamped to the range valid for transformation into [`Color`].
+    ///
+    /// To normalize with **Hue** value clamped in the same way as SVA, use [`ColorHsv::normalized_clamped_h`].
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// use godot::builtin::ColorHsv;
+    /// use godot::builtin::math::assert_eq_approx;
+    ///
+    /// let hsv_c = ColorHsv::from_hsv(1.35, -0.60, 1.15);
+    /// let normalized = hsv_c.normalized_wrapped_h();
+    /// assert_eq_approx!(normalized, ColorHsv::from_hsv(0.35, 0.0, 1.0));
+    /// ```
+    #[must_use]
+    pub fn normalized_wrapped_h(self) -> Self {
+        ColorHsv {
+            h: wrap_hue(self.h),
+            s: self.s.clamp(0.0, 1.0),
+            v: self.v.clamp(0.0, 1.0),
+            a: self.a.clamp(0.0, 1.0),
+        }
+    }
+
+    /// ⚠️ Convert `ColorHsv` into [`Color`].
+    ///
+    /// # Panics
+    ///
+    /// Method will panic if the HSVA values are outside of the valid range `0.0..=1.0`. You can use [`ColorHsv::normalized_clamped_h`] or
+    /// [`ColorHsv::normalized_wrapped_h`] to ensure they are in range, or use [`ColorHsv::try_to_rgb`] implementation.
+    pub fn to_rgb(self) -> Color {
+        self.try_to_rgb().unwrap_or_else(|e| panic!("{e}"))
+    }
+
+    /// Fallible `ColorHsv` conversion into [`Color`]. See also: [`ColorHsv::to_rgb`].
+    pub fn try_to_rgb(self) -> Result<Color, String> {
+        if !self.is_normalized() {
+            return Err(format!("HSVA values need to be in range `0.0..=1.0` before conversion, but were {self:?}. See: `ColorHsv::normalized_*()` methods."));
+        }
+
+        let (r, g, b, a) = hsva_to_rgba(self.h, self.s, self.v, self.a);
+        Ok(Color { r, g, b, a })
+    }
+
+    fn is_normalized(&self) -> bool {
+        self.h >= 0.0
+            && self.h <= 1.0
+            && self.s >= 0.0
+            && self.s <= 1.0
+            && self.v >= 0.0
+            && self.v <= 1.0
+            && self.a >= 0.0
+            && self.a <= 1.0
+    }
+}
+
+impl Default for ColorHsv {
+    fn default() -> Self {
+        Self {
+            h: 0.0,
+            s: 0.0,
+            v: 0.0,
+            a: 1.0,
+        }
+    }
+}
+
+pub(crate) fn rgba_to_hsva(r: f32, g: f32, b: f32, a: f32) -> (f32, f32, f32, f32) {
+    let min = r.min(g).min(b);
+    let max = r.max(g).max(b);
+
+    let mut h: f32;
+    let s: f32;
+    let v = max;
+
+    let delta = max - min;
+
+    if delta.is_zero_approx() {
+        s = 0.0;
+        h = 0.0;
+
+        return (h, s, v, a);
+    }
+
+    s = delta / max;
+
+    if max == r {
+        h = (g - b) / delta;
+        if h < 0.0 {
+            h += 6.0;
+        }
+    } else if max == g {
+        h = 2.0 + (b - r) / delta;
+    } else {
+        h = 4.0 + (r - g) / delta;
+    }
+
+    h /= 6.0;
+
+    (h, s, v, a)
+}
+
+fn hsva_to_rgba(h: f32, s: f32, v: f32, a: f32) -> (f32, f32, f32, f32) {
+    if s.is_zero_approx() {
+        return (v, v, v, a);
+    }
+
+    let h = h * 6.;
+    let i = h.floor();
+    let f = h - i;
+
+    let m = v * (1.0 - s);
+    let n = v * (1.0 - (s * f));
+    let k = v * (1.0 - (s * (1.0 - f)));
+
+    let (r, g, b) = match i as u8 {
+        0 => (v, k, m),
+        1 => (n, v, m),
+        2 => (m, v, k),
+        3 => (m, n, v),
+        4 => (k, m, v),
+        5 => (v, m, n),
+        6 => (v, k, m),
+        // Below shouldn't ever happen, because Hue value is checked to be in range of `0.0..=1.0`, so the maximum floored value of Hue * 6
+        // will always be 6.
+        _ => unreachable!(),
+    };
+
+    (r, g, b, a)
+}
+
+fn wrap_hue(hue: f32) -> f32 {
+    // When running benchmarks, the `(0.0..1.0).contains(&hue)` were 2x slower than manual implementation.
+    #[allow(clippy::manual_range_contains)]
+    if hue >= 0.0 && hue < 1.0 {
+        return hue;
+    }
+    if hue < 0.0 {
+        return 1. + (hue % 1.0);
+    }
+    hue % 1.
+}

--- a/godot-core/src/builtin/mod.rs
+++ b/godot-core/src/builtin/mod.rs
@@ -45,6 +45,7 @@ pub mod __prelude_reexport {
     pub use basis::*;
     pub use callable::*;
     pub use color::*;
+    pub use color_hsv::*;
     pub use dictionary_inner::Dictionary;
     pub use packed_array::*;
     pub use plane::*;
@@ -99,6 +100,7 @@ mod basis;
 mod callable;
 mod color;
 mod color_constants; // After color, so that constants are listed after methods in docs (alphabetic ensures that).
+mod color_hsv;
 mod packed_array;
 mod plane;
 mod projection;

--- a/itest/rust/src/benchmarks/color.rs
+++ b/itest/rust/src/benchmarks/color.rs
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use std::hint::black_box;
+
+use crate::framework::bench;
+
+use godot::builtin::{Color, ColorHsv};
+
+#[bench]
+fn godot_from_hsv() -> Color {
+    Color::from_hsv(black_box(0.23), black_box(0.54), black_box(0.75))
+}
+
+#[bench]
+fn rust_from_hsv() -> Color {
+    ColorHsv::from_hsv(black_box(0.23), black_box(0.54), black_box(0.75)).to_rgb()
+}
+
+#[bench]
+fn color_hsv_hue_wrap() -> ColorHsv {
+    ColorHsv {
+        h: 1.15,
+        ..Default::default()
+    }
+    .normalized_wrapped_h()
+}
+
+#[bench]
+fn rgb_to_hsv_roundtrip() -> Color {
+    let color = Color {
+        r: 0.23,
+        g: 0.56,
+        b: 0.93,
+        a: 1.,
+    };
+
+    color.to_hsv().to_rgb()
+}
+
+#[bench]
+fn rgb_to_hsv_mutate_roundtrip() -> Color {
+    let color = Color {
+        r: 0.23,
+        g: 0.56,
+        b: 0.93,
+        a: 1.,
+    };
+
+    let mut hsv = color.to_hsv();
+
+    hsv.h += 0.15;
+    hsv.s = 2.0;
+    hsv.v += 0.10;
+    hsv = hsv.normalized_wrapped_h();
+
+    hsv.to_rgb()
+}

--- a/itest/rust/src/benchmarks/mod.rs
+++ b/itest/rust/src/benchmarks/mod.rs
@@ -17,6 +17,8 @@ use godot::register::GodotClass;
 
 use crate::framework::bench;
 
+mod color;
+
 #[bench]
 fn builtin_string_ctor() -> GString {
     GString::from("some test string")

--- a/itest/rust/src/builtin_tests/serde_test.rs
+++ b/itest/rust/src/builtin_tests/serde_test.rs
@@ -6,7 +6,7 @@
  */
 
 use crate::framework::itest;
-use godot::builtin::{array, Array, GString, NodePath, StringName, Vector2i};
+use godot::builtin::{array, Array, Color, ColorHsv, GString, NodePath, StringName, Vector2i};
 use serde::{Deserialize, Serialize};
 
 fn serde_roundtrip<T>(value: &T, expected_json: &str)
@@ -77,4 +77,18 @@ fn serde_array_godot_type() {
     let expected_json = r#"[{"x":1,"y":1},{"x":2,"y":2},{"x":3,"y":3}]"#;
 
     serde_roundtrip(&value, expected_json)
+}
+
+#[itest]
+fn color_serde() {
+    let color = Color::default();
+    let expected_json = r#"{"r":0.0,"g":0.0,"b":0.0,"a":1.0}"#;
+    serde_roundtrip(&color, expected_json);
+}
+
+#[itest]
+fn color_hsv_serde() {
+    let color = ColorHsv::default();
+    let expected_json = r#"{"h":0.0,"s":0.0,"v":0.0,"a":1.0}"#;
+    serde_roundtrip(&color, expected_json);
 }


### PR DESCRIPTION
Introduced representation of HSV color model on the Rust side

Currently, there is a possibility of creating `Color` GodotType from HSV values with `Color::from_hsv()`, but there is no option to reverse the process (receive Hue, Saturation, and Value values out of `Color`), which makes it problematic to fully use `HSV` representation.

This PR introduces `ColorHsv` Rust type, which can be converted from and into `Color` GodotType, resolving the issue. 

## Conversion algorithms

Two different algorithm for conversion were found during research:
- Smith, Alvy Ray. "Color gamut transform pairs." ACM Siggraph Computer Graphics 12.3 (1978): 12-19
  - uses float RGB and HSV values (and Color in Godot uses float RGB under the hood, its `r8()`, `g8()` and `b8()` getters are  clamping the floats into 0-255 integer range
  -  is widely used
- Chernov, Vladimir, Jarmo Alander, and Vladimir Bochko. "Integer-based accurate conversion between RGB and HSV color spaces." Computers & Electrical Engineering 46 (2015): 328-337.
  - uses integer RGB and HSV values
  - is slightly more tricky to implement
  - by paper authors claim it should be faster than float-based one

## Benchmarks and chosen algorithm

During development, both algorithms were implemented, but (at least for now) the float-based was chosen. Integer-based could be potentially implemented in the future if such a need arises. Rationale based on debug-build benchmarks:

```
   color.rs:
   -- godot_from_hsv             ...      0.248μs      0.372μs
   -- rust_from_hsv              ...      0.055μs      0.056μs
   -- rgb_to_hsv_roundtrip       ...      0.086μs      0.086μs
   -- rgb_to_hsv_mutate_roundtri ...      0.098μs      0.124μs
```

The float-based algorithm is already very fast - as we need an FFI call from Rust to Godot to pass the `Color` itself, further improvements could be negligible. Furthermore, it's much faster (possibly partly because of the above) than Godot's `HSV->RGB` already.
- `godot_from_hsv` - HSV -> RGB via `Color::from_hsv()` 
- `rust_from_hsv` - HSV -> RGB via proposed implementation, 
- `rgb_to_hsv_roundtrip` - RGB -> HSV -> RGB 
- `rgb_to_hsv_mutate_roundtrip` - same as above, but HSV values are also mutated in between

Additionally, during development, the integer-based algorithm was several times slower than the float-based one, though it is possible that my implementation was faulty in some way (as it is a little trickier to implement), or just the first retrieval of integer RGB values from `Color` and their later conversion from integers to floats could be partly at blame.

An additional benefit is that by keeping the `ColorHsv` representation as `f32` based, it is uniform with the main `Color` representation. 

Some tradeoffs are mentioned in the docs (and the tests are put in place to make sure it is stable):
- the float-based algorithm is not entirely lossless - while `Color::from_hsv()` and implemented `ColorHsv::into<Color>()` results are equal, multiple repeatable conversions between the formats can introduce some loss (less than 0.001 in every value).
- the integer-based algorithm has the potential to be more stable (as it operates fully on integers), but it isn't a guarantee (as the integers needs to be converted to `f32` to construct `Color`, and then retrieved with `Color.*8()` getters.

## Possible refactor
The first commit introduces the logic - after it is approved, I would aim to also refactor the `color` module with the second commit. Planned changes would be 
- at minimum moving it to another directory along with `hsv.rs` (renamed `color_hsv.rs`) and `color_constants.rs`
- at maximum additionally unpacking some code from `color.rs` to separate modules could be also beneficial, as the file is already pretty verbose.

An additional refactor would be to move `ColorHsv` from `godot::builtins` and `godot::prelude`. Maybe make the `godot::builtins::color` namespace? Or move `ColorHsv` from `godot::builtins` entirely, maybe to `godot::engine::colors` (as it isn't technically a `GodotType`, but a helper struct).

Update:
Benchmarks from `itest` CI execution on linux shows a slightly different picture than above (though Godot's `Color::from_hsv()` is still slower):

```
                                              min       median
   color.rs:
   -- godot_from_hsv             ...      0.190μs      0.192μs
   -- rust_from_hsv              ...      0.042μs      0.042μs
   -- rgb_to_hsv_roundtrip       ...      0.080μs      0.081μs
   -- rgb_to_hsv_mutate_roundtri ...      0.095μs      0.096μs
```