### PR TITLE
Add Callable::bindv

### DIFF
--- a/godot-core/src/builtin/callable.rs
+++ b/godot-core/src/builtin/callable.rs
@@ -174,6 +174,13 @@ impl Callable {
         self.as_inner().callv(arguments)
     }
 
+    /// Returns a copy of this Callable with one or more arguments bound, reading them from an array.
+    ///
+    /// _Godot equivalent: `bindv`_
+    pub fn bindv(&self, arguments: VariantArray) -> Self {
+        self.as_inner().bindv(arguments)
+    }
+
     /// Returns the name of the method represented by this callable. If the callable is a lambda function,
     /// returns the function's name.
     ///

--- a/itest/rust/src/builtin_tests/containers/callable_test.rs
+++ b/itest/rust/src/builtin_tests/containers/callable_test.rs
@@ -131,6 +131,18 @@ fn callable_call_engine() {
     obj.free();
 }
 
+#[itest]
+fn callable_bindv() {
+    let obj = CallableTestObj::new_gd();
+    let callable = obj.callable("bar");
+    let callable_bound = callable.bindv(varray![10]);
+
+    assert_eq!(
+        callable_bound.callv(varray![]),
+        10.to_variant().stringify().to_variant()
+    );
+}
+
 // Testing https://github.com/godot-rust/gdext/issues/410
 
 #[derive(GodotClass)]


### PR DESCRIPTION
`Callable::bindv` method is supported since Godot 4.0 but not implemented on gdext.