### PR TITLE
`#[func(virtual)]`: override virtual Rust functions in GDScript

### DIFF
--- a/godot-bindings/src/godot_exe.rs
+++ b/godot-bindings/src/godot_exe.rs
@@ -112,7 +112,7 @@ pub(crate) fn read_godot_version(godot_bin: &Path) -> GodotVersion {
     let output = execute(cmd, "read Godot version");
     let stdout = std::str::from_utf8(&output.stdout).expect("convert Godot version to UTF-8");
 
-    match parse_godot_version(&stdout) {
+    match parse_godot_version(stdout) {
         Ok(parsed) => {
             assert_eq!(
                 parsed.major,

--- a/godot-codegen/src/special_cases/codegen_special_cases.rs
+++ b/godot-codegen/src/special_cases/codegen_special_cases.rs
@@ -138,6 +138,7 @@ const SELECTED_CLASSES: &[&str] = &[
     "EditorPlugin",
     "Engine",
     "FileAccess",
+    "GDScript",
     "HTTPRequest",
     "Image",
     "ImageTextureLayered",

--- a/godot-core/src/builtin/string/string_name.rs
+++ b/godot-core/src/builtin/string/string_name.rs
@@ -121,6 +121,11 @@ impl StringName {
     }
 
     #[doc(hidden)]
+    pub fn string_sys_const(&self) -> sys::GDExtensionConstStringNamePtr {
+        sys::to_const_ptr(self.string_sys())
+    }
+
+    #[doc(hidden)]
     pub fn as_inner(&self) -> inner::InnerStringName {
         inner::InnerStringName::from_outer(self)
     }

--- a/godot-core/src/obj/base.rs
+++ b/godot-core/src/obj/base.rs
@@ -79,6 +79,12 @@ impl<T: GodotClass> Base<T> {
     pub fn as_gd(&self) -> &Gd<T> {
         &self.obj
     }
+
+    // Currently only used in outbound virtual calls (for scripts).
+    #[doc(hidden)]
+    pub fn obj_sys(&self) -> sys::GDExtensionObjectPtr {
+        self.obj.obj_sys()
+    }
 }
 
 impl<T: GodotClass> Debug for Base<T> {

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -423,7 +423,8 @@ impl<T: GodotClass> Gd<T> {
         Self::from_obj_sys_weak_or_none(ptr).unwrap()
     }
 
-    pub(crate) fn obj_sys(&self) -> sys::GDExtensionObjectPtr {
+    #[doc(hidden)]
+    pub fn obj_sys(&self) -> sys::GDExtensionObjectPtr {
         self.raw.obj_sys()
     }
 

--- a/godot-core/src/obj/traits.rs
+++ b/godot-core/src/obj/traits.rs
@@ -183,6 +183,11 @@ pub trait EngineBitfield: Copy {
         Self::try_from_ord(ord)
             .unwrap_or_else(|| panic!("ordinal {ord} does not map to any valid bit flag"))
     }
+
+    // TODO consolidate API: named methods vs. | & ! etc.
+    fn is_set(self, flag: Self) -> bool {
+        self.ord() & flag.ord() != 0
+    }
 }
 
 /// Trait for enums that can be used as indices in arrays.

--- a/godot-core/src/private.rs
+++ b/godot-core/src/private.rs
@@ -130,6 +130,14 @@ where
     }
 }
 
+#[cfg(since_api = "4.3")]
+pub unsafe fn has_virtual_script_method(
+    object_ptr: sys::GDExtensionObjectPtr,
+    method_sname: sys::GDExtensionConstStringNamePtr,
+) -> bool {
+    sys::interface_fn!(object_has_script_method)(sys::to_const_ptr(object_ptr), method_sname) != 0
+}
+
 pub fn flush_stdout() {
     use std::io::Write;
     std::io::stdout().flush().expect("flush stdout");

--- a/godot-ffi/src/extras.rs
+++ b/godot-ffi/src/extras.rs
@@ -58,6 +58,9 @@ impl_as_uninit!(GDExtensionTypePtr, GDExtensionUninitializedTypePtr);
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Helper functions
 
+/// Differentiate from `sys::GDEXTENSION_CALL_ERROR_*` codes.
+pub const GODOT_RUST_CALL_ERROR: GDExtensionCallErrorType = 40;
+
 #[doc(hidden)]
 #[inline]
 pub fn default_call_error() -> GDExtensionCallError {
@@ -105,6 +108,7 @@ pub fn panic_call_error(
         }
         GDEXTENSION_CALL_ERROR_INSTANCE_IS_NULL => "instance is null".to_string(),
         GDEXTENSION_CALL_ERROR_METHOD_NOT_CONST => "method is not const".to_string(), // not handled in Godot
+        GODOT_RUST_CALL_ERROR => "godot-rust function call failed".to_string(),
         _ => format!("unknown reason (error code {error})"),
     };
 

--- a/godot-macros/src/class/data_models/field_var.rs
+++ b/godot-macros/src/class/data_models/field_var.rs
@@ -194,7 +194,7 @@ impl GetterSetterImpl {
         let export_token = make_method_registration(
             class_name,
             FuncDefinition {
-                func: signature,
+                signature,
                 // Since we're analyzing a struct's field, we don't have access to the corresponding get/set function's
                 // external (non-#[func]) attributes. We have to assume the function exists and has the name the user
                 // gave us, with the expected signature.
@@ -202,9 +202,12 @@ impl GetterSetterImpl {
                 // #[cfg()] (for instance) placed on the getter/setter function, but that is not currently supported.
                 external_attributes: Vec::new(),
                 rename: None,
+                is_virtual: false,
                 has_gd_self: false,
             },
         );
+
+        let export_token = export_token.expect("getter/setter generation should not fail");
 
         Self {
             function_name,

--- a/godot-macros/src/class/data_models/func.rs
+++ b/godot-macros/src/class/data_models/func.rs
@@ -386,8 +386,9 @@ fn make_varcall_func(
                 );
 
                 if success.is_none() {
-                    // Signal error and set return type to Nil
-                    (*err).error = sys::GDEXTENSION_CALL_ERROR_INVALID_METHOD; // no better fitting enum?
+                    // Signal error and set return type to Nil.
+                    // None of the sys::GDEXTENSION_CALL_ERROR enums fits; so we use our own outside Godot's official range.
+                    (*err).error = sys::GODOT_RUST_CALL_ERROR;
 
                     // TODO(uninit)
                     sys::interface_fn!(variant_new_nil)(sys::AsUninit::as_uninit(ret));

--- a/godot-macros/src/class/godot_api.rs
+++ b/godot-macros/src/class/godot_api.rs
@@ -13,7 +13,7 @@ use crate::class::{
     into_signature_info, make_method_registration, make_virtual_callback, BeforeKind,
     FuncDefinition, SignatureInfo,
 };
-use crate::util::{bail, KvParser};
+use crate::util::{bail, require_api_version, KvParser};
 use crate::{util, ParseResult};
 
 pub fn attribute_godot_api(input_decl: venial::Declaration) -> ParseResult<TokenStream> {
@@ -513,7 +513,12 @@ where
                 let rename = parser.handle_expr("rename")?.map(|ts| ts.to_string());
 
                 // #[func(virtual)]
-                let is_virtual = parser.handle_alone("virtual")?;
+                let is_virtual = if let Some(span) = parser.handle_alone_with_span("virtual")? {
+                    require_api_version!("4.3", span, "#[func(virtual)]")?;
+                    true
+                } else {
+                    false
+                };
 
                 // #[func(gd_self)]
                 let has_gd_self = parser.handle_alone("gd_self")?;

--- a/godot-macros/src/class/godot_api.rs
+++ b/godot-macros/src/class/godot_api.rs
@@ -401,7 +401,9 @@ fn add_virtual_script_call(
 
     let class_name_str = class_name.to_string();
     let early_bound_name = format_ident!("__earlybound_{}", &function.name);
-    let method_name_str = rename.clone().unwrap_or_else(|| function.name.to_string());
+    let method_name_str = rename
+        .clone()
+        .unwrap_or_else(|| format!("_{}", function.name));
 
     // Clone might not strictly be necessary, but the 2 other callers of into_signature_info() are better off with pass-by-value.
     let signature_info = into_signature_info(

--- a/godot-macros/src/lib.rs
+++ b/godot-macros/src/lib.rs
@@ -391,12 +391,12 @@ use crate::util::ident;
 ///
 /// ## Class hiding
 ///
-/// If you want to register a class with Godot, but not have it show up in the editor then you can use `#[class(hide)]`.
+/// If you want to register a class with Godot, but not have it show up in the editor then you can use `#[class(hidden)]`.
 ///
 /// ```
 /// # use godot::prelude::*;
 /// #[derive(GodotClass)]
-/// #[class(base=Node, init, hide)]
+/// #[class(base=Node, init, hidden)]
 /// pub struct Foo {}
 /// ```
 ///

--- a/godot-macros/src/lib.rs
+++ b/godot-macros/src/lib.rs
@@ -611,11 +611,11 @@ pub fn derive_godot_class(input: TokenStream) -> TokenStream {
 /// # }
 /// ```
 ///
-/// In GDScript:
+/// In GDScript, your method is available with a `_` prefix, following Godot convention for virtual methods:
 /// ```gdscript
 /// extends MyStruct
 ///
-/// func language():
+/// func _language():
 ///    return "GDScript"
 /// ```
 ///

--- a/godot-macros/src/lib.rs
+++ b/godot-macros/src/lib.rs
@@ -444,8 +444,6 @@ pub fn derive_godot_class(input: TokenStream) -> TokenStream {
 
 /// Proc-macro attribute to be used with `impl` blocks of [`#[derive(GodotClass)]`][GodotClass] structs.
 ///
-/// See also [book chapter _Registering functions_](https://godot-rust.github.io/book/register/functions.html) and following.
-///
 /// Can be used in two ways:
 /// ```no_run
 /// # use godot::prelude::*;
@@ -462,35 +460,41 @@ pub fn derive_godot_class(input: TokenStream) -> TokenStream {
 /// impl INode for MyClass { /* ... */ }
 /// ```
 ///
-/// The second case works by implementing the corresponding trait `I<Base>` for the base class of your class
+/// The second case works by implementing the corresponding trait `I*` for the base class of your class
 /// (for example `IRefCounted` or `INode3D`). Then, you can add functionality such as:
 /// * `init` constructors
 /// * lifecycle methods like `ready` or `process`
 /// * `on_notification` method
 /// * `to_string` method
 ///
-/// Neither `#[godot_api]` attribute is required. For small data bundles inheriting `RefCounted`, you may be fine with
+/// Neither of the two `#[godot_api]` blocks is required. For small data bundles inheriting `RefCounted`, you may be fine with
 /// accessing properties directly from GDScript.
 ///
-/// # Examples
+/// See also [book chapter _Registering functions_](https://godot-rust.github.io/book/register/functions.html) and following.
 ///
-/// ## `RefCounted` as a base, overridden `init`
+/// **Table of contents**
+/// - [Constructors](#constructors)
+///   - [User-defined `init`](#user-defined-init)
+///   - [Generated `init`](#generated-init)
+/// - [Lifecycle functions](#lifecycle-functions)
+/// - [User-defined functions](#user-defined-functions)
+///   - [Associated functions and methods](#associated-functions-and-methods)
+///   - [Virtual methods](#virtual-methods)
+/// - [Constants and signals](#signals)
+///
+/// # Constructors
+///
+/// Note that `init` (the Godot default constructor) can be either provided by overriding it, or generated with a `#[class(init)]` attribute
+/// on the struct. Classes without `init` cannot be instantiated from GDScript.
+///
+/// ## User-defined `init`
 ///
 /// ```no_run
-///# use godot::prelude::*;
-///
+/// # use godot::prelude::*;
 /// #[derive(GodotClass)]
 /// // no #[class(init)] here, since init() is overridden below.
 /// // #[class(base=RefCounted)] is implied if no base is specified.
 /// struct MyStruct;
-///
-/// #[godot_api]
-/// impl MyStruct {
-///     #[func]
-///     pub fn hello_world(&mut self) {
-///         godot_print!("Hello World!")
-///     }
-/// }
 ///
 /// #[godot_api]
 /// impl IRefCounted for MyStruct {
@@ -500,19 +504,33 @@ pub fn derive_godot_class(input: TokenStream) -> TokenStream {
 /// }
 /// ```
 ///
-/// Note that `init` can be either provided by overriding it, or generated with a `#[class(init)]` attribute on the struct.
-/// Classes without `init` cannot be instantiated from GDScript.
+/// ## Generated `init`
 ///
-/// ## `Node` as a base, generated `init`
+/// This initializes the `Base<T>` field, and every other field with either `Default::default()` or the value specified in `#[init(default = ...)]`.
 ///
 /// ```no_run
-///# use godot::prelude::*;
-///
+/// # use godot::prelude::*;
 /// #[derive(GodotClass)]
 /// #[class(init, base=Node)]
 /// pub struct MyNode {
 ///     base: Base<Node>,
+///
+///     #[init(default = 42)]
+///     some_integer: i64,
 /// }
+/// ```
+///
+///
+/// # Lifecycle functions
+///
+/// You can override the lifecycle functions `ready`, `process`, `physics_process` and so on, by implementing the trait corresponding to the
+/// base class.
+///
+/// ```no_run
+/// # use godot::prelude::*;
+/// #[derive(GodotClass)]
+/// #[class(init, base=Node)]
+/// pub struct MyNode;
 ///
 /// #[godot_api]
 /// impl INode for MyNode {
@@ -521,6 +539,93 @@ pub fn derive_godot_class(input: TokenStream) -> TokenStream {
 ///     }
 /// }
 /// ```
+///
+///
+/// # User-defined functions
+///
+/// You can use the `#[func]` attribute to declare your own functions. These are exposed to Godot and callable from GDScript.
+///
+/// ## Associated functions and methods
+///
+/// If `#[func]` functions are called from the engine, they implicitly bind the surrounding `Gd<T>` pointer: `Gd::bind()` in case of `&self`,
+/// `Gd::bind_mut()` in case of `&mut self`. To avoid that, use `#[func(gd_self)]`, which requires an explicit first argument of type `Gd<T>`.
+///
+/// Functions without a receiver become static functions in Godot. They can be called from GDScript using `MyStruct.static_function()`.
+/// If they return `Gd<Self>`, they are effectively constructors that allow taking arguments.
+///
+/// ```no_run
+/// # use godot::prelude::*;
+/// #[derive(GodotClass)]
+/// #[class(init)]
+/// struct MyStruct {
+///     field: i64,
+///     base: Base<RefCounted>,
+/// }
+///
+/// #[godot_api]
+/// impl MyStruct {
+///     #[func]
+///     pub fn hello_world(&mut self) {
+///         godot_print!("Hello World!")
+///     }
+///
+///     #[func]
+///     pub fn static_function(constructor_arg: i64) -> Gd<Self> {
+///         Gd::from_init_fn(|base| {
+///            MyStruct { field: constructor_arg, base }
+///         })
+///     }
+///
+///     #[func(gd_self)]
+///     pub fn explicit_receiver(mut this: Gd<Self>, other_arg: bool) {
+///         // Only bind Gd pointer if needed.
+///         if other_arg {
+///             this.bind_mut().field = 55;
+///         }
+///     }
+/// }
+/// ```
+///
+/// ## Virtual methods
+///
+/// Functions with the `#[func(virtual)]` attribute are virtual functions, meaning attached scripts can override them.
+///
+/// ```no_run
+/// # #[cfg(since_api = "4.3")]
+/// # mod conditional {
+/// # use godot::prelude::*;
+/// #[derive(GodotClass)]
+/// #[class(init)]
+/// struct MyStruct {
+///     // Virtual functions require base object.
+///     base: Base<RefCounted>,
+/// }
+///
+/// #[godot_api]
+/// impl MyStruct {
+///     #[func(virtual)]
+///     fn language(&self) -> GString {
+///         "Rust".into()
+///     }
+/// }
+/// # }
+/// ```
+///
+/// In GDScript:
+/// ```gdscript
+/// extends MyStruct
+///
+/// func language():
+///    return "GDScript"
+/// ```
+///
+/// Now, `obj.language()` from Rust will dynamically dispatch the call.
+///
+/// Make sure you understand the limitations in the [tutorial](https://godot-rust.github.io/book/register/virtual-functions.html).
+///
+/// # Constants and signals
+///
+/// Please refer to [the book](https://godot-rust.github.io/book/register/constants.html).
 #[proc_macro_attribute]
 pub fn godot_api(_meta: TokenStream, input: TokenStream) -> TokenStream {
     translate(input, class::attribute_godot_api)

--- a/godot-macros/src/util/mod.rs
+++ b/godot-macros/src/util/mod.rs
@@ -58,7 +58,20 @@ macro_rules! bail {
     }
 }
 
-pub(crate) use bail;
+macro_rules! require_api_version {
+    ($min_version:literal, $span:expr, $attribute:literal) => {
+        if !cfg!(since_api = $min_version) {
+            bail!(
+                $span,
+                "{} requires at least Godot API version {}",
+                $attribute,
+                $min_version
+            )
+        } else {
+            Ok(())
+        }
+    };
+}
 
 pub fn error_fn<T>(msg: impl AsRef<str>, tokens: T) -> Error
 where
@@ -73,7 +86,9 @@ macro_rules! error {
     }
 }
 
+pub(crate) use bail;
 pub(crate) use error;
+pub(crate) use require_api_version;
 
 pub fn reduce_to_signature(function: &Function) -> Function {
     let mut reduced = function.clone();

--- a/godot/src/lib.rs
+++ b/godot/src/lib.rs
@@ -107,6 +107,8 @@
 //!
 //! The following features can be enabled for this crate. All off them are off by default.
 //!
+//! Avoid `default-features = false` unless you know exactly what you are doing; it will disable some required internal features.
+//!
 //! * **`double-precision`**
 //!
 //!   Use `f64` instead of `f32` for the floating-point type [`real`][type@builtin::real]. Requires Godot to be compiled with the

--- a/itest/godot/ManualFfiTests.gd
+++ b/itest/godot/ManualFfiTests.gd
@@ -293,7 +293,7 @@ func test_option_export():
 	test_node.free()
 
 func test_func_rename():
-	var func_rename := FuncRename.new()
+	var func_rename := FuncObj.new()
 
 	assert_eq(func_rename.has_method("long_function_name_for_is_true"), false)
 	assert_eq(func_rename.has_method("is_true"), true)
@@ -307,27 +307,25 @@ func test_func_rename():
 	assert_eq(func_rename.has_method("spell_static"), true)
 	assert_eq(func_rename.spell_static(), "static")
 
-var gd_self_reference: GdSelfReference
+var gd_self_obj: GdSelfObj
 func update_self_reference(value):
-	gd_self_reference.update_internal(value)
+	gd_self_obj.update_internal(value)
 
-# Todo: Once there is a way to assert for a SCRIPT ERROR failure this can be reenabled.
-"""
-func test_gd_self_reference_fails():
-	# Create the gd_self_reference and connect its signal to a gdscript method that calls back into it.
-	gd_self_reference = GdSelfReference.new()
-	gd_self_reference.update_internal_signal.connect(update_self_reference)
-	
-	# The returned value will still be 0 because update_internal can't be called in update_self_reference due to a borrowing issue.
-	assert_eq(gd_self_reference.fail_to_update_internal_value_due_to_conflicting_borrow(10), 0)
-"""
+# TODO: Once there is a way to assert for a SCRIPT ERROR failure, this can be re-enabled.
+#func test_gd_self_obj_fails():
+#	# Create the gd_self_obj and connect its signal to a gdscript method that calls back into it.
+#	gd_self_obj = GdSelfObj.new()
+#	gd_self_obj.update_internal_signal.connect(update_self_reference)
+#	
+#	# The returned value will still be 0 because update_internal can't be called in update_self_reference due to a borrowing issue.
+#	assert_eq(gd_self_obj.fail_to_update_internal_value_due_to_conflicting_borrow(10), 0)
 
-func test_gd_self_reference_succeeds():
-	# Create the gd_self_reference and connect its signal to a gdscript method that calls back into it.
-	gd_self_reference = GdSelfReference.new()
-	gd_self_reference.update_internal_signal.connect(update_self_reference)
+func test_gd_self_obj_succeeds():
+	# Create the gd_self_obj and connect its signal to a gdscript method that calls back into it.
+	gd_self_obj = GdSelfObj.new()
+	gd_self_obj.update_internal_signal.connect(update_self_reference)
 
-	assert_eq(gd_self_reference.succeed_at_updating_internal_value(10), 10)
+	assert_eq(gd_self_obj.succeed_at_updating_internal_value(10), 10)
 
 func sample_func():
 	pass

--- a/itest/godot/SpecialTests.gd
+++ b/itest/godot/SpecialTests.gd
@@ -33,18 +33,23 @@ func test_collision_object_2d_input_event():
 
 	window.add_child(collision_object)
 
-	assert_that(not collision_object.input_event_called())
-	assert_eq(collision_object.get_viewport(), null)
+	assert_that(not collision_object.input_event_called(), "Input event should not be propagated")
+	assert_eq(collision_object.get_viewport(), null, "Collision viewport should be null")
 
 	var event := InputEventMouseMotion.new()
 	event.global_position = Vector2.ZERO
-	window.push_unhandled_input(event)
+
+	# Godot 4.0 compat: behavior of `push_unhandled_input` was not consistent with `push_input`.
+	if Engine.get_version_info().minor == 0:
+		window.push_unhandled_input(event)
+	else:
+		window.push_input(event)
 
 	# Ensure we run a full physics frame
 	await root.get_tree().physics_frame
 
-	assert_that(collision_object.input_event_called())
-	assert_eq(collision_object.get_viewport(), window)
+	assert_that(collision_object.input_event_called(), "Input event should be propagated")
+	assert_eq(collision_object.get_viewport(), window, "Collision viewport should be the (non-null) window")
 
 	window.queue_free()
 

--- a/itest/rust/src/register_tests/func_virtual_test.rs
+++ b/itest/rust/src/register_tests/func_virtual_test.rs
@@ -60,7 +60,7 @@ fn func_virtual() {
     assert_eq!(object.bind().greet_lang(72), GString::from("GDScript#72"));
 
     // Dynamic call: "GDScript".
-    let result = object.call("greet_lang".into(), &[72.to_variant()]);
+    let result = object.call("_greet_lang".into(), &[72.to_variant()]);
     assert_eq!(result, "GDScript#72".to_variant());
 }
 
@@ -102,7 +102,7 @@ fn func_virtual_gd_self() {
     );
 
     // Dynamic call: "GDScript".
-    let result = object.call("greet_lang3".into(), &["Hoi".to_variant()]);
+    let result = object.call("_greet_lang3".into(), &["Hoi".to_variant()]);
     assert_eq!(result, "Hoi GDScript".to_variant());
 }
 
@@ -124,19 +124,19 @@ extends VirtualScriptCalls
 
 var thing
 
-func greet_lang(i: int) -> String:
+func _greet_lang(i: int) -> String:
     return str("GDScript#", i)
     
 func greet_lang2(s: String) -> String:
     return str(s, " GDScript")
 
-func greet_lang3(s: String) -> String:
+func _greet_lang3(s: String) -> String:
     return str(s, " GDScript")
 
-func set_thing(anything):
+func _set_thing(anything):
     thing = anything
 
-func get_thing():
+func _get_thing():
     return thing
 "#;
 
@@ -155,11 +155,11 @@ func get_thing():
     assert_eq!(
         methods,
         varray![
-            "greet_lang",
+            "_greet_lang",
             "greet_lang2",
-            "greet_lang3",
-            "set_thing",
-            "get_thing"
+            "_greet_lang3",
+            "_set_thing",
+            "_get_thing"
         ]
     );
 

--- a/itest/rust/src/register_tests/func_virtual_test.rs
+++ b/itest/rust/src/register_tests/func_virtual_test.rs
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+// Needed for Clippy to accept #[cfg(all())]
+#![allow(clippy::non_minimal_cfg)]
+
+use crate::framework::itest;
+use godot::engine::GDScript;
+use godot::prelude::*;
+
+#[derive(GodotClass)]
+#[class(init)]
+struct VirtualScriptCalls {
+    _base: Base<RefCounted>,
+}
+
+#[godot_api]
+impl VirtualScriptCalls {
+    #[func(virtual)]
+    fn greet_lang(&self, i: i32) -> GString {
+        GString::from(format!("Rust#{i}"))
+    }
+
+    #[func(virtual, rename = greet_lang2)]
+    fn gl2(&self, s: GString) -> GString {
+        GString::from(format!("{s} Rust"))
+    }
+
+    #[func(virtual, gd_self)]
+    fn greet_lang3(_this: Gd<Self>, s: GString) -> GString {
+        GString::from(format!("{s} Rust"))
+    }
+
+    #[func(virtual)]
+    fn set_thing(&mut self, _input: Variant) {
+        panic!("set_thing() must be overridden")
+    }
+
+    #[func(virtual)]
+    fn get_thing(&self) -> Variant {
+        panic!("get_thing() must be overridden")
+    }
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// Tests
+
+#[itest]
+fn func_virtual() {
+    // Without script: "Rust".
+    let mut object = VirtualScriptCalls::new_gd();
+    assert_eq!(object.bind().greet_lang(72), GString::from("Rust#72"));
+
+    // With script: "GDScript".
+    object.set_script(make_script().to_variant());
+    assert_eq!(object.bind().greet_lang(72), GString::from("GDScript#72"));
+
+    // Dynamic call: "GDScript".
+    let result = object.call("greet_lang".into(), &[72.to_variant()]);
+    assert_eq!(result, "GDScript#72".to_variant());
+}
+
+#[itest]
+fn func_virtual_renamed() {
+    // Without script: "Rust".
+    let mut object = VirtualScriptCalls::new_gd();
+    assert_eq!(
+        object.bind().gl2("Hello".into()),
+        GString::from("Hello Rust")
+    );
+
+    // With script: "GDScript".
+    object.set_script(make_script().to_variant());
+    assert_eq!(
+        object.bind().gl2("Hello".into()),
+        GString::from("Hello GDScript")
+    );
+
+    // Dynamic call: "GDScript".
+    let result = object.call("greet_lang2".into(), &["Hello".to_variant()]);
+    assert_eq!(result, "Hello GDScript".to_variant());
+}
+
+#[itest]
+fn func_virtual_gd_self() {
+    // Without script: "Rust".
+    let mut object = VirtualScriptCalls::new_gd();
+    assert_eq!(
+        VirtualScriptCalls::greet_lang3(object.clone(), "Hoi".into()),
+        GString::from("Hoi Rust")
+    );
+
+    // With script: "GDScript".
+    object.set_script(make_script().to_variant());
+    assert_eq!(
+        VirtualScriptCalls::greet_lang3(object.clone(), "Hoi".into()),
+        GString::from("Hoi GDScript")
+    );
+
+    // Dynamic call: "GDScript".
+    let result = object.call("greet_lang3".into(), &["Hoi".to_variant()]);
+    assert_eq!(result, "Hoi GDScript".to_variant());
+}
+
+#[itest]
+fn func_virtual_stateful() {
+    let mut object = VirtualScriptCalls::new_gd();
+    object.set_script(make_script().to_variant());
+
+    let variant = Vector3i::new(1, 2, 2).to_variant();
+    object.bind_mut().set_thing(variant.clone());
+
+    let retrieved = object.bind().get_thing();
+    assert_eq!(retrieved, variant);
+}
+
+fn make_script() -> Gd<GDScript> {
+    let code = r#"
+extends VirtualScriptCalls
+
+var thing
+
+func greet_lang(i: int) -> String:
+    return str("GDScript#", i)
+    
+func greet_lang2(s: String) -> String:
+    return str(s, " GDScript")
+
+func greet_lang3(s: String) -> String:
+    return str(s, " GDScript")
+
+func set_thing(anything):
+    thing = anything
+
+func get_thing():
+    return thing
+"#;
+
+    let mut script = GDScript::new_gd();
+    script.set_source_code(code.into());
+    script.reload(); // Necessary so compile is triggered.
+
+    let methods = script
+        .get_script_method_list()
+        .iter_shared()
+        .map(|dict| dict.get("name").unwrap())
+        .collect::<VariantArray>();
+
+    // Ensure script has been parsed + compiled correctly.
+    assert_eq!(script.get_instance_base_type(), "VirtualScriptCalls".into());
+    assert_eq!(
+        methods,
+        varray![
+            "greet_lang",
+            "greet_lang2",
+            "greet_lang3",
+            "set_thing",
+            "get_thing"
+        ]
+    );
+
+    script
+}

--- a/itest/rust/src/register_tests/mod.rs
+++ b/itest/rust/src/register_tests/mod.rs
@@ -12,4 +12,7 @@ mod gdscript_ffi_test;
 mod option_ffi_test;
 mod var_test;
 
+#[cfg(since_api = "4.3")]
+mod func_virtual_test;
+
 pub use gdscript_ffi_test::gen_ffi;


### PR DESCRIPTION
This adds support for https://github.com/godotengine/godot/pull/87758 in Rust.
Since that PR is not yet merged, CI will fail.

## Feature description

If you have a Rust method
```rs
#[godot_api]
impl MyClass {
    #[func(virtual)]
    fn greet(&self) -> GString {
        "Rust".into()
    }
}
```
, you can now attach a script to an instance of `MyClass` and override this method. This should work for all sorts of scripts, but most common is GDScript:
```gdscript
extends MyClass

func _greet() -> String:
    return "GDScript"
```

Calling `self.greet()` in Rust will now directly return either `"Rust"` (if no script is attached) or `"GDScript"` (if a script is attached).

`greet()` thus always implements late-binding, you cannot call it statically. If that is desired, a separate Rust method can be declared.





## API Design

I deliberately chose the most lightweight syntactical option, since it's very easy to understand and use. Also, turning an existing method into a virtual one requires just adding one keyword.

<details>
<summary>
A "more idiomatic" approach with traits and impls was also considered.
</summary>

<br>

```rs
// Existing impl block for non-virtual methods.
#[godot_api]
impl MyClass {
    ...
}

// Trait to define the new virtual API.
#[godot_api(virtuals)]
trait MyClassVirtuals {
    fn virtual(&self, i: i32) { ... }
}

// Impl block without a body, to signal that gdext implements it.
#[godot_api(virtuals=MyClassVirtuals)]
impl MyClassVirtuals for MyClass {}
```
However, this:
- comes with a ton of boilerplate for the user, at no added value
- makes switching between virtual/non-virtual a significant refactoring exercise
- requires two extra items to handle in the proc-macro API
- needs explicit specification of relations (the `virtuals=` part), i.e. also error potential

The primary goal of gdext is to be ergonomic and useful in practice, and the `trait/impl` approach is pretty much the antithesis thereof. But I believe `#[func(virtual)]`'s late-binding semantics are simple enough for users to understand.
</details>


## Future work

A few things are not done:

1. **Re-entrancy:** we can see if this can be integrated with `base/base_mut` somehow, to allow the script to call back to the same object. 
   - For now, `#[func(gd_self)]` can be used to achieve this.
   
1. **Required implementation:** at the moment, the user must provide a default implementation. Sometimes, you'd want to force the script to override a method though.
   - Godot does not natively support that; GDScript parsing/compilation will always succeed.
   - For now, the Rust method can panic in such cases.
   - We could enable _abstract_ / _pure virtual_ methods in the future that auto-panic. 
   - Maybe it's even possible to check after `_ready()` that a script is attached and the corresponding function is overridden. This would move the error from the time of call to the time of scene-entering.
   
1. **Calling `super` methods.**
   - The script method cannot call the base method; I think this is not supported by GDExtension.
   - Something like this could maybe be emulated if there is demand, but we would need to use a different method. So it's questionable if that's even worth its own feature, as those semantics are trivial to achieve with a separate `#[func]`.

1. **Dynamic dispatch from script side.**
   - Rust calls to `greet` in the above example can either call the script implementation or the Rust fallback.
   - This is not possible when calling from GDScript: `obj._greet()` will either call the script implementation, or fail if there is no script.
   - This also seems to be a limitation in Godot. It can be worked around by having another `#[func]` -- just like for the `super` case. Concretely, this other `#[func]` would forward the call to Rust-side `greet` (thus dispatch dynamically), and would be accessible from GDScript.
   - Maybe we can establish conventions around those use cases and add library support to simplify them.


1. **Diagnostics**
   - Godot already provides quite a good error on signature mismatch:
     ```
       SCRIPT ERROR: Parse Error: The function signature doesn't match the parent.
       Parent signature is "method_name(String) -> String".
     ```

   - Depending on user feedback, we can see if there are additional error messages/diagnostics we can provide.