### PR TITLE
Support macOS arm64 architecture in CI

### DIFF
--- a/.github/composite/godot-itest/action.yml
+++ b/.github/composite/godot-itest/action.yml
@@ -77,7 +77,7 @@ runs:
     # The `| xargs` pattern trims the output, since printed version may contain extra newline, which causes problems in env vars.
     - name: "Inspect Godot version"
       run: |
-        godotVer=$($GODOT4_BIN --version | xargs || true)
+        godotVer=$($GODOT4_BIN --version | xargs)
         gitSha=$(echo $godotVer | sed -E "s/.+custom_build\.//")
         echo "GODOT_BUILT_FROM=_Built from [\`$godotVer\`](https://github.com/godotengine/godot/commit/$gitSha)._" >> $GITHUB_ENV
       shell: bash

--- a/.github/composite/llvm/action.yml
+++ b/.github/composite/llvm/action.yml
@@ -6,11 +6,11 @@
 name: llvm
 description: "Install LLVM + Clang, with caching"
 
-inputs:
-  llvm-version:
-    required: false
-    default: '15.0.7'
-    description: "LLVM versions. Greater than 15 may not be supported in all runners."
+#inputs:
+#  llvm-version:
+#    required: false
+#    default: '15.0.7'
+#    description: "LLVM versions. Greater than 15 may not be supported in all runners."
 
 runs:
   using: "composite"
@@ -19,7 +19,27 @@ runs:
     - name: "Set up install dir"
       run: |
         installDir=$(echo "${{ runner.temp }}/llvm" | sed "s!\\\\!/!")
-        echo "LLVM_INSTALL_DIR=$installDir" >> $GITHUB_ENV
+        echo "INSTALL_DIR=$installDir" >> $GITHUB_ENV
+      shell: bash
+
+    - name: "Print runner arch"
+      run: 'echo "Runner arch: ${{ runner.arch }}"'
+      shell: bash
+
+    # https://docs.github.com/en/actions/learn-github-actions/contexts#runner-context
+    # https://github.com/kylemayes/install-llvm-action?tab=readme-ov-file#arch
+    - name: "Enable x86 architecture"
+      if: runner.arch == 'X86' || runner.arch == 'X64'
+      run: |
+        echo "INSTALL_ARCH=x64" >> $GITHUB_ENV
+        echo "INSTALL_VERSION=15" >> $GITHUB_ENV
+      shell: bash
+
+    - name: "Enable ARM architecture"
+      if: runner.arch == 'ARM' || runner.arch == 'ARM64'
+      run: |
+        echo "INSTALL_ARCH=arm64" >> $GITHUB_ENV
+        echo "INSTALL_VERSION=17" >> $GITHUB_ENV
       shell: bash
 
     - name: "Cache LLVM and clang"
@@ -31,15 +51,17 @@ runs:
 #        path: |
 #          C:/Program Files/LLVM
 #          ./llvm
-        path: ${{ env.LLVM_INSTALL_DIR }}
-        key: "llvm-${{ inputs.llvm-version }}"
+        path: ${{ env.INSTALL_DIR }}
+        key: "llvm-${{ runner.os }}-${{ env.INSTALL_VERSION }}-${{ env.INSTALL_ARCH }}"
 
-    - uses: KyleMayes/install-llvm-action@v1
+    # LLVM version compatibility: https://github.com/KyleMayes/install-llvm-action/blob/master/assets.json
+    - uses: KyleMayes/install-llvm-action@v2
       # if: inputs.llvm == 'true'
       with:
         # Newer versions failed on macOS with "Unsupported target! (platform='darwin', version='17.0.2')"
-        version: "${{ inputs.llvm-version }}"
-        directory: ${{ env.LLVM_INSTALL_DIR }}
+        version: "${{ env.INSTALL_VERSION }}"
+        directory: ${{ env.INSTALL_DIR }}
+        arch: ${{ env.INSTALL_ARCH }}
         cached: ${{ steps.cache-llvm.outputs.cache-hit }}
 
     - name: "Print LLVM dir"

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -11,9 +11,9 @@ on:
   merge_group:
 #  push:
 
+
 env:
   GDEXT_FEATURES: ''
-#  GDEXT_FEATURES: '--features godot/serde'
   RETRY: ${{ github.workspace }}/.github/other/retry.sh
 
   # ASan options: https://github.com/google/sanitizers/wiki/AddressSanitizerFlags
@@ -21,8 +21,9 @@ env:
   # * report_objects: list individual leaked objects when running LeakSanitizer
   LSAN_OPTIONS: report_objects=1
 
-  CARGO_DENY_VERSION: "0.14.20"
-  CARGO_MACHETE_VERSION: "0.6.0"
+  CARGO_DENY_VERSION: "0.14.22"
+  CARGO_MACHETE_VERSION: "0.6.2"
+
 
 defaults:
   run:
@@ -434,7 +435,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: "Check license headers"
-        uses: apache/skywalking-eyes/header@v0.5.0
+        uses: 'apache/skywalking-eyes/header@v0.6.0'
         with:
           # log: debug # optional: set the log level. The default value is `info`.
           config: .github/other/licenserc.yml

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -310,7 +310,7 @@ jobs:
 #            os: ubuntu-20.04
 #            artifact-name: linux-4.2
 #            godot-binary: godot.linuxbsd.editor.dev.x86_64
-#            godot-prebuilt-patch: '4.1.3'
+#            godot-prebuilt-patch: '4.1.4'
 #
 #          - name: linux-4.0
 #            os: ubuntu-20.04
@@ -340,7 +340,7 @@ jobs:
             os: ubuntu-20.04
             artifact-name: linux-memcheck-4.1
             godot-binary: godot.linuxbsd.editor.dev.x86_64.llvm.san
-            godot-prebuilt-patch: '4.1.3'
+            godot-prebuilt-patch: '4.1.4'
             rust-toolchain: nightly
             rust-env-rustflags: -Zrandomize-layout -Zsanitizer=address
             # Sanitizers can't build proc-macros and build scripts; with --target, cargo ignores RUSTFLAGS for those two.

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -206,36 +206,60 @@ jobs:
         # Naming: {os}[-{runtimeVersion}]-{apiVersion}
         # runtimeVersion = version of Godot binary; apiVersion = version of GDExtension API against which gdext is compiled.
 
-        # Order this way because macOS typically has the longest duration, followed by Windows, so it benefits total workflow execution time.
-        # Additionally, the 'linux (msrv *)' special case will then be listed next to the other 'linux' jobs.
+        # Config overview (see job for details).
+        #
+        # Cross-platform:
+        # - Base version:     Godot nightly, no custom
+        # - Double precision: Godot nightly, custom (bindgen), double
+        # - 4.2 compat:       Godot 4.2
+        #
+        # Linux-only:
+        # - Full:             Godot nightly, full codegen
+        # - Double + lazy:    Godot nightly, custom, double, lazy func tables
+        # - Features + exp:   Godot nightly, custom, threads, serde, experimental API
+        # - Memcheck nightly: Godot mem nightly, custom, sanitizer
+        # - Memcheck 4.x:     Godot mem 4.0/4.1, sanitizer
+
         # Note: Windows uses '--target x86_64-pc-windows-msvc' by default as Cargo argument.
         include:
-          # macOS
+          # macOS -- for the unintuitive naming, see https://github.com/actions/runner-images?tab=readme-ov-file#available-images
 
-          - name: macos
+          - name: macos-x86
             os: macos-12
-            artifact-name: macos-nightly
+            artifact-name: macos-x86-nightly
             godot-binary: godot.macos.editor.dev.x86_64
-            rust-extra-args: --features godot/custom-godot
             with-hot-reload: true
 
-          - name: macos-double
+          - name: macos-double-x86
             os: macos-12
-            artifact-name: macos-double-nightly
+            artifact-name: macos-double-x86-nightly
             godot-binary: godot.macos.editor.dev.double.x86_64
             rust-extra-args: --features godot/custom-godot,godot/double-precision
 
-          - name: macos-4.2
+          - name: macos-x86-4.2
             os: macos-12
-            artifact-name: macos-4.2
+            artifact-name: macos-x86-4.2
             godot-binary: godot.macos.editor.dev.x86_64
-#            godot-prebuilt-patch: '4.2.x'
+    #            godot-prebuilt-patch: '4.2.x'
 
-#          - name: macos-4.1
-#            os: macos-12
-#            artifact-name: macos-4.1
-#            godot-binary: godot.macos.editor.dev.x86_64
-#            godot-prebuilt-patch: '4.1.3'
+          - name: macos-arm
+            os: macos-latest
+            artifact-name: macos-arm-nightly
+            godot-binary: godot.macos.editor.dev.arm64
+            with-hot-reload: true
+
+           # custom-godot on macOS arm64 not working, due to clang linker issues.
+#          - name: macos-double-arm
+#            os: macos-latest
+#            artifact-name: macos-double-arm-nightly
+#            godot-binary: godot.macos.editor.dev.double.arm64
+#            rust-extra-args: --features godot/custom-godot,godot/double-precision
+
+          - name: macos-arm-4.2
+            os: macos-latest
+            artifact-name: macos-arm-4.2
+            godot-binary: godot.macos.editor.dev.arm64
+    #            godot-prebuilt-patch: '4.2.x'
 
           # Windows
 
@@ -243,7 +267,6 @@ jobs:
             os: windows-latest
             artifact-name: windows-nightly
             godot-binary: godot.windows.editor.dev.x86_64.exe
-            rust-extra-args: --features godot/custom-godot
             with-hot-reload: true
 
           - name: windows-double
@@ -421,7 +444,7 @@ jobs:
 
       # Machete
       - name: "Install cargo-machete"
-        uses: baptiste0928/cargo-install@v2
+        uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-machete
           version: ${{ env.CARGO_MACHETE_VERSION }}

--- a/.github/workflows/minimal-ci.yml
+++ b/.github/workflows/minimal-ci.yml
@@ -127,13 +127,12 @@ jobs:
       fail-fast: false # cancel all jobs as soon as one fails?
       matrix:
         include:
-          # macOS
+          # macOS (use arm64 for minimal CI)
 
           - name: macos
-            os: macos-12
-            artifact-name: macos-x86-nightly
-            godot-binary: godot.macos.editor.dev.x86_64
-            rust-extra-args: --features godot/custom-godot
+            os: macos-latest
+            artifact-name: macos-arm-nightly
+            godot-binary: godot.macos.editor.dev.arm64
 
           # Windows
 
@@ -141,7 +140,7 @@ jobs:
             os: windows-latest
             artifact-name: windows-nightly
             godot-binary: godot.windows.editor.dev.x86_64.exe
-            rust-extra-args: --features godot/custom-godot
+            # rust-extra-args: --features godot/custom-godot
 
           # Linux
 

--- a/.github/workflows/minimal-ci.yml
+++ b/.github/workflows/minimal-ci.yml
@@ -160,11 +160,11 @@ jobs:
 
           # Linux compat
 
-          - name: linux-4.1.3
+          - name: linux-4.1.4
             os: ubuntu-20.04
             artifact-name: linux-4.1
             godot-binary: godot.linuxbsd.editor.dev.x86_64
-            godot-prebuilt-patch: '4.1.3'
+            godot-prebuilt-patch: '4.1.4'
 
           - name: linux-4.0.4
             os: ubuntu-20.04

--- a/.github/workflows/minimal-ci.yml
+++ b/.github/workflows/minimal-ci.yml
@@ -22,10 +22,10 @@ on:
 
 env:
   GDEXT_FEATURES: ''
+  #  GDEXT_FEATURES: '--features crate/feature'
+  #  GDEXT_CRATE_ARGS: '-p godot-codegen -p godot-ffi -p godot-core -p godot-macros -p godot'
   RETRY: ${{ github.workspace }}/.github/other/retry.sh
 
-#  GDEXT_FEATURES: '--features crate/feature'
-#  GDEXT_CRATE_ARGS: '-p godot-codegen -p godot-ffi -p godot-core -p godot-macros -p godot'
 
 defaults:
   run:
@@ -245,7 +245,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: "Check and fix license headers"
-        uses: apache/skywalking-eyes/header@v0.5.0
+        uses: 'apache/skywalking-eyes/header@v0.6.0'
         with:
           # log: debug # optional: set the log level. The default value is `info`.
           config: .github/other/licenserc.yml

--- a/.github/workflows/minimal-ci.yml
+++ b/.github/workflows/minimal-ci.yml
@@ -131,7 +131,7 @@ jobs:
 
           - name: macos
             os: macos-12
-            artifact-name: macos-nightly
+            artifact-name: macos-x86-nightly
             godot-binary: godot.macos.editor.dev.x86_64
             rust-extra-args: --features godot/custom-godot
 

--- a/.github/workflows/minimal-ci.yml
+++ b/.github/workflows/minimal-ci.yml
@@ -160,17 +160,11 @@ jobs:
 
           # Linux compat
 
-          - name: linux-4.1.4
+          - name: linux-4.1
             os: ubuntu-20.04
             artifact-name: linux-4.1
             godot-binary: godot.linuxbsd.editor.dev.x86_64
             godot-prebuilt-patch: '4.1.4'
-
-          - name: linux-4.0.4
-            os: ubuntu-20.04
-            artifact-name: linux-4.0
-            godot-binary: godot.linuxbsd.editor.dev.x86_64
-            godot-prebuilt-patch: '4.0.4'
 
           # Memory checkers
 

--- a/godot-bindings/Cargo.toml
+++ b/godot-bindings/Cargo.toml
@@ -22,9 +22,9 @@ godot4-prebuilt = { optional = true, git = "https://github.com/godot-rust/godot4
 
 # Version >= 1.5.5 for security: https://blog.rust-lang.org/2022/03/08/cve-2022-24713.html
 # 'unicode-gencat' needed for \d, see: https://docs.rs/regex/1.5.5/regex/#unicode-features
-bindgen = { optional = true, version = "0.65", default-features = false, features = ["runtime"] }
+bindgen = { optional = true, version = "0.69", default-features = false, features = ["runtime"] }
 regex = { optional = true, version = "1.5.5", default-features = false, features = ["std", "unicode-gencat"] }
-which = { optional = true, version = "4" }
+which = { optional = true, version = "6" }
 
 [dev-dependencies]
 # For tests, we need regex unconditionally. Keep this in sync with above dependency.


### PR DESCRIPTION
Now supports two macOS architectures in runners: `x86_64` (Intel) + `arm64` (Silicon).

Also fixes some issues with failing pipelines due to change in underlying images.
Further includes general CI maintenance, see commits.

List of job is quite long now (29), might need tweaking if things become too slow.