### PR TITLE
MSRV 1.77.1 + several supply chain issues

### DIFF
--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -21,7 +21,7 @@ env:
   # * report_objects: list individual leaked objects when running LeakSanitizer
   LSAN_OPTIONS: report_objects=1
 
-  CARGO_DENY_VERSION: "0.14.3"
+  CARGO_DENY_VERSION: "0.14.20"
   CARGO_MACHETE_VERSION: "0.6.0"
 
 defaults:

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -67,7 +67,7 @@ jobs:
         RUSTDOCFLAGS: >
           -D rustdoc::broken-intra-doc-links -D rustdoc::private-intra-doc-links -D rustdoc::invalid-codeblock-attributes 
           -D rustdoc::invalid-rust-codeblocks -D rustdoc::invalid-html-tags -D rustdoc::bare-urls -D rustdoc::unescaped-backticks
-      run: cargo doc -p godot
+      run: cargo doc -p godot --ignore-rust-version
 
 
   clippy:

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -126,7 +126,7 @@ jobs:
 
           - name: linux
             os: ubuntu-20.04
-            rust-toolchain: '1.70.0'
+            rust-toolchain: "1.77.1"
             rust-special: -msrv
 
     steps:

--- a/.github/workflows/minimal-ci.yml
+++ b/.github/workflows/minimal-ci.yml
@@ -69,7 +69,7 @@ jobs:
           RUSTDOCFLAGS: >
             -D rustdoc::broken-intra-doc-links -D rustdoc::private-intra-doc-links -D rustdoc::invalid-codeblock-attributes 
             -D rustdoc::invalid-rust-codeblocks -D rustdoc::invalid-html-tags -D rustdoc::bare-urls -D rustdoc::unescaped-backticks
-        run: cargo doc -p godot
+        run: cargo doc -p godot --ignore-rust-version
 
 
   clippy:

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   notify-docs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       # Checkout is always needed, for the notify step
       - name: "Checkout"
@@ -30,7 +30,7 @@ jobs:
       # So we use the Rust version provided by the GitHub runners, which hopefully is >= MSRV.
       - name: "Compile"
         if: github.event_name == 'pull_request' && github.event.action != 'closed'
-        run: cargo check -p godot $GDEXT_FEATURES
+        run: cargo check -p godot $GDEXT_FEATURES --ignore-rust-version
 
 #      - name: "Dump GitHub context"
 #        env:

--- a/examples/dodge-the-creeps/rust/Cargo.toml
+++ b/examples/dodge-the-creeps/rust/Cargo.toml
@@ -2,7 +2,7 @@
 name = "dodge-the-creeps"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.77.1"
 license = "MPL-2.0"
 publish = false
 

--- a/godot-bindings/Cargo.toml
+++ b/godot-bindings/Cargo.toml
@@ -2,7 +2,7 @@
 name = "godot-bindings"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.77.1"
 license = "MPL-2.0"
 keywords = ["gamedev", "godot", "engine", "ffi", "sys"]
 categories = ["game-engines", "graphics"]

--- a/godot-cell/Cargo.toml
+++ b/godot-cell/Cargo.toml
@@ -2,7 +2,7 @@
 name = "godot-cell"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.77.1"
 license = "MPL-2.0"
 keywords = ["gamedev", "godot", "engine", "ffi"]
 categories = ["game-engines", "graphics"]

--- a/godot-codegen/Cargo.toml
+++ b/godot-codegen/Cargo.toml
@@ -2,7 +2,7 @@
 name = "godot-codegen"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.77.1"
 license = "MPL-2.0"
 keywords = ["gamedev", "godot", "engine", "codegen"]
 categories = ["game-engines", "graphics"]

--- a/godot-core/Cargo.toml
+++ b/godot-core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "godot-core"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.77.1"
 license = "MPL-2.0"
 keywords = ["gamedev", "godot", "engine", "2d", "3d"] # possibly: "ffi"
 categories = ["game-engines", "graphics"]

--- a/godot-core/Cargo.toml
+++ b/godot-core/Cargo.toml
@@ -25,7 +25,7 @@ trace = ["godot-ffi/trace"]
 godot-ffi = { path = "../godot-ffi" }
 
 # See https://docs.rs/glam/latest/glam/index.html#feature-gates
-glam = { version = "0.23", features = ["debug-glam-assert"] }
+glam = { version = "0.27", features = ["debug-glam-assert"] }
 serde = { version = "1", features = ["derive"], optional = true }
 godot-cell = { path = "../godot-cell" }
 

--- a/godot-ffi/Cargo.toml
+++ b/godot-ffi/Cargo.toml
@@ -2,7 +2,7 @@
 name = "godot-ffi"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.77.1"
 license = "MPL-2.0"
 keywords = ["gamedev", "godot", "engine", "ffi"]
 categories = ["game-engines", "graphics"]

--- a/godot-macros/Cargo.toml
+++ b/godot-macros/Cargo.toml
@@ -2,7 +2,7 @@
 name = "godot-macros"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.77.1"
 license = "MPL-2.0"
 keywords = ["gamedev", "godot", "engine", "derive", "macro"]
 categories = ["game-engines", "graphics"]

--- a/godot/Cargo.toml
+++ b/godot/Cargo.toml
@@ -2,7 +2,7 @@
 name = "godot"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.77.1"
 license = "MPL-2.0"
 keywords = ["gamedev", "godot", "engine", "2d", "3d"] # possibly: "ffi"
 categories = ["game-engines", "graphics"]

--- a/itest/rust/Cargo.toml
+++ b/itest/rust/Cargo.toml
@@ -2,7 +2,7 @@
 name = "itest"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.77.1"
 license = "MPL-2.0"
 publish = false
 


### PR DESCRIPTION
Changes:
1. Increment minimum supported Rust version, in a significant update
    - previous: **1.70.0**, released June 1, 2023
    - new: **1.77.1**, released yesterday
    - needed for [`ptr::from_ref()`](https://doc.rust-lang.org/stable/releases.html#version-1760-2024-02-08) as well as upcoming [C-strings](https://doc.rust-lang.org/stable/releases.html#version-1770-2024-03-21)

2. Update glam: 0.23 -> 0.27
   - no particular reason

3. Update cargo-deny: 0.14.3 -> 0.14.20
    - fixes CI breakage in `krates` dependency, see e.g. [this CI run](https://github.com/godot-rust/gdext/actions/runs/8480662757/job/23237095619)

4. Explicitly specify `1.77.1` for `doc-lints` CI job
   - `stable` still pulls in 1.77.0 occasionally (not through CI cache)