### PR TITLE
Sum, Product implementations for Iterator<Vector*>

### DIFF
--- a/godot-core/src/builtin/vectors/vector3.rs
+++ b/godot-core/src/builtin/vectors/vector3.rs
@@ -414,6 +414,21 @@ mod test {
         assert_eq_approx!(vector1.slerp(vector2, 0.5).length(), real!(6.258_311));
     }
 
+    #[test]
+    fn iter_sum() {
+        let vecs = vec![
+            Vector3::new(1.0, 2.0, 3.0),
+            Vector3::new(4.0, 5.0, 6.0),
+            Vector3::new(7.0, 8.0, 9.0),
+        ];
+
+        let sum_refs = vecs.iter().sum();
+        let sum = vecs.into_iter().sum();
+
+        assert_eq_approx!(sum, Vector3::new(12.0, 15.0, 18.0));
+        assert_eq_approx!(sum_refs, Vector3::new(12.0, 15.0, 18.0));
+    }
+
     #[cfg(feature = "serde")]
     #[test]
     fn serde_roundtrip() {

--- a/godot-core/src/builtin/vectors/vector4i.rs
+++ b/godot-core/src/builtin/vectors/vector4i.rs
@@ -223,4 +223,15 @@ mod test {
             Some(Vector4Axis::W),
         );
     }
+
+    #[test]
+    fn test_iter_elementwise_prod() {
+        let vecs = vec![Vector4i::new(1, 2, 3, 4), Vector4i::new(5, 6, 7, 8)];
+        let expected = Vector4i::new(5, 12, 21, 32);
+        let prod_refs: Vector4i = vecs.iter().product();
+        let prod: Vector4i = vecs.into_iter().product();
+
+        assert_eq!(prod_refs, expected);
+        assert_eq!(prod, expected);
+    }
 }


### PR DESCRIPTION
Add implementations for `std::iter::Sum` and `std::iter::Product` for the Vector (and IVector) types.

Note both operations are element-wise (this comes from glam).

Due to there being multiple Add and Mul implementations (ultimately in glam), I noticed having to specify types explicitly in some circumstances. I imagine this can probably be improved but I am not an expert on generic programming.