### PR TITLE
New trait `ArrayElement` constrains what is allowed inside `Array<T>`

### DIFF
--- a/godot-codegen/src/generator/builtins.rs
+++ b/godot-codegen/src/generator/builtins.rs
@@ -150,7 +150,7 @@ fn make_special_builtin_methods(class_name: &TyName, _ctx: &Context) -> TokenStr
         quote! {
             pub fn from_outer_typed<T>(outer: &Array<T>) -> Self
                 where
-                    T: crate::builtin::meta::GodotType
+                    T: crate::builtin::meta::ArrayElement
             {
                 Self {
                     _outer_lifetime: std::marker::PhantomData,

--- a/godot-core/src/builtin/meta/godot_convert/impls.rs
+++ b/godot-core/src/builtin/meta/godot_convert/impls.rs
@@ -6,7 +6,7 @@
  */
 
 use crate::builtin::meta::{
-    impl_godot_as_self, ConvertError, FromGodot, GodotConvert, GodotType, ToGodot,
+    impl_godot_as_self, ArrayElement, ConvertError, FromGodot, GodotConvert, GodotType, ToGodot,
 };
 use crate::builtin::Variant;
 use godot_ffi as sys;
@@ -158,6 +158,8 @@ macro_rules! impl_godot_scalar {
             }
         }
 
+        impl ArrayElement for $T {}
+
         impl GodotConvert for $T {
             type Via = $T;
         }
@@ -202,6 +204,8 @@ macro_rules! impl_godot_scalar {
             }
         }
 
+        impl ArrayElement for $T {}
+
         impl GodotConvert for $T {
             type Via = $T;
         }
@@ -226,6 +230,7 @@ impl_godot_as_self!(i64);
 impl_godot_as_self!(f64);
 impl_godot_as_self!(());
 
+// Also implements ArrayElement.
 impl_godot_scalar!(
     i32 as i64,
     crate::builtin::meta::FromFfiError::I32,

--- a/godot-core/src/builtin/meta/mod.rs
+++ b/godot-core/src/builtin/meta/mod.rs
@@ -41,7 +41,7 @@ mod sealed {
 
     use godot_ffi::GodotNullableFfi;
 
-    use super::GodotType;
+    use super::{ArrayElement, GodotType};
     use crate::builtin::*;
     use crate::obj::*;
 
@@ -92,7 +92,7 @@ mod sealed {
     impl Sealed for f32 {}
     impl Sealed for () {}
     impl Sealed for Variant {}
-    impl<T: GodotType> Sealed for Array<T> {}
+    impl<T: ArrayElement> Sealed for Array<T> {}
     impl<T: GodotClass> Sealed for RawGd<T> {}
     impl<T: GodotClass> Sealed for Gd<T> {}
     impl<T> Sealed for Option<T>
@@ -240,6 +240,18 @@ where
         T::godot_type_name()
     }
 }
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+
+/// Marker trait to identify types that can be stored in [`Array<T>`][crate::builtin::Array].
+///
+/// The types for which this trait is implemented, overlap mostly with [`GodotType`].
+/// This is done consistently what GDScript allows inside `Array[T]`.
+///
+/// Notable differences are:
+/// - Only `VariantArray`, not `Array<T>` is allowed (typed arrays cannot be nested).
+/// - `Option` is only supported for `Option<Gd<T>>`, but not e.g. `Option<i32>`.
+pub trait ArrayElement: GodotType {}
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/godot-core/src/builtin/variant/impls.rs
+++ b/godot-core/src/builtin/variant/impls.rs
@@ -6,7 +6,9 @@
  */
 
 use super::*;
-use crate::builtin::meta::{FromVariantError, GodotFfiVariant, GodotType, PropertyInfo};
+use crate::builtin::meta::{
+    ArrayElement, FromVariantError, GodotFfiVariant, GodotType, PropertyInfo,
+};
 use crate::builtin::*;
 use crate::engine::global;
 use godot_ffi as sys;
@@ -21,7 +23,7 @@ use godot_ffi as sys;
 // that requires the pointer the be initialized. But some other types will cause a memory leak in 4.1 if
 // initialized.
 //
-// Thus we can use `init` to indicate when it must be initialized in 4.0.
+// Therefore, we can use `init` to indicate when it must be initialized in 4.0.
 macro_rules! impl_ffi_variant {
     ($T:ty, $from_fn:ident, $to_fn:ident $(; $godot_type_name:ident)?) => {
         impl GodotFfiVariant for $T {
@@ -82,6 +84,8 @@ macro_rules! impl_ffi_variant {
 
             impl_ffi_variant!(@godot_type_name $T $(, $godot_type_name)?);
         }
+
+        impl ArrayElement for $T {}
     };
 
     (@godot_type_name $T:ty) => {
@@ -105,8 +109,11 @@ macro_rules! impl_ffi_variant {
 mod impls {
     use super::*;
 
-    impl_ffi_variant!(Aabb, aabb_to_variant, aabb_from_variant; AABB);
+    // Also implements ArrayType.
     impl_ffi_variant!(bool, bool_to_variant, bool_from_variant);
+    impl_ffi_variant!(i64, int_to_variant, int_from_variant; int);
+    impl_ffi_variant!(f64, float_to_variant, float_from_variant; float);
+    impl_ffi_variant!(Aabb, aabb_to_variant, aabb_from_variant; AABB);
     impl_ffi_variant!(Basis, basis_to_variant, basis_from_variant);
     impl_ffi_variant!(Callable, callable_to_variant, callable_from_variant);
     impl_ffi_variant!(Vector2, vector2_to_variant, vector2_from_variant);
@@ -138,8 +145,6 @@ mod impls {
     impl_ffi_variant!(Transform2D, transform_2d_to_variant, transform_2d_from_variant);
     impl_ffi_variant!(Transform3D, transform_3d_to_variant, transform_3d_from_variant);
     impl_ffi_variant!(Dictionary, dictionary_to_variant, dictionary_from_variant);
-    impl_ffi_variant!(i64, int_to_variant, int_from_variant; int);
-    impl_ffi_variant!(f64, float_to_variant, float_from_variant; float);
 
 }
 

--- a/godot-core/src/builtin/variant/mod.rs
+++ b/godot-core/src/builtin/variant/mod.rs
@@ -5,7 +5,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use crate::builtin::meta::{impl_godot_as_self, ConvertError, FromGodot, ToGodot};
+use crate::builtin::meta::{impl_godot_as_self, ArrayElement, ConvertError, FromGodot, ToGodot};
 use crate::builtin::{GString, StringName};
 use crate::gen::central::VariantDispatch;
 use godot_ffi as sys;
@@ -376,6 +376,8 @@ impl Variant {
         unsafe { std::slice::from_raw_parts_mut(variant_array, length) }
     }
 }
+
+impl ArrayElement for Variant {}
 
 // SAFETY:
 // `from_opaque` properly initializes a dereferenced pointer to an `OpaqueVariant`.

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -13,7 +13,8 @@ use godot_ffi as sys;
 use sys::{static_assert_eq_size_align, VariantType};
 
 use crate::builtin::meta::{
-    CallContext, ConvertError, FromFfiError, FromGodot, GodotConvert, GodotType, ToGodot,
+    ArrayElement, CallContext, ConvertError, FromFfiError, FromGodot, GodotConvert, GodotType,
+    ToGodot,
 };
 use crate::builtin::{Callable, NodePath, StringName, Variant};
 use crate::obj::raw::RawGd;
@@ -619,6 +620,9 @@ impl<T: GodotClass> GodotType for Gd<T> {
         false
     }
 }
+
+impl<T: GodotClass> ArrayElement for Gd<T> {}
+impl<T: GodotClass> ArrayElement for Option<Gd<T>> {}
 
 impl<T> Default for Gd<T>
 where


### PR DESCRIPTION
So far, it was possible to declare `Array<Array<i32>>` or `Array<Option<i32>>`, which is not supported by Godot's typed arrays. The trait `ArrayElement` rectifies that.