### PR TITLE
Experimental refactoring of `GodotFfi`

### DIFF
--- a/godot-codegen/src/generator/builtins.rs
+++ b/godot-codegen/src/generator/builtins.rs
@@ -117,7 +117,7 @@ fn make_builtin_class(class: &BuiltinClass, ctx: &mut Context) -> GeneratedBuilt
             pub fn from_outer(outer: &#outer_class) -> Self {
                 Self {
                     _outer_lifetime: std::marker::PhantomData,
-                    sys_ptr: outer.sys(),
+                    sys_ptr: sys::SysPtr::force_mut(outer.sys()),
                 }
             }
             #special_constructors
@@ -154,7 +154,7 @@ fn make_special_builtin_methods(class_name: &TyName, _ctx: &Context) -> TokenStr
             {
                 Self {
                     _outer_lifetime: std::marker::PhantomData,
-                    sys_ptr: outer.sys(),
+                    sys_ptr: sys::SysPtr::force_mut(outer.sys()),
                 }
             }
         }

--- a/godot-core/src/builtin/array.rs
+++ b/godot-core/src/builtin/array.rs
@@ -937,7 +937,7 @@ impl<T: GodotType> GodotFfiVariant for Array<T> {
         }
 
         let array = unsafe {
-            sys::from_sys_init_or_init_default::<Self>(|self_ptr| {
+            sys::new_with_uninit_or_init::<Self>(|self_ptr| {
                 let array_from_variant = sys::builtin_fn!(array_from_variant);
                 array_from_variant(self_ptr, sys::SysPtr::force_mut(variant.var_sys()));
             })

--- a/godot-core/src/builtin/array.rs
+++ b/godot-core/src/builtin/array.rs
@@ -225,7 +225,7 @@ impl<T: GodotType> Array<T> {
     /// # Panics
     ///
     /// If `index` is out of bounds.
-    fn ptr(&self, index: usize) -> *const Variant {
+    fn ptr(&self, index: usize) -> sys::GDExtensionConstVariantPtr {
         let ptr = self.ptr_or_null(index);
         assert!(
             !ptr.is_null(),
@@ -236,7 +236,7 @@ impl<T: GodotType> Array<T> {
     }
 
     /// Returns a pointer to the element at the given index, or null if out of bounds.
-    fn ptr_or_null(&self, index: usize) -> *const Variant {
+    fn ptr_or_null(&self, index: usize) -> sys::GDExtensionConstVariantPtr {
         // SAFETY: array_operator_index_const returns null for invalid indexes.
         let variant_ptr = unsafe {
             let index = to_i64(index);
@@ -244,8 +244,7 @@ impl<T: GodotType> Array<T> {
         };
 
         // Signature is wrong in GDExtension, semantically this is a const ptr
-        let variant_ptr = sys::to_const_ptr(variant_ptr);
-        Variant::ptr_from_sys(variant_ptr)
+        sys::SysPtr::as_const(variant_ptr)
     }
 
     /// Returns a mutable pointer to the element at the given index.
@@ -253,7 +252,7 @@ impl<T: GodotType> Array<T> {
     /// # Panics
     ///
     /// If `index` is out of bounds.
-    fn ptr_mut(&mut self, index: usize) -> *mut Variant {
+    fn ptr_mut(&mut self, index: usize) -> sys::GDExtensionVariantPtr {
         let ptr = self.ptr_mut_or_null(index);
         assert!(
             !ptr.is_null(),
@@ -264,14 +263,14 @@ impl<T: GodotType> Array<T> {
     }
 
     /// Returns a pointer to the element at the given index, or null if out of bounds.
-    fn ptr_mut_or_null(&mut self, index: usize) -> *mut Variant {
+    fn ptr_mut_or_null(&mut self, index: usize) -> sys::GDExtensionVariantPtr {
         // SAFETY: array_operator_index returns null for invalid indexes.
         let variant_ptr = unsafe {
             let index = to_i64(index);
             interface_fn!(array_operator_index)(self.sys_mut(), index)
         };
 
-        Variant::ptr_from_sys_mut(variant_ptr)
+        variant_ptr
     }
 
     /// # Safety
@@ -490,8 +489,8 @@ impl<T: GodotType + FromGodot> Array<T> {
         // Panics on out-of-bounds
         let ptr = self.ptr(index);
 
-        // SAFETY: `ptr()` just verified that the index is not out of bounds.
-        let variant = unsafe { &*ptr };
+        // SAFETY: `ptr` is a live pointer to a variant since `ptr.is_null()` just verified that the index is not out of bounds.
+        let variant = unsafe { Variant::borrow_var_sys(ptr) };
         T::from_variant(variant)
     }
 
@@ -501,8 +500,8 @@ impl<T: GodotType + FromGodot> Array<T> {
         if ptr.is_null() {
             None
         } else {
-            // SAFETY: `ptr.is_null()` just verified that the index is not out of bounds.
-            let variant = unsafe { &*ptr };
+            // SAFETY: `ptr` is a live pointer to a variant since `ptr.is_null()` just verified that the index is not out of bounds.
+            let variant = unsafe { Variant::borrow_var_sys(ptr) };
             Some(T::from_variant(variant))
         }
     }
@@ -663,7 +662,9 @@ impl<T: GodotType + ToGodot> Array<T> {
 
         // SAFETY: `ptr_mut` just checked that the index is not out of bounds.
         unsafe {
-            *ptr_mut = value.to_variant();
+            value
+                .to_variant()
+                .move_return_var_ptr(ptr_mut, sys::PtrcallType::Standard);
         }
     }
 
@@ -970,14 +971,14 @@ impl<T: GodotType + ToGodot> From<&[T]> for Array<T> {
         // the nulls with values of type `T`.
         unsafe { array.as_inner_mut() }.resize(to_i64(len));
 
-        let ptr = array.ptr_mut_or_null(0);
-        for (i, element) in slice.iter().enumerate() {
-            // SAFETY: The array contains exactly `len` elements, stored contiguously in memory.
-            // Also, the pointer is non-null, as we checked for emptiness above.
-            unsafe {
-                *ptr.offset(to_isize(i)) = element.to_variant();
-            }
+        // SAFETY: `array` has `len` elements since we just resized it, and they are all valid `Variant`s. Additionally, since
+        // the array was created in this function, and we do not access the array while this slice exists, the slice has unique
+        // access to the elements.
+        let elements = unsafe { Variant::borrow_var_slice_mut(array.ptr_mut(0), len) };
+        for (element, array_slot) in slice.iter().zip(elements.iter_mut()) {
+            *array_slot = element.to_variant();
         }
+
         array
     }
 }
@@ -1010,14 +1011,13 @@ impl<T: GodotType + FromGodot> From<&Array<T>> for Vec<T> {
     fn from(array: &Array<T>) -> Vec<T> {
         let len = array.len();
         let mut vec = Vec::with_capacity(len);
-        let ptr = array.ptr(0);
-        for offset in 0..to_isize(len) {
-            // SAFETY: Arrays are stored contiguously in memory, so we can use pointer arithmetic
-            // instead of going through `array_operator_index_const` for every index.
-            let variant = unsafe { &*ptr.offset(offset) };
-            let element = T::from_variant(variant);
-            vec.push(element);
-        }
+
+        // SAFETY: Unless `experimental-threads` is enabled, then we cannot have concurrent access to this array.
+        // And since we dont concurrently access the array in this function, we can create a slice to its contents.
+        let elements = unsafe { Variant::borrow_var_slice(array.ptr(0), len) };
+
+        vec.extend(elements.iter().map(T::from_variant));
+
         vec
     }
 }
@@ -1040,7 +1040,8 @@ impl<'a, T: GodotType + FromGodot> Iterator for Iter<'a, T> {
             let element_ptr = self.array.ptr_or_null(idx);
 
             // SAFETY: We just checked that the index is not out of bounds, so the pointer won't be null.
-            let variant = unsafe { &*element_ptr };
+            // We immediately convert this to the right element, so barring `experimental-threads` the pointer wont be invalidated in time.
+            let variant = unsafe { Variant::borrow_var_sys(element_ptr) };
             let element = T::from_variant(variant);
             Some(element)
         } else {

--- a/godot-core/src/builtin/array.rs
+++ b/godot-core/src/builtin/array.rs
@@ -969,7 +969,7 @@ impl<T: GodotType + ToGodot> From<&[T]> for Array<T> {
         // SAFETY: `array` has `len` elements since we just resized it, and they are all valid `Variant`s. Additionally, since
         // the array was created in this function, and we do not access the array while this slice exists, the slice has unique
         // access to the elements.
-        let elements = unsafe { Variant::borrow_var_slice_mut(array.ptr_mut(0), len) };
+        let elements = unsafe { Variant::borrow_slice_mut(array.ptr_mut(0), len) };
         for (element, array_slot) in slice.iter().zip(elements.iter_mut()) {
             *array_slot = element.to_variant();
         }
@@ -1009,7 +1009,7 @@ impl<T: GodotType + FromGodot> From<&Array<T>> for Vec<T> {
 
         // SAFETY: Unless `experimental-threads` is enabled, then we cannot have concurrent access to this array.
         // And since we dont concurrently access the array in this function, we can create a slice to its contents.
-        let elements = unsafe { Variant::borrow_var_slice(array.ptr(0), len) };
+        let elements = unsafe { Variant::borrow_slice(array.ptr(0), len) };
 
         vec.extend(elements.iter().map(T::from_variant));
 

--- a/godot-core/src/builtin/array.rs
+++ b/godot-core/src/builtin/array.rs
@@ -659,9 +659,7 @@ impl<T: GodotType + ToGodot> Array<T> {
 
         // SAFETY: `ptr_mut` just checked that the index is not out of bounds.
         unsafe {
-            value
-                .to_variant()
-                .move_return_var_ptr(ptr_mut, sys::PtrcallType::Standard);
+            value.to_variant().move_into_var_ptr(ptr_mut);
         }
     }
 

--- a/godot-core/src/builtin/array.rs
+++ b/godot-core/src/builtin/array.rs
@@ -54,7 +54,6 @@ use super::meta::{
 // for `T: GodotType` because `drop()` requires `sys_mut()`, which is on the `GodotFfi`
 // trait, whose `from_sys_init()` requires `Default`, which is only implemented for `T:
 // GodotType`. Whew. This could be fixed by splitting up `GodotFfi` if desired.
-#[repr(C)]
 pub struct Array<T: GodotType> {
     // Safety Invariant: The type of all values in `opaque` matches the type `T`.
     opaque: sys::types::OpaqueArray,
@@ -265,12 +264,10 @@ impl<T: GodotType> Array<T> {
     /// Returns a pointer to the element at the given index, or null if out of bounds.
     fn ptr_mut_or_null(&mut self, index: usize) -> sys::GDExtensionVariantPtr {
         // SAFETY: array_operator_index returns null for invalid indexes.
-        let variant_ptr = unsafe {
+        unsafe {
             let index = to_i64(index);
             interface_fn!(array_operator_index)(self.sys_mut(), index)
-        };
-
-        variant_ptr
+        }
     }
 
     /// # Safety

--- a/godot-core/src/builtin/callable.rs
+++ b/godot-core/src/builtin/callable.rs
@@ -296,14 +296,14 @@ unsafe impl GodotFfi for Callable {
 
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Opaque;
         fn new_from_sys;
+        fn new_with_uninit;
+        fn from_arg_ptr;
         fn sys;
         fn sys_mut;
-        fn new_with_uninit;
         fn move_return_ptr;
-        fn from_arg_ptr;
     }
 
-    unsafe fn new_with_init(init_fn: impl FnOnce(&mut Self)) -> Self {
+    fn new_with_init(init_fn: impl FnOnce(&mut Self)) -> Self {
         let mut result = Self::invalid();
         init_fn(&mut result);
         result
@@ -386,8 +386,7 @@ mod custom_callable {
         r_return: sys::GDExtensionVariantPtr,
         r_error: *mut sys::GDExtensionCallError,
     ) {
-        let arg_refs: &[&Variant] =
-            Variant::borrow_var_ref_slice(p_args, p_argument_count as usize);
+        let arg_refs: &[&Variant] = Variant::borrow_ref_slice(p_args, p_argument_count as usize);
 
         let c: &mut C = CallableUserdata::inner_from_raw(callable_userdata);
 
@@ -404,8 +403,7 @@ mod custom_callable {
     ) where
         F: FnMut(&[&Variant]) -> Result<Variant, ()>,
     {
-        let arg_refs: &[&Variant] =
-            Variant::borrow_var_ref_slice(p_args, p_argument_count as usize);
+        let arg_refs: &[&Variant] = Variant::borrow_ref_slice(p_args, p_argument_count as usize);
 
         let w: &mut FnWrapper<F> = CallableUserdata::inner_from_raw(callable_userdata);
 

--- a/godot-core/src/builtin/callable.rs
+++ b/godot-core/src/builtin/callable.rs
@@ -270,10 +270,6 @@ impl Callable {
     pub fn as_inner(&self) -> inner::InnerCallable {
         inner::InnerCallable::from_outer(self)
     }
-
-    fn inc_ref(&self) {
-        std::mem::forget(self.clone())
-    }
 }
 
 impl_builtin_traits! {

--- a/godot-core/src/builtin/callable.rs
+++ b/godot-core/src/builtin/callable.rs
@@ -445,7 +445,7 @@ mod custom_callable {
         let c: &T = CallableUserdata::inner_from_raw(callable_userdata);
         let s = crate::builtin::GString::from(c.to_string());
 
-        s.move_return_string_ptr(r_out, sys::PtrcallType::Standard);
+        s.move_into_string_ptr(r_out);
         *r_is_valid = true as sys::GDExtensionBool;
     }
 
@@ -456,9 +456,7 @@ mod custom_callable {
     ) {
         let w: &mut FnWrapper<F> = CallableUserdata::inner_from_raw(callable_userdata);
 
-        w.name
-            .clone()
-            .move_return_string_ptr(r_out, sys::PtrcallType::Standard);
+        w.name.clone().move_into_string_ptr(r_out);
         *r_is_valid = true as sys::GDExtensionBool;
     }
 }

--- a/godot-core/src/builtin/callable.rs
+++ b/godot-core/src/builtin/callable.rs
@@ -25,7 +25,6 @@ use sys::{ffi_methods, GodotFfi};
 /// Currently it is impossible to use `bind` and `unbind` in GDExtension, see [godot-cpp#802].
 ///
 /// [godot-cpp#802]: https://github.com/godotengine/godot-cpp/issues/802
-#[repr(C, align(8))]
 pub struct Callable {
     opaque: sys::types::OpaqueCallable,
 }

--- a/godot-core/src/builtin/dictionary.rs
+++ b/godot-core/src/builtin/dictionary.rs
@@ -25,7 +25,6 @@ use super::meta::impl_godot_as_self;
 /// # Thread safety
 ///
 /// The same principles apply as for [`VariantArray`]. Consult its documentation for details.
-#[repr(C)]
 pub struct Dictionary {
     opaque: OpaqueDictionary,
 }
@@ -245,12 +244,9 @@ impl Dictionary {
     fn get_ptr_mut<K: ToGodot>(&mut self, key: K) -> sys::GDExtensionVariantPtr {
         let key = key.to_variant();
 
-        // SAFETY: accessing an unknown key _mutably_ creates that entry in the dictionary, with value `NIL`.
-        let ptr =
-            unsafe { interface_fn!(dictionary_operator_index)(self.sys_mut(), key.var_sys()) };
-
         // Never a null pointer, since entry either existed already or was inserted above.
-        ptr
+        // SAFETY: accessing an unknown key _mutably_ creates that entry in the dictionary, with value `NIL`.
+        unsafe { interface_fn!(dictionary_operator_index)(self.sys_mut(), key.var_sys()) }
     }
 }
 

--- a/godot-core/src/builtin/dictionary.rs
+++ b/godot-core/src/builtin/dictionary.rs
@@ -205,9 +205,7 @@ impl Dictionary {
 
         // SAFETY: `self.get_ptr_mut(key)` always returns a valid pointer to a value in the dictionary; either pre-existing or newly inserted.
         unsafe {
-            value
-                .to_variant()
-                .move_return_var_ptr(self.get_ptr_mut(key), sys::PtrcallType::Standard);
+            value.to_variant().move_into_var_ptr(self.get_ptr_mut(key));
         }
     }
 

--- a/godot-core/src/builtin/macros.rs
+++ b/godot-core/src/builtin/macros.rs
@@ -13,7 +13,7 @@ macro_rules! impl_builtin_traits_inner {
             #[inline]
             fn default() -> Self {
                 unsafe {
-                    Self::from_sys_init(|self_ptr| {
+                    Self::new_with_uninit(|self_ptr| {
                         let ctor = ::godot_ffi::builtin_fn!($gd_method);
                         ctor(self_ptr, std::ptr::null_mut())
                     })
@@ -27,9 +27,9 @@ macro_rules! impl_builtin_traits_inner {
             #[inline]
             fn clone(&self) -> Self {
                 unsafe {
-                    Self::from_sys_init(|self_ptr| {
+                    Self::new_with_uninit(|self_ptr| {
                         let ctor = ::godot_ffi::builtin_fn!($gd_method);
-                        let args = [self.sys_const()];
+                        let args = [self.sys()];
                         ctor(self_ptr, args.as_ptr());
                     })
                 }
@@ -129,8 +129,8 @@ macro_rules! impl_builtin_froms {
             fn from(other: &$From) -> Self {
                 unsafe {
                     // TODO should this be from_sys_init_default()?
-                    Self::from_sys_init(|ptr| {
-                        let args = [other.sys_const()];
+                    Self::new_with_uninit(|ptr| {
+                        let args = [other.sys()];
                         ::godot_ffi::builtin_call! {
                             $from_fn(ptr, args.as_ptr())
                         }

--- a/godot-core/src/builtin/meta/class_name.rs
+++ b/godot-core/src/builtin/meta/class_name.rs
@@ -82,7 +82,7 @@ impl ClassName {
     /// The returned pointer is valid indefinitely, as entries are never deleted from the cache.
     /// Since we use `Box<StringName>`, `HashMap` reallocations don't affect the validity of the StringName.
     #[doc(hidden)]
-    pub fn string_sys(&self) -> sys::GDExtensionStringNamePtr {
+    pub fn string_sys(&self) -> sys::GDExtensionConstStringNamePtr {
         self.with_string_name(|s| s.string_sys())
     }
 

--- a/godot-core/src/builtin/meta/mod.rs
+++ b/godot-core/src/builtin/meta/mod.rs
@@ -265,10 +265,10 @@ impl PropertyInfo {
 
         sys::GDExtensionPropertyInfo {
             type_: self.variant_type.sys(),
-            name: self.property_name.string_sys(),
-            class_name: self.class_name.string_sys(),
+            name: sys::SysPtr::force_mut(self.property_name.string_sys()),
+            class_name: sys::SysPtr::force_mut(self.class_name.string_sys()),
             hint: u32::try_from(self.hint.ord()).expect("hint.ord()"),
-            hint_string: self.hint_string.string_sys(),
+            hint_string: sys::SysPtr::force_mut(self.hint_string.string_sys()),
             usage: u32::try_from(self.usage.ord()).expect("usage.ord()"),
         }
     }
@@ -328,7 +328,7 @@ impl MethodInfo {
         let default_argument_vec = self
             .default_arguments
             .iter()
-            .map(|arg| arg.var_sys())
+            .map(|arg| sys::SysPtr::force_mut(arg.var_sys()))
             .collect::<Vec<_>>()
             .into_boxed_slice();
 
@@ -337,7 +337,7 @@ impl MethodInfo {
 
         sys::GDExtensionMethodInfo {
             id: self.id,
-            name: self.method_name.string_sys(),
+            name: sys::SysPtr::force_mut(self.method_name.string_sys()),
             return_value: self.return_type.property_sys(),
             argument_count,
             arguments,

--- a/godot-core/src/builtin/meta/registration/method.rs
+++ b/godot-core/src/builtin/meta/registration/method.rs
@@ -118,11 +118,14 @@ impl ClassMethodInfo {
         let mut arguments_metadata: Vec<sys::GDExtensionClassMethodArgumentMetadata> =
             self.arguments.iter().map(|info| info.metadata).collect();
 
-        let mut default_arguments_sys: Vec<sys::GDExtensionVariantPtr> =
-            self.default_arguments.iter().map(|v| v.var_sys()).collect();
+        let mut default_arguments_sys: Vec<sys::GDExtensionVariantPtr> = self
+            .default_arguments
+            .iter()
+            .map(|v| sys::SysPtr::force_mut(v.var_sys()))
+            .collect();
 
         let method_info_sys = sys::GDExtensionClassMethodInfo {
-            name: self.method_name.string_sys(),
+            name: sys::SysPtr::force_mut(self.method_name.string_sys()),
             method_userdata: std::ptr::null_mut(),
             call_func: self.call_func,
             ptrcall_func: self.ptrcall_func,

--- a/godot-core/src/builtin/meta/return_marshal.rs
+++ b/godot-core/src/builtin/meta/return_marshal.rs
@@ -50,10 +50,10 @@ impl<T: FromGodot> PtrcallReturn for PtrcallReturnT<T> {
     unsafe fn call(
         mut process_return_ptr: impl FnMut(sys::GDExtensionTypePtr),
     ) -> Result<Self::Ret, ConvertError> {
-        let ffi =
-            <<T::Via as GodotType>::Ffi as sys::GodotFfi>::from_sys_init_default(|return_ptr| {
-                process_return_ptr(return_ptr)
-            });
+        let ffi = <<T::Via as GodotType>::Ffi as sys::GodotFfi>::new_with_init(|return_val| {
+            let return_ptr = sys::GodotFfi::sys_mut(return_val);
+            process_return_ptr(return_ptr)
+        });
 
         T::Via::try_from_ffi(ffi).and_then(T::try_from_godot)
     }

--- a/godot-core/src/builtin/meta/return_marshal.rs
+++ b/godot-core/src/builtin/meta/return_marshal.rs
@@ -7,6 +7,7 @@
 
 use crate::obj::{Gd, GodotClass};
 use crate::sys;
+use sys::GodotFfi;
 
 use super::{ConvertError, FromGodot, GodotType};
 
@@ -51,7 +52,7 @@ impl<T: FromGodot> PtrcallReturn for PtrcallReturnT<T> {
         mut process_return_ptr: impl FnMut(sys::GDExtensionTypePtr),
     ) -> Result<Self::Ret, ConvertError> {
         let ffi = <<T::Via as GodotType>::Ffi as sys::GodotFfi>::new_with_init(|return_val| {
-            let return_ptr = sys::GodotFfi::sys_mut(return_val);
+            let return_ptr = return_val.sys_mut();
             process_return_ptr(return_ptr)
         });
 

--- a/godot-core/src/builtin/meta/signature.rs
+++ b/godot-core/src/builtin/meta/signature.rs
@@ -222,10 +222,10 @@ macro_rules! impl_varcall_signature_for_tuple {
                 ];
 
                 let mut variant_ptrs = Vec::with_capacity(explicit_args.len() + varargs.len());
-                variant_ptrs.extend(explicit_args.iter().map(Variant::var_sys_const));
-                variant_ptrs.extend(varargs.iter().map(Variant::var_sys_const));
+                variant_ptrs.extend(explicit_args.iter().map(Variant::var_sys));
+                variant_ptrs.extend(varargs.iter().map(Variant::var_sys));
 
-                let variant: Result<Variant, CallError> = Variant::from_var_sys_init_result(|return_ptr| {
+                let variant: Result<Variant, CallError> = Variant::new_with_var_uninit_result(|return_ptr| {
                     let mut err = sys::default_call_error();
                     class_fn(
                         method_bind.0,
@@ -302,8 +302,8 @@ macro_rules! impl_varcall_signature_for_tuple {
                 ];
 
                 let mut type_ptrs = Vec::with_capacity(explicit_args.len() + varargs.len());
-                type_ptrs.extend(explicit_args.iter().map(sys::GodotFfi::sys_const));
-                type_ptrs.extend(varargs.iter().map(sys::GodotFfi::sys_const));
+                type_ptrs.extend(explicit_args.iter().map(sys::GodotFfi::sys));
+                type_ptrs.extend(varargs.iter().map(sys::GodotFfi::sys));
 
                 // Important: this calls from_sys_init_default().
                 let result = PtrcallReturnT::<$R>::call(|return_ptr| {

--- a/godot-core/src/builtin/meta/signature.rs
+++ b/godot-core/src/builtin/meta/signature.rs
@@ -467,7 +467,7 @@ unsafe fn varcall_arg<P: FromGodot, const N: isize>(
     args_ptr: *const sys::GDExtensionConstVariantPtr,
     call_ctx: &CallContext,
 ) -> Result<P, CallError> {
-    let variant_ref = &*Variant::ptr_from_sys(*args_ptr.offset(N));
+    let variant_ref = Variant::borrow_var_sys(*args_ptr.offset(N));
 
     P::try_from_variant(variant_ref)
         .map_err(|err| CallError::failed_param_conversion::<P>(call_ctx, N, err))

--- a/godot-core/src/builtin/meta/signature.rs
+++ b/godot-core/src/builtin/meta/signature.rs
@@ -266,9 +266,9 @@ macro_rules! impl_varcall_signature_for_tuple {
                     )*
                 ];
 
-                let variant_ptrs = explicit_args.iter().map(Variant::var_sys_const).collect::<Vec<_>>();
+                let variant_ptrs = explicit_args.iter().map(Variant::var_sys).collect::<Vec<_>>();
 
-                let variant = Variant::from_var_sys_init(|return_ptr| {
+                let variant = Variant::new_with_var_uninit(|return_ptr| {
                     let mut err = sys::default_call_error();
                     object_call_script_method(
                         object_ptr,

--- a/godot-core/src/builtin/packed_array.rs
+++ b/godot-core/src/builtin/packed_array.rs
@@ -71,7 +71,6 @@ macro_rules! impl_packed_array {
         /// but any writes must be externally synchronized. The Rust compiler will enforce this as
         /// long as you use only Rust threads, but it cannot protect against concurrent modification
         /// on other threads (e.g. created through GDScript).
-        #[repr(C)]
         pub struct $PackedArray {
             opaque: $Opaque,
         }

--- a/godot-core/src/builtin/packed_array.rs
+++ b/godot-core/src/builtin/packed_array.rs
@@ -362,13 +362,13 @@ macro_rules! impl_packed_array {
             /// # Panics
             ///
             /// If `index` is out of bounds.
-            fn ptr_mut(&self, index: usize) -> *mut $Element {
+            fn ptr_mut(&mut self, index: usize) -> *mut $Element {
                 self.check_bounds(index);
 
                 // SAFETY: We just checked that the index is not out of bounds.
                 let ptr = unsafe {
                     let item_ptr: *mut $IndexRetType =
-                        (interface_fn!($operator_index))(self.sys(), to_i64(index));
+                        (interface_fn!($operator_index))(self.sys_mut(), to_i64(index));
                     item_ptr as *mut $Element
                 };
                 assert!(!ptr.is_null());
@@ -475,31 +475,7 @@ macro_rules! impl_packed_array {
                 sys::VariantType::$PackedArray
             }
 
-            ffi_methods! { type sys::GDExtensionTypePtr = *mut Opaque;
-                fn from_sys;
-                fn sys;
-                fn from_sys_init;
-                // SAFETY:
-                // Nothing special needs to be done beyond a `std::mem::swap` when returning a packed array.
-                fn move_return_ptr;
-            }
-
-            // SAFETY:
-            // Packed arrays are properly initialized through a `from_sys` call, but the ref-count should be
-            // incremented as that is the callee's responsibility.
-            //
-            // Using `std::mem::forget(array.clone())` increments the ref count.
-            unsafe fn from_arg_ptr(ptr: sys::GDExtensionTypePtr, _call_type: sys::PtrcallType) -> Self {
-                let array = Self::from_sys(ptr);
-                std::mem::forget(array.clone());
-                array
-            }
-
-            unsafe fn from_sys_init_default(init_fn: impl FnOnce(sys::GDExtensionTypePtr)) -> Self {
-                let mut result = Self::default();
-                init_fn(result.sys_mut());
-                result
-            }
+            ffi_methods! { type sys::GDExtensionTypePtr = *mut Opaque; .. }
         }
 
         $crate::builtin::meta::impl_godot_as_self!($PackedArray);

--- a/godot-core/src/builtin/plane.rs
+++ b/godot-core/src/builtin/plane.rs
@@ -267,7 +267,20 @@ unsafe impl GodotFfi for Plane {
         sys::VariantType::Plane
     }
 
-    ffi_methods! { type sys::GDExtensionTypePtr = *mut Self; .. }
+    ffi_methods! { type sys::GDExtensionTypePtr = *mut Self;
+        fn new_from_sys;
+        fn sys;
+        fn sys_mut;
+        fn new_with_uninit;
+        fn from_arg_ptr;
+        fn move_return_ptr;
+    }
+
+    unsafe fn new_with_init(init: impl FnOnce(&mut Self)) -> Self {
+        let mut plane = Plane::new(Vector3::UP, 0.0);
+        init(&mut plane);
+        plane
+    }
 }
 
 impl_godot_as_self!(Plane);

--- a/godot-core/src/builtin/plane.rs
+++ b/godot-core/src/builtin/plane.rs
@@ -269,14 +269,14 @@ unsafe impl GodotFfi for Plane {
 
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Self;
         fn new_from_sys;
-        fn sys;
-        fn sys_mut;
         fn new_with_uninit;
         fn from_arg_ptr;
+        fn sys;
+        fn sys_mut;
         fn move_return_ptr;
     }
 
-    unsafe fn new_with_init(init: impl FnOnce(&mut Self)) -> Self {
+    fn new_with_init(init: impl FnOnce(&mut Self)) -> Self {
         let mut plane = Plane::new(Vector3::UP, 0.0);
         init(&mut plane);
         plane

--- a/godot-core/src/builtin/rid.rs
+++ b/godot-core/src/builtin/rid.rs
@@ -8,7 +8,7 @@
 use std::num::NonZeroU64;
 
 use godot_ffi as sys;
-use sys::{ffi_methods, static_assert, static_assert_eq_size, GodotFfi};
+use sys::{ffi_methods, static_assert, static_assert_eq_size_align, GodotFfi};
 
 use super::meta::impl_godot_as_self;
 
@@ -45,7 +45,7 @@ pub enum Rid {
 // Ensure that `Rid`s actually have the layout we expect. Since `Rid` has the same size as `u64`, it cannot
 // have any padding. As the `Valid` variant must take up all but one of the niches (since it contains a
 // `NonZerou64`), and the `Invalid` variant must take up the final niche.
-static_assert_eq_size!(Rid, u64);
+static_assert_eq_size_align!(Rid, u64);
 
 // SAFETY:
 // As Rid and u64 have the same size, and `Rid::Invalid` is initialized, it must be represented by some `u64`
@@ -125,14 +125,14 @@ unsafe impl GodotFfi for Rid {
 
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Self;
         fn new_from_sys;
-        fn sys;
-        fn sys_mut;
         fn new_with_uninit;
         fn from_arg_ptr;
+        fn sys;
+        fn sys_mut;
         fn move_return_ptr;
     }
 
-    unsafe fn new_with_init(init: impl FnOnce(&mut Self)) -> Self {
+    fn new_with_init(init: impl FnOnce(&mut Self)) -> Self {
         let mut rid = Self::Invalid;
         init(&mut rid);
         rid

--- a/godot-core/src/builtin/rid.rs
+++ b/godot-core/src/builtin/rid.rs
@@ -123,7 +123,20 @@ unsafe impl GodotFfi for Rid {
         sys::VariantType::Rid
     }
 
-    ffi_methods! { type sys::GDExtensionTypePtr = *mut Self; .. }
+    ffi_methods! { type sys::GDExtensionTypePtr = *mut Self;
+        fn new_from_sys;
+        fn sys;
+        fn sys_mut;
+        fn new_with_uninit;
+        fn from_arg_ptr;
+        fn move_return_ptr;
+    }
+
+    unsafe fn new_with_init(init: impl FnOnce(&mut Self)) -> Self {
+        let mut rid = Self::Invalid;
+        init(&mut rid);
+        rid
+    }
 }
 
 impl_godot_as_self!(Rid);

--- a/godot-core/src/builtin/signal.rs
+++ b/godot-core/src/builtin/signal.rs
@@ -44,7 +44,7 @@ impl Signal {
             sys::from_sys_init_or_init_default::<Self>(|self_ptr| {
                 let ctor = sys::builtin_fn!(signal_from_object_signal);
                 let raw = object.to_ffi();
-                let args = [raw.as_arg_ptr(), signal_name.sys_const()];
+                let args = [raw.as_arg_ptr(), signal_name.sys()];
                 ctor(self_ptr, args.as_ptr());
             })
         }
@@ -55,7 +55,7 @@ impl Signal {
     /// _Godot equivalent: `Signal()`_
     pub fn invalid() -> Self {
         unsafe {
-            Self::from_sys_init(|self_ptr| {
+            Self::new_with_uninit(|self_ptr| {
                 let ctor = sys::builtin_fn!(signal_construct_default);
                 ctor(self_ptr, ptr::null_mut())
             })
@@ -163,20 +163,17 @@ unsafe impl GodotFfi for Signal {
     }
 
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Opaque;
-        fn from_sys;
+        fn new_from_sys;
         fn sys;
-        fn from_sys_init;
+        fn sys_mut;
+        fn new_with_uninit;
         fn move_return_ptr;
+        fn from_arg_ptr;
     }
 
-    unsafe fn from_arg_ptr(ptr: sys::GDExtensionTypePtr, _call_type: sys::PtrcallType) -> Self {
-        Self::from_sys(ptr)
-    }
-
-    #[cfg(before_api = "4.1")]
-    unsafe fn from_sys_init_default(init_fn: impl FnOnce(sys::GDExtensionTypePtr)) -> Self {
+    unsafe fn new_with_init(init_fn: impl FnOnce(&mut Self)) -> Self {
         let mut result = Self::invalid();
-        init_fn(result.sys_mut());
+        init_fn(&mut result);
         result
     }
 }

--- a/godot-core/src/builtin/signal.rs
+++ b/godot-core/src/builtin/signal.rs
@@ -163,14 +163,14 @@ unsafe impl GodotFfi for Signal {
 
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Opaque;
         fn new_from_sys;
+        fn new_with_uninit;
+        fn from_arg_ptr;
         fn sys;
         fn sys_mut;
-        fn new_with_uninit;
         fn move_return_ptr;
-        fn from_arg_ptr;
     }
 
-    unsafe fn new_with_init(init_fn: impl FnOnce(&mut Self)) -> Self {
+    fn new_with_init(init_fn: impl FnOnce(&mut Self)) -> Self {
         let mut result = Self::invalid();
         init_fn(&mut result);
         result

--- a/godot-core/src/builtin/signal.rs
+++ b/godot-core/src/builtin/signal.rs
@@ -21,7 +21,6 @@ use sys::{ffi_methods, GodotFfi};
 /// A `Signal` represents a signal of an Object instance in Godot.
 ///
 /// Signals are composed of a reference to an `Object` and the name of the signal on this object.
-#[repr(C, align(8))]
 pub struct Signal {
     opaque: sys::types::OpaqueSignal,
 }

--- a/godot-core/src/builtin/signal.rs
+++ b/godot-core/src/builtin/signal.rs
@@ -41,7 +41,7 @@ impl Signal {
     {
         let signal_name = signal_name.into();
         unsafe {
-            sys::from_sys_init_or_init_default::<Self>(|self_ptr| {
+            sys::new_with_uninit_or_init::<Self>(|self_ptr| {
                 let ctor = sys::builtin_fn!(signal_from_object_signal);
                 let raw = object.to_ffi();
                 let args = [raw.as_arg_ptr(), signal_name.sys()];

--- a/godot-core/src/builtin/string/gstring.rs
+++ b/godot-core/src/builtin/string/gstring.rs
@@ -134,11 +134,8 @@ impl GString {
     /// `dst` must be a valid string pointer.
     pub(crate) unsafe fn move_into_string_ptr(self, dst: sys::GDExtensionStringPtr) {
         let dst: sys::GDExtensionTypePtr = dst.cast();
-        // SAFETY: `dst` is a valid string pointer. Additionally `String` doesn't behave differently for `Standard` and `Virtual`
-        // pointer calls.
-        unsafe {
-            self.move_return_ptr(dst, sys::PtrcallType::Standard);
-        }
+
+        self.move_return_ptr(dst, sys::PtrcallType::Standard);
     }
 
     #[doc(hidden)]

--- a/godot-core/src/builtin/string/gstring.rs
+++ b/godot-core/src/builtin/string/gstring.rs
@@ -125,7 +125,20 @@ impl GString {
         fn new_with_string_uninit = new_with_uninit;
         fn string_sys = sys;
         fn string_sys_mut = sys_mut;
-        fn move_return_string_ptr = move_return_ptr;
+    }
+
+    /// Moves this string into a string sys pointer. This is the same as using [`GodotFfi::move_return_ptr`].
+    ///
+    /// # Safety
+    ///
+    /// `dst` must be a valid string pointer.
+    pub(crate) unsafe fn move_into_string_ptr(self, dst: sys::GDExtensionStringPtr) {
+        let dst: sys::GDExtensionTypePtr = dst.cast();
+        // SAFETY: `dst` is a valid string pointer. Additionally `String` doesn't behave differently for `Standard` and `Virtual`
+        // pointer calls.
+        unsafe {
+            self.move_return_ptr(dst, sys::PtrcallType::Standard);
+        }
     }
 
     #[doc(hidden)]

--- a/godot-core/src/builtin/string/node_path.rs
+++ b/godot-core/src/builtin/string/node_path.rs
@@ -58,24 +58,7 @@ unsafe impl GodotFfi for NodePath {
         sys::VariantType::NodePath
     }
 
-    ffi_methods! { type sys::GDExtensionTypePtr = *mut Opaque;
-        fn from_sys;
-        fn sys;
-        fn from_sys_init;
-        fn move_return_ptr;
-    }
-
-    unsafe fn from_arg_ptr(ptr: sys::GDExtensionTypePtr, _call_type: sys::PtrcallType) -> Self {
-        let node_path = Self::from_sys(ptr);
-        std::mem::forget(node_path.clone());
-        node_path
-    }
-
-    unsafe fn from_sys_init_default(init_fn: impl FnOnce(GDExtensionTypePtr)) -> Self {
-        let mut result = Self::default();
-        init_fn(result.sys_mut());
-        result
-    }
+    ffi_methods! { type sys::GDExtensionTypePtr = *mut Opaque; .. }
 }
 
 impl_godot_as_self!(NodePath);
@@ -126,7 +109,7 @@ impl From<&GString> for NodePath {
         unsafe {
             sys::from_sys_init_or_init_default::<Self>(|self_ptr| {
                 let ctor = sys::builtin_fn!(node_path_from_string);
-                let args = [string.sys_const()];
+                let args = [string.sys()];
                 ctor(self_ptr, args.as_ptr());
             })
         }

--- a/godot-core/src/builtin/string/node_path.rs
+++ b/godot-core/src/builtin/string/node_path.rs
@@ -8,7 +8,7 @@
 use std::fmt;
 
 use godot_ffi as sys;
-use godot_ffi::{ffi_methods, GDExtensionTypePtr, GodotFfi};
+use godot_ffi::{ffi_methods, GodotFfi};
 
 use crate::builtin::inner;
 use crate::builtin::meta::impl_godot_as_self;
@@ -16,7 +16,6 @@ use crate::builtin::meta::impl_godot_as_self;
 use super::{GString, StringName};
 
 /// A pre-parsed scene tree path.
-#[repr(C)]
 pub struct NodePath {
     opaque: sys::types::OpaqueNodePath,
 }
@@ -107,7 +106,7 @@ where
 impl From<&GString> for NodePath {
     fn from(string: &GString) -> Self {
         unsafe {
-            sys::from_sys_init_or_init_default::<Self>(|self_ptr| {
+            sys::new_with_uninit_or_init::<Self>(|self_ptr| {
                 let ctor = sys::builtin_fn!(node_path_from_string);
                 let args = [string.sys()];
                 ctor(self_ptr, args.as_ptr());

--- a/godot-core/src/builtin/string/string_name.rs
+++ b/godot-core/src/builtin/string/string_name.rs
@@ -122,6 +122,11 @@ impl StringName {
         fn string_sys_mut = sys_mut;
     }
 
+    /// Convert a `StringName` sys pointer to a reference to a `StringName`.
+    ///
+    /// # Safety
+    ///
+    /// `ptr` must point to a live `StringName` for the duration of `'a`.
     pub(crate) unsafe fn borrow_string_sys<'a>(
         ptr: sys::GDExtensionConstStringNamePtr,
     ) -> &'a StringName {

--- a/godot-core/src/builtin/string/string_name.rs
+++ b/godot-core/src/builtin/string/string_name.rs
@@ -122,7 +122,9 @@ impl StringName {
         fn string_sys_mut = sys_mut;
     }
 
-    pub unsafe fn borrow_string_sys<'a>(ptr: sys::GDExtensionConstStringNamePtr) -> &'a StringName {
+    pub(crate) unsafe fn borrow_string_sys<'a>(
+        ptr: sys::GDExtensionConstStringNamePtr,
+    ) -> &'a StringName {
         sys::static_assert_eq_size!(StringName, sys::types::OpaqueStringName);
         &*(ptr.cast::<StringName>())
     }

--- a/godot-core/src/builtin/string/string_name.rs
+++ b/godot-core/src/builtin/string/string_name.rs
@@ -122,7 +122,7 @@ impl StringName {
         fn string_sys_mut = sys_mut;
     }
 
-    /// Convert a `StringName` sys pointer to a reference to a `StringName`.
+    /// Convert a `StringName` sys pointer to a reference with unbounded lifetime.
     ///
     /// # Safety
     ///
@@ -130,7 +130,7 @@ impl StringName {
     pub(crate) unsafe fn borrow_string_sys<'a>(
         ptr: sys::GDExtensionConstStringNamePtr,
     ) -> &'a StringName {
-        sys::static_assert_eq_size!(StringName, sys::types::OpaqueStringName);
+        sys::static_assert_eq_size_align!(StringName, sys::types::OpaqueStringName);
         &*(ptr.cast::<StringName>())
     }
 

--- a/godot-core/src/builtin/string/string_name.rs
+++ b/godot-core/src/builtin/string/string_name.rs
@@ -26,7 +26,8 @@ use crate::builtin::{GString, NodePath};
 /// relying on lexicographical ordering.
 ///
 /// Instead, we provide [`transient_ord()`][Self::transient_ord] for ordering relations.
-#[repr(C)]
+// Currently we rely on `transparent` for `borrow_string_sys`.
+#[repr(transparent)]
 pub struct StringName {
     opaque: sys::types::OpaqueStringName,
 }
@@ -225,7 +226,7 @@ where
 impl From<&GString> for StringName {
     fn from(string: &GString) -> Self {
         unsafe {
-            sys::from_sys_init_or_init_default::<Self>(|self_ptr| {
+            sys::new_with_uninit_or_init::<Self>(|self_ptr| {
                 let ctor = sys::builtin_fn!(string_name_from_string);
                 let args = [string.sys()];
                 ctor(self_ptr, args.as_ptr());

--- a/godot-core/src/builtin/variant/impls.rs
+++ b/godot-core/src/builtin/variant/impls.rs
@@ -26,9 +26,9 @@ macro_rules! impl_ffi_variant {
         impl GodotFfiVariant for $T {
             fn ffi_to_variant(&self) -> Variant {
                 let variant = unsafe {
-                    Variant::from_var_sys_init(|variant_ptr| {
+                    Variant::new_with_var_uninit(|variant_ptr| {
                         let converter = sys::builtin_fn!($from_fn);
-                        converter(variant_ptr, self.sys());
+                        converter(variant_ptr, sys::SysPtr::force_mut(self.sys()));
                     })
                 };
 
@@ -56,7 +56,7 @@ macro_rules! impl_ffi_variant {
                 let result = unsafe {
                     sys::from_sys_init_or_init_default(|self_ptr| {
                         let converter = sys::builtin_fn!($to_fn);
-                        converter(self_ptr, variant.var_sys());
+                        converter(self_ptr, sys::SysPtr::force_mut(variant.var_sys()));
                     })
                 };
 

--- a/godot-core/src/builtin/variant/impls.rs
+++ b/godot-core/src/builtin/variant/impls.rs
@@ -10,7 +10,6 @@ use crate::builtin::meta::{FromVariantError, GodotFfiVariant, GodotType, Propert
 use crate::builtin::*;
 use crate::engine::global;
 use godot_ffi as sys;
-use sys::GodotFfi;
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Macro definitions

--- a/godot-core/src/builtin/variant/impls.rs
+++ b/godot-core/src/builtin/variant/impls.rs
@@ -54,7 +54,7 @@ macro_rules! impl_ffi_variant {
                 //
                 // This was changed in 4.1.
                 let result = unsafe {
-                    sys::from_sys_init_or_init_default(|self_ptr| {
+                    sys::new_with_uninit_or_init(|self_ptr| {
                         let converter = sys::builtin_fn!($to_fn);
                         converter(self_ptr, sys::SysPtr::force_mut(variant.var_sys()));
                     })

--- a/godot-core/src/builtin/variant/mod.rs
+++ b/godot-core/src/builtin/variant/mod.rs
@@ -225,7 +225,7 @@ impl Variant {
     pub unsafe fn from_var_sys_init_or_init_default(
         init_fn: impl FnOnce(sys::GDExtensionVariantPtr),
     ) -> Self {
-        Self::new_with_var_init(|value| init_fn(value))
+        Self::new_with_var_init(|value| init_fn(value.var_sys_mut()))
     }
 
     /// # Safety

--- a/godot-core/src/builtin/variant/mod.rs
+++ b/godot-core/src/builtin/variant/mod.rs
@@ -213,7 +213,20 @@ impl Variant {
         fn new_with_var_init = new_with_init;
         fn var_sys = sys;
         fn var_sys_mut = sys_mut;
-        fn move_return_var_ptr = move_return_ptr;
+    }
+
+    /// Moves this variant into a variant sys pointer. This is the same as using [`GodotFfi::move_return_ptr`].
+    ///
+    /// # Safety
+    ///
+    /// `dst` must be a valid variant pointer.
+    pub(crate) unsafe fn move_into_var_ptr(self, dst: sys::GDExtensionVariantPtr) {
+        let dst: sys::GDExtensionTypePtr = dst.cast();
+        // SAFETY: `dst` is a valid string pointer. Additionally `Variant` doesn't behave differently for `Standard` and `Virtual`
+        // pointer calls.
+        unsafe {
+            self.move_return_ptr(dst, sys::PtrcallType::Standard);
+        }
     }
 
     /// # Safety

--- a/godot-core/src/builtin/variant/mod.rs
+++ b/godot-core/src/builtin/variant/mod.rs
@@ -221,8 +221,9 @@ impl Variant {
     }
 
     /// # Safety
-    /// See [`GodotFfi::from_sys_init`] and [`GodotFfi::from_sys_init_default`].
+    /// See [`GodotFfi::new_with_uninit`] and [`GodotFfi::new_with_init`].
     #[cfg(before_api = "4.1")]
+    #[doc(hidden)]
     pub unsafe fn new_with_var_uninit_or_init(
         init_fn: impl FnOnce(sys::GDExtensionVariantPtr),
     ) -> Self {
@@ -230,7 +231,7 @@ impl Variant {
     }
 
     /// # Safety
-    /// See [`GodotFfi::from_sys_init`] and [`GodotFfi::from_sys_init_default`].
+    /// See [`GodotFfi::new_with_uninit`] and [`GodotFfi::new_with_init`].
     #[cfg(since_api = "4.1")]
     #[doc(hidden)]
     pub unsafe fn new_with_var_uninit_or_init(
@@ -240,7 +241,7 @@ impl Variant {
     }
 
     /// # Safety
-    /// See [`GodotFfi::from_sys_init`].
+    /// See [`GodotFfi::new_with_uninit`].
     #[doc(hidden)]
     pub unsafe fn new_with_var_uninit_result<E>(
         init_fn: impl FnOnce(sys::GDExtensionUninitializedVariantPtr) -> Result<(), E>,
@@ -267,7 +268,7 @@ impl Variant {
         variant_ptr as *mut Variant
     }
 
-    pub unsafe fn borrow_var_sys<'a>(ptr: sys::GDExtensionConstVariantPtr) -> &'a Variant {
+    pub(crate) unsafe fn borrow_var_sys<'a>(ptr: sys::GDExtensionConstVariantPtr) -> &'a Variant {
         sys::static_assert_eq_size!(Variant, sys::types::OpaqueVariant);
         &*(ptr.cast::<Variant>())
     }

--- a/godot-core/src/builtin/variant/mod.rs
+++ b/godot-core/src/builtin/variant/mod.rs
@@ -26,7 +26,7 @@ pub use sys::{VariantOperator, VariantType};
 /// See also [Godot documentation for `Variant`](https://docs.godotengine.org/en/stable/classes/class_variant.html).
 #[repr(transparent)]
 pub struct Variant {
-    opaque: OpaqueVariant,
+    _opaque: OpaqueVariant,
 }
 
 impl Variant {
@@ -236,7 +236,7 @@ impl Variant {
         Self::new_with_var_uninit(init_fn)
     }
 
-    /// Fallible construction of a `Variant` using a function.
+    /// Fallible construction of a `Variant` using a fallible initialization function.
     ///
     /// # Safety
     ///
@@ -262,7 +262,7 @@ impl Variant {
     ///
     /// `ptr` must point to a live `Variant` for the duration of `'a`.
     pub(crate) unsafe fn borrow_var_sys<'a>(ptr: sys::GDExtensionConstVariantPtr) -> &'a Variant {
-        sys::static_assert_eq_size!(Variant, sys::types::OpaqueVariant);
+        sys::static_assert_eq_size_align!(Variant, sys::types::OpaqueVariant);
 
         // SAFETY: `ptr` is a pointer to a live `Variant` for the duration of `'a`.
         unsafe { &*(ptr.cast::<Variant>()) }
@@ -278,6 +278,7 @@ impl Variant {
         variant_ptr_array: *const sys::GDExtensionConstVariantPtr,
         length: usize,
     ) -> &'a [&'a Variant] {
+        sys::static_assert_eq_size_align!(Variant, sys::types::OpaqueVariant);
         // Godot may pass null to signal "no arguments" (e.g. in custom callables).
         if variant_ptr_array.is_null() {
             debug_assert_eq!(
@@ -305,7 +306,7 @@ impl Variant {
         variant_array: sys::GDExtensionConstVariantPtr,
         length: usize,
     ) -> &'a [Variant] {
-        sys::static_assert_eq_size!(Variant, sys::types::OpaqueVariant);
+        sys::static_assert_eq_size_align!(Variant, sys::types::OpaqueVariant);
 
         // Godot may pass null to signal "no arguments" (e.g. in custom callables).
         if variant_array.is_null() {
@@ -320,7 +321,7 @@ impl Variant {
         // See https://doc.rust-lang.org/reference/type-layout.html#pointers-and-references-layout.
         let variant_array = variant_array.cast::<Variant>();
 
-        // SAFETY: `variant_array` isn't null so it is safe to call `from_raw_parts` on the pointer cast to `*const &Variant`.
+        // SAFETY: `variant_array` isn't null so it is safe to call `from_raw_parts` on the pointer cast to `*const Variant`.
         unsafe { std::slice::from_raw_parts(variant_array, length) }
     }
 
@@ -334,7 +335,7 @@ impl Variant {
         variant_array: sys::GDExtensionVariantPtr,
         length: usize,
     ) -> &'a mut [Variant] {
-        sys::static_assert_eq_size!(Variant, sys::types::OpaqueVariant);
+        sys::static_assert_eq_size_align!(Variant, sys::types::OpaqueVariant);
 
         // Godot may pass null to signal "no arguments" (e.g. in custom callables).
         if variant_array.is_null() {
@@ -349,7 +350,7 @@ impl Variant {
         // See https://doc.rust-lang.org/reference/type-layout.html#pointers-and-references-layout.
         let variant_array = variant_array.cast::<Variant>();
 
-        // SAFETY: `variant_array` isn't null so it is safe to call `from_raw_parts_mut` on the pointer cast to `*const &Variant`.
+        // SAFETY: `variant_array` isn't null so it is safe to call `from_raw_parts_mut` on the pointer cast to `*mut Variant`.
         unsafe { std::slice::from_raw_parts_mut(variant_array, length) }
     }
 }

--- a/godot-core/src/engine/script_instance.rs
+++ b/godot-core/src/engine/script_instance.rs
@@ -579,7 +579,7 @@ mod script_instance_info {
         r_error: *mut sys::GDExtensionCallError,
     ) {
         let method = StringName::new_from_string_sys(p_method);
-        let args = Variant::borrow_var_ref_slice(p_args, p_argument_count as usize);
+        let args = Variant::borrow_ref_slice(p_args, p_argument_count as usize);
         let ctx = || format!("error when calling {}::call", type_name::<T>());
 
         let result = handle_panic(ctx, || {

--- a/godot-core/src/engine/script_instance.rs
+++ b/godot-core/src/engine/script_instance.rs
@@ -358,7 +358,7 @@ mod script_instance_info {
     ///
     /// - We expect the engine to provide a valid variant pointer the return value can be moved into.
     unsafe fn transfer_variant_to_godot(variant: Variant, return_ptr: sys::GDExtensionVariantPtr) {
-        variant.move_return_var_ptr(return_ptr, sys::PtrcallType::Standard)
+        variant.move_into_var_ptr(return_ptr)
     }
 
     /// # Safety
@@ -390,7 +390,7 @@ mod script_instance_info {
     ///
     /// - The engine has to provide a valid string return pointer.
     unsafe fn transfer_string_to_godot(string: GString, return_ptr: sys::GDExtensionStringPtr) {
-        string.move_return_string_ptr(return_ptr, sys::PtrcallType::Standard);
+        string.move_into_string_ptr(return_ptr);
     }
 
     /// # Safety

--- a/godot-core/src/engine/script_instance.rs
+++ b/godot-core/src/engine/script_instance.rs
@@ -317,7 +317,6 @@ mod script_instance_info {
     use std::cell::{BorrowError, Ref, RefMut};
     use std::ffi::c_void;
     use std::mem::ManuallyDrop;
-    use std::ops::Deref;
 
     use crate::builtin::{GString, StringName, Variant};
     use crate::engine::ScriptLanguage;
@@ -436,7 +435,7 @@ mod script_instance_info {
         p_value: sys::GDExtensionConstVariantPtr,
     ) -> sys::GDExtensionBool {
         let name = StringName::new_from_string_sys(p_name);
-        let value = &*Variant::ptr_from_sys(p_value);
+        let value = Variant::borrow_var_sys(p_value);
         let ctx = || format!("error when calling {}::set", type_name::<T>());
 
         let result = handle_panic(ctx, || {
@@ -920,7 +919,7 @@ mod script_instance_info {
         p_value: sys::GDExtensionConstVariantPtr,
     ) -> sys::GDExtensionBool {
         let name = StringName::new_from_string_sys(p_name);
-        let value = &*Variant::ptr_from_sys(p_value);
+        let value = Variant::borrow_var_sys(p_value);
 
         let ctx = || {
             format!(

--- a/godot-core/src/engine/script_instance.rs
+++ b/godot-core/src/engine/script_instance.rs
@@ -359,7 +359,7 @@ mod script_instance_info {
     ///
     /// - We expect the engine to provide a valid variant pointer the return value can be moved into.
     unsafe fn transfer_variant_to_godot(variant: Variant, return_ptr: sys::GDExtensionVariantPtr) {
-        variant.move_var_ptr(return_ptr)
+        variant.move_return_var_ptr(return_ptr, sys::PtrcallType::Standard)
     }
 
     /// # Safety
@@ -391,7 +391,7 @@ mod script_instance_info {
     ///
     /// - The engine has to provide a valid string return pointer.
     unsafe fn transfer_string_to_godot(string: GString, return_ptr: sys::GDExtensionStringPtr) {
-        string.move_string_ptr(return_ptr);
+        string.move_return_string_ptr(return_ptr, sys::PtrcallType::Standard);
     }
 
     /// # Safety
@@ -580,7 +580,7 @@ mod script_instance_info {
         r_error: *mut sys::GDExtensionCallError,
     ) {
         let method = StringName::new_from_string_sys(p_method);
-        let args = Variant::unbounded_refs_from_sys(p_args, p_argument_count as usize);
+        let args = Variant::borrow_var_ref_slice(p_args, p_argument_count as usize);
         let ctx = || format!("error when calling {}::call", type_name::<T>());
 
         let result = handle_panic(ctx, || {

--- a/godot-core/src/init/mod.rs
+++ b/godot-core/src/init/mod.rs
@@ -289,8 +289,8 @@ fn ensure_godot_features_compatible() {
     // SAFETY: main thread, after initialize(), valid string pointers.
     let gdext_is_double = cfg!(feature = "double-precision");
     let godot_is_double = unsafe {
-        let is_single = sys::godot_has_feature(os_class.string_sys(), single.sys_const());
-        let is_double = sys::godot_has_feature(os_class.string_sys(), double.sys_const());
+        let is_single = sys::godot_has_feature(os_class.string_sys(), single.sys());
+        let is_double = sys::godot_has_feature(os_class.string_sys(), double.sys());
 
         assert_ne!(
             is_single, is_double,

--- a/godot-core/src/log.rs
+++ b/godot-core/src/log.rs
@@ -123,11 +123,11 @@ pub fn print(varargs: &[Variant]) {
         let call_fn = call_fn.unwrap_unchecked();
 
         let mut args = Vec::new();
-        args.extend(varargs.iter().map(Variant::sys_const));
+        args.extend(varargs.iter().map(Variant::sys));
 
         let args_ptr = args.as_ptr();
-        let _variant = Variant::from_sys_init_default(|return_ptr| {
-            call_fn(return_ptr, args_ptr, args.len() as i32);
+        let _variant = Variant::new_with_init(|return_var| {
+            call_fn(return_var.sys_mut(), args_ptr, args.len() as i32);
         });
     }
 
@@ -147,11 +147,11 @@ pub fn print_rich(varargs: &[Variant]) {
         let call_fn = call_fn.unwrap_unchecked();
 
         let mut args = Vec::new();
-        args.extend(varargs.iter().map(Variant::sys_const));
+        args.extend(varargs.iter().map(Variant::sys));
 
         let args_ptr = args.as_ptr();
-        let _variant = Variant::from_sys_init_default(|return_ptr| {
-            call_fn(return_ptr, args_ptr, args.len() as i32);
+        let _variant = Variant::new_with_init(|return_var| {
+            call_fn(return_var.sys_mut(), args_ptr, args.len() as i32);
         });
     }
 

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -445,7 +445,7 @@ impl<T: GodotClass> Gd<T> {
     pub unsafe fn from_sys_init_opt(init_fn: impl FnOnce(sys::GDExtensionTypePtr)) -> Option<Self> {
         // TODO(uninit) - should we use GDExtensionUninitializedTypePtr instead? Then update all the builtin codegen...
         let init_fn = |ptr| {
-            init_fn(sys::AsUninit::force_init(ptr));
+            init_fn(sys::SysPtr::force_init(ptr));
         };
 
         // Note: see _call_native_mb_ret_obj() in godot-cpp, which does things quite different (e.g. querying the instance binding).

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -10,7 +10,7 @@ use std::ops::{Deref, DerefMut};
 
 use godot_ffi as sys;
 
-use sys::{static_assert_eq_size, VariantType};
+use sys::{static_assert_eq_size_align, VariantType};
 
 use crate::builtin::meta::{
     CallContext, ConvertError, FromFfiError, FromGodot, GodotConvert, GodotType, ToGodot,
@@ -94,7 +94,7 @@ pub struct Gd<T: GodotClass> {
 }
 
 // Size equality check (should additionally be covered by mem::transmute())
-static_assert_eq_size!(
+static_assert_eq_size_align!(
     sys::GDExtensionObjectPtr,
     sys::types::OpaqueObject,
     "Godot FFI: pointer type `Object*` should have size advertised in JSON extension file"
@@ -405,6 +405,14 @@ impl<T: GodotClass> Gd<T> {
     #[doc(hidden)]
     pub fn obj_sys(&self) -> sys::GDExtensionObjectPtr {
         self.raw.obj_sys()
+    }
+
+    #[doc(hidden)]
+    pub fn script_sys(&self) -> sys::GDExtensionScriptLanguagePtr
+    where
+        T: Inherits<crate::engine::ScriptLanguage>,
+    {
+        self.raw.script_sys()
     }
 
     /// Returns a callable referencing a method from this object named `method_name`.

--- a/godot-core/src/obj/raw.rs
+++ b/godot-core/src/obj/raw.rs
@@ -518,7 +518,7 @@ where
         // In 4.1, argument pointers were standardized to always be `T**`.
         #[cfg(before_api = "4.1")]
         {
-            self.sys_const()
+            self.sys()
         }
 
         #[cfg(since_api = "4.1")]

--- a/godot-core/src/obj/raw.rs
+++ b/godot-core/src/obj/raw.rs
@@ -349,6 +349,13 @@ impl<T: GodotClass> RawGd<T> {
     pub(super) fn obj_sys(&self) -> sys::GDExtensionObjectPtr {
         self.obj as sys::GDExtensionObjectPtr
     }
+
+    pub(super) fn script_sys(&self) -> sys::GDExtensionScriptLanguagePtr
+    where
+        T: super::Inherits<crate::engine::ScriptLanguage>,
+    {
+        self.obj.cast()
+    }
 }
 
 impl<T> RawGd<T>
@@ -453,7 +460,7 @@ where
         Self::from_obj_sys_weak(obj)
     }
 
-    unsafe fn new_with_init(init: impl FnOnce(&mut Self)) -> Self {
+    fn new_with_init(init: impl FnOnce(&mut Self)) -> Self {
         let mut obj = Self {
             obj: std::ptr::null_mut(),
             cached_rtti: None,

--- a/godot-core/src/registry/callbacks.rs
+++ b/godot-core/src/registry/callbacks.rs
@@ -103,9 +103,8 @@ pub unsafe extern "C" fn get_virtual<T: cap::ImplementsGodotVirtual>(
     name: sys::GDExtensionConstStringNamePtr,
 ) -> sys::GDExtensionClassCallVirtual {
     // This string is not ours, so we cannot call the destructor on it.
-    let borrowed_string = StringName::from_string_sys(sys::force_mut_ptr(name));
+    let borrowed_string = StringName::borrow_string_sys(name);
     let method_name = borrowed_string.to_string();
-    std::mem::forget(borrowed_string);
 
     T::__virtual_call(method_name.as_str())
 }
@@ -115,9 +114,8 @@ pub unsafe extern "C" fn default_get_virtual<T: UserClass>(
     name: sys::GDExtensionConstStringNamePtr,
 ) -> sys::GDExtensionClassCallVirtual {
     // This string is not ours, so we cannot call the destructor on it.
-    let borrowed_string = StringName::from_string_sys(sys::force_mut_ptr(name));
+    let borrowed_string = StringName::borrow_string_sys(name);
     let method_name = borrowed_string.to_string();
-    std::mem::forget(borrowed_string);
 
     T::__default_virtual_call(method_name.as_str())
 }
@@ -168,9 +166,7 @@ pub unsafe extern "C" fn get_property<T: cap::GodotGet>(
 ) -> sys::GDExtensionBool {
     let storage = as_storage::<T>(instance);
     let instance = storage.get();
-    let property = StringName::from_string_sys(sys::force_mut_ptr(name));
-
-    std::mem::forget(property.clone());
+    let property = StringName::new_from_string_sys(name);
 
     match T::__godot_get_property(&*instance, property) {
         Some(value) => {
@@ -189,11 +185,8 @@ pub unsafe extern "C" fn set_property<T: cap::GodotSet>(
     let storage = as_storage::<T>(instance);
     let mut instance = storage.get_mut();
 
-    let property = StringName::from_string_sys(sys::force_mut_ptr(name));
-    let value = Variant::from_var_sys(sys::force_mut_ptr(value));
-
-    std::mem::forget(property.clone());
-    std::mem::forget(value.clone());
+    let property = StringName::new_from_string_sys(name);
+    let value = Variant::new_from_var_sys(value);
 
     T::__godot_set_property(&mut *instance, property, value) as sys::GDExtensionBool
 }

--- a/godot-core/src/registry/callbacks.rs
+++ b/godot-core/src/registry/callbacks.rs
@@ -133,7 +133,7 @@ pub unsafe extern "C" fn to_string<T: cap::GodotToString>(
     let string = T::__godot_to_string(&*instance);
 
     // Transfer ownership to Godot
-    string.move_string_ptr(out_string);
+    string.move_return_string_ptr(out_string, sys::PtrcallType::Standard);
 }
 
 #[cfg(before_api = "4.2")]
@@ -170,7 +170,7 @@ pub unsafe extern "C" fn get_property<T: cap::GodotGet>(
 
     match T::__godot_get_property(&*instance, property) {
         Some(value) => {
-            value.move_var_ptr(ret);
+            value.move_return_var_ptr(ret, sys::PtrcallType::Standard);
             true as sys::GDExtensionBool
         }
         None => false as sys::GDExtensionBool,

--- a/godot-core/src/registry/callbacks.rs
+++ b/godot-core/src/registry/callbacks.rs
@@ -133,7 +133,7 @@ pub unsafe extern "C" fn to_string<T: cap::GodotToString>(
     let string = T::__godot_to_string(&*instance);
 
     // Transfer ownership to Godot
-    string.move_return_string_ptr(out_string, sys::PtrcallType::Standard);
+    string.move_into_string_ptr(out_string);
 }
 
 #[cfg(before_api = "4.2")]
@@ -170,7 +170,7 @@ pub unsafe extern "C" fn get_property<T: cap::GodotGet>(
 
     match T::__godot_get_property(&*instance, property) {
         Some(value) => {
-            value.move_return_var_ptr(ret, sys::PtrcallType::Standard);
+            value.move_into_var_ptr(ret);
             true as sys::GDExtensionBool
         }
         None => false as sys::GDExtensionBool,

--- a/godot-ffi/src/extras.rs
+++ b/godot-ffi/src/extras.rs
@@ -23,37 +23,70 @@ impl Distinct for GDExtensionConstTypePtr {}
 // Extension traits for conversion
 
 /// Convert a GDExtension pointer type to its uninitialized version.
-pub trait AsUninit {
-    type Ptr;
+pub trait SysPtr {
+    type Const;
+    type Uninit;
 
     #[allow(clippy::wrong_self_convention)]
-    fn as_uninit(self) -> Self::Ptr;
+    fn as_const(self) -> Self::Const;
+    #[allow(clippy::wrong_self_convention)]
+    fn as_uninit(self) -> Self::Uninit;
 
-    fn force_init(uninit: Self::Ptr) -> Self;
+    fn force_mut(const_ptr: Self::Const) -> Self;
+    fn force_init(uninit_ptr: Self::Uninit) -> Self;
 }
 
-macro_rules! impl_as_uninit {
-    ($Ptr:ty, $Uninit:ty) => {
-        impl AsUninit for $Ptr {
-            type Ptr = $Uninit;
+macro_rules! impl_sys_ptr {
+    ($Ptr:ty, $Const:ty, $Uninit:ty) => {
+        impl SysPtr for $Ptr {
+            type Const = $Const;
+            type Uninit = $Uninit;
 
-            fn as_uninit(self) -> $Uninit {
-                self as $Uninit
+            fn as_const(self) -> Self::Const {
+                self as Self::Const
             }
 
-            fn force_init(uninit: Self::Ptr) -> Self {
-                uninit as Self
+            #[allow(clippy::wrong_self_convention)]
+            fn as_uninit(self) -> Self::Uninit {
+                self as Self::Uninit
+            }
+
+            fn force_mut(const_ptr: Self::Const) -> Self {
+                const_ptr as Self
+            }
+
+            fn force_init(uninit_ptr: Self::Uninit) -> Self {
+                uninit_ptr as Self
             }
         }
     };
 }
 
-#[rustfmt::skip]
-impl_as_uninit!(GDExtensionStringNamePtr, GDExtensionUninitializedStringNamePtr);
-impl_as_uninit!(GDExtensionVariantPtr, GDExtensionUninitializedVariantPtr);
-impl_as_uninit!(GDExtensionStringPtr, GDExtensionUninitializedStringPtr);
-impl_as_uninit!(GDExtensionObjectPtr, GDExtensionUninitializedObjectPtr);
-impl_as_uninit!(GDExtensionTypePtr, GDExtensionUninitializedTypePtr);
+impl_sys_ptr!(
+    GDExtensionStringNamePtr,
+    GDExtensionConstStringNamePtr,
+    GDExtensionUninitializedStringNamePtr
+);
+impl_sys_ptr!(
+    GDExtensionVariantPtr,
+    GDExtensionConstVariantPtr,
+    GDExtensionUninitializedVariantPtr
+);
+impl_sys_ptr!(
+    GDExtensionStringPtr,
+    GDExtensionConstStringPtr,
+    GDExtensionUninitializedStringPtr
+);
+impl_sys_ptr!(
+    GDExtensionObjectPtr,
+    GDExtensionConstObjectPtr,
+    GDExtensionUninitializedObjectPtr
+);
+impl_sys_ptr!(
+    GDExtensionTypePtr,
+    GDExtensionConstTypePtr,
+    GDExtensionUninitializedTypePtr
+);
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Helper functions

--- a/godot-ffi/src/godot_ffi.rs
+++ b/godot-ffi/src/godot_ffi.rs
@@ -31,13 +31,13 @@ pub unsafe trait GodotFfi {
     /// which is different depending on the type.
     /// The type in `ptr` must not require any special consideration upon referencing. Such as
     /// incrementing a refcount.
-    unsafe fn from_sys(ptr: sys::GDExtensionTypePtr) -> Self;
+    unsafe fn new_from_sys(ptr: sys::GDExtensionConstTypePtr) -> Self;
 
     /// Construct uninitialized opaque data, then initialize it with `init_fn` function.
     ///
     /// # Safety
     /// `init_fn` must be a function that correctly handles a (possibly-uninitialized) _type ptr_.
-    unsafe fn from_sys_init(init_fn: impl FnOnce(sys::GDExtensionUninitializedTypePtr)) -> Self;
+    unsafe fn new_with_uninit(init_fn: impl FnOnce(sys::GDExtensionUninitializedTypePtr)) -> Self;
 
     /// Like [`Self::from_sys_init`], but pre-initializes the sys pointer to a `Default::default()` instance
     /// before calling `init_fn`.
@@ -49,44 +49,23 @@ pub unsafe trait GodotFfi {
     ///
     /// # Safety
     /// `init_fn` must be a function that correctly handles a (possibly-uninitialized) _type ptr_.
-    unsafe fn from_sys_init_default(init_fn: impl FnOnce(sys::GDExtensionTypePtr)) -> Self
-    where
-        Self: Sized, // + Default
-    {
-        // SAFETY: this default implementation is potentially incorrect.
-        // By implementing the GodotFfi trait, you acknowledge that these may need to be overridden.
-        Self::from_sys_init(|ptr| init_fn(sys::AsUninit::force_init(ptr)))
-
-        // TODO consider using this, if all the implementors support it
-        // let mut result = Self::default();
-        // init_fn(result.sys_mut().as_uninit());
-        // result
-    }
+    unsafe fn new_with_init(init_fn: impl FnOnce(&mut Self)) -> Self;
 
     /// Return Godot opaque pointer, for an immutable operation.
     ///
     /// Note that this is a `*mut` pointer despite taking `&self` by shared-ref.
     /// This is because most of Godot's Rust API is not const-correct. This can still
     /// enhance user code (calling `sys_mut` ensures no aliasing at the time of the call).
-    fn sys(&self) -> sys::GDExtensionTypePtr;
+    fn sys(&self) -> sys::GDExtensionConstTypePtr;
 
     /// Return Godot opaque pointer, for a mutable operation.
     ///
     /// Should usually not be overridden; behaves like `sys()` but ensures no aliasing
     /// at the time of the call (not necessarily during any subsequent modifications though).
-    fn sys_mut(&mut self) -> sys::GDExtensionTypePtr {
-        self.sys()
-    }
-
-    // TODO check if sys() can take over this
-    // also, from_sys() might take *const T
-    // possibly separate 2 pointer types
-    fn sys_const(&self) -> sys::GDExtensionConstTypePtr {
-        self.sys()
-    }
+    fn sys_mut(&mut self) -> sys::GDExtensionTypePtr;
 
     fn as_arg_ptr(&self) -> sys::GDExtensionConstTypePtr {
-        self.sys_const()
+        self.sys()
     }
 
     /// Construct from a pointer to an argument in a call.
@@ -120,7 +99,7 @@ pub unsafe trait GodotFfi {
 pub unsafe fn from_sys_init_or_init_default<T: GodotFfi>(
     init_fn: impl FnOnce(sys::GDExtensionTypePtr),
 ) -> T {
-    T::from_sys_init_default(init_fn)
+    T::new_with_init(|value| init_fn(value.sys_mut()))
 }
 
 /// # Safety
@@ -130,7 +109,7 @@ pub unsafe fn from_sys_init_or_init_default<T: GodotFfi>(
 pub unsafe fn from_sys_init_or_init_default<T: GodotFfi>(
     init_fn: impl FnOnce(sys::GDExtensionUninitializedTypePtr),
 ) -> T {
-    T::from_sys_init(init_fn)
+    T::new_with_uninit(init_fn)
 }
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
@@ -183,73 +162,104 @@ pub enum PtrcallType {
 #[doc(hidden)]
 macro_rules! ffi_methods_one {
     // type $Ptr = *mut Opaque
-    (OpaquePtr $Ptr:ty; $( #[$attr:meta] )? $vis:vis $from_sys:ident = from_sys) => {
+    (OpaquePtr $Ptr:ty; $( #[$attr:meta] )? $vis:vis $new_from_sys:ident = new_from_sys) => {
         $( #[$attr] )? $vis
-        unsafe fn $from_sys(ptr: $Ptr) -> Self {
-            let opaque = std::ptr::read(ptr as *mut _);
-            Self::from_opaque(opaque)
+        unsafe fn $new_from_sys(ptr: <$Ptr as $crate::SysPtr>::Const) -> Self {
+            let opaque = std::ptr::read(ptr.cast());
+            let new = Self::from_opaque(opaque);
+            std::mem::forget(new.clone());
+            new
         }
     };
-    (OpaquePtr $Ptr:ty; $( #[$attr:meta] )? $vis:vis $from_sys_init:ident = from_sys_init) => {
+    (OpaquePtr $Ptr:ty; $( #[$attr:meta] )? $vis:vis $new_with_uninit:ident = new_with_uninit) => {
         $( #[$attr] )? $vis
-        unsafe fn $from_sys_init(init: impl FnOnce(<$Ptr as $crate::AsUninit>::Ptr)) -> Self {
+        unsafe fn $new_with_uninit(init: impl FnOnce(<$Ptr as $crate::SysPtr>::Uninit)) -> Self {
             let mut raw = std::mem::MaybeUninit::uninit();
-            init(raw.as_mut_ptr() as <$Ptr as $crate::AsUninit>::Ptr);
+            init(raw.as_mut_ptr() as *mut _);
 
             Self::from_opaque(raw.assume_init())
         }
     };
+    (OpaquePtr $Ptr:ty; $( #[$attr:meta] )? $vis:vis $new_with_init:ident = new_with_init) => {
+        $( #[$attr] )? $vis
+        unsafe fn $new_with_init(init: impl FnOnce(&mut Self)) -> Self {
+            let mut default = Default::default();
+            init(&mut default);
+            default
+        }
+    };
     (OpaquePtr $Ptr:ty; $( #[$attr:meta] )? $vis:vis $sys:ident = sys) => {
         $( #[$attr] )? $vis
-        fn $sys(&self) -> $Ptr {
-            &self.opaque as *const _ as $Ptr
+        fn $sys(&self) -> <$Ptr as $crate::SysPtr>::Const {
+            std::ptr::from_ref(&self.opaque).cast()
+        }
+    };
+    (OpaquePtr $Ptr:ty; $( #[$attr:meta] )? $vis:vis $sys_mut:ident = sys_mut) => {
+        $( #[$attr] )? $vis
+        fn $sys_mut(&mut self) -> $Ptr {
+            std::ptr::from_mut(&mut self.opaque).cast()
         }
     };
     (OpaquePtr $Ptr:ty; $( #[$attr:meta] )? $vis:vis $from_arg_ptr:ident = from_arg_ptr) => {
         $( #[$attr] )? $vis
         unsafe fn $from_arg_ptr(ptr: $Ptr, _call_type: $crate::PtrcallType) -> Self {
-            Self::from_sys(ptr as *mut _)
+            Self::new_from_sys(ptr.cast())
         }
     };
     (OpaquePtr $Ptr:ty; $( #[$attr:meta] )? $vis:vis $move_return_ptr:ident = move_return_ptr) => {
         $( #[$attr] )? $vis
         unsafe fn $move_return_ptr(mut self, dst: $Ptr, _call_type: $crate::PtrcallType) {
-            std::ptr::swap(dst as *mut _, std::ptr::addr_of_mut!(self.opaque))
+            std::ptr::swap(dst.cast(), std::ptr::addr_of_mut!(self.opaque))
         }
     };
 
     // type $Ptr = *mut Self
-    (SelfPtr $Ptr:ty; $( #[$attr:meta] )? $vis:vis $from_sys:ident = from_sys) => {
+    (SelfPtr $Ptr:ty; $( #[$attr:meta] )? $vis:vis $new_from_sys:ident = new_from_sys) => {
         $( #[$attr] )? $vis
-        unsafe fn $from_sys(ptr: $Ptr) -> Self {
-            *(ptr as *mut Self)
+        unsafe fn $new_from_sys(ptr: <$Ptr as $crate::SysPtr>::Const) -> Self {
+            let borrowed = &*ptr.cast::<Self>();
+            borrowed.clone()
         }
     };
-    (SelfPtr $Ptr:ty; $( #[$attr:meta] )? $vis:vis $from_sys_init:ident = from_sys_init) => {
+    (SelfPtr $Ptr:ty; $( #[$attr:meta] )? $vis:vis $new_with_uninit:ident = new_with_uninit) => {
         $( #[$attr] )? $vis
-        unsafe fn $from_sys_init(init: impl FnOnce(<$Ptr as $crate::AsUninit>::Ptr)) -> Self {
+        unsafe fn $new_with_uninit(init: impl FnOnce(<$Ptr as $crate::SysPtr>::Uninit)) -> Self {
             let mut raw = std::mem::MaybeUninit::<Self>::uninit();
-            init(raw.as_mut_ptr() as <$Ptr as $crate::AsUninit>::Ptr);
+            init(raw.as_mut_ptr().cast());
 
             raw.assume_init()
         }
     };
+    (SelfPtr $Ptr:ty; $( #[$attr:meta] )? $vis:vis $new_with_init:ident = new_with_init) => {
+        $( #[$attr] )? $vis
+        unsafe fn $new_with_init(init: impl FnOnce(&mut Self)) -> Self {
+            let mut default = Default::default();
+            init(&mut default);
+            default
+        }
+    };
     (SelfPtr $Ptr:ty; $( #[$attr:meta] )? $vis:vis $sys:ident = sys) => {
         $( #[$attr] )? $vis
-        fn $sys(&self) -> $Ptr {
-            self as *const Self as $Ptr
+        fn $sys(&self) -> <$Ptr as $crate::SysPtr>::Const {
+            std::ptr::from_ref(self).cast()
+        }
+    };
+    (SelfPtr $Ptr:ty; $( #[$attr:meta] )? $vis:vis $sys_mut:ident = sys_mut) => {
+        $( #[$attr] )? $vis
+        fn $sys_mut(&mut self) -> $Ptr {
+            std::ptr::from_mut(self).cast()
         }
     };
     (SelfPtr $Ptr:ty; $( #[$attr:meta] )? $vis:vis $from_arg_ptr:ident = from_arg_ptr) => {
         $( #[$attr] )? $vis
         unsafe fn $from_arg_ptr(ptr: $Ptr, _call_type: $crate::PtrcallType) -> Self {
-            *(ptr as *mut Self)
+            Self::new_from_sys(ptr.cast())
         }
     };
     (SelfPtr $Ptr:ty; $( #[$attr:meta] )? $vis:vis $move_return_ptr:ident = move_return_ptr) => {
         $( #[$attr] )? $vis
         unsafe fn $move_return_ptr(self, dst: $Ptr, _call_type: $crate::PtrcallType) {
-            *(dst as *mut Self) = self
+            *(dst.cast::<Self>()) = self
         }
     };
 }
@@ -272,9 +282,11 @@ macro_rules! ffi_methods_rest {
     ( // impl GodotFfi for T (default all 5)
         $Impl:ident $Ptr:ty; ..
     ) => {
-        $crate::ffi_methods_one!($Impl $Ptr; from_sys = from_sys);
-        $crate::ffi_methods_one!($Impl $Ptr; from_sys_init = from_sys_init);
+        $crate::ffi_methods_one!($Impl $Ptr; new_from_sys = new_from_sys);
+        $crate::ffi_methods_one!($Impl $Ptr; new_with_uninit = new_with_uninit);
+        $crate::ffi_methods_one!($Impl $Ptr; new_with_init = new_with_init);
         $crate::ffi_methods_one!($Impl $Ptr; sys = sys);
+        $crate::ffi_methods_one!($Impl $Ptr; sys_mut = sys_mut);
         $crate::ffi_methods_one!($Impl $Ptr; from_arg_ptr = from_arg_ptr);
         $crate::ffi_methods_one!($Impl $Ptr; move_return_ptr = move_return_ptr);
     };
@@ -474,17 +486,28 @@ mod scalars {
             sys::VariantType::Nil
         }
 
-        unsafe fn from_sys(_ptr: sys::GDExtensionTypePtr) -> Self {
+        unsafe fn new_from_sys(_ptr: sys::GDExtensionConstTypePtr) -> Self {
             // Do nothing
         }
 
-        unsafe fn from_sys_init(_init: impl FnOnce(sys::GDExtensionUninitializedTypePtr)) -> Self {
+        unsafe fn new_with_uninit(
+            _init: impl FnOnce(sys::GDExtensionUninitializedTypePtr),
+        ) -> Self {
             // Do nothing
         }
 
-        fn sys(&self) -> sys::GDExtensionTypePtr {
+        unsafe fn new_with_init(_init: impl FnOnce(&mut ())) -> Self {
+            // Do nothing
+        }
+
+        fn sys(&self) -> sys::GDExtensionConstTypePtr {
             // ZST dummy pointer
-            self as *const _ as sys::GDExtensionTypePtr
+            std::ptr::from_ref(self).cast()
+        }
+
+        fn sys_mut(&mut self) -> sys::GDExtensionTypePtr {
+            // ZST dummy pointer
+            std::ptr::from_mut(self).cast()
         }
 
         // SAFETY:

--- a/godot-ffi/src/godot_ffi.rs
+++ b/godot-ffi/src/godot_ffi.rs
@@ -96,7 +96,7 @@ pub unsafe trait GodotFfi {
 ///
 /// See [`GodotFfi::from_sys_init`] and [`GodotFfi::from_sys_init_default`].
 #[cfg(before_api = "4.1")]
-pub unsafe fn from_sys_init_or_init_default<T: GodotFfi>(
+pub unsafe fn new_with_uninit_or_init<T: GodotFfi>(
     init_fn: impl FnOnce(sys::GDExtensionTypePtr),
 ) -> T {
     T::new_with_init(|value| init_fn(value.sys_mut()))
@@ -106,7 +106,7 @@ pub unsafe fn from_sys_init_or_init_default<T: GodotFfi>(
 ///
 /// See [`GodotFfi::from_sys_init`] and [`GodotFfi::from_sys_init_default`].
 #[cfg(since_api = "4.1")]
-pub unsafe fn from_sys_init_or_init_default<T: GodotFfi>(
+pub unsafe fn new_with_uninit_or_init<T: GodotFfi>(
     init_fn: impl FnOnce(sys::GDExtensionUninitializedTypePtr),
 ) -> T {
     T::new_with_uninit(init_fn)

--- a/godot-ffi/src/lib.rs
+++ b/godot-ffi/src/lib.rs
@@ -52,8 +52,7 @@ pub use paste;
 pub use gensym::gensym;
 
 pub use crate::godot_ffi::{
-    from_sys_init_or_init_default, GodotFfi, GodotNullableFfi, PrimitiveConversionError,
-    PtrcallType,
+    new_with_uninit_or_init, GodotFfi, GodotNullableFfi, PrimitiveConversionError, PtrcallType,
 };
 
 // Method tables

--- a/godot-ffi/src/toolbox.rs
+++ b/godot-ffi/src/toolbox.rs
@@ -35,6 +35,24 @@ macro_rules! static_assert_eq_size {
     };
 }
 
+/// Verifies at compile time that two types `T` and `U` have the same size and alignment.
+#[macro_export]
+macro_rules! static_assert_eq_size_align {
+    ($T:ty, $U:ty) => {
+        godot_ffi::static_assert!(
+            std::mem::size_of::<$T>() == std::mem::size_of::<$U>()
+                && std::mem::align_of::<$T>() == std::mem::align_of::<$U>()
+        );
+    };
+    ($T:ty, $U:ty, $msg:literal) => {
+        godot_ffi::static_assert!(
+            std::mem::size_of::<$T>() == std::mem::size_of::<$U>()
+                && std::mem::align_of::<$T>() == std::mem::align_of::<$U>(),
+            $msg
+        );
+    };
+}
+
 /// Trace output.
 #[cfg(feature = "trace")]
 #[macro_export]

--- a/godot-ffi/src/toolbox.rs
+++ b/godot-ffi/src/toolbox.rs
@@ -24,17 +24,6 @@ macro_rules! static_assert {
     };
 }
 
-/// Verifies at compile time that two types `T` and `U` have the same size.
-#[macro_export]
-macro_rules! static_assert_eq_size {
-    ($T:ty, $U:ty) => {
-        godot_ffi::static_assert!(std::mem::size_of::<$T>() == std::mem::size_of::<$U>());
-    };
-    ($T:ty, $U:ty, $msg:literal) => {
-        godot_ffi::static_assert!(std::mem::size_of::<$T>() == std::mem::size_of::<$U>(), $msg);
-    };
-}
-
 /// Verifies at compile time that two types `T` and `U` have the same size and alignment.
 #[macro_export]
 macro_rules! static_assert_eq_size_align {

--- a/godot-macros/src/class/godot_api.rs
+++ b/godot-macros/src/class/godot_api.rs
@@ -427,7 +427,7 @@ fn add_virtual_script_call(
     let code = quote! {
         let object_ptr = #object_ptr;
         let method_sname = ::godot::builtin::StringName::from(#method_name_str);
-        let method_sname_ptr = method_sname.string_sys_const();
+        let method_sname_ptr = method_sname.string_sys();
         let has_virtual_method = unsafe { ::godot::private::has_virtual_script_method(object_ptr, method_sname_ptr) };
 
         if has_virtual_method {

--- a/itest/rust/src/builtin_tests/containers/variant_test.rs
+++ b/itest/rust/src/builtin_tests/containers/variant_test.rs
@@ -261,7 +261,7 @@ fn variant_sys_conversion() {
     let v = Variant::from(7);
     let ptr = v.sys();
 
-    let v2 = unsafe { Variant::from_sys(ptr) };
+    let v2 = unsafe { Variant::new_from_sys(ptr) };
     assert_eq!(v2, v);
 }
 
@@ -281,7 +281,7 @@ fn variant_sys_conversion2() {
     };
 
     let v2 = unsafe {
-        Variant::from_sys_init(|ptr| {
+        Variant::new_with_uninit(|ptr| {
             std::ptr::copy(
                 buffer.as_ptr(),
                 ptr as *mut u8,

--- a/itest/rust/src/object_tests/object_test.rs
+++ b/itest/rust/src/object_tests/object_test.rs
@@ -55,7 +55,7 @@ fn object_user_roundtrip_return() {
     let ptr = raw.sys();
     std::mem::forget(obj);
 
-    let raw2 = unsafe { RawGd::<RefcPayload>::from_sys(ptr) };
+    let raw2 = unsafe { RawGd::<RefcPayload>::new_from_sys(ptr) };
     let obj2 = Gd::from_ffi(raw2);
     assert_eq!(obj2.bind().value, value);
 } // drop
@@ -70,8 +70,8 @@ fn object_user_roundtrip_write() {
     let raw = obj.to_ffi();
 
     let raw2 = unsafe {
-        RawGd::<RefcPayload>::from_sys_init(|ptr| {
-            raw.move_return_ptr(sys::AsUninit::force_init(ptr), sys::PtrcallType::Standard)
+        RawGd::<RefcPayload>::new_with_uninit(|ptr| {
+            raw.move_return_ptr(sys::SysPtr::force_init(ptr), sys::PtrcallType::Standard)
         })
     };
     let obj2 = Gd::from_ffi(raw2);
@@ -89,7 +89,7 @@ fn object_engine_roundtrip() {
     let raw = obj.to_ffi();
     let ptr = raw.sys();
 
-    let raw2 = unsafe { RawGd::<Node3D>::from_sys(ptr) };
+    let raw2 = unsafe { RawGd::<Node3D>::new_from_sys(ptr) };
     let obj2 = Gd::from_ffi(raw2);
     assert_eq!(obj2.get_position(), pos);
     obj.free();

--- a/itest/rust/src/register_tests/option_ffi_test.rs
+++ b/itest/rust/src/register_tests/option_ffi_test.rs
@@ -19,7 +19,7 @@ fn option_some_sys_conversion() {
     let v_raw = v.to_ffi();
     let ptr = v_raw.sys();
 
-    let v2_raw = unsafe { RawGd::<Object>::from_sys(ptr) };
+    let v2_raw = unsafe { RawGd::<Object>::new_from_sys(ptr) };
     let v2 = Option::<Gd<Object>>::from_ffi(v2_raw);
     assert_eq!(v2, v);
 
@@ -34,7 +34,7 @@ fn option_none_sys_conversion() {
     let v_raw = v.to_ffi();
     let ptr = v_raw.sys();
 
-    let v2_raw = unsafe { RawGd::<Object>::from_sys(ptr) };
+    let v2_raw = unsafe { RawGd::<Object>::new_from_sys(ptr) };
     let v2 = Option::<Gd<Object>>::from_ffi(v2_raw);
     assert_eq!(v2, v);
 }


### PR DESCRIPTION
This is not finalized because this is a refactoring that i just randomly tried today. Before i work more on it and finish it up (beyond making it compile if it doesn't compile on all targets yet) i'd want to see if this is something we want to actually do.

So basically, i had an issue while working on #621 where the names of `GodotFfi` methods (as well as the types they use) don't entirely reflect what the methods do or are intended to do (and some other minor correctness things). So a summary here:

### `from_sys`
This creates a new value of type `Self` from an ffi pointer, however this is documented to not increment any refcounts or anything. Which is weird. If it creates a `Self` it really should be a fully valid value of type `Self` right?

So instead i split this in two:
- `new_from_sys(ptr: ..) -> Self`, which does in fact create a new value from a sys pointer. Including incrementing refcounts and such.
- `borrow_sys<'a>(ptr: ..) -> &'a Self` which creates a reference out of the pointer.

Might consider adding a third one, which has the old behavior. I.e it constructs a `Self` without incrementing refcounts or anything, explicitly for the case where we want that behavior. It could be called `new_from_sys_weak` or something?

Unfortunately, `borrow_sys` cannot be implemented for `RawGd`, so i had to split it into a new trait `GodotFfiBorrowable`. However it's still fairly useful in that we can now explicitly borrow a reference to types like `StringName`. It is also used to implement `new_from_sys` in some cases.

This has cleaned up some ugly code, like we dont need to remember to `std::mem::forget(string_name.clone())` whenever we create one. And we can use `StringName::borrow_sys(ptr)` instead of `ManuallyDrop::new(StringName::from_sys(ptr))` where we used that pattern. 

### `from_sys_init`/`from_sys_init_default`

From the name, one would assume it takes a sys pointer and returns a `Self`. But they dont. They create a brand new value from an initialization function. So i renamed them to `new_with_uninit` and `new_with_init`. 

Now since `new_with_init`(`from_sys_init_default`) is gonna pass along an initialized pointer, i changed it from taking a closure which takes a pointer, to taking a closure `FnOnce(&mut Self)`. Which also makes this a safe function.

`new_with_init` doesn't have a default implementation anymore, instead the `ffi_methods` macro will try to implement it with `Default::default()`. Which will fail in some cases so needs to be manually implemented in those cases.

### Using `Const` pointers

Many places just use the non-const version of pointers even if the const one is more accurate. i changed this around a bit so now:
- `sys()` returns a const pointer
- removed `sys_const()`
- `sys_mut()` doesn't have a default impl (we cannot implement this correctly through calling `sys()`)
- `new_from_sys()` takes a const pointer

This does mean we need to convert const-pointers into their non-const form sometimes where we didnt before. But overall it actually worked fairly well in most places. And it does help with some type safety in various places, like making sure we use `sys_mut()` when it's actually possible to and more correct to do so.

### New traits

#### `SysPtr`
`AsUninit` is replaced by `SysPtr` which contains conversions for both uninit and const pointers.