### PR TITLE
Replace `StringName::from_latin1_with_nul` with a `From<CStr>` conversion

### DIFF
--- a/godot-codegen/src/util.rs
+++ b/godot-codegen/src/util.rs
@@ -34,7 +34,12 @@ pub fn make_imports() -> TokenStream {
 pub fn make_string_name(identifier: &str) -> TokenStream {
     let lit = Literal::byte_string(format!("{identifier}\0").as_bytes());
     quote! {
-        StringName::from_latin1_with_nul(#lit)
+        // TODO: C-string literals cannot currently be constructed in proc-macros, see the tracking issue:
+        // https://github.com/rust-lang/rust/issues/119750
+        {
+            #[allow(deprecated)]
+            StringName::from_latin1_with_nul(#lit)
+        }
     }
 }
 

--- a/godot-core/src/builtin/string/node_path.rs
+++ b/godot-core/src/builtin/string/node_path.rs
@@ -16,6 +16,11 @@ use crate::builtin::meta::impl_godot_as_self;
 use super::{GString, StringName};
 
 /// A pre-parsed scene tree path.
+///
+/// # Null bytes
+///
+/// Note that Godot ignores any bytes after a null-byte. This means that for instance `"hello, world!"` and `"hello, world!\0 ignored by Godot"`
+/// will be treated as the same string if converted to a `NodePath`.
 pub struct NodePath {
     opaque: sys::types::OpaqueNodePath,
 }
@@ -93,13 +98,21 @@ impl fmt::Debug for NodePath {
 
 impl_rust_string_conv!(NodePath);
 
-impl<S> From<S> for NodePath
-where
-    S: AsRef<str>,
-{
-    fn from(string: S) -> Self {
-        let intermediate = GString::from(string.as_ref());
-        Self::from(&intermediate)
+impl From<&str> for NodePath {
+    fn from(s: &str) -> Self {
+        GString::from(s).into()
+    }
+}
+
+impl From<String> for NodePath {
+    fn from(s: String) -> Self {
+        GString::from(s).into()
+    }
+}
+
+impl From<&String> for NodePath {
+    fn from(s: &String) -> Self {
+        GString::from(s).into()
     }
 }
 

--- a/itest/rust/src/builtin_tests/string/gstring_test.rs
+++ b/itest/rust/src/builtin_tests/string/gstring_test.rs
@@ -96,3 +96,22 @@ fn string_hash() {
     .collect();
     assert_eq!(set.len(), 5);
 }
+
+#[itest]
+fn string_with_null() {
+    // Godot always ignores bytes after a null byte.
+    let cases: &[(&str, &str)] = &[
+        (
+            "some random string",
+            "some random string\0 with a null byte",
+        ),
+        ("", "\0"),
+    ];
+
+    for (left, right) in cases.iter() {
+        let left = GString::from(*left);
+        let right = GString::from(*right);
+
+        assert_eq!(left, right);
+    }
+}

--- a/itest/rust/src/builtin_tests/string/node_path_test.rs
+++ b/itest/rust/src/builtin_tests/string/node_path_test.rs
@@ -64,3 +64,22 @@ fn node_path_hash() {
     .collect();
     assert_eq!(set.len(), 5);
 }
+
+#[itest]
+fn node_path_with_null() {
+    // Godot always ignores bytes after a null byte.
+    let cases: &[(&str, &str)] = &[
+        (
+            "some random string",
+            "some random string\0 with a null byte",
+        ),
+        ("", "\0"),
+    ];
+
+    for (left, right) in cases.iter() {
+        let left = NodePath::from(*left);
+        let right = NodePath::from(*right);
+
+        assert_eq!(left, right);
+    }
+}

--- a/itest/rust/src/builtin_tests/string/string_name_test.rs
+++ b/itest/rust/src/builtin_tests/string/string_name_test.rs
@@ -127,17 +127,38 @@ fn string_name_is_empty() {
 
 #[itest]
 #[cfg(since_api = "4.2")]
-fn string_name_from_latin1_with_nul() {
-    let cases: [(&[u8], &str); 3] = [
-        (b"pure ASCII\t[~]\0", "pure ASCII\t[~]\0"),
-        (b"\xB1\0", "±"),
-        (b"Latin-1 \xA3 \xB1 text \xBE\0", "Latin-1 £ ± text ¾"),
+fn string_name_from_cstr() {
+    use std::ffi::CStr;
+
+    let cases: [(&CStr, &str); 3] = [
+        (c"pure ASCII\t[~]", "pure ASCII\t[~]"),
+        (c"\xB1", "±"),
+        (c"Latin-1 \xA3 \xB1 text \xBE", "Latin-1 £ ± text ¾"),
     ];
 
     for (bytes, string) in cases.into_iter() {
-        let a = StringName::from_latin1_with_nul(bytes);
+        let a = StringName::from(bytes);
         let b = StringName::from(string);
 
         assert_eq!(a, b);
+    }
+}
+
+#[itest]
+fn string_name_with_null() {
+    // Godot always ignores bytes after a null byte.
+    let cases: &[(&str, &str)] = &[
+        (
+            "some random string",
+            "some random string\0 with a null byte",
+        ),
+        ("", "\0"),
+    ];
+
+    for (left, right) in cases.iter() {
+        let left = StringName::from(*left);
+        let right = StringName::from(*right);
+
+        assert_eq!(left, right);
     }
 }


### PR DESCRIPTION
`from_latin1_with_nul` is now deprecated, we can't quite remove it yet since c-string literals arent supported in proc-macros and we use this method in our codegen.

Also replaces the blanket impls of `From<S: AsRef<str>>` for the stringy types with manual impls for `String`, `&str`, and `&String`. This was needed to avoid orphan rules for the `From<CStr>` impl, and i extended it to all the stringy types for consistency. Additionally such a blanket impl is a very strong guarantee, so it's probably better to avoid the guarantee anyway.