### PR TITLE
`ConvertError`: add back default, new constructor with message

### DIFF
--- a/godot-core/src/builtin/array.rs
+++ b/godot-core/src/builtin/array.rs
@@ -434,7 +434,7 @@ impl<T: GodotType> Array<T> {
         } else {
             Err(FromGodotError::BadArrayType {
                 expected: target_ty,
-                got: self_ty,
+                actual: self_ty,
             }
             .into_error(self))
         }


### PR DESCRIPTION
Fixes https://github.com/godot-rust/gdext/issues/643.

There are unrelated CI errors we'd need to investigate, as upstream changed:
```
  mismatch in property export_packedbytearray, 
  GDScript: "{ "name": "export_packedbytearray", "class_name": &"", "type": 29, "hint": 23, "hint_string": "2:int", "usage": 4102 }"
    , Rust: "{ "name": "export_packedbytearray", "class_name": &"", "type": 29, "hint": 0, "hint_string": "PackedByteArray", "usage": 4102 }"
  mismatch in property export_packedint32array, 
  GDScript: "{ "name": "export_packedint32array", "class_name": &"", "type": 30, "hint": 23, "hint_string": "2:int", "usage": 4102 }"
    , Rust: "{ "name": "export_packedint32array", "class_name": &"", "type": 30, "hint": 0, "hint_string": "PackedInt32Array", "usage": 4102 }"
  mismatch in property export_packedint64array, 
  GDScript: "{ "name": "export_packedint64array", "class_name": &"", "type": 31, "hint": 23, "hint_string": "2:int", "usage": 4102 }"
    , Rust: "{ "name": "export_packedint64array", "class_name": &"", "type": 31, "hint": 0, "hint_string": "PackedInt64Array", "usage": 4102 }"
  mismatch in property export_packedfloat32array, 
  GDScript: "{ "name": "export_packedfloat32array", "class_name": &"", "type": 32, "hint": 23, "hint_string": "3:float", "usage": 4102 }"
    , Rust: "{ "name": "export_packedfloat32array", "class_name": &"", "type": 32, "hint": 0, "hint_string": "PackedFloat32Array", "usage": 4102 }"
  mismatch in property export_packedfloat64array, 
  GDScript: "{ "name": "export_packedfloat64array", "class_name": &"", "type": 33, "hint": 23, "hint_string": "3:float", "usage": 4102 }"
    , Rust: "{ "name": "export_packedfloat64array", "class_name": &"", "type": 33, "hint": 0, "hint_string": "PackedFloat64Array", "usage": 4102 }"
  mismatch in property export_packedstringarray, 
  GDScript: "{ "name": "export_packedstringarray", "class_name": &"", "type": 34, "hint": 23, "hint_string": "4:String", "usage": 4102 }"
    , Rust: "{ "name": "export_packedstringarray", "class_name": &"", "type": 34, "hint": 0, "hint_string": "PackedStringArray", "usage": 4102 }"
  mismatch in property export_packedvector2array, 
  GDScript: "{ "name": "export_packedvector2array", "class_name": &"", "type": 35, "hint": 23, "hint_string": "5:Vector2", "usage": 4102 }"
    , Rust: "{ "name": "export_packedvector2array", "class_name": &"", "type": 35, "hint": 0, "hint_string": "PackedVector2Array", "usage": 4102 }"
  mismatch in property export_packedvector3array, 
  GDScript: "{ "name": "export_packedvector3array", "class_name": &"", "type": 36, "hint": 23, "hint_string": "9:Vector3", "usage": 4102 }"
    , Rust: "{ "name": "export_packedvector3array", "class_name": &"", "type": 36, "hint": 0, "hint_string": "PackedVector3Array", "usage": 4102 }"
  mismatch in property export_packedcolorarray, 
  GDScript: "{ "name": "export_packedcolorarray", "class_name": &"", "type": 37, "hint": 23, "hint_string": "20:Color", "usage": 4102 }"
    , Rust: "{ "name": "export_packedcolorarray", "class_name": &"", "type": 37, "hint": 0, "hint_string": "PackedColorArray", "usage": 4102 }"
```