### PR TITLE
Fix: Ensure class servers methods are loaded after hot reload

### DIFF
--- a/godot-core/src/init/mod.rs
+++ b/godot-core/src/init/mod.rs
@@ -5,6 +5,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+use std::sync::atomic::{AtomicBool, Ordering::Relaxed};
+
 use godot_ffi as sys;
 
 use sys::GodotFfi;
@@ -53,6 +55,8 @@ pub unsafe fn __gdext_load_library<E: ExtensionLibrary>(
     is_success.unwrap_or(0)
 }
 
+static LEVEL_SERVERS_CORE_LOADED: AtomicBool = AtomicBool::new(false);
+
 unsafe extern "C" fn ffi_initialize_layer<E: ExtensionLibrary>(
     _userdata: *mut std::ffi::c_void,
     init_level: sys::GDExtensionInitializationLevel,
@@ -60,10 +64,29 @@ unsafe extern "C" fn ffi_initialize_layer<E: ExtensionLibrary>(
     let level = InitLevel::from_sys(init_level);
     let ctx = || format!("failed to initialize GDExtension level `{:?}`", level);
 
-    // Swallow panics. TODO consider crashing if gdext init fails.
-    let _ = crate::private::handle_panic(ctx, || {
+    fn try_load<E: ExtensionLibrary>(level: InitLevel) {
+        // Workaround for https://github.com/godot-rust/gdext/issues/629:
+        // When using editor plugins, Godot may unload all levels but only reload from Scene upward.
+        // Manually run initialization of lower levels.
+
+        // TODO: Remove this workaround once after the upstream issue is resolved.
+        if level == InitLevel::Scene {
+            if !LEVEL_SERVERS_CORE_LOADED.load(Relaxed) {
+                try_load::<E>(InitLevel::Core);
+                try_load::<E>(InitLevel::Servers);
+            }
+        } else if level == InitLevel::Core {
+            // When it's normal initialization, the `Servers` level is normally initialized.
+            LEVEL_SERVERS_CORE_LOADED.store(true, Relaxed);
+        }
+
         gdext_on_level_init(level);
         E::on_level_init(level);
+    }
+
+    // Swallow panics. TODO consider crashing if gdext init fails.
+    let _ = crate::private::handle_panic(ctx, || {
+        try_load::<E>(level);
     });
 }
 
@@ -76,6 +99,11 @@ unsafe extern "C" fn ffi_deinitialize_layer<E: ExtensionLibrary>(
 
     // Swallow panics.
     let _ = crate::private::handle_panic(ctx, || {
+        if level == InitLevel::Core {
+            // Once the CORE api is unloaded, reset the flag to initial state.
+            LEVEL_SERVERS_CORE_LOADED.store(false, Relaxed);
+        }
+
         E::on_level_deinit(level);
         gdext_on_level_deinit(level);
     });


### PR DESCRIPTION
This pull request addresses issue #629.

## Background

Based on a preliminary analysis, the following observations were made (note that these findings may not be entirely accurate):

1. Upon the initial load of the DLL, `gdext_on_level_init` is invoked in the order of `InitLevel::Servers` followed by `InitLevel::Scene`.
2. When the DLL is rebuilt, the editor detects the updated DLL and initiates a hot reload.
3. Before hot reloading, all nodes created within the editor are removed (as verified by calling `exit_tree` on instances of classes registered through gdext).
4. Upon loading the new DLL, `gdext_on_level_init(InitLevel::Scene)` is immediately called for the new DLL memory space, skipping the call to `InitLevel::Servers`.
5. As a result, attempting to reference `class_servers_api` in the editor plugin after a hot reload leads to a panic due to the missed `InitLevel::Servers` call.

## Workaround

The core issue appears to stem from upstream not invoking the initialization function after hot reloading. The ideal solution would involve upstream sequentially calling class initialization functions following a hot reload. However, as a temporary workaround, we ensure that the `class servers API` is loaded at least once by the library, even if `InitLevel::Server` is skipped.

## Questions

- Following a hot reload, the call to `crate::auto_register_classes(sys::ClassApiLevel::Core)` is omitted. Should a similar lazy loading approach be applied to `InitLevel::Core`?
- `gdext_on_level_init` seems to be guaranteed to be called on the main thread. To prevent re-entry, is it acceptable to reduce overhead by using `unsafe static mut` or `AtomicBool` instead of `std::sync::Mutex`?

Given my limited understanding of the internal architecture, I am uncertain about the potential side effects this may entail. Your review and feedback would be greatly appreciated.
