### PR TITLE
Make servers register at the right level

### DIFF
--- a/godot-codegen/src/special_cases/special_cases.rs
+++ b/godot-codegen/src/special_cases/special_cases.rs
@@ -319,3 +319,31 @@ pub fn get_interface_extra_docs(trait_name: &str) -> Option<&'static str> {
         _ => None,
     }
 }
+
+// Unclear on if some of these classes should be registered earlier than `Scene`:
+// - `RenderData` + `RenderDataExtension`
+// - `RenderSceneData` + `RenderSceneDataExtension`
+
+#[rustfmt::skip]
+pub fn is_class_level_server(class_name: &str) -> bool {
+    matches!(class_name, 
+        // TODO: These should actually be at level `Core`
+        "Object" | "OpenXRExtensionWrapperExtension" |
+
+        // Shouldn't be inherited from in rust but are still servers.
+        "AudioServer" | "CameraServer" | "NavigationServer2D" | "NavigationServer3D" | "RenderingServer" | "TranslationServer" | "XRServer" |
+
+        // PhysicsServer2D
+        "PhysicsDirectBodyState2D" | "PhysicsDirectBodyState2DExtension" |
+        "PhysicsDirectSpaceState2D" | "PhysicsDirectSpaceState2DExtension" | 
+        "PhysicsServer2D" | "PhysicsServer2DExtension" |
+        "PhysicsServer2DManager" |
+
+        // PhysicsServer3D
+        "PhysicsDirectBodyState3D" | "PhysicsDirectBodyState3DExtension" |
+        "PhysicsDirectSpaceState3D" | "PhysicsDirectSpaceState3DExtension" | 
+        "PhysicsServer3D" | "PhysicsServer3DExtension" | 
+        "PhysicsServer3DManager" |
+        "PhysicsServer3DRenderingServerHandler" 
+    )
+}

--- a/godot-codegen/src/util.rs
+++ b/godot-codegen/src/util.rs
@@ -5,7 +5,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use crate::models::json::JsonClass;
+use crate::{models::json::JsonClass, special_cases};
 
 use crate::models::domain::ClassCodegenLevel;
 use proc_macro2::{Ident, Literal, TokenStream};
@@ -65,7 +65,7 @@ pub fn get_api_level(class: &JsonClass) -> ClassCodegenLevel {
             )
     }
 
-    if class.name.ends_with("Server") {
+    if special_cases::is_class_level_server(&class.name) {
         ClassCodegenLevel::Servers
     } else if class.api_type == "editor" || override_editor(&class.name) {
         ClassCodegenLevel::Editor

--- a/itest/rust/src/lib.rs
+++ b/itest/rust/src/lib.rs
@@ -5,7 +5,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use godot::init::{gdextension, ExtensionLibrary};
+use godot::init::{gdextension, ExtensionLibrary, InitLevel};
 
 mod benchmarks;
 mod builtin_tests;
@@ -19,4 +19,9 @@ mod register_tests;
 // Entry point
 
 #[gdextension(entry_point=itest_init)]
-unsafe impl ExtensionLibrary for framework::IntegrationTests {}
+unsafe impl ExtensionLibrary for framework::IntegrationTests {
+    fn on_level_init(level: InitLevel) {
+        // Testing that we can initialize and use `Object`-derived classes during `Servers` init level. See `object_tests::init_level_test`.
+        object_tests::initialize_init_level_test(level);
+    }
+}

--- a/itest/rust/src/object_tests/init_level_test.rs
+++ b/itest/rust/src/object_tests/init_level_test.rs
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use crate::framework::itest;
+use godot::init::InitLevel;
+use godot::obj::NewAlloc;
+use godot::register::{godot_api, GodotClass};
+use std::sync::atomic::{AtomicBool, Ordering};
+
+static HAS_RUN: AtomicBool = AtomicBool::new(false);
+
+#[derive(GodotClass)]
+#[class(base = Object, init)]
+struct SomeObject {}
+
+#[godot_api]
+impl SomeObject {
+    #[func]
+    pub fn set_has_run_true(&self) {
+        HAS_RUN.store(true, Ordering::Release);
+    }
+}
+
+// Run during on the `on_level_init` of the entry point.
+pub fn initialize_init_level_test(level: InitLevel) {
+    if level == InitLevel::Servers {
+        assert!(!HAS_RUN.load(Ordering::Acquire));
+
+        let mut some_object = SomeObject::new_alloc();
+        // Need to go through Godot here as otherwise we bypass the failure.
+        some_object.call("set_has_run_true".into(), &[]);
+        some_object.free();
+    }
+}
+
+// Ensure that the above function actually ran.
+#[itest]
+fn class_run_during_servers_init() {
+    assert!(HAS_RUN.load(Ordering::Acquire));
+}

--- a/itest/rust/src/object_tests/mod.rs
+++ b/itest/rust/src/object_tests/mod.rs
@@ -8,6 +8,7 @@
 mod base_test;
 mod class_rename_test;
 mod dynamic_call_test;
+mod init_level_test;
 mod object_swap_test;
 mod object_test;
 mod onready_test;
@@ -16,3 +17,6 @@ mod property_test;
 mod reentrant_test;
 mod singleton_test;
 mod virtual_methods_test;
+
+// Need to test this in the init level method.
+pub use init_level_test::initialize_init_level_test;


### PR DESCRIPTION
A somewhat more robust check for what init level classes should be registered at. Unsure if it's perfect but still better.

Also includes `Object` as that is not only the superclass of all servers but also needed in some cases.