### PR TITLE
Refactor `Enum` in codegen

### DIFF
--- a/godot-codegen/src/generator/central_files.rs
+++ b/godot-codegen/src/generator/central_files.rs
@@ -7,7 +7,7 @@
 
 use crate::context::Context;
 use crate::conv;
-use crate::generator::{enums, gdext_build_struct};
+use crate::generator::gdext_build_struct;
 use crate::models::domain::{Enumerator, ExtensionApi};
 use crate::util::ident;
 use proc_macro2::{Ident, Literal, TokenStream};
@@ -265,7 +265,7 @@ fn make_global_enums(api: &ExtensionApi) -> Vec<TokenStream> {
             continue;
         }
 
-        let def = enums::make_enum_definition(enum_);
+        let def = enum_.to_declaration();
         global_enum_defs.push(def);
     }
 

--- a/godot-codegen/src/generator/enums.rs
+++ b/godot-codegen/src/generator/enums.rs
@@ -5,236 +5,226 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use crate::models::domain::{Enum, Enumerator, EnumeratorValue};
-use crate::util;
-use proc_macro2::{Literal, TokenStream};
-use quote::quote;
+//! Functions for codegenning enums.
+//!
+//! See also models/domain/enums.rs for other enum-related methods.
 
-pub fn make_enums(enums: &[Enum]) -> TokenStream {
-    let definitions = enums.iter().map(make_enum_definition);
+use crate::{
+    models::domain::{self, Enum},
+    util::ident,
+};
+use proc_macro2::{Ident, TokenStream};
+use quote::{quote, ToTokens};
+
+pub fn make_enums(enums: &[domain::Enum]) -> TokenStream {
+    let definitions = enums.iter().map(Enum::to_declaration);
 
     quote! {
         #( #definitions )*
     }
 }
 
-pub fn make_enum_definition(enum_: &Enum) -> TokenStream {
-    // TODO enums which have unique ords could be represented as Rust enums
-    // This would allow exhaustive matches (or at least auto-completed matches + #[non_exhaustive]). But even without #[non_exhaustive],
-    // this might be a forward compatibility hazard, if Godot deprecates enumerators and adds new ones with existing ords.
+/// Codegen methods.
+impl domain::Enum {
+    /// Creates a declaration of this enum.
+    ///
+    /// This will also implement all relevant traits and generate appropriate constants for each enumerator.
+    pub fn to_declaration(&self) -> TokenStream {
+        // Things needed for the type definition
+        let derives = self.derives();
+        let enum_doc = self.enum_doc();
+        let name = &self.name;
 
-    let rust_enum_name = &enum_.name;
-    let godot_name_doc = if rust_enum_name != enum_.godot_name.as_str() {
-        let doc = format!("Godot enum name: `{}`.", enum_.godot_name);
-        quote! { #[doc = #doc] }
-    } else {
-        TokenStream::new()
-    };
+        // Values
+        let enumerators = self.to_const_declarations();
 
-    let rust_enumerators = &enum_.enumerators;
+        // Trait implementations
+        let engine_trait_impl = self.to_engine_trait_impl();
+        let index_enum_impl = self.to_index_impl();
+        let bitwise_impls = self.bitwise_operators();
 
-    let mut enumerators = Vec::with_capacity(rust_enumerators.len());
+        // Various types
+        let ord_type = self.ord_type();
+        let engine_trait = self.engine_trait();
 
-    // This is only used for enum ords (i32), not bitfield flags (u64).
-    let mut unique_ords = Vec::with_capacity(rust_enumerators.len());
+        quote! {
+            #[repr(transparent)]
+            #[derive(#( #derives ),*)]
+            #( #[doc = #enum_doc] )*
+            pub struct #name {
+                ord: #ord_type
+            }
 
-    for enumerator in rust_enumerators.iter() {
-        let def = make_enumerator_definition(enumerator);
-        enumerators.push(def);
+            impl #name {
+                #enumerators
+            }
 
-        if let EnumeratorValue::Enum(ord) = enumerator.value {
-            unique_ords.push(ord);
+            #engine_trait_impl
+            #index_enum_impl
+            #bitwise_impls
+
+            impl crate::builtin::meta::GodotConvert for #name {
+                type Via = #ord_type;
+            }
+
+            impl crate::builtin::meta::ToGodot for #name {
+                fn to_godot(&self) -> Self::Via {
+                    <Self as #engine_trait>::ord(*self)
+                }
+            }
+
+            impl crate::builtin::meta::FromGodot for #name {
+                fn try_from_godot(via: Self::Via) -> std::result::Result<Self, crate::builtin::meta::ConvertError> {
+                    <Self as #engine_trait>::try_from_ord(via)
+                        .ok_or_else(|| crate::builtin::meta::FromGodotError::InvalidEnum.into_error(via))
+                }
+            }
         }
     }
 
-    let mut derives = vec!["Copy", "Clone", "Eq", "PartialEq", "Hash", "Debug"];
+    /// Creates an implementation of `IndexEnum` for this enum.
+    ///
+    /// Returns `None` if `self` isn't an indexable enum.
+    fn to_index_impl(&self) -> Option<TokenStream> {
+        let enum_max = self.count_index_enum()?;
+        let name = &self.name;
 
-    if enum_.is_bitfield {
-        derives.push("Default");
+        Some(quote! {
+            impl crate::obj::IndexEnum for #name {
+                const ENUMERATOR_COUNT: usize = #enum_max;
+            }
+        })
     }
 
-    let derives = derives.into_iter().map(util::ident);
+    /// Creates an implementation of the engine trait for this enum.
+    ///
+    /// This will implement the trait returned by [`Enum::engine_trait`].
+    fn to_engine_trait_impl(&self) -> TokenStream {
+        let name = &self.name;
+        let engine_trait = self.engine_trait();
 
-    let index_enum_impl = if enum_.is_bitfield {
-        // Bitfields don't implement IndexEnum.
-        TokenStream::new()
-    } else {
-        // Enums implement IndexEnum only if they are "index-like" (see docs).
-        if let Some(enum_max) = try_count_index_enum(enum_) {
+        if self.is_bitfield {
             quote! {
-                impl crate::obj::IndexEnum for #rust_enum_name {
-                    const ENUMERATOR_COUNT: usize = #enum_max;
+                impl #engine_trait for #name {
+                    fn try_from_ord(ord: u64) -> Option<Self> {
+                        Some(Self { ord })
+                    }
+
+                    fn ord(self) -> u64 {
+                        self.ord
+                    }
+                }
+            }
+        } else {
+            let unique_ords = self.unique_ords().expect("self is an enum");
+
+            quote! {
+                impl #engine_trait for #name {
+                    fn try_from_ord(ord: i32) -> Option<Self> {
+                        match ord {
+                            #( ord @ #unique_ords )|* => Some(Self { ord }),
+                            _ => None,
+                        }
+                    }
+
+                    fn ord(self) -> i32 {
+                        self.ord
+                    }
+                }
+            }
+        }
+    }
+
+    /// Creates declarations for all the constants of this enum.
+    fn to_const_declarations(&self) -> TokenStream {
+        let declarations = self
+            .enumerators
+            .iter()
+            .map(|field| field.to_const_declaration((&self.name).into_token_stream()))
+            .collect::<Vec<_>>();
+
+        quote! {
+            #( #declarations )*
+        }
+    }
+
+    /// Creates implementations for any bitwise operators.
+    ///
+    /// Currently this is just [`BitOr`](std::ops::BitOr) for bitfields but that could be expanded in the future.
+    fn bitwise_operators(&self) -> TokenStream {
+        let name = &self.name;
+
+        if self.is_bitfield {
+            quote! {
+                impl std::ops::BitOr for #name {
+                    type Output = Self;
+
+                    fn bitor(self, rhs: Self) -> Self::Output {
+                        Self { ord: self.ord | rhs.ord }
+                    }
                 }
             }
         } else {
             TokenStream::new()
         }
-    };
+    }
 
-    let bitfield_ops;
-    let self_as_trait;
-    let engine_impl;
-    let enum_ord_type;
+    /// Which derives should be implemented for this enum.
+    fn derives(&self) -> Vec<Ident> {
+        let mut derives = vec!["Copy", "Clone", "Eq", "PartialEq", "Hash", "Debug"];
 
-    if enum_.is_bitfield {
-        bitfield_ops = quote! {
-            // impl #enum_name {
-            //     pub const UNSET: Self = Self { ord: 0 };
-            // }
-            impl std::ops::BitOr for #rust_enum_name {
-                type Output = Self;
-
-                fn bitor(self, rhs: Self) -> Self::Output {
-                    Self { ord: self.ord | rhs.ord }
-                }
-            }
-        };
-        enum_ord_type = quote! { u64 };
-        self_as_trait = quote! { <Self as crate::obj::EngineBitfield> };
-        engine_impl = quote! {
-            impl crate::obj::EngineBitfield for #rust_enum_name {
-                fn try_from_ord(ord: u64) -> Option<Self> {
-                    Some(Self { ord })
-                }
-
-                fn ord(self) -> u64 {
-                    self.ord
-                }
-            }
-        };
-    } else {
-        // Ordinals are not necessarily in order.
-        unique_ords.sort();
-        unique_ords.dedup();
-
-        bitfield_ops = TokenStream::new();
-        enum_ord_type = quote! { i32 };
-        self_as_trait = quote! { <Self as crate::obj::EngineEnum> };
-        engine_impl = quote! {
-            impl crate::obj::EngineEnum for #rust_enum_name {
-                fn try_from_ord(ord: i32) -> Option<Self> {
-                    match ord {
-                        #( ord @ #unique_ords )|* => Some(Self { ord }),
-                        _ => None,
-                    }
-                }
-
-                fn ord(self) -> i32 {
-                    self.ord
-                }
-            }
-        };
-    };
-
-    // Enumerator ordinal stored as i32, since that's enough to hold all current values and the default repr in C++.
-    // Public interface is i64 though, for consistency (and possibly forward compatibility?).
-    // Bitfield ordinals are stored as u64. See also: https://github.com/godotengine/godot-cpp/pull/1320
-    quote! {
-        #[repr(transparent)]
-        #[derive(#( #derives ),*)]
-        #godot_name_doc
-        pub struct #rust_enum_name {
-            ord: #enum_ord_type
-        }
-        impl #rust_enum_name {
-            #(
-                #enumerators
-            )*
+        if self.is_bitfield {
+            derives.push("Default");
         }
 
-        #engine_impl
-        #index_enum_impl
-        #bitfield_ops
+        derives.into_iter().map(ident).collect()
+    }
 
-        impl crate::builtin::meta::GodotConvert for #rust_enum_name {
-            type Via = #enum_ord_type;
+    /// Returns the documentation for this enum.
+    ///
+    /// Each string is one line of documentation, usually this needs to be wrapped in a `#[doc = ..]`.
+    fn enum_doc(&self) -> Vec<String> {
+        let mut docs = Vec::new();
+
+        if self.name != self.godot_name {
+            docs.push(format!("Godot enum name: `{}`.", self.godot_name))
         }
 
-        impl crate::builtin::meta::ToGodot for #rust_enum_name {
-            fn to_godot(&self) -> Self::Via {
-                #self_as_trait::ord(*self)
-            }
-        }
-
-        impl crate::builtin::meta::FromGodot for #rust_enum_name {
-            fn try_from_godot(via: Self::Via) -> std::result::Result<Self, crate::builtin::meta::ConvertError> {
-                #self_as_trait::try_from_ord(via)
-                    .ok_or_else(|| crate::builtin::meta::FromGodotError::InvalidEnum.into_error(via))
-            }
-        }
+        docs
     }
 }
 
-pub fn make_enumerator_ord(ord: i32) -> Literal {
-    Literal::i32_suffixed(ord)
-}
+/// Codegen methods.
+impl domain::Enumerator {
+    /// Creates a `const` declaration for self of the type `enum_type`.
+    ///
+    /// That is, it'll be a declaration like
+    /// ```ignore
+    /// pub const NAME: enum_type = ..;
+    /// ```
+    fn to_const_declaration(&self, enum_type: TokenStream) -> TokenStream {
+        let Self {
+            name,
+            godot_name,
+            value,
+        } = self;
 
-// ----------------------------------------------------------------------------------------------------------------------------------------------
-// Implementation
+        let docs = if &name.to_string() != godot_name {
+            let doc = format!("Godot enumerator name: `{godot_name}`");
 
-fn make_bitfield_flag_ord(ord: u64) -> Literal {
-    Literal::u64_suffixed(ord)
-}
+            quote! {
+                #[doc(alias = #godot_name)]
+                #[doc = #doc]
+            }
+        } else {
+            TokenStream::new()
+        };
 
-fn make_enumerator_definition(enumerator: &Enumerator) -> TokenStream {
-    let ordinal_lit = match enumerator.value {
-        EnumeratorValue::Enum(ord) => make_enumerator_ord(ord),
-        EnumeratorValue::Bitfield(ord) => make_bitfield_flag_ord(ord),
-    };
-
-    let rust_ident = &enumerator.name;
-    let godot_name_str = &enumerator.godot_name;
-
-    let doc = if rust_ident == godot_name_str {
-        TokenStream::new()
-    } else {
-        let doc_string = format!("Godot enumerator name: `{}`.", godot_name_str);
         quote! {
-            #[doc(alias = #godot_name_str)]
-            #[doc = #doc_string]
+            #docs
+            pub const #name: #enum_type = #enum_type {
+                ord: #value
+            };
         }
-    };
-
-    quote! {
-        #doc
-        pub const #rust_ident: Self = Self { ord: #ordinal_lit };
     }
-}
-
-/// If an enum qualifies as "indexable" (can be used as array index), returns the number of possible values.
-///
-/// See `godot::obj::IndexEnum` for what constitutes "indexable".
-fn try_count_index_enum(enum_: &Enum) -> Option<usize> {
-    if enum_.is_bitfield || enum_.enumerators.is_empty() {
-        return None;
-    }
-
-    // Sort by ordinal value. Allocates for every enum in the JSON, but should be OK (most enums are indexable).
-    let enumerators = {
-        let mut enumerators = enum_.enumerators.iter().collect::<Vec<_>>();
-        enumerators.sort_by_key(|v| v.value.to_i64());
-        enumerators
-    };
-
-    // Highest ordinal must be the "MAX" one.
-    // The presence of "MAX" indicates that Godot devs intended the enum to be used as an index.
-    // The condition is not strictly necessary and could theoretically be relaxed; there would need to be concrete use cases though.
-    let last = enumerators.last().unwrap(); // safe because of is_empty check above.
-    if !last.godot_name.ends_with("_MAX") {
-        return None;
-    }
-
-    // The rest of the enumerators must be contiguous and without gaps (duplicates are OK).
-    let mut last_value = 0;
-    for enumerator in enumerators.iter() {
-        let e_value = enumerator.value.to_i64();
-
-        if last_value != e_value && last_value + 1 != e_value {
-            return None;
-        }
-
-        last_value = e_value;
-    }
-
-    Some(last_value as usize)
 }

--- a/godot-codegen/src/generator/notifications.rs
+++ b/godot-codegen/src/generator/notifications.rs
@@ -6,7 +6,6 @@
  */
 
 use crate::context::Context;
-use crate::generator::enums;
 use crate::models::domain::TyName;
 use crate::models::json::JsonClassConstant;
 use crate::{conv, util};
@@ -89,7 +88,7 @@ pub fn make_notification_enum(
     let mut notification_enumerators_ord = Vec::new();
     for (constant_ident, constant_value) in all_constants {
         notification_enumerators_pascal.push(constant_ident);
-        notification_enumerators_ord.push(enums::make_enumerator_ord(constant_value));
+        notification_enumerators_ord.push(constant_value);
     }
 
     let code = quote! {

--- a/godot-codegen/src/models/domain.rs
+++ b/godot-codegen/src/models/domain.rs
@@ -20,6 +20,10 @@ use quote::{format_ident, quote, ToTokens};
 use std::collections::HashMap;
 use std::fmt;
 
+mod enums;
+
+pub use enums::{Enum, Enumerator, EnumeratorValue};
+
 pub struct ExtensionApi {
     pub builtins: Vec<BuiltinVariant>,
     pub classes: Vec<Class>,
@@ -178,48 +182,6 @@ pub struct Singleton {
     pub name: TyName,
     // Note: `type` currently has always same value as `name`, thus redundant
     // type_: String,
-}
-
-pub struct Enum {
-    pub name: Ident,
-    pub godot_name: String,
-    pub is_bitfield: bool,
-    pub enumerators: Vec<Enumerator>,
-}
-
-// ----------------------------------------------------------------------------------------------------------------------------------------------
-// Enumerators
-
-pub struct Enumerator {
-    pub name: Ident,
-
-    pub godot_name: String,
-
-    // i64 is common denominator for enum, bitfield and constant values.
-    // Note that values > i64::MAX will be implicitly wrapped, see https://github.com/not-fl3/nanoserde/issues/89.
-    pub value: EnumeratorValue,
-}
-pub enum EnumeratorValue {
-    Enum(i32),
-    Bitfield(u64),
-}
-
-impl EnumeratorValue {
-    pub fn to_i64(&self) -> i64 {
-        // Conversion is safe because i64 is used in the original JSON.
-        match self {
-            EnumeratorValue::Enum(i) => *i as i64,
-            EnumeratorValue::Bitfield(i) => *i as i64,
-        }
-    }
-
-    /// This method is needed for platform-dependent types like raw `VariantOperator`, which can be `i32` or `u32`.
-    /// Do not suffix them.
-    ///
-    /// See also `BuiltinVariant::unsuffixed_ord_lit()`.
-    pub fn unsuffixed_lit(&self) -> Literal {
-        Literal::i64_unsuffixed(self.to_i64())
-    }
 }
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------

--- a/godot-codegen/src/models/domain/enums.rs
+++ b/godot-codegen/src/models/domain/enums.rs
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+//! Definition of engine enums/bitfields and related types.
+//!
+//! See also generator/enums.rs for functions related to turning enums into `TokenStream`s.
+
+use crate::util::ident;
+
+use proc_macro2::{Ident, Literal, TokenStream};
+use quote::{quote, ToTokens};
+
+pub struct Enum {
+    pub name: Ident,
+    pub godot_name: String,
+    pub is_bitfield: bool,
+    pub enumerators: Vec<Enumerator>,
+}
+
+impl Enum {
+    /// The type we use to represent values of this enum.
+    pub fn ord_type(&self) -> Ident {
+        if self.is_bitfield {
+            ident("u64")
+        } else {
+            ident("i32")
+        }
+    }
+
+    /// Returns all unique enumerator ords, sorted.
+    ///
+    /// Returns `None` if `self` is a bitfield.
+    pub fn unique_ords(&self) -> Option<Vec<i32>> {
+        let mut unique_ords = self
+            .enumerators
+            .iter()
+            .map(|enumerator| enumerator.value.as_enum())
+            .collect::<Option<Vec<i32>>>()?;
+
+        unique_ords.sort();
+        unique_ords.dedup();
+
+        Some(unique_ords)
+    }
+
+    /// Returns tokens representing the engine trait this enum should implement.
+    pub fn engine_trait(&self) -> TokenStream {
+        if self.is_bitfield {
+            quote! { crate::obj::EngineBitfield }
+        } else {
+            quote! { crate::obj::EngineEnum }
+        }
+    }
+
+    /// Returns the maximum index of an indexable enum.
+    ///
+    /// Return `None` if `self` isn't an indexable enum. Meaning it is either a bitfield, or it is an enum that can't be used as an index.
+    pub fn count_index_enum(&self) -> Option<usize> {
+        if self.is_bitfield {
+            return None;
+        }
+
+        // Sort by ordinal value. Allocates for every enum in the JSON, but should be OK (most enums are indexable).
+        let enumerators = {
+            let mut enumerators = self.enumerators.clone();
+            enumerators.sort_by_key(|v| v.value.to_i64());
+            enumerators
+        };
+
+        // Highest ordinal must be the "MAX" one.
+        // The presence of "MAX" indicates that Godot devs intended the enum to be used as an index.
+        // The condition is not strictly necessary and could theoretically be relaxed; there would need to be concrete use cases though.
+        let last = enumerators.last()?; // If there isn't a last we can assume it shouldn't be used as an index.
+
+        if !last.godot_name.ends_with("_MAX") {
+            return None;
+        }
+
+        // The rest of the enumerators must be contiguous and without gaps (duplicates are OK).
+        let mut last_value = 0;
+
+        for enumerator in enumerators.iter() {
+            let current_value = enumerator.value.to_i64();
+
+            if !(current_value == last_value || current_value == last_value + 1) {
+                return None;
+            }
+
+            last_value = current_value;
+        }
+
+        Some(last_value as usize)
+    }
+}
+
+#[derive(Clone)]
+pub struct Enumerator {
+    pub name: Ident,
+
+    pub godot_name: String,
+
+    // i64 is common denominator for enum, bitfield and constant values.
+    // Note that values > i64::MAX will be implicitly wrapped, see https://github.com/not-fl3/nanoserde/issues/89.
+    pub value: EnumeratorValue,
+}
+
+#[derive(Clone)]
+pub enum EnumeratorValue {
+    Enum(i32),
+    Bitfield(u64),
+}
+
+impl EnumeratorValue {
+    /// Tries to convert `self` into an enum value.
+    fn as_enum(&self) -> Option<i32> {
+        match self {
+            EnumeratorValue::Enum(i) => Some(*i),
+            EnumeratorValue::Bitfield(_) => None,
+        }
+    }
+
+    /// Converts `self` to an `i64`.
+    ///
+    /// This may map some bitfield values to negative numbers.
+    pub fn to_i64(&self) -> i64 {
+        // Conversion is safe because i64 is used in the original JSON.
+        match self {
+            EnumeratorValue::Enum(i) => *i as i64,
+            EnumeratorValue::Bitfield(i) => *i as i64,
+        }
+    }
+
+    /// This method is needed for platform-dependent types like raw `VariantOperator`, which can be `i32` or `u32`.
+    /// Do not suffix them.
+    ///
+    /// See also `BuiltinVariant::unsuffixed_ord_lit()`.
+    pub fn unsuffixed_lit(&self) -> Literal {
+        Literal::i64_unsuffixed(self.to_i64())
+    }
+}
+
+impl ToTokens for EnumeratorValue {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        match self {
+            EnumeratorValue::Enum(i) => i.to_tokens(tokens),
+            EnumeratorValue::Bitfield(i) => i.to_tokens(tokens),
+        }
+    }
+}


### PR DESCRIPTION
not intended to be merged, just an example of a possible way to refactor some of the logic surrounding enum codegen

i think the biggest improvement here is largely just from breaking up the big functions into smaller pieces