### PR TITLE
Store Property / Method list in ScriptInstanceData #647

### DIFF
--- a/godot-core/src/builtin/meta/mod.rs
+++ b/godot-core/src/builtin/meta/mod.rs
@@ -246,7 +246,7 @@ where
 /// Rusty abstraction of `sys::GDExtensionPropertyInfo`.
 ///
 /// Keeps the actual allocated values (the `sys` equivalent only keeps pointers, which fall out of scope).
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 // Note: is not #[non_exhaustive], so adding fields is a breaking change. Mostly used internally at the moment though.
 pub struct PropertyInfo {
     pub variant_type: VariantType,
@@ -288,7 +288,7 @@ impl PropertyInfo {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct MethodInfo {
     pub id: i32,
     pub method_name: StringName,

--- a/itest/rust/src/builtin_tests/script/script_instance_tests.rs
+++ b/itest/rust/src/builtin_tests/script/script_instance_tests.rs
@@ -116,12 +116,12 @@ impl ScriptInstance for TestScriptInstance {
         }
     }
 
-    fn get_property_list(&self) -> &[PropertyInfo] {
-        &self.prop_list
+    fn get_property_list(&self) -> Vec<PropertyInfo> {
+        self.prop_list.clone()
     }
 
-    fn get_method_list(&self) -> &[MethodInfo] {
-        &self.method_list
+    fn get_method_list(&self) -> Vec<MethodInfo> {
+        self.method_list.clone()
     }
 
     fn call(


### PR DESCRIPTION
Instead of accepting a reference to a slice of `PropertyInfo`s or `MethodInfo`s from the trait and then hoping that the length didn't change when freeing the list, we now store the lists inside the `ScriptInstanceData`. 

When the engine requests to free the list pointer, we can use the list to recover the length and later drop the rust data as well. 

Fixes #647 _[edit Bromeon]_
cc @lilizoey 