### PR TITLE
Provide a default for `Rid`

### DIFF
--- a/godot-core/src/builtin/rid.rs
+++ b/godot-core/src/builtin/rid.rs
@@ -116,6 +116,13 @@ impl std::fmt::Display for Rid {
     }
 }
 
+impl Default for Rid {
+    /// Produces an invalid Rid
+    fn default() -> Self {
+        Self::Invalid
+    }
+}
+
 // SAFETY:
 // This type is represented as `Self` in Godot, so `*mut Self` is sound.
 unsafe impl GodotFfi for Rid {


### PR DESCRIPTION
A default value for `Rid` makes it possible to use it as a member of `GodotClass`-derived struct, which can be useful for custom Resources.

The default value of `Invalid` is both logical--it shouldn't point to any resource a user doesn't specify--and it's what's done in-engine (godot@46dc27/core/templates/rid.h:40 - `uint64_t _id = 0;`).