### PR TITLE
Fix: changed bitfields to be i64 instead of u64

### DIFF
--- a/godot-codegen/src/generator/enums.rs
+++ b/godot-codegen/src/generator/enums.rs
@@ -197,11 +197,11 @@ fn make_enum_engine_trait_impl(enum_: &Enum) -> TokenStream {
             // }
 
             impl #engine_trait for #name {
-                fn try_from_ord(ord: u64) -> Option<Self> {
+                fn try_from_ord(ord: i64) -> Option<Self> {
                     Some(Self { ord })
                 }
 
-                fn ord(self) -> u64 {
+                fn ord(self) -> i64 {
                     self.ord
                 }
             }

--- a/godot-codegen/src/models/domain/enums.rs
+++ b/godot-codegen/src/models/domain/enums.rs
@@ -39,7 +39,7 @@ impl Enum {
     /// The type we use to represent values of this enum.
     pub fn ord_type(&self) -> Ident {
         if self.is_bitfield {
-            ident("u64")
+            ident("i64")
         } else {
             ident("i32")
         }
@@ -126,7 +126,7 @@ pub struct Enumerator {
 #[derive(Clone)]
 pub enum EnumeratorValue {
     Enum(i32),
-    Bitfield(u64),
+    Bitfield(i64),
 }
 
 impl EnumeratorValue {
@@ -145,7 +145,7 @@ impl EnumeratorValue {
         // Conversion is safe because i64 is used in the original JSON.
         match self {
             EnumeratorValue::Enum(i) => *i as i64,
-            EnumeratorValue::Bitfield(i) => *i as i64,
+            EnumeratorValue::Bitfield(i) => *i,
         }
     }
 

--- a/godot-codegen/src/models/domain_mapping.rs
+++ b/godot-codegen/src/models/domain_mapping.rs
@@ -571,14 +571,7 @@ impl Enum {
 impl Enumerator {
     pub fn from_json(json: &JsonEnumConstant, rust_name: Ident, is_bitfield: bool) -> Self {
         let value = if is_bitfield {
-            let ord = json.value.try_into().unwrap_or_else(|_| {
-                panic!(
-                    "bitfield value {} = {} is negative; please report this",
-                    json.name, json.value
-                )
-            });
-
-            EnumeratorValue::Bitfield(ord)
+            EnumeratorValue::Bitfield(json.value)
         } else {
             let ord = json.value.try_into().unwrap_or_else(|_| {
                 panic!(

--- a/godot-core/src/obj/traits.rs
+++ b/godot-core/src/obj/traits.rs
@@ -167,12 +167,12 @@ pub trait EngineEnum: Copy {
 
 /// Auto-implemented for all engine-provided bitfields.
 pub trait EngineBitfield: Copy {
-    fn try_from_ord(ord: u64) -> Option<Self>;
+    fn try_from_ord(ord: i64) -> Option<Self>;
 
     /// Ordinal value of the bit flag, as specified in Godot.
-    fn ord(self) -> u64;
+    fn ord(self) -> i64;
 
-    fn from_ord(ord: u64) -> Self {
+    fn from_ord(ord: i64) -> Self {
         Self::try_from_ord(ord)
             .unwrap_or_else(|| panic!("ordinal {ord} does not map to any valid bit flag"))
     }

--- a/itest/rust/src/object_tests/property_template_test.rs
+++ b/itest/rust/src/object_tests/property_template_test.rs
@@ -61,12 +61,12 @@ fn property_template_test(ctx: &TestContext) {
         let mut rust_usage = rust_prop.get("usage").unwrap().to::<i64>();
 
         // the GDSscript variables are script variables, and so have `PROPERTY_USAGE_SCRIPT_VARIABLE` set.
-        if rust_usage == PropertyUsageFlags::STORAGE.ord() as i64 {
+        if rust_usage == PropertyUsageFlags::STORAGE.ord() {
             // `PROPERTY_USAGE_SCRIPT_VARIABLE` does the same thing as `PROPERTY_USAGE_STORAGE` and so
             // GDScript doesn't set both if it doesn't need to.
-            rust_usage = PropertyUsageFlags::SCRIPT_VARIABLE.ord() as i64
+            rust_usage = PropertyUsageFlags::SCRIPT_VARIABLE.ord()
         } else {
-            rust_usage |= PropertyUsageFlags::SCRIPT_VARIABLE.ord() as i64;
+            rust_usage |= PropertyUsageFlags::SCRIPT_VARIABLE.ord();
         }
 
         rust_prop.set("usage", rust_usage);


### PR DESCRIPTION
_[Edit Bromeon]: Direct links to issue in other repos:_

- https://github.com/godotengine/godot/issues/88962
- https://github.com/GodotSteam/GodotSteam/issues/424


---

I found that gdext and godot-cpp are incorrectly generating bitfield bindings as u64 when they should be i64. 

This is what gdext is currently referencing as its reasoning for using u64: https://github.com/godotengine/godot-cpp/pull/1320/files

However, upon further inspecting the godot source code, it can actually be seen that the godot engine is mapping all bitfields to i64 instead of u64:

https://github.com/godotengine/godot/blob/81f3d43cc1ba01136795fb2059bbaa55bc514a16/core/object/class_db.cpp#L949

So it appears that godot-cpp is incorrectly binding to u64 and that mistake bubbled into gdext as well.

I noticed this because the gdext bindings started erroring on our windows machines where windows interpretes 0xffffffff to be -1 and Linux interprets it to 4294967295 implicitly.  The -1 was causing issues on the godot gen bindings for windows when using godotsteam.
