### PR TITLE
Track ptrcall/varcall in tests; smaller improvements

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -69,7 +69,7 @@ jobs:
           --arg commitSha '${{ github.event.pull_request.head.sha }}' \
           --arg date '${{ github.event.pull_request.updated_at }}' \
           --arg prAuthor '${{ github.event.pull_request.user.login }}' \
-          --arg prTitle '$PR_TITLE' \
+          --arg prTitle "$PR_TITLE" \
           '{
             "op": "put",
             "repo": "gdext",

--- a/examples/hot-reload/godot/test/run-test.sh
+++ b/examples/hot-reload/godot/test/run-test.sh
@@ -29,7 +29,7 @@ cp MainScene.tscn ../MainScene.tscn
 
 # Compile original Rust source.
 cargoArgs=""
-#cargoArgs="--features godot/trace"
+#cargoArgs="--features godot/debug-log"
 cargo build -p hot-reload $cargoArgs
 
 # Wait briefly so artifacts are present on file system.

--- a/godot-core/Cargo.toml
+++ b/godot-core/Cargo.toml
@@ -19,7 +19,7 @@ custom-godot = ["godot-ffi/custom-godot", "godot-codegen/custom-godot"]
 double-precision = ["godot-codegen/double-precision"]
 experimental-godot-api = ["godot-codegen/experimental-godot-api"]
 experimental-threads = ["godot-ffi/experimental-threads"]
-trace = ["godot-ffi/trace"]
+debug-log = ["godot-ffi/debug-log"]
 
 [dependencies]
 godot-ffi = { path = "../godot-ffi" }

--- a/godot-core/Cargo.toml
+++ b/godot-core/Cargo.toml
@@ -20,6 +20,7 @@ double-precision = ["godot-codegen/double-precision"]
 experimental-godot-api = ["godot-codegen/experimental-godot-api"]
 experimental-threads = ["godot-ffi/experimental-threads"]
 debug-log = ["godot-ffi/debug-log"]
+trace = []
 
 [dependencies]
 godot-ffi = { path = "../godot-ffi" }

--- a/godot-core/src/builtin/meta/mod.rs
+++ b/godot-core/src/builtin/meta/mod.rs
@@ -288,6 +288,9 @@ impl PropertyInfo {
     }
 }
 
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+
+// TODO(bromeon): Rename to ScriptMethodInfo; check difference with with existing MethodInfo; public fields good as-is?
 #[derive(Debug, Clone)]
 pub struct MethodInfo {
     pub id: i32,

--- a/godot-core/src/builtin/meta/mod.rs
+++ b/godot-core/src/builtin/meta/mod.rs
@@ -26,6 +26,9 @@ use godot_ffi as sys;
 use registration::method::MethodParamOrReturnInfo;
 use sys::{GodotFfi, GodotNullableFfi};
 
+#[cfg(feature = "trace")]
+pub use signature::trace;
+
 /// Conversion of [`GodotFfi`] types to/from [`Variant`].
 #[doc(hidden)]
 pub trait GodotFfiVariant: Sized + GodotFfi {

--- a/godot-core/src/builtin/variant/impls.rs
+++ b/godot-core/src/builtin/variant/impls.rs
@@ -11,6 +11,8 @@ use crate::builtin::*;
 use crate::engine::global;
 use godot_ffi as sys;
 
+// For godot-cpp, see https://github.com/godotengine/godot-cpp/blob/master/include/godot_cpp/core/type_info.hpp.
+
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Macro definitions
 
@@ -211,12 +213,12 @@ impl GodotType for Variant {
             property_name: StringName::from(property_name),
             hint: global::PropertyHint::NONE,
             hint_string: GString::new(),
-            usage: global::PropertyUsageFlags::NIL_IS_VARIANT,
+            usage: global::PropertyUsageFlags::DEFAULT | global::PropertyUsageFlags::NIL_IS_VARIANT,
         }
     }
 
     fn param_metadata() -> sys::GDExtensionClassMethodArgumentMetadata {
-        sys::GDEXTENSION_METHOD_ARGUMENT_METADATA_INT_IS_INT8
+        sys::GDEXTENSION_METHOD_ARGUMENT_METADATA_NONE
     }
 
     fn godot_type_name() -> String {

--- a/godot-core/src/private.rs
+++ b/godot-core/src/private.rs
@@ -214,14 +214,14 @@ where
 }
 
 pub fn handle_varcall_panic<F, R>(
-    call_ctx: CallContext,
+    call_ctx: &CallContext,
     out_err: &mut sys::GDExtensionCallError,
     code: F,
 ) where
     F: FnOnce() -> Result<R, CallError> + std::panic::UnwindSafe,
 {
     let outcome: Result<Result<R, CallError>, String> =
-        handle_panic_with_print(|| &call_ctx, code, false);
+        handle_panic_with_print(|| call_ctx, code, false);
 
     let call_error = match outcome {
         // All good.
@@ -231,7 +231,7 @@ pub fn handle_varcall_panic<F, R>(
         Ok(Err(err)) => err,
 
         // Panic occurred (typically through user): forward message.
-        Err(panic_msg) => CallError::failed_by_user_panic(&call_ctx, panic_msg),
+        Err(panic_msg) => CallError::failed_by_user_panic(call_ctx, panic_msg),
     };
 
     // Print failed calls to Godot's console.

--- a/godot-core/src/private.rs
+++ b/godot-core/src/private.rs
@@ -5,16 +5,19 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use godot_ffi::Global;
 use std::collections::HashMap;
 use std::sync::{atomic, Arc, Mutex};
 
-pub use crate::gen::classes::class_macros;
-pub use crate::registry::{callbacks, ClassPlugin, ErasedRegisterFn, PluginItem};
-pub use crate::storage::{as_storage, Storage};
+use godot_ffi::Global;
 pub use sys::out;
 
+#[cfg(feature = "trace")]
+pub use crate::builtin::meta::trace;
 use crate::builtin::meta::{CallContext, CallError};
+pub use crate::gen::classes::class_macros;
+pub use crate::obj::rtti::ObjectRtti;
+pub use crate::registry::{callbacks, ClassPlugin, ErasedRegisterFn, PluginItem};
+pub use crate::storage::{as_storage, Storage};
 use crate::{log, sys};
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
@@ -96,8 +99,6 @@ pub(crate) fn iterate_plugins(mut visitor: impl FnMut(&ClassPlugin)) {
 #[allow(non_camel_case_types)]
 pub trait You_forgot_the_attribute__godot_api {}
 
-pub use crate::obj::rtti::ObjectRtti;
-
 pub struct ClassConfig {
     pub is_tool: bool,
 }
@@ -154,6 +155,9 @@ pub fn is_class_runtime(is_tool: bool) -> bool {
     // If we run all classes in the editor (!tool_only_in_editor), then it's not a runtime class.
     global_config.tool_only_in_editor
 }
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// Trace handling
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Panic handling

--- a/godot-ffi/Cargo.toml
+++ b/godot-ffi/Cargo.toml
@@ -13,7 +13,7 @@ codegen-fmt = ["godot-codegen/codegen-fmt"]
 codegen-lazy-fptrs = ["godot-codegen/codegen-lazy-fptrs"]
 experimental-godot-api = ["godot-codegen/experimental-godot-api"]
 experimental-threads = []
-trace = []
+debug-log = []
 
 # TODO: get rid of paste and gensym, they are trivially implementable with proc-macros. Update cargo-deny.
 # Especially gensym which pulls in entire syn for 10 LoC. See https://github.com/regiontog/gensym/blob/master/src/lib.rs.

--- a/godot-ffi/src/toolbox.rs
+++ b/godot-ffi/src/toolbox.rs
@@ -43,7 +43,7 @@ macro_rules! static_assert_eq_size_align {
 }
 
 /// Trace output.
-#[cfg(feature = "trace")]
+#[cfg(feature = "debug-log")]
 #[macro_export]
 macro_rules! out {
     ()                          => (eprintln!());
@@ -52,7 +52,7 @@ macro_rules! out {
 }
 
 /// Trace output.
-#[cfg(not(feature = "trace"))]
+#[cfg(not(feature = "debug-log"))]
 // TODO find a better way than sink-writing to avoid warnings, #[allow(unused_variables)] doesn't work
 #[macro_export]
 macro_rules! out {

--- a/godot-macros/src/class/data_models/func.rs
+++ b/godot-macros/src/class/data_models/func.rs
@@ -25,7 +25,7 @@ pub struct FuncDefinition {
 /// Returns a C function which acts as the callback when a virtual method of this instance is invoked.
 //
 // There are currently no virtual static methods. Additionally, virtual static methods don't really make a lot
-// of sense. Therefore there is no need to support them.
+// of sense. Therefore, there is no need to support them.
 pub fn make_virtual_callback(
     class_name: &Ident,
     signature_info: SignatureInfo,
@@ -40,20 +40,22 @@ pub fn make_virtual_callback(
         class_name.to_string().as_str(),
         method_name.to_string().as_str(),
     );
-    let invocation = make_ptrcall_invocation(&call_ctx, &sig_tuple, &wrapped_method, true);
+    let invocation = make_ptrcall_invocation(&wrapped_method, true);
 
     quote! {
         {
             use ::godot::sys;
+            type Sig = #sig_tuple;
 
-            unsafe extern "C" fn function(
+            unsafe extern "C" fn virtual_fn(
                 instance_ptr: sys::GDExtensionClassInstancePtr,
                 args_ptr: *const sys::GDExtensionConstTypePtr,
                 ret: sys::GDExtensionTypePtr,
             ) {
+                let call_ctx = #call_ctx;
                 #invocation;
             }
-            Some(function)
+            Some(virtual_fn)
         }
     }
 }
@@ -89,8 +91,8 @@ pub fn make_method_registration(
     };
 
     let call_ctx = make_call_context(&class_name_str, &method_name_str);
-    let varcall_func = make_varcall_func(&call_ctx, &sig_tuple, &forwarding_closure);
-    let ptrcall_func = make_ptrcall_func(&call_ctx, &sig_tuple, &forwarding_closure);
+    let varcall_fn_decl = make_varcall_fn(&call_ctx, &forwarding_closure);
+    let ptrcall_fn_decl = make_ptrcall_fn(&call_ctx, &forwarding_closure);
 
     // String literals II
     let param_ident_strs = signature_info
@@ -116,8 +118,8 @@ pub fn make_method_registration(
 
             let method_name = StringName::from(#method_name_str);
 
-            let varcall_func = #varcall_func;
-            let ptrcall_func = #ptrcall_func;
+            #varcall_fn_decl;
+            #ptrcall_fn_decl;
 
             // SAFETY:
             // `get_varcall_func` upholds all the requirements for `call_func`.
@@ -126,8 +128,8 @@ pub fn make_method_registration(
                 ClassMethodInfo::from_signature::<Sig>(
                     #class_name::class_name(),
                     method_name,
-                    Some(varcall_func),
-                    Some(ptrcall_func),
+                    Some(varcall_fn),
+                    Some(ptrcall_fn),
                     #method_flags,
                     &[
                         #( #param_ident_strs ),*
@@ -259,7 +261,7 @@ fn make_forwarding_closure(
                         unsafe { ::godot::private::as_storage::<#class_name>(instance_ptr) };
 
                     #before_method_call
-                    <#class_name>::#method_name(::godot::private::Storage::get_gd(storage), #(#params),*)
+                    #class_name::#method_name(::godot::private::Storage::get_gd(storage), #(#params),*)
                 }
             }
         }
@@ -268,7 +270,7 @@ fn make_forwarding_closure(
             quote! {
                 |_, params| {
                     let ( #(#params,)* ) = params;
-                    <#class_name>::#method_name(#(#params),*)
+                    #class_name::#method_name(#(#params),*)
                 }
             }
         }
@@ -367,26 +369,26 @@ fn make_method_flags(
     method_type: ReceiverType,
     is_rust_virtual: bool,
 ) -> Result<TokenStream, String> {
-    let scope = quote! { ::godot::engine::global::MethodFlags };
+    let flags = quote! { ::godot::engine::global::MethodFlags };
 
     let base_flags = match method_type {
         ReceiverType::Ref => {
-            quote! { #scope::NORMAL | #scope::CONST }
+            quote! { #flags::NORMAL | #flags::CONST }
         }
         // Conservatively assume Gd<Self> receivers to mutate the object, since user can call bind_mut().
         ReceiverType::Mut | ReceiverType::GdSelf => {
-            quote! { #scope::NORMAL }
+            quote! { #flags::NORMAL }
         }
         ReceiverType::Static => {
             if is_rust_virtual {
                 return Err("Static methods cannot be virtual".to_string());
             }
-            quote! { #scope::STATIC }
+            quote! { #flags::NORMAL | #flags::STATIC }
         }
     };
 
     let flags = if is_rust_virtual {
-        quote! { #base_flags | #scope::VIRTUAL }
+        quote! { #base_flags | #flags::VIRTUAL }
     } else {
         base_flags
     };
@@ -395,74 +397,55 @@ fn make_method_flags(
 }
 
 /// Generate code for a C FFI function that performs a varcall.
-fn make_varcall_func(
-    call_ctx: &TokenStream,
-    sig_tuple: &TokenStream,
-    wrapped_method: &TokenStream,
-) -> TokenStream {
-    let invocation = make_varcall_invocation(call_ctx, sig_tuple, wrapped_method);
+fn make_varcall_fn(call_ctx: &TokenStream, wrapped_method: &TokenStream) -> TokenStream {
+    let invocation = make_varcall_invocation(wrapped_method);
 
     // TODO reduce amount of code generated, by delegating work to a library function. Could even be one that produces this function pointer.
     quote! {
-        {
-            unsafe extern "C" fn function(
-                _method_data: *mut std::ffi::c_void,
-                instance_ptr: sys::GDExtensionClassInstancePtr,
-                args_ptr: *const sys::GDExtensionConstVariantPtr,
-                arg_count: sys::GDExtensionInt,
-                ret: sys::GDExtensionVariantPtr,
-                err: *mut sys::GDExtensionCallError,
-            ) {
-                ::godot::private::handle_varcall_panic(
-                    #call_ctx,
-                    &mut *err,
-                    || #invocation
-                );
-            }
-
-            function
+        unsafe extern "C" fn varcall_fn(
+            _method_data: *mut std::ffi::c_void,
+            instance_ptr: sys::GDExtensionClassInstancePtr,
+            args_ptr: *const sys::GDExtensionConstVariantPtr,
+            arg_count: sys::GDExtensionInt,
+            ret: sys::GDExtensionVariantPtr,
+            err: *mut sys::GDExtensionCallError,
+        ) {
+            let call_ctx = #call_ctx;
+            ::godot::private::handle_varcall_panic(
+                &call_ctx,
+                &mut *err,
+                || #invocation
+            );
         }
     }
 }
 
 /// Generate code for a C FFI function that performs a ptrcall.
-fn make_ptrcall_func(
-    call_ctx: &TokenStream,
-    sig_tuple: &TokenStream,
-    wrapped_method: &TokenStream,
-) -> TokenStream {
-    let invocation = make_ptrcall_invocation(call_ctx, sig_tuple, wrapped_method, false);
+fn make_ptrcall_fn(call_ctx: &TokenStream, wrapped_method: &TokenStream) -> TokenStream {
+    let invocation = make_ptrcall_invocation(wrapped_method, false);
 
     quote! {
-        {
-            unsafe extern "C" fn function(
-                _method_data: *mut std::ffi::c_void,
-                instance_ptr: sys::GDExtensionClassInstancePtr,
-                args_ptr: *const sys::GDExtensionConstTypePtr,
-                ret: sys::GDExtensionTypePtr,
-            ) {
-                let _success = ::godot::private::handle_panic(
-                    || #call_ctx,
-                    || #invocation
-                );
+        unsafe extern "C" fn ptrcall_fn(
+            _method_data: *mut std::ffi::c_void,
+            instance_ptr: sys::GDExtensionClassInstancePtr,
+            args_ptr: *const sys::GDExtensionConstTypePtr,
+            ret: sys::GDExtensionTypePtr,
+        ) {
+            let call_ctx = #call_ctx;
+            let _success = ::godot::private::handle_panic(
+                || &call_ctx,
+                || #invocation
+            );
 
-                // if success.is_err() {
-                //     // TODO set return value to T::default()?
-                // }
-            }
-
-            function
+            // if success.is_err() {
+            //     // TODO set return value to T::default()?
+            // }
         }
     }
 }
 
 /// Generate code for a `ptrcall` call expression.
-fn make_ptrcall_invocation(
-    call_ctx: &TokenStream,
-    sig_tuple: &TokenStream,
-    wrapped_method: &TokenStream,
-    is_virtual: bool,
-) -> TokenStream {
+fn make_ptrcall_invocation(wrapped_method: &TokenStream, is_virtual: bool) -> TokenStream {
     let ptrcall_type = if is_virtual {
         quote! { sys::PtrcallType::Virtual }
     } else {
@@ -470,9 +453,9 @@ fn make_ptrcall_invocation(
     };
 
     quote! {
-         <#sig_tuple as ::godot::builtin::meta::PtrcallSignatureTuple>::in_ptrcall(
+         <Sig as ::godot::builtin::meta::PtrcallSignatureTuple>::in_ptrcall(
             instance_ptr,
-            & #call_ctx,
+            &call_ctx,
             args_ptr,
             ret,
             #wrapped_method,
@@ -482,15 +465,11 @@ fn make_ptrcall_invocation(
 }
 
 /// Generate code for a `varcall()` call expression.
-fn make_varcall_invocation(
-    call_ctx: &TokenStream,
-    sig_tuple: &TokenStream,
-    wrapped_method: &TokenStream,
-) -> TokenStream {
+fn make_varcall_invocation(wrapped_method: &TokenStream) -> TokenStream {
     quote! {
-        <#sig_tuple as ::godot::builtin::meta::VarcallSignatureTuple>::in_varcall(
+        <Sig as ::godot::builtin::meta::VarcallSignatureTuple>::in_varcall(
             instance_ptr,
-            & #call_ctx,
+            &call_ctx,
             args_ptr,
             arg_count,
             ret,

--- a/godot/Cargo.toml
+++ b/godot/Cargo.toml
@@ -21,6 +21,7 @@ experimental-wasm = []
 # Private features, they are under no stability guarantee
 codegen-full = ["godot-core/codegen-full"]
 debug-log = ["godot-core/debug-log"]
+trace = ["godot-core/trace"]
 
 [dependencies]
 godot-core = { path = "../godot-core" }

--- a/godot/Cargo.toml
+++ b/godot/Cargo.toml
@@ -20,7 +20,7 @@ experimental-wasm = []
 
 # Private features, they are under no stability guarantee
 codegen-full = ["godot-core/codegen-full"]
-trace = ["godot-core/trace"]
+debug-log = ["godot-core/debug-log"]
 
 [dependencies]
 godot-core = { path = "../godot-core" }

--- a/itest/godot/input/GenFfiTests.template.gd
+++ b/itest/godot/input/GenFfiTests.template.gd
@@ -15,21 +15,29 @@ func test_varcall_IDENT():
 	var ffi = GenFfi.new()
 
 	var from_rust: Variant = ffi.return_IDENT()
+	_check_callconv("return_IDENT", "varcall")
+
 	assert_that(ffi.accept_IDENT(from_rust), "ffi.accept_IDENT(from_rust)")
+	_check_callconv("accept_IDENT", "varcall")
 
 	var from_gdscript: Variant = VAL
 	var mirrored: Variant = ffi.mirror_IDENT(from_gdscript)
 	assert_eq(mirrored, from_gdscript, "mirrored == from_gdscript")
+	_check_callconv("mirror_IDENT", "varcall")
 #)
 
 #(
 func test_varcall_static_IDENT():
 	var from_rust: Variant = GenFfi.return_static_IDENT()
+	_check_callconv("return_static_IDENT", "varcall")
+
 	assert_that(GenFfi.accept_static_IDENT(from_rust), "ffi.accept_static_IDENT(from_rust)")
+	_check_callconv("accept_static_IDENT", "varcall")
 
 	var from_gdscript: Variant = VAL
 	var mirrored: Variant = GenFfi.mirror_static_IDENT(from_gdscript)
 	assert_eq(mirrored, from_gdscript, "mirrored_static == from_gdscript")
+	_check_callconv("mirror_static_IDENT", "varcall")
 #)
 
 #(
@@ -37,20 +45,38 @@ func test_ptrcall_IDENT():
 	var ffi := GenFfi.new()
 
 	var from_rust: TYPE = ffi.return_IDENT()
+	_check_callconv("return_IDENT", "ptrcall")
+
 	assert_that(ffi.accept_IDENT(from_rust), "ffi.accept_IDENT(from_rust)")
+	_check_callconv("accept_IDENT", "ptrcall")
 
 	var from_gdscript: TYPE = VAL
 	var mirrored: TYPE = ffi.mirror_IDENT(from_gdscript)
 	assert_eq(mirrored, from_gdscript, "mirrored == from_gdscript")
+	_check_callconv("mirror_IDENT", "ptrcall")
 #)
 
 #(
 func test_ptrcall_static_IDENT():
 	var from_rust: TYPE = GenFfi.return_static_IDENT()
+	_check_callconv("return_static_IDENT", "ptrcall")
+
 	assert_that(GenFfi.accept_static_IDENT(from_rust), "ffi.accept_static_IDENT(from_rust)")
+	_check_callconv("accept_static_IDENT", "ptrcall")
 
 	var from_gdscript: TYPE = VAL
 	var mirrored: TYPE = GenFfi.mirror_static_IDENT(from_gdscript)
 	assert_eq(mirrored, from_gdscript, "mirrored_static == from_gdscript")
+	_check_callconv("mirror_static_IDENT", "ptrcall")
 #)
-	
+
+func _check_callconv(function: String, expected: String) -> void:
+	# TODO Ptrcall not yet implemented in Godot:
+	# * Methods that involve at least 1 parameter of type Variant (interestingly not a return value).
+	# * Static methods (oversight).
+	if function.contains("_static_") or function == "accept_variant" or function == "mirror_variant":
+		# This test deliberately fails in case Godot implements support for either of the above, to notify us.
+		expected = "varcall"
+
+	var ok = GenFfi.check_last_notrace(function, expected)
+	assert_that(ok, str("calling convention mismatch in function '", function, "'"))

--- a/itest/godot/input/GenFfiTests.template.gd
+++ b/itest/godot/input/GenFfiTests.template.gd
@@ -78,5 +78,17 @@ func _check_callconv(function: String, expected: String) -> void:
 		# This test deliberately fails in case Godot implements support for either of the above, to notify us.
 		expected = "varcall"
 
+	# Special cases that were only implemented/fixed Godot 4.2+, but are still present in older versions.
+	# Covers Vector4, Vector4i, NewVector4(Vector4), NewVector4i(Vector4i), Projection
+	elif Engine.get_version_info().minor < 2 \
+	and (function.begins_with("return_") or function.begins_with("mirror_")) \
+	and ( \
+		function.ends_with("vector4") \
+		or function.ends_with("vector4i") \
+		or function.ends_with("projection") \
+		or function.ends_with("variant") \
+	):
+		expected = "varcall"
+
 	var ok = GenFfi.check_last_notrace(function, expected)
 	assert_that(ok, str("calling convention mismatch in function '", function, "'"))

--- a/itest/rust/Cargo.toml
+++ b/itest/rust/Cargo.toml
@@ -19,7 +19,7 @@ serde = ["dep:serde", "dep:serde_json", "godot/serde"]
 
 
 [dependencies]
-godot = { path = "../../godot", default-features = false }
+godot = { path = "../../godot", default-features = false, features = ["trace"] }
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1.0", optional = true }
 

--- a/itest/rust/build.rs
+++ b/itest/rust/build.rs
@@ -169,6 +169,7 @@ fn collect_inputs() -> Vec<Input> {
     push_newtype!(inputs; Vector4, NewVector4(Vector4), Vector4(-18.5, 24.75, -1.25, 777.875), NewVector4(Vector4::new(-18.5, 24.75, -1.25, 777.875)));
     push_newtype!(inputs; Vector2i, NewVector2i(Vector2i), Vector2i(-2147483648, 2147483647), NewVector2i(Vector2i::new(-2147483648, 2147483647)));
     push_newtype!(inputs; Vector3i, NewVector3i(Vector3i), Vector3i(-1, -2147483648, 2147483647), NewVector3i(Vector3i::new(-1, -2147483648, 2147483647)));
+    push_newtype!(inputs; Vector4i, NewVector4i(Vector4i), Vector4i(-1, -2147483648, 2147483647, 1), NewVector4i(Vector4i::new(-1, -2147483648, 2147483647, 1)));
     push_newtype!(inputs; Callable, NewCallable(Callable), Callable(), NewCallable(Callable::invalid()));
 
     // Data structures

--- a/itest/rust/build.rs
+++ b/itest/rust/build.rs
@@ -213,6 +213,7 @@ fn main() {
 
         use godot::builtin::*;
         use godot::builtin::meta::*;
+        use godot::log::godot_error;
         use godot::obj::{Gd, InstanceId};
         use godot::engine::global::Error;
         use godot::engine::{Node, Resource};
@@ -288,7 +289,7 @@ fn rustfmt_if_needed(out_files: Vec<std::path::PathBuf>) {
 }
 
 fn generate_rust_methods(inputs: &[Input]) -> Vec<TokenStream> {
-    inputs
+    let mut generated_methods = inputs
         .iter()
         .map(|input| {
             let Input {
@@ -337,7 +338,50 @@ fn generate_rust_methods(inputs: &[Input]) -> Vec<TokenStream> {
                 }
             }
         })
-        .collect()
+        .collect::<Vec<_>>();
+
+    let manual_methods = quote! {
+        #[func]
+        fn check_last_notrace(last_method_name: String, expected_callconv: String) -> bool {
+            let last = godot::private::trace::pop();
+            let mut ok = true;
+
+            if last.class != "GenFfi" {
+                godot_error!("Expected class GenFfi, got {}", last.class);
+                ok = false;
+            }
+
+            if last.method != last_method_name {
+                godot_error!("Expected method {}, got {}", last_method_name, last.method);
+                ok = false;
+            }
+
+            if !last.is_inbound {
+                godot_error!("Expected inbound call, got outbound");
+                ok = false;
+            }
+
+            let expect_ptrcall = expected_callconv == "ptrcall";
+            if last.is_ptrcall != expect_ptrcall {
+                let actual = Self::to_string(last.is_ptrcall);
+                godot_error!("Expected {expected_callconv}, got {actual}");
+                ok = false;
+            }
+
+            ok
+        }
+
+        fn to_string(is_ptrcall: bool) -> &'static str {
+            if is_ptrcall {
+                "ptrcall"
+            } else {
+                "varcall"
+            }
+        }
+    };
+
+    generated_methods.push(manual_methods);
+    generated_methods
 }
 
 struct PropertyTests {


### PR DESCRIPTION
Tests that inbound GDScript -> Rust `#[func]` calls are using the expected calling convention (`ptrcall` or `varcall`).

There are some exceptions due to incomplete implementation in Godot:
- Static methods, see https://github.com/godotengine/godot/issues/91282
- Any methods accepting `Variant` parameters
- Several special cases before 4.2

Also renames the `trace` feature to `debug-log`, fixes some `#[func]` FFI registrations, and fixes a doc CI issue.