### PR TITLE
Fix `ci-status` job not considering cancellations + 2 other issues

### DIFF
--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -270,7 +270,7 @@ jobs:
           # If the experimental part causes problems, consider using only godot/codegen-full.
           - name: linux-full
             os: ubuntu-20.04
-            artifact-name: linux-full-nightly
+            artifact-name: linux-nightly
             godot-binary: godot.linuxbsd.editor.dev.x86_64
             rust-extra-args: --features codegen-full-experimental
 
@@ -447,6 +447,8 @@ jobs:
       - doc-lints
       - clippy
       - unit-test
+      - miri-test
+      - proptest
       - godot-itest
       - run-examples
       - cargo-deny-machete

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -456,10 +456,23 @@ jobs:
 
     runs-on: ubuntu-20.04
     steps:
-      - name: "Success"
-        if: ${{ !(contains(needs.*.result, 'failure')) }}
-        run: exit 0
-
-      - name: "Failure"
-        if: ${{ contains(needs.*.result, 'failure') }}
-        run: exit 1
+      # Deliberate choice to use bash script and not GitHub Action glob syntax, as that is not well-documented and hard to get right.
+      # For example: contains(needs.*.result, 'success') does NOT work because * is a logical OR, thus true if a single job succeeds.
+      - name: "Determine success or failure"
+        run: |
+          DEPENDENCIES='${{ toJson(needs) }}'
+          
+          echo "Dependency jobs:"
+          all_success=true
+          for job in $(echo "$DEPENDENCIES" | jq -r 'keys[]'); do
+              status=$(echo "$DEPENDENCIES" | jq -r ".[\"$job\"].result")
+              echo "* $job -> $status"
+              if [[ "$status" != "success" ]]; then
+                  all_success=false
+              fi
+          done
+          
+          if [[ "$all_success" == "false" ]]; then
+              echo "One or more dependency jobs failed or were cancelled."
+              exit 1
+          fi

--- a/.github/workflows/minimal-ci.yml
+++ b/.github/workflows/minimal-ci.yml
@@ -267,10 +267,21 @@ jobs:
 
     runs-on: ubuntu-20.04
     steps:
-      - name: "Success"
-        if: ${{ !(contains(needs.*.result, 'failure')) }}
-        run: exit 0
-
-      - name: "Failure"
-        if: ${{ contains(needs.*.result, 'failure') }}
-        run: exit 1
+      - name: "Determine success or failure"
+        run: |
+          DEPENDENCIES='${{ toJson(needs) }}'
+          
+          echo "Dependency jobs:"
+          all_success=true
+          for job in $(echo "$DEPENDENCIES" | jq -r 'keys[]'); do
+              status=$(echo "$DEPENDENCIES" | jq -r ".[\"$job\"].result")
+              echo "* $job -> $status"
+              if [[ "$status" != "success" ]]; then
+                  all_success=false
+              fi
+          done
+          
+          if [[ "$all_success" == "false" ]]; then
+              echo "One or more dependency jobs failed or were cancelled."
+              exit 1
+          fi


### PR DESCRIPTION
3 issues in total:
- wrong artifact name in `linux-full` job
- 2 jobs `miri-test` and `proptest` were not set as dependencies, i.e. their outcome was irrelevant
- final job `ci-status` did not catch cancellations