### PR TITLE
Make mutable Script Instance functions reentrant

### DIFF
--- a/godot-core/src/engine/mod.rs
+++ b/godot-core/src/engine/mod.rs
@@ -15,7 +15,7 @@ pub use crate::gen::central::global;
 pub use crate::gen::classes::*;
 pub use crate::gen::utilities;
 pub use io::*;
-pub use script_instance::{create_script_instance, ScriptInstance};
+pub use script_instance::{create_script_instance, ScriptInstance, SiMut};
 
 use crate::builtin::meta::CallContext;
 use crate::sys;

--- a/godot-core/src/obj/base.rs
+++ b/godot-core/src/obj/base.rs
@@ -41,6 +41,12 @@ impl<T: GodotClass> Base<T> {
         Base::from_obj(Gd::from_obj_sys_weak(base.as_gd().obj_sys()))
     }
 
+    /// # Safety
+    /// The returned Base is a weak pointer, so holding it will not keep the object alive. It must not be accessed after the object is destroyed.
+    pub(crate) unsafe fn from_gd(gd: &Gd<T>) -> Self {
+        Base::from_obj(Gd::from_obj_sys_weak(gd.obj_sys()))
+    }
+
     // Note: not &mut self, to only borrow one field and not the entire struct
     pub(crate) unsafe fn from_sys(base_ptr: sys::GDExtensionObjectPtr) -> Self {
         assert!(!base_ptr.is_null(), "instance base is null pointer");

--- a/itest/godot/ScriptInstanceTests.gd
+++ b/itest/godot/ScriptInstanceTests.gd
@@ -73,3 +73,35 @@ func test_script_instance_to_string():
 	var object = create_script_instance()
 
 	assert_eq(object.to_string(), "script instance to string")
+
+
+func test_script_instance_mut_call():
+	var object = create_script_instance()
+	var before = object.script_property_b
+	
+	var result = object.script_method_toggle_property_b()
+
+	assert(result)
+	assert_eq(object.script_property_b, !before)
+
+
+func test_script_instance_re_entering_call():
+	var object = create_script_instance()
+	var before = object.script_property_b
+	
+	var result = object.script_method_re_entering()
+
+	assert(result)
+	assert_eq(object.script_property_b, !before)
+
+
+func test_object_script_instance():
+	var object = Node.new()
+	var script = TestScript.new()
+
+	object.script = script
+
+	var result = object.script_method_re_entering()
+
+	assert(result)
+	object.free()


### PR DESCRIPTION
Closes #554

Adds a ref guard around a `&mut T where T: ScriptInstance`  for the `ScriptInstance` trait. This guard exposes an API to access the script instance base object, through which reentrant calls can be achieved.

This also switches the script instance internals from a `RefCell` to a `GdCell` and introduces a new `WithBase` trait that can be shared between `GodotClass` and `ScriptInstance`. 

----

I'm open to factor the `WithBase` introduction into a seperate PR if that is preferred.