### PR TITLE
Remove most `#[deprecated]` symbols

### DIFF
--- a/godot-codegen/src/generator/classes.rs
+++ b/godot-codegen/src/generator/classes.rs
@@ -319,19 +319,10 @@ fn make_constructor_and_default(class: &Class, ctx: &Context) -> (TokenStream, T
         // Abstract base classes or non-singleton classes without constructor
         constructor = TokenStream::new();
         has_godot_default_impl = false;
-    } else if class.is_refcounted {
-        // RefCounted, Resource, etc
-        constructor = quote! {
-            #[deprecated = "Replaced with `new_gd` in extension trait `NewGd`."]
-            pub fn new() -> Gd<Self> {
-                // <Self as crate::obj::NewGd>::new_gd()
-                crate::obj::Gd::default()
-            }
-        };
-        has_godot_default_impl = true;
     } else {
-        // Manually managed classes: Object, Node etc
-        constructor = quote! {};
+        // Manually managed classes (Object, Node, ...) as well as ref-counted ones (RefCounted, Resource, ...).
+        // The constructors are provided as associated methods in NewGd::new_gd() and NewAlloc::new_alloc().
+        constructor = TokenStream::new();
         has_godot_default_impl = true;
     }
 

--- a/godot-core/src/engine/io/resources.rs
+++ b/godot-core/src/engine/io/resources.rs
@@ -84,7 +84,7 @@ where
 /// use godot::prelude::*;
 /// use godot::engine::save;
 ///
-/// save(Resource::new(), "res://base_resource.tres")
+/// save(Resource::new_gd(), "res://base_resource.tres")
 /// ```
 /// use godot::
 #[inline]

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -143,27 +143,6 @@ where
         Self::from_init_fn(move |_base| user_object)
     }
 
-    #[deprecated = "Use `Gd::from_object()` instead."]
-    pub fn new(user_object: T) -> Self {
-        Self::from_object(user_object)
-    }
-
-    #[deprecated = "Use `Gd::default()` or the short-hands `T::new_gd()` and `T::new_alloc()` instead."]
-    pub fn new_default() -> Self
-    where
-        T: cap::GodotDefault,
-    {
-        Self::default_instance()
-    }
-
-    #[deprecated = "Use `Gd::from_init_fn()` instead."]
-    pub fn with_base<F>(init: F) -> Self
-    where
-        F: FnOnce(crate::obj::Base<T::Base>) -> T,
-    {
-        Self::from_init_fn(init)
-    }
-
     /// Hands out a guard for a shared borrow, through which the user instance can be read.
     ///
     /// The pattern is very similar to interior mutability with standard [`RefCell`][std::cell::RefCell].
@@ -755,10 +734,10 @@ impl<T: GodotClass> std::panic::RefUnwindSafe for Gd<T> {}
 /// ## Example
 ///
 /// ```no_run
-/// use godot::engine::RefCounted;
+/// use godot::prelude::*;
 /// use godot::obj::NotUniqueError;
 ///
-/// let shared = RefCounted::new();
+/// let shared = RefCounted::new_gd();
 /// let cloned = shared.clone();
 /// let result = NotUniqueError::check(shared);
 ///
@@ -782,13 +761,13 @@ impl NotUniqueError {
     /// ## Example
     ///
     /// ```no_run
-    /// use godot::engine::RefCounted;
+    /// use godot::prelude::*;
     /// use godot::obj::NotUniqueError;
     ///
-    /// let unique = RefCounted::new();
+    /// let unique = RefCounted::new_gd();
     /// assert!(NotUniqueError::check(unique).is_ok());
     ///
-    /// let shared = RefCounted::new();
+    /// let shared = RefCounted::new_gd();
     /// let cloned = shared.clone();
     /// assert!(NotUniqueError::check(shared).is_err());
     /// assert!(NotUniqueError::check(cloned).is_err());

--- a/godot-core/src/obj/traits.rs
+++ b/godot-core/src/obj/traits.rs
@@ -126,20 +126,7 @@ impl<T: GodotClass> Inherits<T> for T {}
 pub trait ExportableObject: GodotClass {}
 
 /// Implemented for all user-defined classes, providing extensions on the raw object to interact with `Gd`.
-// #[deprecated = "Use `NewGd` and `NewAlloc` traits instead."]
 pub trait UserClass: Bounds<Declarer = bounds::DeclUser> {
-    /// Return a new Gd which contains a default-constructed instance.
-    ///
-    /// `MyClass::new_gd()` is equivalent to `Gd::<MyClass>::default()`.
-    #[deprecated = "Use `NewAlloc::new_alloc()` instead."]
-    #[must_use]
-    fn alloc_gd() -> Gd<Self>
-    where
-        Self: cap::GodotDefault + Bounds<Memory = bounds::MemManual>,
-    {
-        Gd::default_instance()
-    }
-
     #[doc(hidden)]
     fn __config() -> crate::private::ClassConfig;
 

--- a/godot-macros/src/class/data_models/field_export.rs
+++ b/godot-macros/src/class/data_models/field_export.rs
@@ -15,20 +15,20 @@ use crate::ParseResult;
 
 /// Store info from `#[export]` attribute.
 pub enum FieldExport {
-    /// ### GDScript Annotations
+    /// ### GDScript annotations
     /// - `@export`
     ///
-    /// ### Property Hints
-    /// - `PROPERTY_HINT_NONE` (usually)
+    /// ### Property hints
+    /// - `NONE` (usually)
     ///
     /// Can become other property hints, depends on context.
     Default,
 
-    /// ### GDScript Annotations
+    /// ### GDScript annotations
     /// - `@export_range`
     ///
-    /// ### Property Hints
-    /// - `PROPERTY_HINT_RANGE`
+    /// ### Property hints
+    /// - `RANGE`
     Range {
         min: TokenStream,
         max: TokenStream,
@@ -41,31 +41,31 @@ pub enum FieldExport {
         hide_slider: bool,
     },
 
-    /// ### GDScript Annotations
+    /// ### GDScript annotations
     /// - `@export_enum`
     ///
-    /// ### Property Hints
-    /// - `PROPERTY_HINT_ENUM`
+    /// ### Property hints
+    /// - `ENUM`
     Enum { variants: Vec<ValueWithKey> },
 
-    /// ### GDScript Annotations
+    /// ### GDScript annotations
     /// - `@export_exp_easing`
     ///
-    /// ### Property Hints
-    /// - `PROPERTY_HINT_EXP_EASING`
+    /// ### Property hints
+    /// - `EXP_EASING`
     ExpEasing {
         attenuation: bool,
         positive_only: bool,
     },
 
-    /// ### GDScript Annotations
+    /// ### GDScript annotations
     /// - `@export_flags`
     ///
-    /// ### Property Hints
-    /// - `PROPERTY_HINT_FLAGS`
+    /// ### Property hints
+    /// - `FLAGS`
     Flags { bits: Vec<ValueWithKey> },
 
-    /// ### GDScript Annotations
+    /// ### GDScript annotations
     /// - `@export_flags_2d_physics`
     /// - `@export_flags_2d_render`
     /// - `@export_flags_2d_navigation`
@@ -73,50 +73,50 @@ pub enum FieldExport {
     /// - `@export_flags_3d_render`
     /// - `@export_flags_3d_navigation`
     ///
-    /// ### Property Hints
-    /// - `PROPERTY_HINT_LAYERS_2D_PHYSICS`
-    /// - `PROPERTY_HINT_LAYERS_2D_RENDER`
-    /// - `PROPERTY_HINT_LAYERS_2D_NAVIGATION`
-    /// - `PROPERTY_HINT_LAYERS_3D_PHYSICS`
-    /// - `PROPERTY_HINT_LAYERS_3D_RENDER`
-    /// - `PROPERTY_HINT_LAYERS_3D_NAVIGATION`
+    /// ### Property hints
+    /// - `LAYERS_2D_PHYSICS`
+    /// - `LAYERS_2D_RENDER`
+    /// - `LAYERS_2D_NAVIGATION`
+    /// - `LAYERS_3D_PHYSICS`
+    /// - `LAYERS_3D_RENDER`
+    /// - `LAYERS_3D_NAVIGATION`
     Layers {
         dimension: LayerDimension,
         kind: LayerKind,
     },
 
-    /// ### GDScript Annotations
+    /// ### GDScript annotations
     /// - `@export_file`
     /// - `@export_global_file`
     /// - `@export_dir`
     /// - `@export_global_dir`
     ///
-    /// ### Property Hints
-    /// - `PROPERTY_HINT_FILE`
-    /// - `PROPERTY_HINT_GLOBAL_FILE`
-    /// - `PROPERTY_HINT_DIR`
-    /// - `PROPERTY_HINT_GLOBAL_DIR`
+    /// ### Property hints
+    /// - `FILE`
+    /// - `GLOBAL_FILE`
+    /// - `DIR`
+    /// - `GLOBAL_DIR`
     File { global: bool, kind: FileKind },
 
-    /// ### GDScript Annotations
+    /// ### GDScript annotations
     /// - `@export_multiline`
     ///
-    /// ### Property Hints
-    /// - `PROPERTY_HINT_MULTILINE_TEXT`
+    /// ### Property hints
+    /// - `MULTILINE_TEXT`
     Multiline,
 
-    /// ### GDScript Annotations
+    /// ### GDScript annotations
     /// - `@export_placeholder`
     ///
-    /// ### Property Hints
-    /// - `PROPERTY_HINT_PLACEHOLDER_TEXT`
+    /// ### Property hints
+    /// - `PLACEHOLDER_TEXT`
     PlaceholderText { placeholder: TokenStream },
 
-    /// ### GDScript Annotations
+    /// ### GDScript annotations
     /// - `@export_color_no_alpha`
     ///
-    /// ### Property Hints
-    /// - `PROPERTY_HINT_COLOR_NO_ALPHA`
+    /// ### Property hints
+    /// - `COLOR_NO_ALPHA`
     ColorNoAlpha,
 }
 

--- a/godot/src/prelude.rs
+++ b/godot/src/prelude.rs
@@ -30,5 +30,4 @@ pub use super::obj::EngineBitfield as _;
 pub use super::obj::EngineEnum as _;
 pub use super::obj::NewAlloc as _;
 pub use super::obj::NewGd as _;
-pub use super::obj::UserClass as _; // TODO: remove (exposed functions are deprecated)
 pub use super::obj::WithBaseField as _; // base(), base_mut(), to_gd()

--- a/itest/rust/src/object_tests/property_test.rs
+++ b/itest/rust/src/object_tests/property_test.rs
@@ -46,7 +46,7 @@ struct HasProperty {
     #[var]
     texture_val: Gd<Texture>,
 
-    #[var(get = get_texture_val, set = set_texture_val, hint = PROPERTY_HINT_RESOURCE_TYPE, hint_string = "Texture")]
+    #[var(get = get_texture_val, set = set_texture_val, hint = RESOURCE_TYPE, hint_string = "Texture")]
     texture_val_rw: Option<Gd<Texture>>,
 }
 


### PR DESCRIPTION
Cleans up the API by removing most of the symbols that have been deprecated for several months.

`#[base]` is still retained as it was removed [only 1 month ago](https://github.com/godot-rust/gdext/pull/577) and impacts every single user. We can schedule removal later.