### PR TITLE
fix: OpenXR is not available on iOS

### DIFF
--- a/godot-codegen/src/special_cases/special_cases.rs
+++ b/godot-codegen/src/special_cases/special_cases.rs
@@ -71,8 +71,9 @@ pub fn is_godot_type_deleted(godot_ty: &str) -> bool {
 
     // OpenXR has not been available for macOS before 4.2.
     // See e.g. https://github.com/GodotVR/godot-xr-tools/issues/479.
+    // OpenXR is also not available on iOS: https://github.com/godotengine/godot/blob/13ba673c42951fd7cfa6fd8a7f25ede7e9ad92bb/modules/openxr/config.py#L2
     // Do not hardcode a list of OpenXR classes, as more may be added in future Godot versions; instead use prefix.
-    #[cfg(all(before_api = "4.2", target_os = "macos"))]
+    #[cfg(any(all(before_api = "4.2", target_os = "macos"), target_os = "ios"))]
     if godot_ty.starts_with("OpenXR") {
         return true;
     }


### PR DESCRIPTION
# What?
Add `OpenXR` to exclusion list when it's building for iOS

# Why?
`gdext` is not being able to load on iOS because is trying to load OpenXR [which is not available there](https://github.com/godotengine/godot/blob/master/modules/openxr/config.py#L2).

```
2024-03-01 15:22:11.208723-0800 GodotProject[5232:98778] USER ERROR: Parameter "mb" is null.
2024-03-01 15:22:11.208772-0800 GodotProject[5232:98778]    at: gdextension_classdb_get_method_bind (core/extension/gdextension_interface.cpp:1347)
USER ERROR: Parameter "mb" is null.
   at: gdextension_classdb_get_method_bind (core/extension/gdextension_interface.cpp:1347)
2024-03-01 15:22:11.210251-0800 GodotProject[5232:98778] USER ERROR: Rust function panicked in file /Users/user/.cargo/git/checkouts/gdext-76630c89719e160c/5e18af8/godot-ffi/src/toolbox.rs at line 249. Context: failed to initialize GDExtension level `Scene`
2024-03-01 15:22:11.210272-0800 GodotProject[5232:98778]    at: <function unset> (/Users/user/.cargo/git/checkouts/gdext-76630c89719e160c/5e18af8/godot-core/src/lib.rs:161)
USER ERROR: Rust function panicked in file /Users/user/.cargo/git/checkouts/gdext-76630c89719e160c/5e18af8/godot-ffi/src/toolbox.rs at line 249. Context: failed to initialize GDExtension level `Scene`
   at: <function unset> (/Users/user/.cargo/git/checkouts/gdext-76630c89719e160c/5e18af8/godot-core/src/lib.rs:161)
2024-03-01 15:22:11.210291-0800 GodotProject[5232:98778] USER ERROR: Panic msg:
  Failed to load class method OpenXRAPIExtension::get_instance (hash 2455072627).
  Make sure gdext and Godot are compatible: https://godot-rust.github.io/book/gdext/advanced/compatibility.html
2024-03-01 15:22:11.210300-0800 GodotProject[5232:98778]    at: <function unset> (/Users/user/.cargo/git/checkouts/gdext-76630c89719e160c/5e18af8/godot-core/src/lib.rs:107)
USER ERROR: Panic msg:
  Failed to load class method OpenXRAPIExtension::get_instance (hash 2455072627).
  Make sure gdext and Godot are compatible: https://godot-rust.github.io/book/gdext/advanced/compatibility.html
   at: <function unset> (/Users/user/.cargo/git/checkouts/gdext-76630c89719e160c/5e18af8/godot-core/src/lib.rs:107)
```