### PR TITLE
fix `#[var]` docs typo

### DIFF
--- a/godot-cell/src/lib.rs
+++ b/godot-cell/src/lib.rs
@@ -48,7 +48,7 @@ pub struct GdCell<T> {
     /// The actual value we're handing out references to, uses `UnsafeCell` as we're passing out `&mut`
     /// references to its contents even when we only have a `&` reference to the cell.
     value: UnsafeCell<T>,
-    /// We dont want to be able to take `GdCell` out of a pin, so `GdCell` cannot implement `Unpin`.
+    /// We don't want to be able to take `GdCell` out of a pin, so `GdCell` cannot implement `Unpin`.
     _pin: PhantomPinned,
 }
 
@@ -93,7 +93,7 @@ impl<T> GdCell<T> {
         // This is the case because the only way for a new `GdMut` or `GdRef` to be made after this is for
         // either this guard to be dropped or `make_inaccessible` to be called and succeed.
         //
-        // If this guard is dropped, then we dont need to worry.
+        // If this guard is dropped, then we don't need to worry.
         //
         // If `make_inaccessible` is called and succeeds, then a mutable reference from this guard is passed
         // in. In which case, we cannot use this guard again until the resulting inaccessible guard is

--- a/godot-codegen/src/generator/classes.rs
+++ b/godot-codegen/src/generator/classes.rs
@@ -347,7 +347,7 @@ fn make_constructor_and_default(class: &Class, ctx: &Context) -> (TokenStream, T
 }
 
 fn make_deref_impl(class_name: &TyName, base_ty: &TokenStream) -> TokenStream {
-    // The base_ty of `Object` is `NoBase`, and we dont want every engine class to deref to `NoBase`.
+    // The base_ty of `Object` is `NoBase`, and we don't want every engine class to deref to `NoBase`.
     if class_name.rust_ty == "Object" {
         return TokenStream::new();
     }

--- a/godot-core/src/builtin/array.rs
+++ b/godot-core/src/builtin/array.rs
@@ -134,7 +134,7 @@ impl<T: GodotType> Array<T> {
 
     /// Reverses the order of the elements in the array.
     pub fn reverse(&mut self) {
-        // SAFETY: We do not write any values that dont already exist in the array, so all values have the correct type.
+        // SAFETY: We do not write any values that don't already exist in the array, so all values have the correct type.
         unsafe { self.as_inner_mut() }.reverse();
     }
 
@@ -145,7 +145,7 @@ impl<T: GodotType> Array<T> {
     /// considered equal may have their order changed when using `sort_unstable`.
     #[doc(alias = "sort")]
     pub fn sort_unstable(&mut self) {
-        // SAFETY: We do not write any values that dont already exist in the array, so all values have the correct type.
+        // SAFETY: We do not write any values that don't already exist in the array, so all values have the correct type.
         unsafe { self.as_inner_mut() }.sort();
     }
 
@@ -158,7 +158,7 @@ impl<T: GodotType> Array<T> {
     /// `sort_unstable`.
     #[doc(alias = "sort_custom")]
     pub fn sort_unstable_custom(&mut self, func: Callable) {
-        // SAFETY: We do not write any values that dont already exist in the array, so all values have the correct type.
+        // SAFETY: We do not write any values that don't already exist in the array, so all values have the correct type.
         unsafe { self.as_inner_mut() }.sort_custom(func);
     }
 
@@ -166,7 +166,7 @@ impl<T: GodotType> Array<T> {
     /// global random number generator common to methods such as `randi`. Call `randomize` to
     /// ensure that a new seed will be used each time if you want non-reproducible shuffling.
     pub fn shuffle(&mut self) {
-        // SAFETY: We do not write any values that dont already exist in the array, so all values have the correct type.
+        // SAFETY: We do not write any values that don't already exist in the array, so all values have the correct type.
         unsafe { self.as_inner_mut() }.shuffle();
     }
 
@@ -1008,7 +1008,7 @@ impl<T: GodotType + FromGodot> From<&Array<T>> for Vec<T> {
         let mut vec = Vec::with_capacity(len);
 
         // SAFETY: Unless `experimental-threads` is enabled, then we cannot have concurrent access to this array.
-        // And since we dont concurrently access the array in this function, we can create a slice to its contents.
+        // And since we don't concurrently access the array in this function, we can create a slice to its contents.
         let elements = unsafe { Variant::borrow_slice(array.ptr(0), len) };
 
         vec.extend(elements.iter().map(T::from_variant));

--- a/godot-ffi/src/lib.rs
+++ b/godot-ffi/src/lib.rs
@@ -75,7 +75,7 @@ pub use string_cache::StringCache;
 pub use toolbox::*;
 
 // SAFETY: In Godot 4.0.4 the extension interface stores a c_char pointer, this is safe to access from different threads as no
-// mutation happens after initialization. This was changed in 4.1, so we dont need to manually implement `Sync` or `Send` after 4.0.
+// mutation happens after initialization. This was changed in 4.1, so we don't need to manually implement `Sync` or `Send` after 4.0.
 // So we instead rely on rust to infer that it is `Sync` and `Send`.
 #[cfg(before_api = "4.1")]
 unsafe impl Sync for GDExtensionInterface {}

--- a/godot-macros/src/class/data_models/func.rs
+++ b/godot-macros/src/class/data_models/func.rs
@@ -24,7 +24,7 @@ pub struct FuncDefinition {
 
 /// Returns a C function which acts as the callback when a virtual method of this instance is invoked.
 //
-// There are currently no virtual static methods. Additionally, virtual static methods dont really make a lot
+// There are currently no virtual static methods. Additionally, virtual static methods don't really make a lot
 // of sense. Therefore there is no need to support them.
 pub fn make_virtual_callback(
     class_name: &Ident,

--- a/godot-macros/src/lib.rs
+++ b/godot-macros/src/lib.rs
@@ -105,9 +105,9 @@ use crate::util::ident;
 /// # Inheritance
 ///
 /// Unlike C++, Rust doesn't really have inheritance, but the GDExtension API lets us "inherit"
-/// from a built-in engine class.
+/// from a Godot-provided engine class.
 ///
-/// By default, classes created with this library inherit from `RefCounted`.
+/// By default, classes created with this library inherit from `RefCounted`, like GDScript.
 ///
 /// To specify a different class to inherit from, add `#[class(base = Base)]` as an annotation on
 /// your `struct`:
@@ -164,7 +164,7 @@ use crate::util::ident;
 ///
 /// If you want to implement your own getter and/or setter, write those as a function on your Rust
 /// type, expose it using `#[func]`, and annotate the field with
-/// `#[export(get = ..., set = ...)]`:
+/// `#[var(get = ..., set = ...)]`:
 ///
 /// ```
 /// # use godot::prelude::*;
@@ -226,7 +226,7 @@ use crate::util::ident;
 /// }
 /// ```
 ///
-/// If you dont also include a `#[var]` attribute, then a default one will be generated.
+/// If you don't also include a `#[var]` attribute, then a default one will be generated.
 /// `#[export]` also supports all of GDScript's annotations, in a slightly different format. The format is
 /// translated from an annotation by following these four rules:
 ///
@@ -403,7 +403,7 @@ use crate::util::ident;
 /// ```
 ///
 /// Even though this class is a `Node` and it has an init function, it still won't show up in the editor as a node you can add to a scene
-/// because we have added a `hide` key to the class. This will also prevent it from showing up in documentation.
+/// because we have added a `hidden` key to the class. This will also prevent it from showing up in documentation.
 ///
 /// # Further field customization
 ///

--- a/itest/godot/SpecialTests.gd
+++ b/itest/godot/SpecialTests.gd
@@ -15,7 +15,7 @@ extends TestSuiteSpecial
 # This tests #267, which was caused by us incorrectly handing Objects when passed as arguments to virtual 
 # methods. `_input_event` is the easiest such method to test. However it can only be triggered by letting a 
 # full physics frame pass after calling `push_unhandled_input`. Thus we cannot use the standard API for 
-# testing this at the moment, since we dont have any way to let frames pass in between the start and end of 
+# testing this at the moment, since we don't have any way to let frames pass in between the start and end of 
 # an integration test. 
 func test_collision_object_2d_input_event():
 	var collision_object := CollisionObject2DTest.new()

--- a/itest/rust/src/object_tests/enum_test.rs
+++ b/itest/rust/src/object_tests/enum_test.rs
@@ -64,7 +64,7 @@ fn enum_hash() {
 }
 
 // Testing https://github.com/godot-rust/gdext/issues/335
-// This fails upon calling the function, we dont actually need to make a good call.
+// This fails upon calling the function, we don't actually need to make a good call.
 #[itest]
 fn add_surface_from_arrays() {
     let mut mesh = ArrayMesh::new();


### PR DESCRIPTION
This part confused me while CTRL+F-ing through the docs.

Relevant thread: https://discord.com/channels/723850269347283004/1231202121630748762