### PR TITLE
Add `CallError`, `try_*` varcalls and improve error diagnostics

### DIFF
--- a/godot-codegen/src/generator/central_files.rs
+++ b/godot-codegen/src/generator/central_files.rs
@@ -126,18 +126,26 @@ pub fn make_core_central_code(api: &ExtensionApi, ctx: &mut Context) -> TokenStr
             )*
         }
 
-        #[cfg(FALSE)]
-        impl FromVariant for VariantDispatch {
-            fn try_from_variant(variant: &Variant) -> Result<Self, VariantConversionError> {
-                let dispatch = match variant.get_type() {
+        impl VariantDispatch {
+            pub fn from_variant(variant: &Variant) -> Self {
+                match variant.get_type() {
                     VariantType::Nil => Self::Nil,
                     #(
                         VariantType::#variant_ty_enumerators_pascal
                             => Self::#variant_ty_enumerators_pascal(variant.to::<#variant_ty_enumerators_rust>()),
                     )*
-                };
+                }
+            }
+        }
 
-                Ok(dispatch)
+        impl std::fmt::Debug for VariantDispatch {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                match self {
+                    Self::Nil => write!(f, "null"),
+                    #(
+                        Self::#variant_ty_enumerators_pascal(v) => write!(f, "{v:?}"),
+                    )*
+                }
             }
         }
 

--- a/godot-codegen/src/models/domain.rs
+++ b/godot-codegen/src/models/domain.rs
@@ -594,6 +594,11 @@ impl FnReturn {
             }
         }
     }
+
+    pub fn call_result_decl(&self) -> TokenStream {
+        let ret = self.type_tokens();
+        quote! { -> Result<#ret, crate::builtin::meta::CallError> }
+    }
 }
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------

--- a/godot-core/src/builtin/array.rs
+++ b/godot-core/src/builtin/array.rs
@@ -948,7 +948,7 @@ impl<T: GodotType> GodotFfiVariant for Array<T> {
         if variant.get_type() != Self::variant_type() {
             return Err(FromVariantError::BadType {
                 expected: Self::variant_type(),
-                got: variant.get_type(),
+                actual: variant.get_type(),
             }
             .into_error(variant));
         }

--- a/godot-core/src/builtin/meta/call_error.rs
+++ b/godot-core/src/builtin/meta/call_error.rs
@@ -1,0 +1,326 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use crate::builtin::meta::{CallContext, ConvertError, ToGodot};
+use crate::builtin::Variant;
+use crate::sys;
+use godot_ffi::{join_with, VariantType};
+use std::error::Error;
+use std::fmt;
+
+/// Error capable of representing failed function calls.
+///
+/// This type is returned from _varcall_ functions in the Godot API that begin with `try_` prefixes,
+/// e.g. [`Object::try_call()`](crate::engine::Object::try_call) or [`Node::try_rpc()`](crate::engine::Node::try_rpc).
+///
+/// Allows to inspect the involved class and method via `class_name()` and `method_name()`. Implements the `std::error::Error` trait, so
+/// it comes with `Display` and `Error::source()` APIs.
+///
+/// # Possible error causes
+/// Several reasons can cause a function call to fail. The reason is described in the `Display` impl.
+///
+/// - **Invalid method**: The method does not exist on the object.
+/// - **Failed argument conversion**: The arguments passed to the method cannot be converted to the declared parameter types.
+/// - **Failed return value conversion**: The return value of a dynamic method (`Variant`) cannot be converted to the expected return type.
+/// - **Too many or too few arguments**: The number of arguments passed to the method does not match the number of parameters.
+/// - **User panic**: A Rust method caused a panic.
+///
+/// # Chained errors
+/// Let's say you have this code, and you want to call the method dynamically with `Object::try_call()`.
+///
+/// Then, the immediate `CallError` will refer to the `Object::try_call` method, and its source will refer to `MyClass::my_method`
+/// (the actual method that failed).
+/// ```no_run
+/// use godot::prelude::*;
+/// use std::error::Error;
+/// # use godot_core::builtin::meta::CallError;
+/// #[derive(GodotClass)]
+/// # #[class(init)]
+/// struct MyClass;
+///
+/// #[godot_api]
+/// impl MyClass {
+///     #[func]
+///     fn my_method(&self, arg: i64) {}
+/// }
+///
+/// fn some_method() {
+///     let obj: Gd<MyClass> = MyClass::new_gd();
+///
+///     // Dynamic call. Note: forgot to pass the argument.
+///     let result: Result<Variant, CallError> = obj.try_call("my_method", &[]);
+///
+///     // Get immediate and original errors. Note that source() can be None or have type ConvertError.
+///     let outer: CallError = result.unwrap_err();
+///     let inner: CallError = outer.source().downcast_ref::<CallError>().unwrap();
+/// }
+#[derive(Debug)]
+pub struct CallError {
+    class_name: String,
+    function_name: String,
+    call_expr: String,
+    reason: String,
+    source: Option<SourceError>,
+}
+
+impl CallError {
+    // Naming:
+    // - check_* means possible failure -- Result<(), Self> is returned.
+    // - failed_* means definitive failure -- Self is returned.
+
+    /// Name of the class/builtin whose method failed. **Not** the dynamic type.
+    ///
+    /// Returns `None` if this is a utility function (without a surrounding class/builtin).
+    ///
+    /// This is the static and not the dynamic type. For example, if you invoke `call()` on a `Gd<Node>`, you are effectively invoking
+    /// `Object::call()` (through `DerefMut`), and the class name will be `Object`.
+    pub fn class_name(&self) -> Option<&str> {
+        if self.class_name.is_empty() {
+            None
+        } else {
+            Some(&self.class_name)
+        }
+    }
+
+    /// Name of the function or method that failed.
+    pub fn method_name(&self) -> &str {
+        &self.function_name
+    }
+
+    /// Describes the error.
+    ///
+    /// This is the same as the `Display`/`ToString` repr, but without the prefix mentioning that this is a function call error,
+    /// and without any source error information.
+    fn message(&self, with_source: bool) -> String {
+        let Self {
+            call_expr, reason, ..
+        } = self;
+
+        let reason_str = if reason.is_empty() {
+            String::new()
+        } else {
+            format!("\n  Reason: {reason}")
+        };
+
+        // let source_str = if with_source {
+        //     self.source()
+        //         .map(|e| format!("\n  Source: {}", e))
+        //         .unwrap_or_default()
+        // } else {
+        //     String::new()
+        // };
+
+        let source_str = match &self.source {
+            Some(SourceError::Convert(e)) if with_source => format!("\n  Source: {}", e),
+            Some(SourceError::Call(e)) if with_source => format!("\n  Source: {}", e.message(true)),
+            _ => String::new(),
+        };
+
+        format!("{call_expr}{reason_str}{source_str}")
+    }
+
+    /// Checks whether number of arguments matches the number of parameters.
+    pub(crate) fn check_arg_count(
+        call_ctx: &CallContext,
+        arg_count: i64,
+        param_count: i64,
+    ) -> Result<(), Self> {
+        // This will need to be adjusted once optional parameters are supported in #[func].
+        if arg_count == param_count {
+            return Ok(());
+        }
+
+        let param_plural = plural(param_count);
+        let arg_plural = plural(arg_count);
+
+        Err(Self::new(
+            call_ctx,
+            format!(
+                "function has {param_count} parameter{param_plural}, but received {arg_count} argument{arg_plural}"
+            ),
+            None,
+        ))
+    }
+
+    /// Checks the Godot side of a varcall (low-level `sys::GDExtensionCallError`).
+    pub(crate) fn check_out_varcall<T: ToGodot>(
+        call_ctx: &CallContext,
+        err: sys::GDExtensionCallError,
+        explicit_args: &[T],
+        varargs: &[Variant],
+    ) -> Result<(), Self> {
+        if err.error == sys::GDEXTENSION_CALL_OK {
+            return Ok(());
+        }
+
+        let mut arg_types = Vec::with_capacity(explicit_args.len() + varargs.len());
+        arg_types.extend(explicit_args.iter().map(|arg| arg.to_variant().get_type()));
+        arg_types.extend(varargs.iter().map(Variant::get_type));
+
+        let explicit_args_str = join_args(explicit_args.iter().map(|arg| arg.to_variant()));
+        let vararg_str = if varargs.is_empty() {
+            String::new()
+        } else {
+            format!(", varargs {}", join_args(varargs.into_iter().cloned()))
+        };
+
+        let call_expr = format!("{call_ctx}({explicit_args_str}{vararg_str})");
+
+        // If the call error encodes an error generated by us, decode it.
+        let mut source_error = None;
+        if err.error == sys::GODOT_RUST_CUSTOM_CALL_ERROR {
+            source_error = crate::private::call_error_remove(&err) //.
+                .map(|e| SourceError::Call(Box::new(e)));
+        }
+
+        Err(Self::failed_varcall_inner(
+            call_ctx,
+            call_expr,
+            err,
+            &arg_types,
+            source_error,
+        ))
+    }
+
+    /// Returns an error for a failed parameter conversion.
+    pub(crate) fn failed_param_conversion<P>(
+        call_ctx: &CallContext,
+        param_index: isize,
+        convert_error: ConvertError,
+    ) -> Self {
+        let param_ty = std::any::type_name::<P>();
+
+        Self::new(
+            call_ctx,
+            format!("parameter [{param_index}] of type {param_ty} failed to convert to Variant; {convert_error}"),
+            Some(convert_error),
+        )
+    }
+
+    /// Returns an error for a failed return type conversion.
+    pub(crate) fn failed_return_conversion<R>(
+        call_ctx: &CallContext,
+        convert_error: ConvertError,
+    ) -> Self {
+        let return_ty = std::any::type_name::<R>();
+
+        Self::new(
+            call_ctx,
+            format!("return type {return_ty} failed to convert from Variant; {convert_error}"),
+            Some(convert_error),
+        )
+    }
+
+    fn failed_varcall_inner(
+        call_ctx: &CallContext,
+        call_expr: String,
+        err: sys::GDExtensionCallError,
+        arg_types: &[VariantType],
+        source: Option<SourceError>,
+    ) -> Self {
+        // This specializes on reflection-style calls, e.g. call(), rpc() etc.
+        // In these cases, varargs are the _actual_ arguments, with required args being metadata such as method name.
+
+        debug_assert_ne!(err.error, sys::GDEXTENSION_CALL_OK); // already checked outside
+
+        let sys::GDExtensionCallError {
+            error,
+            argument,
+            expected,
+        } = err;
+
+        let argc = arg_types.len();
+        let reason = match error {
+            sys::GDEXTENSION_CALL_ERROR_INVALID_METHOD => "method not found".to_string(),
+            sys::GDEXTENSION_CALL_ERROR_INVALID_ARGUMENT => {
+                let from = arg_types[argument as usize];
+                let to = VariantType::from_sys(expected as sys::GDExtensionVariantType);
+                let i = argument + 1;
+
+                format!("cannot convert argument #{i} from {from:?} to {to:?}")
+            }
+            sys::GDEXTENSION_CALL_ERROR_TOO_MANY_ARGUMENTS => {
+                format!("too many arguments; expected {argument}, but called with {argc}")
+            }
+            sys::GDEXTENSION_CALL_ERROR_TOO_FEW_ARGUMENTS => {
+                format!("too few arguments; expected {argument}, but called with {argc}")
+            }
+            sys::GDEXTENSION_CALL_ERROR_INSTANCE_IS_NULL => "instance is null".to_string(),
+            sys::GDEXTENSION_CALL_ERROR_METHOD_NOT_CONST => "method is not const".to_string(), // not handled in Godot
+            sys::GODOT_RUST_CUSTOM_CALL_ERROR => String::new(),
+            _ => format!("unknown reason (error code {error})"),
+        };
+
+        Self {
+            class_name: call_ctx.class_name.to_string(),
+            function_name: call_ctx.function_name.to_string(),
+            call_expr,
+            reason,
+            source,
+        }
+    }
+
+    #[doc(hidden)]
+    pub fn failed_by_user_panic(call_ctx: &CallContext, reason: String) -> Self {
+        Self::new(call_ctx, reason, None)
+    }
+
+    fn new(call_ctx: &CallContext, reason: String, source: Option<ConvertError>) -> Self {
+        Self {
+            class_name: call_ctx.class_name.to_string(),
+            function_name: call_ctx.function_name.to_string(),
+            call_expr: format!("{call_ctx}()"),
+            reason,
+            source: source.map(|e| SourceError::Convert(Box::new(e))),
+        }
+    }
+}
+
+impl fmt::Display for CallError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "godot-rust function call failed: {}", self.message(true))
+    }
+}
+
+impl Error for CallError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self.source.as_ref() {
+            Some(SourceError::Convert(e)) => deref_to::<ConvertError>(e),
+            Some(SourceError::Call(e)) => deref_to::<CallError>(e),
+            None => None,
+        }
+    }
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// Implementation
+
+#[derive(Debug)]
+enum SourceError {
+    Convert(Box<ConvertError>),
+    Call(Box<CallError>),
+}
+
+/// Explicit dereferencing to a certain type. Avoids accidentally returning `&Box<T>` or so.
+fn deref_to<T>(t: &T) -> Option<&(dyn Error + 'static)>
+where
+    T: Error + 'static,
+{
+    Some(t)
+}
+
+fn join_args(args: impl Iterator<Item = Variant>) -> String {
+    join_with(args, ", ", |arg| arg.brief_debug())
+}
+
+fn plural(count: i64) -> &'static str {
+    if count == 1 {
+        ""
+    } else {
+        "s"
+    }
+}

--- a/godot-core/src/builtin/meta/call_error.rs
+++ b/godot-core/src/builtin/meta/call_error.rs
@@ -8,7 +8,7 @@
 use crate::builtin::meta::{CallContext, ConvertError, ToGodot};
 use crate::builtin::Variant;
 use crate::sys;
-use godot_ffi::{join_with, VariantType};
+use godot_ffi::{join_debug, VariantType};
 use std::error::Error;
 use std::fmt;
 
@@ -314,7 +314,7 @@ where
 }
 
 fn join_args(args: impl Iterator<Item = Variant>) -> String {
-    join_with(args, ", ", |arg| arg.brief_debug())
+    join_debug(args)
 }
 
 fn plural(count: i64) -> &'static str {

--- a/godot-core/src/builtin/meta/call_error.rs
+++ b/godot-core/src/builtin/meta/call_error.rs
@@ -196,7 +196,7 @@ impl CallError {
 
         Self::new(
             call_ctx,
-            format!("parameter [{param_index}] of type {param_ty} failed to convert to Variant; {convert_error}"),
+            format!("parameter [{param_index}] of type {param_ty} failed conversion"),
             Some(convert_error),
         )
     }
@@ -210,7 +210,7 @@ impl CallError {
 
         Self::new(
             call_ctx,
-            format!("return type {return_ty} failed to convert from Variant; {convert_error}"),
+            format!("return value {return_ty} failed conversion"),
             Some(convert_error),
         )
     }

--- a/godot-core/src/builtin/meta/godot_convert/convert_error.rs
+++ b/godot-core/src/builtin/meta/godot_convert/convert_error.rs
@@ -229,7 +229,7 @@ pub(crate) enum FromVariantError {
     /// Variant type does not match expected type
     BadType {
         expected: VariantType,
-        got: VariantType,
+        actual: VariantType,
     },
 
     WrongClass {
@@ -247,11 +247,12 @@ impl FromVariantError {
 
     fn description(&self) -> String {
         match self {
-            Self::BadType { expected, got } => {
-                format!("Variant type mismatch -- expected `{expected:?}` but got `{got:?}`")
+            Self::BadType { expected, actual } => {
+                // Note: wording is the same as in CallError::failed_param_conversion_engine()
+                format!("expected type `{expected:?}`, got `{actual:?}`")
             }
             Self::WrongClass { expected } => {
-                format!("Variant class mismatch -- expected `{expected}`")
+                format!("expected class `{expected}`")
             }
         }
     }

--- a/godot-core/src/builtin/meta/godot_convert/convert_error.rs
+++ b/godot-core/src/builtin/meta/godot_convert/convert_error.rs
@@ -24,14 +24,6 @@ pub struct ConvertError {
 
 impl ConvertError {
     /// Create a new custom error for a conversion.
-    pub fn new() -> Self {
-        Self {
-            kind: ErrorKind::Custom,
-            cause: None,
-            value: None,
-        }
-    }
-
     fn custom() -> Self {
         Self {
             kind: ErrorKind::Custom,
@@ -85,12 +77,6 @@ impl ConvertError {
 
     fn description(&self) -> Option<String> {
         self.kind.description()
-    }
-}
-
-impl Default for ConvertError {
-    fn default() -> Self {
-        Self::new()
     }
 }
 

--- a/godot-core/src/builtin/meta/godot_convert/convert_error.rs
+++ b/godot-core/src/builtin/meta/godot_convert/convert_error.rs
@@ -19,30 +19,35 @@ type Cause = Box<dyn Error + Send + Sync>;
 pub struct ConvertError {
     kind: ErrorKind,
     cause: Option<Cause>,
-    value: Option<String>,
+    value_str: Option<String>,
 }
 
 impl ConvertError {
+    // Constructors are private (or hidden) as only the library or its proc-macros should construct this type.
+
     /// Create a new custom error for a conversion.
     fn custom() -> Self {
         Self {
             kind: ErrorKind::Custom,
             cause: None,
-            value: None,
+            value_str: None,
         }
     }
 
     /// Create a new custom error for a conversion with the value that failed to convert.
-    pub fn with_value<V>(value: V) -> Self
+    pub(crate) fn with_kind_value<V>(kind: ErrorKind, value: V) -> Self
     where
         V: fmt::Debug,
     {
-        let mut err = Self::custom();
-        err.value = Some(format!("{value:?}"));
-        err
+        Self {
+            kind,
+            cause: None,
+            value_str: Some(format!("{value:?}")),
+        }
     }
 
     /// Create a new custom error with a rust-error as an underlying cause for the conversion error.
+    #[doc(hidden)]
     pub fn with_cause<C>(cause: C) -> Self
     where
         C: Into<Cause>,
@@ -54,6 +59,7 @@ impl ConvertError {
 
     /// Create a new custom error with a rust-error as an underlying cause for the conversion error, and the
     /// value that failed to convert.
+    #[doc(hidden)]
     pub fn with_cause_value<C, V>(cause: C, value: V) -> Self
     where
         C: Into<Cause>,
@@ -61,7 +67,7 @@ impl ConvertError {
     {
         let mut err = Self::custom();
         err.cause = Some(cause.into());
-        err.value = Some(format!("{value:?}"));
+        err.value_str = Some(format!("{value:?}"));
         err
     }
 
@@ -72,7 +78,7 @@ impl ConvertError {
 
     /// Returns a string representation of the value that failed to convert, if one exists.
     pub fn value_str(&self) -> Option<&str> {
-        self.value.as_deref()
+        self.value_str.as_deref()
     }
 
     fn description(&self) -> Option<String> {
@@ -89,8 +95,8 @@ impl fmt::Display for ConvertError {
             (None, None) => write!(f, "unknown error: {:?}", self.kind)?,
         }
 
-        if let Some(value) = self.value.as_ref() {
-            write!(f, "\n\tvalue: `{value:?}`")?;
+        if let Some(value) = self.value_str.as_ref() {
+            write!(f, ": {value}")?;
         }
 
         Ok(())
@@ -141,11 +147,7 @@ impl FromGodotError {
     where
         V: fmt::Debug,
     {
-        ConvertError {
-            kind: ErrorKind::FromGodot(self),
-            cause: None,
-            value: Some(format!("{value:?}")),
-        }
+        ConvertError::with_kind_value(ErrorKind::FromGodot(self), value)
     }
 
     fn description(&self) -> String {
@@ -203,11 +205,7 @@ impl FromFfiError {
     where
         V: fmt::Debug,
     {
-        ConvertError {
-            kind: ErrorKind::FromFfi(self),
-            cause: None,
-            value: Some(format!("{value:?}")),
-        }
+        ConvertError::with_kind_value(ErrorKind::FromFfi(self), value)
     }
 
     fn description(&self) -> String {
@@ -244,20 +242,16 @@ impl FromVariantError {
     where
         V: fmt::Debug,
     {
-        ConvertError {
-            kind: ErrorKind::FromVariant(self),
-            cause: None,
-            value: Some(format!("{value:?}")),
-        }
+        ConvertError::with_kind_value(ErrorKind::FromVariant(self), value)
     }
 
     fn description(&self) -> String {
         match self {
             Self::BadType { expected, got } => {
-                format!("expected Variant of type `{expected:?}` but got Variant of type `{got:?}`")
+                format!("Variant type mismatch -- expected `{expected:?}` but got `{got:?}`")
             }
             Self::WrongClass { expected } => {
-                format!("expected class `{expected}`, got variant with wrong class")
+                format!("Variant class mismatch -- expected `{expected}`")
             }
         }
     }

--- a/godot-core/src/builtin/meta/mod.rs
+++ b/godot-core/src/builtin/meta/mod.rs
@@ -7,11 +7,13 @@
 
 pub mod registration;
 
+mod call_error;
 mod class_name;
 mod godot_convert;
 mod return_marshal;
 mod signature;
 
+pub use call_error::*;
 pub use class_name::*;
 pub use godot_convert::*;
 #[doc(hidden)]

--- a/godot-core/src/builtin/variant/impls.rs
+++ b/godot-core/src/builtin/variant/impls.rs
@@ -40,7 +40,7 @@ macro_rules! impl_ffi_variant {
                 if variant.get_type() != Self::variant_type() {
                     return Err(FromVariantError::BadType {
                         expected: Self::variant_type(),
-                        got: variant.get_type(),
+                        actual: variant.get_type(),
                     }
                     .into_error(variant));
                 }
@@ -158,7 +158,7 @@ impl GodotFfiVariant for () {
 
         Err(FromVariantError::BadType {
             expected: VariantType::Nil,
-            got: variant.get_type(),
+            actual: variant.get_type(),
         }
         .into_error(variant))
     }

--- a/godot-core/src/builtin/variant/mod.rs
+++ b/godot-core/src/builtin/variant/mod.rs
@@ -5,7 +5,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+use crate::builtin::meta::{impl_godot_as_self, ConvertError, FromGodot, ToGodot};
 use crate::builtin::{GString, StringName};
+use crate::gen::central::VariantDispatch;
 use godot_ffi as sys;
 use std::{fmt, ptr};
 use sys::types::OpaqueVariant;
@@ -14,8 +16,6 @@ use sys::{ffi_methods, interface_fn, GodotFfi};
 mod impls;
 
 pub use sys::{VariantOperator, VariantType};
-
-use super::meta::{impl_godot_as_self, ConvertError, FromGodot, ToGodot};
 
 /// Godot variant type, able to store a variety of different types.
 ///
@@ -375,8 +375,6 @@ impl fmt::Display for Variant {
 
 impl fmt::Debug for Variant {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let ty = self.get_type();
-        let val = self.stringify();
-        write!(f, "Variant(ty={ty:?}, val={val})")
+        VariantDispatch::from_variant(self).fmt(f)
     }
 }

--- a/godot-core/src/builtin/variant/mod.rs
+++ b/godot-core/src/builtin/variant/mod.rs
@@ -228,7 +228,6 @@ impl Variant {
     }
 
     /// # Safety
-    ///
     /// See [`GodotFfi::from_sys_init`] and [`GodotFfi::from_sys_init_default`].
     #[cfg(before_api = "4.1")]
     pub unsafe fn from_var_sys_init_or_init_default(
@@ -238,7 +237,6 @@ impl Variant {
     }
 
     /// # Safety
-    ///
     /// See [`GodotFfi::from_sys_init`] and [`GodotFfi::from_sys_init_default`].
     #[cfg(since_api = "4.1")]
     #[doc(hidden)]
@@ -246,6 +244,22 @@ impl Variant {
         init_fn: impl FnOnce(sys::GDExtensionUninitializedVariantPtr),
     ) -> Self {
         Self::from_var_sys_init(init_fn)
+    }
+
+    /// # Safety
+    /// See [`GodotFfi::from_sys_init`].
+    #[doc(hidden)]
+    pub unsafe fn from_var_sys_init_result<E>(
+        init_fn: impl FnOnce(sys::GDExtensionUninitializedVariantPtr) -> Result<(), E>,
+    ) -> Result<Self, E> {
+        // Relies on current macro expansion of from_var_sys_init() having a certain implementation.
+
+        let mut raw = std::mem::MaybeUninit::<OpaqueVariant>::uninit();
+
+        let var_uninit_ptr =
+            raw.as_mut_ptr() as <sys::GDExtensionVariantPtr as ::godot_ffi::AsUninit>::Ptr;
+
+        init_fn(var_uninit_ptr).map(|_err| Self::from_opaque(raw.assume_init()))
     }
 
     #[doc(hidden)]

--- a/godot-core/src/log.rs
+++ b/godot-core/src/log.rs
@@ -7,6 +7,20 @@
 
 //! Printing and logging functionality.
 
+// https://stackoverflow.com/a/40234666
+#[macro_export]
+#[doc(hidden)]
+macro_rules! inner_function {
+    () => {{
+        fn f() {}
+        fn type_name_of<T>(_: T) -> &'static str {
+            std::any::type_name::<T>()
+        }
+        let name = type_name_of(f);
+        name.strip_suffix("::f").unwrap()
+    }};
+}
+
 #[macro_export]
 #[doc(hidden)]
 macro_rules! inner_godot_msg {
@@ -19,9 +33,10 @@ macro_rules! inner_godot_msg {
 
             // Check whether engine is loaded, otherwise fall back to stderr.
             if $crate::sys::is_initialized() {
+                let function = format!("{}\0", $crate::inner_function!());
                 $crate::sys::interface_fn!($godot_fn)(
                     $crate::sys::c_str_from_str(&msg),
-                    $crate::sys::c_str(b"<function unset>\0"),
+                    $crate::sys::c_str_from_str(&function),
                     $crate::sys::c_str_from_str(concat!(file!(), "\0")),
                     line!() as i32,
                     false as $crate::sys::GDExtensionBool, // whether to create a toast notification in editor

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -487,9 +487,11 @@ where
         let is_panic_unwind = std::thread::panicking();
         let error_or_panic = |msg: String| {
             if is_panic_unwind {
-                crate::godot_error!(
-                    "Encountered 2nd panic in free() during panic unwind; will skip destruction:\n{msg}"
-                );
+                if crate::private::has_error_print_level(1) {
+                    crate::godot_error!(
+                        "Encountered 2nd panic in free() during panic unwind; will skip destruction:\n{msg}"
+                    );
+                }
             } else {
                 panic!("{}", msg);
             }

--- a/godot-core/src/private.rs
+++ b/godot-core/src/private.rs
@@ -158,6 +158,7 @@ pub fn is_class_runtime(is_tool: bool) -> bool {
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Panic handling
 
+#[derive(Debug)]
 struct GodotPanicInfo {
     line: u32,
     file: String,
@@ -180,9 +181,9 @@ fn format_panic_message(msg: String) -> String {
     let indented = msg.replace('\n', lbegin);
 
     if indented.len() != msg.len() {
-        format!("Panic msg:{lbegin}{indented}")
+        format!("[panic]{lbegin}{indented}")
     } else {
-        format!("Panic msg:  {msg}")
+        format!("[panic]  {msg}")
     }
 }
 

--- a/godot-core/src/registry/mod.rs
+++ b/godot-core/src/registry/mod.rs
@@ -425,6 +425,8 @@ fn fill_class_info(item: PluginItem, c: &mut ClassRegistrationInfo) {
             #[cfg(before_api = "4.2")]
             assert!(generated_recreate_fn.is_none()); // not used
 
+            #[cfg(before_api = "4.3")]
+            let _ = is_tool; // mark used
             #[cfg(since_api = "4.3")]
             {
                 c.godot_params.is_runtime =

--- a/godot-ffi/src/extras.rs
+++ b/godot-ffi/src/extras.rs
@@ -59,7 +59,7 @@ impl_as_uninit!(GDExtensionTypePtr, GDExtensionUninitializedTypePtr);
 // Helper functions
 
 /// Differentiate from `sys::GDEXTENSION_CALL_ERROR_*` codes.
-pub const GODOT_RUST_CALL_ERROR: GDExtensionCallErrorType = 40;
+pub const GODOT_RUST_CUSTOM_CALL_ERROR: GDExtensionCallErrorType = 40;
 
 #[doc(hidden)]
 #[inline]
@@ -71,6 +71,7 @@ pub fn default_call_error() -> GDExtensionCallError {
     }
 }
 
+// TODO remove this, in favor of CallError
 #[doc(hidden)]
 #[inline]
 #[track_caller] // panic message points to call site
@@ -108,7 +109,7 @@ pub fn panic_call_error(
         }
         GDEXTENSION_CALL_ERROR_INSTANCE_IS_NULL => "instance is null".to_string(),
         GDEXTENSION_CALL_ERROR_METHOD_NOT_CONST => "method is not const".to_string(), // not handled in Godot
-        GODOT_RUST_CALL_ERROR => "godot-rust function call failed".to_string(),
+        GODOT_RUST_CUSTOM_CALL_ERROR => "godot-rust function call failed".to_string(),
         _ => format!("unknown reason (error code {error})"),
     };
 

--- a/godot-ffi/src/godot_ffi.rs
+++ b/godot-ffi/src/godot_ffi.rs
@@ -218,41 +218,6 @@ macro_rules! ffi_methods_one {
         }
     };
 
-    // type $Ptr = Opaque
-    (OpaqueValue $Ptr:ty; $( #[$attr:meta] )? $vis:vis $from_sys:ident = from_sys) => {
-        $( #[$attr] )? $vis
-        unsafe fn $from_sys(ptr: $Ptr) -> Self {
-            let opaque = std::mem::transmute(ptr);
-            Self::from_opaque(opaque)
-        }
-    };
-    (OpaqueValue $Ptr:ty; $( #[$attr:meta] )? $vis:vis $from_sys_init:ident = from_sys_init) => {
-        $( #[$attr] )? $vis
-        unsafe fn $from_sys_init(init: impl FnOnce(<$Ptr as $crate::AsUninit>::Ptr)) -> Self {
-            let mut raw = std::mem::MaybeUninit::uninit();
-            init(std::mem::transmute(raw.as_mut_ptr()));
-            Self::from_opaque(raw.assume_init())
-        }
-    };
-    (OpaqueValue $Ptr:ty; $( #[$attr:meta] )? $vis:vis $sys:ident = sys) => {
-        $( #[$attr] )? $vis
-        fn $sys(&self) -> $Ptr {
-            unsafe { std::mem::transmute(self.opaque) }
-        }
-    };
-    (OpaqueValue $Ptr:ty; $( #[$attr:meta] )? $vis:vis $from_arg_ptr:ident = from_arg_ptr) => {
-        $( #[$attr] )? $vis
-        unsafe fn $from_arg_ptr(ptr: $Ptr, _call_type: $crate::PtrcallType) -> Self {
-            Self::from_sys(ptr as *mut _)
-        }
-    };
-    (OpaqueValue $Ptr:ty; $( #[$attr:meta] )? $vis:vis $move_return_ptr:ident = move_return_ptr) => {
-        $( #[$attr] )? $vis
-        unsafe fn $move_return_ptr(mut self, dst: $Ptr, _call_type: $crate::PtrcallType) {
-            std::ptr::swap(dst, std::mem::transmute::<_, $Ptr>(self.opaque))
-        }
-    };
-
     // type $Ptr = *mut Self
     (SelfPtr $Ptr:ty; $( #[$attr:meta] )? $vis:vis $from_sys:ident = from_sys) => {
         $( #[$attr] )? $vis

--- a/godot-ffi/src/toolbox.rs
+++ b/godot-ffi/src/toolbox.rs
@@ -145,6 +145,14 @@ where
     join_with(iter, ", ", |item| format!("{item}"))
 }
 
+pub fn join_debug<T, I>(iter: I) -> String
+where
+    T: std::fmt::Debug,
+    I: Iterator<Item = T>,
+{
+    join_with(iter, ", ", |item| format!("{item:?}"))
+}
+
 pub fn join_with<T, I, F>(mut iter: I, sep: &str, mut format_elem: F) -> String
 where
     I: Iterator<Item = T>,

--- a/godot-ffi/src/toolbox.rs
+++ b/godot-ffi/src/toolbox.rs
@@ -137,6 +137,32 @@ pub unsafe fn bitwise_equal<T>(lhs: *const T, rhs: *const T) -> bool {
         == std::slice::from_raw_parts(rhs as *const u8, std::mem::size_of::<T>())
 }
 
+pub fn join<T, I>(iter: I) -> String
+where
+    T: std::fmt::Display,
+    I: Iterator<Item = T>,
+{
+    join_with(iter, ", ", |item| format!("{item}"))
+}
+
+pub fn join_with<T, I, F>(mut iter: I, sep: &str, mut format_elem: F) -> String
+where
+    I: Iterator<Item = T>,
+    F: FnMut(&T) -> String,
+{
+    let mut result = String::new();
+
+    if let Some(first) = iter.next() {
+        result.push_str(&format_elem(&first));
+        for item in iter {
+            result.push_str(sep);
+            result.push_str(&format_elem(&item));
+        }
+    }
+
+    result
+}
+
 /*
 pub fn unqualified_type_name<T>() -> &'static str {
     let type_name = std::any::type_name::<T>();

--- a/godot-macros/src/class/derive_godot_class.rs
+++ b/godot-macros/src/class/derive_godot_class.rs
@@ -330,6 +330,8 @@ fn parse_struct_attributes(class: &Struct) -> ParseResult<ClassAttributes> {
         }
 
         // #[class(hidden)]
+        // TODO consider naming this "internal"; godot-cpp uses that terminology:
+        // https://github.com/godotengine/godot-cpp/blob/master/include/godot_cpp/core/class_db.hpp#L327
         if let Some(span) = parser.handle_alone_with_span("hidden")? {
             require_api_version!("4.2", span, "#[class(hidden)]")?;
             is_hidden = true;

--- a/godot-macros/src/derive/derive_from_godot.rs
+++ b/godot-macros/src/derive/derive_from_godot.rs
@@ -61,7 +61,8 @@ fn make_fromgodot_for_int_enum(name: &Ident, enum_: &CStyleEnum, int: &Ident) ->
                     #(
                         #discriminants => Ok(#name::#names),
                     )*
-                    other => Err(::godot::builtin::meta::ConvertError::with_cause_value(#bad_variant_error, other))
+                    // Pass `via` and not `other`, to retain debug info of original type.
+                    other => Err(::godot::builtin::meta::ConvertError::with_cause_value(#bad_variant_error, via))
                 }
             }
         }
@@ -81,7 +82,8 @@ fn make_fromgodot_for_gstring_enum(name: &Ident, enum_: &CStyleEnum) -> TokenStr
                     #(
                         #names_str => Ok(#name::#names),
                     )*
-                    other => Err(::godot::builtin::meta::ConvertError::with_cause_value(#bad_variant_error, other))
+                    // Pass `via` and not `other`, to retain debug info of original type.
+                    other => Err(::godot::builtin::meta::ConvertError::with_cause_value(#bad_variant_error, via))
                 }
             }
         }

--- a/itest/rust/src/framework/runner.rs
+++ b/itest/rust/src/framework/runner.rs
@@ -184,7 +184,7 @@ impl IntegrationTests {
                     // could not be caught, causing UB at the Godot FFI boundary (in practice, this will be a defined Godot crash with
                     // stack trace though).
                     godot_error!("GDScript test panicked");
-                    godot::private::print_panic(e);
+                    godot::private::extract_panic_message(e);
                     TestOutcome::Failed
                 }
             };
@@ -310,9 +310,9 @@ fn run_rust_test(test: &RustTestCase, ctx: &TestContext) -> TestOutcome {
 
     // Explicit type to prevent tests from returning a value
     let err_context = || format!("itest `{}` failed", test.name);
-    let success: Option<()> = godot::private::handle_panic(err_context, || (test.function)(ctx));
+    let success: Result<(), _> = godot::private::handle_panic(err_context, || (test.function)(ctx));
 
-    TestOutcome::from_bool(success.is_some())
+    TestOutcome::from_bool(success.is_ok())
 }
 
 fn print_test_pre(test_case: &str, test_file: String, last_file: &mut Option<String>, flush: bool) {

--- a/itest/rust/src/object_tests/dynamic_call_test.rs
+++ b/itest/rust/src/object_tests/dynamic_call_test.rs
@@ -7,11 +7,11 @@
 
 use godot::builtin::meta::{CallError, FromGodot, ToGodot};
 use godot::builtin::{StringName, Variant, Vector3};
-use godot::engine::{Node3D, Object};
+use godot::engine::{Node, Node3D, Object};
 use godot::obj::{InstanceId, NewAlloc};
 use std::error::Error;
 
-use crate::framework::{expect_panic, itest};
+use crate::framework::{expect_panic, itest, runs_release};
 use crate::object_tests::object_test::ObjPayload;
 
 #[itest]
@@ -44,6 +44,9 @@ fn dynamic_call_with_args() {
     node.free();
 }
 
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// Erroneous dynamic calls to #[func]
+
 #[itest]
 fn dynamic_call_with_too_few_args() {
     let mut obj = ObjPayload::new_alloc();
@@ -65,7 +68,7 @@ fn dynamic_call_with_too_few_args() {
         call_error.to_string(),
         "godot-rust function call failed: Object::call(&\"take_1_int\")\
         \n  Source: ObjPayload::take_1_int()\
-        \n  Reason: function has 1 parameter, but received 0 arguments"
+        \n    Reason: function has 1 parameter, but received 0 arguments"
     );
 
     // Method where error originated (this is not repeated in all tests, the logic for chaining is the same).
@@ -73,7 +76,7 @@ fn dynamic_call_with_too_few_args() {
     assert_eq!(
         source.to_string(),
         "godot-rust function call failed: ObjPayload::take_1_int()\
-        \n  Reason: function has 1 parameter, but received 0 arguments"
+        \n    Reason: function has 1 parameter, but received 0 arguments"
     );
 
     let source = source
@@ -103,9 +106,36 @@ fn dynamic_call_with_too_many_args() {
     assert_eq!(call_error.method_name(), "call");
     assert_eq!(
         call_error.to_string(),
-        "godot-rust function call failed: Object::call(&\"take_1_int\", varargs 42, 43)\
+        "godot-rust function call failed: Object::call(&\"take_1_int\", [va] 42, 43)\
         \n  Source: ObjPayload::take_1_int()\
-        \n  Reason: function has 1 parameter, but received 2 arguments"
+        \n    Reason: function has 1 parameter, but received 2 arguments"
+    );
+
+    obj.free();
+}
+
+#[itest]
+fn dynamic_call_parameter_mismatch() {
+    let mut obj = ObjPayload::new_alloc();
+
+    // Use panicking version.
+    expect_panic("call with wrong argument type", || {
+        obj.call("take_1_int".into(), &["string".to_variant()]);
+    });
+
+    // Use Result-based version.
+    let call_error = obj
+        .try_call("take_1_int".into(), &["string".to_variant()])
+        .expect_err("expected failed call");
+
+    assert_eq!(call_error.class_name(), Some("Object"));
+    assert_eq!(call_error.method_name(), "call");
+    assert_eq!(
+        call_error.to_string(),
+        "godot-rust function call failed: Object::call(&\"take_1_int\", [va] \"string\")\
+        \n  Source: ObjPayload::take_1_int()\
+        \n    Reason: parameter #0 (i64) conversion\
+        \n  Source: expected type `Int`, got `String`: \"string\""
     );
 
     obj.free();
@@ -124,8 +154,123 @@ fn dynamic_call_with_panic() {
         call_error.to_string(),
         "godot-rust function call failed: Object::call(&\"do_panic\")\
         \n  Source: ObjPayload::do_panic()\
-        \n  Reason: Panic msg:  do_panic exploded"
+        \n    Reason: [panic]  do_panic exploded"
     );
 
     obj.free();
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// Erroneous dynamic calls to engine APIs
+
+#[itest]
+fn dynamic_call_with_too_few_args_engine() {
+    // Disabled in release (parameter count is unchecked by engine).
+    // Before 4.2, the Godot check had a bug: https://github.com/godotengine/godot/pull/80844.
+    if runs_release() || cfg!(before_api = "4.2") {
+        return;
+    }
+
+    let mut node = Node::new_alloc();
+
+    // Use panicking version.
+    expect_panic("call with too few arguments", || {
+        node.call("rpc_config".into(), &["some_method".to_variant()]);
+    });
+
+    // Use Result-based version.
+    let call_error = node
+        .try_call("rpc_config".into(), &["some_method".to_variant()])
+        .expect_err("expected failed call");
+
+    assert_eq!(call_error.class_name(), Some("Object"));
+    assert_eq!(call_error.method_name(), "call");
+    assert_eq!(
+        call_error.to_string(),
+        "godot-rust function call failed: Object::call(&\"rpc_config\", [va] \"some_method\")\
+        \n    Reason: function has 2 parameters, but received 1 argument"
+    );
+
+    node.free();
+}
+
+#[itest]
+fn dynamic_call_with_too_many_args_engine() {
+    // Disabled in release (parameter count is unchecked by engine).
+    // Before 4.2, the Godot check had a bug: https://github.com/godotengine/godot/pull/80844.
+    if runs_release() || cfg!(before_api = "4.2") {
+        return;
+    }
+
+    let mut node = Node::new_alloc();
+
+    // Use panicking version.
+    expect_panic("call with too many arguments", || {
+        node.call(
+            "rpc_config".into(),
+            &["some_method".to_variant(), Variant::nil(), 123.to_variant()],
+        );
+    });
+
+    // Use Result-based version.
+    let call_error = node
+        .try_call(
+            "rpc_config".into(),
+            &["some_method".to_variant(), Variant::nil(), 123.to_variant()],
+        )
+        .expect_err("expected failed call");
+
+    assert_eq!(call_error.class_name(), Some("Object"));
+    assert_eq!(call_error.method_name(), "call");
+    assert_eq!(
+        call_error.to_string(),
+        "godot-rust function call failed: Object::call(&\"rpc_config\", [va] \"some_method\", null, 123)\
+        \n    Reason: function has 2 parameters, but received 3 arguments"
+    );
+
+    node.free();
+}
+
+#[itest]
+fn dynamic_call_parameter_mismatch_engine() {
+    // Disabled in release (parameter types are unchecked by engine).
+    if runs_release() {
+        return;
+    }
+
+    let mut node = Node::new_alloc();
+
+    // Use panicking version.
+    expect_panic("call with wrong argument type", || {
+        node.call("set_name".into(), &[123.to_variant()]);
+    });
+
+    // Use Result-based version.
+    let call_error = node
+        .try_call("set_name".into(), &[123.to_variant()])
+        .expect_err("expected failed call");
+
+    // Note: currently no mention of Node::set_name(). Not sure if easily possible to add.
+    assert_eq!(call_error.class_name(), Some("Object"));
+    assert_eq!(call_error.method_name(), "call");
+    assert_eq!(
+        call_error.to_string(),
+        "godot-rust function call failed: Object::call(&\"set_name\", [va] 123)\
+        \n    Reason: parameter #1 conversion -- expected type `String`, got `Int`"
+    );
+
+    node.free();
+}
+
+#[itest(skip)]
+fn dynamic_call_return_mismatch() {
+    // Cannot easily test this, as both calls to #[func] and Godot APIs are either strongly typed and correct (ensured by codegen),
+    // or they return Variant, which then fails on user side only.
+
+    // Even GDScript -> Rust calls cannot really use this. Given this GDScript code:
+    //   var obj = ObjPayload.new()
+    // 	 var result: String = obj.take_1_int(20)
+    //
+    // The parser will fail since it knows the signature of take_1_int(). And if we enforce `: Variant` type hints, it will just
+    // cause a runtime error, but that's entirely handled in GDScript.
 }

--- a/itest/rust/src/object_tests/dynamic_call_test.rs
+++ b/itest/rust/src/object_tests/dynamic_call_test.rs
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use godot::builtin::meta::{CallError, FromGodot, ToGodot};
+use godot::builtin::{StringName, Variant, Vector3};
+use godot::engine::{Node3D, Object};
+use godot::obj::{InstanceId, NewAlloc};
+use std::error::Error;
+
+use crate::framework::{expect_panic, itest};
+use crate::object_tests::object_test::ObjPayload;
+
+#[itest]
+fn dynamic_call_no_args() {
+    let mut node = Node3D::new_alloc().upcast::<Object>();
+
+    let static_id = node.instance_id();
+    let reflect_id_variant = node.call(StringName::from("get_instance_id"), &[]);
+
+    let reflect_id = InstanceId::from_variant(&reflect_id_variant);
+
+    assert_eq!(static_id, reflect_id);
+    node.free();
+}
+
+#[itest]
+fn dynamic_call_with_args() {
+    let mut node = Node3D::new_alloc();
+
+    let expected_pos = Vector3::new(2.5, 6.42, -1.11);
+
+    let none = node.call(
+        StringName::from("set_position"),
+        &[expected_pos.to_variant()],
+    );
+    let actual_pos = node.call(StringName::from("get_position"), &[]);
+
+    assert_eq!(none, Variant::nil());
+    assert_eq!(actual_pos, expected_pos.to_variant());
+    node.free();
+}
+
+#[itest]
+fn dynamic_call_with_too_few_args() {
+    let mut obj = ObjPayload::new_alloc();
+
+    // Use panicking version.
+    expect_panic("call with too few arguments", || {
+        obj.call("take_1_int".into(), &[]);
+    });
+
+    // Use Result-based version.
+    let call_error = obj
+        .try_call("take_1_int".into(), &[])
+        .expect_err("expected failed call");
+
+    // User-facing method to which error was propagated.
+    assert_eq!(call_error.class_name(), Some("Object"));
+    assert_eq!(call_error.method_name(), "call");
+    assert_eq!(
+        call_error.to_string(),
+        "godot-rust function call failed: Object::call(&\"take_1_int\")\
+        \n  Source: ObjPayload::take_1_int()\
+        \n  Reason: function has 1 parameter, but received 0 arguments"
+    );
+
+    // Method where error originated (this is not repeated in all tests, the logic for chaining is the same).
+    let source = call_error.source().expect("must have source CallError");
+    assert_eq!(
+        source.to_string(),
+        "godot-rust function call failed: ObjPayload::take_1_int()\
+        \n  Reason: function has 1 parameter, but received 0 arguments"
+    );
+
+    let source = source
+        .downcast_ref::<CallError>()
+        .expect("source must be CallError");
+    assert_eq!(source.class_name(), Some("ObjPayload"));
+    assert_eq!(source.method_name(), "take_1_int");
+
+    obj.free();
+}
+
+#[itest]
+fn dynamic_call_with_too_many_args() {
+    let mut obj = ObjPayload::new_alloc();
+
+    // Use panicking version.
+    expect_panic("call with too many arguments", || {
+        obj.call("take_1_int".into(), &[42.to_variant(), 43.to_variant()]);
+    });
+
+    // Use Result-based version.
+    let call_error = obj
+        .try_call("take_1_int".into(), &[42.to_variant(), 43.to_variant()])
+        .expect_err("expected failed call");
+
+    assert_eq!(call_error.class_name(), Some("Object"));
+    assert_eq!(call_error.method_name(), "call");
+    assert_eq!(
+        call_error.to_string(),
+        "godot-rust function call failed: Object::call(&\"take_1_int\", varargs 42, 43)\
+        \n  Source: ObjPayload::take_1_int()\
+        \n  Reason: function has 1 parameter, but received 2 arguments"
+    );
+
+    obj.free();
+}
+
+#[itest]
+fn dynamic_call_with_panic() {
+    let mut obj = ObjPayload::new_alloc();
+
+    let result = obj.try_call("do_panic".into(), &[]);
+    let call_error = result.expect_err("panic should cause a call error");
+
+    assert_eq!(call_error.class_name(), Some("Object"));
+    assert_eq!(call_error.method_name(), "call");
+    assert_eq!(
+        call_error.to_string(),
+        "godot-rust function call failed: Object::call(&\"do_panic\")\
+        \n  Source: ObjPayload::do_panic()\
+        \n  Reason: Panic msg:  do_panic exploded"
+    );
+
+    obj.free();
+}

--- a/itest/rust/src/object_tests/mod.rs
+++ b/itest/rust/src/object_tests/mod.rs
@@ -7,6 +7,7 @@
 
 mod base_test;
 mod class_rename_test;
+mod dynamic_call_test;
 mod object_swap_test;
 mod object_test;
 mod onready_test;

--- a/itest/rust/src/object_tests/object_test.rs
+++ b/itest/rust/src/object_tests/object_test.rs
@@ -802,68 +802,6 @@ fn object_user_share_drop() {
 }
 
 #[itest]
-fn object_call_no_args() {
-    let mut node = Node3D::new_alloc().upcast::<Object>();
-
-    let static_id = node.instance_id();
-    let reflect_id_variant = node.call(StringName::from("get_instance_id"), &[]);
-
-    let reflect_id = InstanceId::from_variant(&reflect_id_variant);
-
-    assert_eq!(static_id, reflect_id);
-    node.free();
-}
-
-#[itest]
-fn object_call_with_args() {
-    let mut node = Node3D::new_alloc();
-
-    let expected_pos = Vector3::new(2.5, 6.42, -1.11);
-
-    let none = node.call(
-        StringName::from("set_position"),
-        &[expected_pos.to_variant()],
-    );
-    let actual_pos = node.call(StringName::from("get_position"), &[]);
-
-    assert_eq!(none, Variant::nil());
-    assert_eq!(actual_pos, expected_pos.to_variant());
-    node.free();
-}
-
-#[itest]
-fn object_call_with_too_few_args() {
-    let mut obj = ObjPayload::new_alloc();
-
-    expect_panic("call with too few arguments", || {
-        obj.call("take_1_int".into(), &[]);
-    });
-
-    obj.free();
-}
-
-#[itest]
-fn object_call_with_too_many_args() {
-    let mut obj = ObjPayload::new_alloc();
-
-    expect_panic("call with too many arguments", || {
-        obj.call("take_1_int".into(), &[42.to_variant(), 43.to_variant()]);
-    });
-
-    obj.free();
-}
-
-#[itest(skip)] // Not yet implemented.
-fn object_call_panic_is_nil() {
-    let mut obj = ObjPayload::new_alloc();
-
-    let result = obj.call("do_panic".into(), &[]);
-    assert_eq!(result, Variant::nil());
-
-    obj.free();
-}
-
-#[itest]
 fn object_get_scene_tree(ctx: &TestContext) {
     let node = Node3D::new_alloc();
 
@@ -892,7 +830,7 @@ impl ObjPayload {
 
     #[func]
     fn do_panic(&self) {
-        panic!("panic from Rust");
+        panic!("do_panic exploded");
     }
 }
 


### PR DESCRIPTION
Overhauls the entire call diagnostic system, changing panics to `Result`s internally and significantly improving user-facing error messages.

Fallible varcall methods such as `Object::call()` or `Node::call_group()` now receive an additional `try_*` overload which returns `Result<T, CallError>` instead of panicking. `CallError` is a new type that embodies function call errors, and allows to inspect the affected class/method, as well as the chain of calls.

Incidentally improves `ConvertError` messages, makes `Variant`'s `Debug` impl more concise, and disables excessive panic printing in integration tests.

There is some work left for later PRs:
- Utility functions (those should not get `try_` overloads, but at least use the same code path).
- `Variant::call()`
- `Callable::call()`.
- Don't print error on `try_*` invocations.
- More robust passing of `CallError` across Godot function boundaries (maybe 1 per thread instead of ever-growing).