### PR TITLE
Fix packed array exports

### DIFF
--- a/godot-core/src/builtin/packed_array.rs
+++ b/godot-core/src/builtin/packed_array.rs
@@ -503,6 +503,21 @@ macro_rules! impl_packed_array {
         }
 
         $crate::builtin::meta::impl_godot_as_self!($PackedArray);
+
+        impl $crate::property::Export for $PackedArray {
+            fn default_export_info() -> $crate::property::PropertyHintInfo {
+                if sys::GdextBuild::since_api("4.3") {
+                    // In 4.3 Godot can (and does) use type hint strings for packed arrays.
+                    // https://github.com/godotengine/godot/pull/82952
+                    $crate::property::PropertyHintInfo {
+                        hint: $crate::engine::global::PropertyHint::TYPE_STRING,
+                        hint_string: <$Element as $crate::property::TypeStringHint>::type_string().into(),
+                    }
+                } else {
+                    $crate::property::PropertyHintInfo::with_hint_none(<$PackedArray as $crate::builtin::meta::GodotType>::godot_type_name())
+                }
+            }
+        }
     }
 }
 

--- a/godot-core/src/property.rs
+++ b/godot-core/src/property.rs
@@ -391,15 +391,16 @@ mod export_impls {
     impl_property_by_godot_convert!(Color);
 
     // Arrays
-    impl_property_by_godot_convert!(PackedByteArray);
-    impl_property_by_godot_convert!(PackedInt32Array);
-    impl_property_by_godot_convert!(PackedInt64Array);
-    impl_property_by_godot_convert!(PackedFloat32Array);
-    impl_property_by_godot_convert!(PackedFloat64Array);
-    impl_property_by_godot_convert!(PackedStringArray);
-    impl_property_by_godot_convert!(PackedVector2Array);
-    impl_property_by_godot_convert!(PackedVector3Array);
-    impl_property_by_godot_convert!(PackedColorArray);
+    // We manually implement `Export`.
+    impl_property_by_godot_convert!(PackedByteArray, no_export);
+    impl_property_by_godot_convert!(PackedInt32Array, no_export);
+    impl_property_by_godot_convert!(PackedInt64Array, no_export);
+    impl_property_by_godot_convert!(PackedFloat32Array, no_export);
+    impl_property_by_godot_convert!(PackedFloat64Array, no_export);
+    impl_property_by_godot_convert!(PackedStringArray, no_export);
+    impl_property_by_godot_convert!(PackedVector2Array, no_export);
+    impl_property_by_godot_convert!(PackedVector3Array, no_export);
+    impl_property_by_godot_convert!(PackedColorArray, no_export);
 
     // Primitives
     impl_property_by_godot_convert!(f64);


### PR DESCRIPTION
Packed arrays use type string hints in godot 4.3+ now. This checks at runtime if we're running 4.3 for exports and uses that too if we are.

This shouldn't be a particularly hot path so i figured a runtime check works well enough, and it's a simple way to support the compile against 4.2 and run in 4.3 usecase.