### PR TITLE
Replace `NodeExt` + `PackedSceneExt` traits with `impl` blocks, extending classes directly

### DIFF
--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -109,7 +109,7 @@ jobs:
         # Note: Windows uses '--target x86_64-pc-windows-msvc' by default as Cargo argument.
         include:
           - name: macos
-            os: macos-11
+            os: macos-latest # arm64
 
           - name: windows
             os: windows-latest

--- a/godot-codegen/src/special_cases/special_cases.rs
+++ b/godot-codegen/src/special_cases/special_cases.rs
@@ -40,6 +40,11 @@ pub fn is_class_method_deleted(class_name: &TyName, method: &JsonClassMethod, ct
         // Already covered by manual APIs
         //| ("Object", "to_string")
         | ("Object", "get_instance_id")
+        
+        // Removed because it is a worse version of Node::get_node_or_null(): it _seems_ like it's fallible due to Option<T> return type,
+        // however Godot will emit an error message if the node is absent. In the future with non-null types, this may be re-introduced.
+        // Alternatively, both get_node/get_node_or_null could become generic and use the get_node_as/try_get_node_as impl (removing those).
+        | ("Node", "get_node")
 
         // Removed in https://github.com/godotengine/godot/pull/88418, but they cannot reasonably be used before, either.
         | ("GDExtension", "open_library")

--- a/godot-core/src/engine/io/resources.rs
+++ b/godot-core/src/engine/io/resources.rs
@@ -8,11 +8,11 @@
 use crate::builtin::GString;
 use crate::engine::global::Error as GodotError;
 use crate::gen::classes::{Resource, ResourceLoader, ResourceSaver};
-use crate::obj::{Gd, GodotClass, Inherits};
+use crate::obj::{Gd, Inherits};
 
 use super::IoError;
 
-/// Loads a resource from the filesystem located at `path`, panicking on error.
+/// ⚠️ Loads a resource from the filesystem located at `path`, panicking on error.
 ///
 /// See [`try_load`] for more information.
 ///
@@ -29,7 +29,7 @@ use super::IoError;
 #[inline]
 pub fn load<T>(path: impl Into<GString>) -> Gd<T>
 where
-    T: GodotClass + Inherits<Resource>,
+    T: Inherits<Resource>,
 {
     let path = path.into();
     load_impl(&path).unwrap_or_else(|err| panic!("failed: {err}"))
@@ -37,16 +37,16 @@ where
 
 /// Loads a resource from the filesystem located at `path`.
 ///
-/// The resource is loaded on the method call (unless it's referenced already elsewhere, e.g. in another script or in the scene),
-/// which might cause slight delay, especially when loading scenes.
+/// The resource is loaded during the method call, unless it is already referenced elsewhere, e.g. in another script or in the scene.
+/// This might cause slight delay, especially when loading scenes.
 ///
 /// This function can fail if resource can't be loaded by [`ResourceLoader`] or if the subsequent cast into `T` fails.
 ///
 /// This method is a simplified version of [`ResourceLoader::load()`][crate::engine::ResourceLoader::load],
 /// which can be used for more advanced scenarios.
 ///
-/// # Note:
-/// Resource paths can be obtained by right-clicking on a resource in the Godot editor (_FileSystem_ dock) and choosing "Copy Path",
+/// # Note
+/// Resource paths can be obtained by right-clicking on a resource in the Godot editor (_FileSystem_ dock) and choosing _Copy Path_,
 /// or by dragging the file from the _FileSystem_ dock into the script.
 ///
 /// The path must be absolute (typically starting with `res://`), a local path will fail.
@@ -67,12 +67,12 @@ where
 #[inline]
 pub fn try_load<T>(path: impl Into<GString>) -> Result<Gd<T>, IoError>
 where
-    T: GodotClass + Inherits<Resource>,
+    T: Inherits<Resource>,
 {
     load_impl(&path.into())
 }
 
-/// Saves a [`Resource`]-inheriting [`GodotClass`] `obj` into file located at `path`.
+/// ⚠️ Saves a [`Resource`]-inheriting object into the file located at `path`.
 ///
 /// See [`try_save`] for more information.
 ///
@@ -84,20 +84,20 @@ where
 /// use godot::prelude::*;
 /// use godot::engine::save;
 ///
-/// save(Resource::new_gd(), "res://base_resource.tres")
+/// save(Resource::new_gd(), "res://BaseResource.tres")
 /// ```
 /// use godot::
 #[inline]
 pub fn save<T>(obj: Gd<T>, path: impl Into<GString>)
 where
-    T: GodotClass + Inherits<Resource>,
+    T: Inherits<Resource>,
 {
     let path = path.into();
     save_impl(obj, &path)
         .unwrap_or_else(|err| panic!("failed to save resource at path '{}': {}", &path, err));
 }
 
-/// Saves a [Resource]-inheriting [GodotClass] `obj` into file located at `path`.
+/// Saves a [`Resource`]-inheriting object into the file located at `path`.
 ///
 /// This function can fail if [`ResourceSaver`] can't save the resource to file, as it is a simplified version of
 /// [`ResourceSaver::save()`][crate::engine::ResourceSaver::save]. The underlying method can be used for more advances scenarios.
@@ -127,7 +127,7 @@ where
 #[inline]
 pub fn try_save<T>(obj: Gd<T>, path: impl Into<GString>) -> Result<(), IoError>
 where
-    T: GodotClass + Inherits<Resource>,
+    T: Inherits<Resource>,
 {
     save_impl(obj, &path.into())
 }
@@ -139,7 +139,7 @@ where
 // Note that more optimizations than that likely make no sense, as loading is quite expensive
 fn load_impl<T>(path: &GString) -> Result<Gd<T>, IoError>
 where
-    T: GodotClass + Inherits<Resource>,
+    T: Inherits<Resource>,
 {
     // TODO unclone GString
     match ResourceLoader::singleton()
@@ -163,7 +163,7 @@ where
 
 fn save_impl<T>(obj: Gd<T>, path: &GString) -> Result<(), IoError>
 where
-    T: GodotClass + Inherits<Resource>,
+    T: Inherits<Resource>,
 {
     // TODO unclone GString
     let res = ResourceSaver::singleton()

--- a/godot-core/src/engine/manual_extensions.rs
+++ b/godot-core/src/engine/manual_extensions.rs
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use crate::builtin::NodePath;
+use crate::engine::{Node, PackedScene};
+use crate::obj::{Gd, Inherits};
+
+/// Manual extensions for the `Node` class.
+impl Node {
+    /// ⚠️ Retrieves the node at path `path`, panicking if not found or bad type.
+    ///
+    /// # Panics
+    /// If the node is not found, or if it does not have type `T` or inherited.
+    pub fn get_node_as<T>(&self, path: impl Into<NodePath>) -> Gd<T>
+    where
+        T: Inherits<Node>,
+    {
+        let path = path.into();
+        let copy = path.clone(); // TODO avoid copy
+
+        self.try_get_node_as(path).unwrap_or_else(|| {
+            panic!(
+                "There is no node of type {ty} at path `{copy}`",
+                ty = T::class_name()
+            )
+        })
+    }
+
+    /// Retrieves the node at path `path` (fallible).
+    ///
+    /// If the node is not found, or if it does not have type `T` or inherited,
+    /// `None` will be returned.
+    pub fn try_get_node_as<T>(&self, path: impl Into<NodePath>) -> Option<Gd<T>>
+    where
+        T: Inherits<Node>,
+    {
+        let path = path.into();
+
+        // TODO differentiate errors (not found, bad type) with Result
+        self.get_node_or_null(path)
+            .and_then(|node| node.try_cast::<T>().ok())
+    }
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+
+/// Manual extensions for the `PackedScene` class.
+impl PackedScene {
+    /// ⚠️ Instantiates the scene as type `T`, panicking if not found or bad type.
+    ///
+    /// # Panics
+    /// If the scene is not type `T` or inherited.
+    pub fn instantiate_as<T>(&self) -> Gd<T>
+    where
+        T: Inherits<Node>,
+    {
+        self.try_instantiate_as::<T>()
+            .unwrap_or_else(|| panic!("Failed to instantiate {to}", to = T::class_name()))
+    }
+
+    /// Instantiates the scene as type `T` (fallible).
+    ///
+    /// If the scene is not type `T` or inherited.
+    pub fn try_instantiate_as<T>(&self) -> Option<Gd<T>>
+    where
+        T: Inherits<Node>,
+    {
+        self.instantiate().and_then(|gd| gd.try_cast::<T>().ok())
+    }
+}

--- a/godot-core/src/obj/traits.rs
+++ b/godot-core/src/obj/traits.rs
@@ -365,7 +365,7 @@ pub trait WithBaseField: GodotClass + Bounds<Declarer = bounds::DeclUser> {
 
 /// Extension trait for all reference-counted classes.
 pub trait NewGd: GodotClass {
-    /// Return a new Gd which contains a default-constructed instance.
+    /// Return a new, ref-counted `Gd` containing a default-constructed instance.
     ///
     /// `MyClass::new_gd()` is equivalent to `Gd::<MyClass>::default()`.
     fn new_gd() -> Gd<Self>;
@@ -382,7 +382,7 @@ where
 
 /// Extension trait for all manually managed classes.
 pub trait NewAlloc: GodotClass {
-    /// Return a new Gd which contains a default-constructed instance.
+    /// Return a new, manually-managed `Gd` containing a default-constructed instance.
     ///
     /// The result must be manually managed, e.g. by attaching it to the scene tree or calling `free()` after usage.
     /// Failure to do so will result in memory leaks.

--- a/godot/src/prelude.rs
+++ b/godot/src/prelude.rs
@@ -17,15 +17,13 @@ pub use super::builtin::meta::{FromGodot, ToGodot};
 pub use super::engine::{
     load, try_load, utilities, AudioStreamPlayer, Camera2D, Camera3D, GFile, IAudioStreamPlayer,
     ICamera2D, ICamera3D, INode, INode2D, INode3D, IObject, IPackedScene, IRefCounted, IResource,
-    ISceneTree, Input, Node, Node2D, Node3D, Object, PackedScene, PackedSceneExt, RefCounted,
-    Resource, SceneTree,
+    ISceneTree, Input, Node, Node2D, Node3D, Object, PackedScene, RefCounted, Resource, SceneTree,
 };
 pub use super::init::{gdextension, ExtensionLibrary, InitLevel};
 pub use super::log::*;
 pub use super::obj::{Base, Gd, GdMut, GdRef, GodotClass, Inherits, InstanceId, OnReady};
 
 // Make trait methods available.
-pub use super::engine::NodeExt as _;
 pub use super::obj::EngineBitfield as _;
 pub use super::obj::EngineEnum as _;
 pub use super::obj::NewAlloc as _;

--- a/itest/rust/src/engine_tests/node_test.rs
+++ b/itest/rust/src/engine_tests/node_test.rs
@@ -8,7 +8,7 @@
 use std::str::FromStr;
 
 use godot::builtin::{NodePath, Variant};
-use godot::engine::{global, Node, Node3D, NodeExt, PackedScene, SceneTree};
+use godot::engine::{global, Node, Node3D, PackedScene, SceneTree};
 use godot::obj::{NewAlloc, NewGd};
 
 use crate::framework::{itest, TestContext};


### PR DESCRIPTION
We have two traits `NodeExt` + `PackedSceneExt`, which have always been in a weird place: they only accomodate 1 method + its fallible overload, are hard to discover and annoying to import. There is no polymorphic use for the trait, and we have signature duplication for the trait and its impl.

This PR gets rid of those two traits and moves the functions directly into the class. As such, they are listed in the class' documentation and are thus more likely to be found. They also no longer require an extra `use` statement.

For now, this PR also removes `Node::get_node()` which does not add any value over `Node::get_node_or_null()`, can however be misunderstood due to `Option<T>`. This may still change depending on usage.