### PR TITLE
For v4.3+, switch `#[class(tool)]` to use Godot's native "runtime class" feature

### DIFF
--- a/godot-ffi/src/binding/multi_threaded.rs
+++ b/godot-ffi/src/binding/multi_threaded.rs
@@ -73,7 +73,10 @@ impl BindingStorage {
 }
 
 pub struct GdextConfig {
+    /// True if only `#[class(tool)]` classes are active in editor; false if all classes are.
     pub tool_only_in_editor: bool,
+
+    /// Whether the extension is loaded in an editor.
     is_editor: OnceLock<bool>,
 }
 

--- a/godot-macros/src/class/derive_godot_class.rs
+++ b/godot-macros/src/class/derive_godot_class.rs
@@ -104,6 +104,8 @@ pub fn derive_godot_class(decl: Declaration) -> ParseResult<TokenStream> {
         quote! { None }
     };
 
+    let is_tool = struct_cfg.is_tool;
+
     Ok(quote! {
         impl ::godot::obj::GodotClass for #class_name {
             type Base = #base_class;
@@ -136,6 +138,7 @@ pub fn derive_godot_class(decl: Declaration) -> ParseResult<TokenStream> {
                 },
                 free_fn: #prv::callbacks::free::<#class_name>,
                 default_get_virtual_fn: #default_get_virtual_fn,
+                is_tool: #is_tool,
                 is_editor_plugin: #is_editor_plugin,
                 is_hidden: #is_hidden,
                 is_instantiable: #is_instantiable,

--- a/godot-macros/src/class/godot_api.rs
+++ b/godot-macros/src/class/godot_api.rs
@@ -729,6 +729,8 @@ fn transform_trait_impl(original_impl: venial::Impl) -> ParseResult<TokenStream>
                     impl ::godot::obj::cap::GodotNotification for #class_name {
                         fn __godot_notification(&mut self, what: i32) {
                             use ::godot::obj::UserClass as _;
+
+                            #[cfg(before_api = "4.3")]
                             if ::godot::private::is_class_inactive(Self::__config().is_tool) {
                                 return;
                             }
@@ -751,6 +753,8 @@ fn transform_trait_impl(original_impl: venial::Impl) -> ParseResult<TokenStream>
                     impl ::godot::obj::cap::GodotGet for #class_name {
                         fn __godot_get_property(&self, property: ::godot::builtin::StringName) -> Option<::godot::builtin::Variant> {
                             use ::godot::obj::UserClass as _;
+
+                            #[cfg(before_api = "4.3")]
                             if ::godot::private::is_class_inactive(Self::__config().is_tool) {
                                 return None;
                             }
@@ -772,6 +776,8 @@ fn transform_trait_impl(original_impl: venial::Impl) -> ParseResult<TokenStream>
                     impl ::godot::obj::cap::GodotSet for #class_name {
                         fn __godot_set_property(&mut self, property: ::godot::builtin::StringName, value: ::godot::builtin::Variant) -> bool {
                             use ::godot::obj::UserClass as _;
+
+                            #[cfg(before_api = "4.3")]
                             if ::godot::private::is_class_inactive(Self::__config().is_tool) {
                                 return false;
                             }

--- a/godot-macros/src/util/mod.rs
+++ b/godot-macros/src/util/mod.rs
@@ -261,10 +261,16 @@ pub(crate) fn extract_cfg_attrs(
     })
 }
 
+#[cfg(before_api = "4.3")]
 pub fn make_virtual_tool_check() -> TokenStream {
     quote! {
         if ::godot::private::is_class_inactive(Self::__config().is_tool) {
             return None;
         }
     }
+}
+
+#[cfg(since_api = "4.3")]
+pub fn make_virtual_tool_check() -> TokenStream {
+    TokenStream::new()
 }


### PR DESCRIPTION
For Godot 4.0, 4.1 and 4.2, gdext emulates a mode where classes' lifecycle methods are not executed in the editor, unless `#[class(tool)]` is specified or the global `editor_run_behavior()` is configured.

Starting from Godot 4.3, GDExtension provides this feature natively, dubbed "runtime classes" (formerly "gameplay classes").
This has been implemented in https://github.com/godotengine/godot/pull/82554 and merged a few hours ago. 

This PR thus conditionally switches to the native implementation, when API 4.3 is targeted.

I briefly tested the functionality with dodge-the-creeps, but it might be that there are still some bugs, as it's hard to write automated tests for this. Let us know in case things don't work as expected.