### PR TITLE
Remove 3 methods from `GDExtension` class, following upstream

### DIFF
--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -265,14 +265,17 @@ jobs:
 
           # Don't use latest Ubuntu (22.04) as it breaks lots of ecosystem compatibility.
           # If ever moving to ubuntu-latest, need to manually install libtinfo5 for LLVM.
-          - name: linux
+
+          # Uses full+experimental codegen, so that compatibility breakage towards nightly is detected.
+          # If the experimental part causes problems, consider using only godot/codegen-full.
+          - name: linux-full
             os: ubuntu-20.04
-            artifact-name: linux-nightly
+            artifact-name: linux-full-nightly
             godot-binary: godot.linuxbsd.editor.dev.x86_64
-            rust-extra-args: --features godot/custom-godot
+            rust-extra-args: --features codegen-full-experimental
 
           # Combines now a lot of features, but should be OK. lazy-function-tables doesn't work with experimental-threads.
-          - name: linux-double-full-lazy
+          - name: linux-double-lazy
             os: ubuntu-20.04
             artifact-name: linux-double-nightly
             godot-binary: godot.linuxbsd.editor.dev.double.x86_64

--- a/.github/workflows/minimal-ci.yml
+++ b/.github/workflows/minimal-ci.yml
@@ -145,11 +145,11 @@ jobs:
 
           # Linux
 
-          - name: linux
+          - name: linux-full
             os: ubuntu-20.04
             artifact-name: linux-nightly
             godot-binary: godot.linuxbsd.editor.dev.x86_64
-            rust-extra-args: --features godot/custom-godot
+            rust-extra-args: --features codegen-full-experimental
 
           - name: linux-features
             os: ubuntu-20.04

--- a/godot-codegen/src/special_cases/special_cases.rs
+++ b/godot-codegen/src/special_cases/special_cases.rs
@@ -41,6 +41,11 @@ pub fn is_class_method_deleted(class_name: &TyName, method: &JsonClassMethod, ct
         //| ("Object", "to_string")
         | ("Object", "get_instance_id")
 
+        // Removed in https://github.com/godotengine/godot/pull/88418, but they cannot reasonably be used before, either.
+        | ("GDExtension", "open_library")
+        | ("GDExtension", "initialize_library")
+        | ("GDExtension", "close_library")
+
         // Thread APIs
         | ("ResourceLoader", "load_threaded_get")
         | ("ResourceLoader", "load_threaded_get_status")


### PR DESCRIPTION
The following methods could not be properly used; the GDExtension team thus decided to unbind them from the API despite a breaking change:

* `GDExtension::open_library`
* `GDExtension::initialize_library`
* `GDExtension::close_library`

We follow suit by removing them from our API as well, thus preventing loading errors in the method tables.
This PR also changes both minimal and full CI to use full codegen, to make these issues more obvious.

Related Godot PR: https://github.com/godotengine/godot/pull/88418