### PR TITLE
doc: Adjusted `#[signal]` doc with example using parameter.

### DIFF
--- a/godot-macros/src/lib.rs
+++ b/godot-macros/src/lib.rs
@@ -323,7 +323,7 @@ use crate::util::ident;
 ///
 /// # Signals
 ///
-/// The `#[signal]` attribute is quite limited at the moment and can only be used for parameter-less signals.
+/// The `#[signal]` attribute is quite limited at the moment. The functions it decorates (the signals) can accept parameters.
 /// It will be fundamentally reworked.
 ///
 /// ```no_run
@@ -336,6 +336,9 @@ use crate::util::ident;
 /// impl MyClass {
 ///     #[signal]
 ///     fn some_signal();
+///
+///     #[signal]
+///     fn some_signal_with_parameters(my_parameter: Gd<Node>);
 /// }
 /// ```
 ///


### PR DESCRIPTION
`#[signal]` will be reworked in the near future, but in the meantime the API docs should show that it is possible to use `signal` with parameters as seen in [PR#279](https://github.com/godot-rust/gdext/pull/279).