### PR TITLE
 Improve trait errors with `#[diagnostic::on_unimplemented]`

### DIFF
--- a/.github/composite/rust/action.yml
+++ b/.github/composite/rust/action.yml
@@ -49,12 +49,24 @@ runs:
         rustup default ${{ inputs.rust }}
       shell: bash
 
+    - name: "Extract Rust version"
+      # Transforms into format "1.78.0-stable" or "1.80.0-nightly-d2d24e395", which can be used as cache key.
+      run: |
+        version=$(rustc --version)
+        if echo "$version" | grep -q "nightly"; then
+          version=$(echo "$version" | sed -E 's/rustc ([0-9]+\.[0-9]+\.[0-9]+)-nightly \(([a-f0-9]+) .*/\1-nightly-\2/')
+        else
+          version=$(echo "$version" | sed -E 's/rustc ([0-9]+\.[0-9]+\.[0-9]+) .*/\1-stable/')
+        fi
+        echo "INSTALLED_RUST_VERSION=$version" >> $GITHUB_ENV
+      shell: bash
+
     - name: "Reuse cached dependencies"
       uses: Swatinem/rust-cache@v2
       with:
         # A cache key that is used instead of the automatic `job`-based key, and is stable over multiple jobs.
         # default: empty
-        shared-key: "${{ runner.os }}-${{ inputs.rust }}${{ inputs.cache-key }}"
+        shared-key: "${{ runner.os }}-${{ env.INSTALLED_RUST_VERSION }}${{ inputs.cache-key }}"
 
         # An additional cache key that is added alongside the automatic `job`-based
         # cache key and can be used to further differentiate jobs.

--- a/.github/composite/rust/action.yml
+++ b/.github/composite/rust/action.yml
@@ -34,6 +34,7 @@ runs:
       id: configure
       env:
         CS: ${{ inputs.components }}
+      # TODO use actual Rust version, e.g. 1.78 in cache, not just "stable"
       run: |
         echo "Rust cache shared-key: '${{ runner.os }}-${{ inputs.rust }}${{ inputs.cache-key }}'"
         echo "components=$( for c in ${CS//,/ }; do echo -n ' --component' $c; done )" >> $GITHUB_OUTPUT

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -58,10 +58,9 @@ jobs:
     - name: "Patch Cargo.toml to use nightly extension API"
       run: .github/other/patch-prebuilt.sh nightly
 
+    # rustdoc is included as component.
     - name: "Install Rust"
       uses: ./.github/composite/rust
-      with:
-        components: rustdoc
 
     - name: "Check rustdoc"
       env:

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -127,7 +127,7 @@ jobs:
 
           - name: linux
             os: ubuntu-20.04
-            rust-toolchain: "1.77.1"
+            rust-toolchain: "1.78"
             rust-special: -msrv
 
     steps:

--- a/.github/workflows/minimal-ci.yml
+++ b/.github/workflows/minimal-ci.yml
@@ -59,10 +59,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # rustdoc is included as component.
       - name: "Install Rust"
         uses: ./.github/composite/rust
-        with:
-          components: rustdoc
 
       - name: "Check rustdoc"
         env:

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -17,6 +17,9 @@ on:
     branches:
       - master
 
+env:
+  # Keep this a variable for easy search&replace.
+  MSRV: 1.78
 
 jobs:
   notify-docs:
@@ -25,6 +28,18 @@ jobs:
       # Checkout is always needed, for the notify step
       - name: "Checkout"
         uses: actions/checkout@v4
+
+      # If Rust version is below msrv, install latest stable.
+      - name: "Install Rust"
+        run: |
+          # Get middle part of version, e.g. 78 from 1.78.0
+          isMinorVer=$(rustc --version | sed -E 's/rustc [0-9]+\.([0-9]+)\..*/\1/')
+          shouldMinorVer=$(echo $MSRV | sed -E 's/[0-9]+\.([0-9]+)(\.|$).*/\1/')
+          
+          if [ $isMinorVer -lt $shouldMinorVer ]; then
+            echo "Rust version is below MSRV; install latest stable..."
+            rustup update stable
+          fi
 
       # This is just a sanity check to make sure that the follow-up docs generation doesn't break.
       # So we use the Rust version provided by the GitHub runners, which hopefully is >= MSRV.

--- a/examples/dodge-the-creeps/rust/Cargo.toml
+++ b/examples/dodge-the-creeps/rust/Cargo.toml
@@ -2,7 +2,7 @@
 name = "dodge-the-creeps"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.77.1"
+rust-version = "1.78"
 license = "MPL-2.0"
 publish = false
 

--- a/godot-bindings/Cargo.toml
+++ b/godot-bindings/Cargo.toml
@@ -2,7 +2,7 @@
 name = "godot-bindings"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.77.1"
+rust-version = "1.78"
 license = "MPL-2.0"
 keywords = ["gamedev", "godot", "engine", "ffi", "sys"]
 categories = ["game-engines", "graphics"]

--- a/godot-cell/Cargo.toml
+++ b/godot-cell/Cargo.toml
@@ -2,7 +2,7 @@
 name = "godot-cell"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.77.1"
+rust-version = "1.78"
 license = "MPL-2.0"
 keywords = ["gamedev", "godot", "engine", "ffi"]
 categories = ["game-engines", "graphics"]

--- a/godot-codegen/Cargo.toml
+++ b/godot-codegen/Cargo.toml
@@ -2,7 +2,7 @@
 name = "godot-codegen"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.77.1"
+rust-version = "1.78"
 license = "MPL-2.0"
 keywords = ["gamedev", "godot", "engine", "codegen"]
 categories = ["game-engines", "graphics"]

--- a/godot-core/Cargo.toml
+++ b/godot-core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "godot-core"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.77.1"
+rust-version = "1.78"
 license = "MPL-2.0"
 keywords = ["gamedev", "godot", "engine", "2d", "3d"] # possibly: "ffi"
 categories = ["game-engines", "graphics"]

--- a/godot-core/src/builtin/dictionary.rs
+++ b/godot-core/src/builtin/dictionary.rs
@@ -412,7 +412,7 @@ impl<'a> DictionaryIter<'a> {
             self.next_idx += 1;
         }
 
-        self.last_key = new_key.clone();
+        self.last_key.clone_from(&new_key);
         new_key
     }
 

--- a/godot-core/src/builtin/meta/godot_convert/mod.rs
+++ b/godot-core/src/builtin/meta/godot_convert/mod.rs
@@ -21,6 +21,11 @@ use super::{GodotFfiVariant, GodotType};
 ///
 /// [`GodotType`] is a stronger bound than [`GodotConvert`], since it expresses that a type is _directly_ representable
 /// in Godot (without intermediate "via"). Every `GodotType` also implements `GodotConvert` with `Via = Self`.
+
+#[diagnostic::on_unimplemented(
+    message = "`GodotConvert` is needed for `#[func]` parameters/returns, as well as `#[var]` and `#[export]` properties",
+    note = "check following errors for more information"
+)]
 pub trait GodotConvert {
     /// The type through which `Self` is represented in Godot.
     type Via: GodotType;

--- a/godot-core/src/builtin/meta/mod.rs
+++ b/godot-core/src/builtin/meta/mod.rs
@@ -251,6 +251,11 @@ where
 /// Notable differences are:
 /// - Only `VariantArray`, not `Array<T>` is allowed (typed arrays cannot be nested).
 /// - `Option` is only supported for `Option<Gd<T>>`, but not e.g. `Option<i32>`.
+#[diagnostic::on_unimplemented(
+    message = "`Array<T>` can only store element types supported in Godot arrays (no nesting).",
+    label = "does not implement `Var`",
+    note = "see also: https://godot-rust.github.io/docs/gdext/master/godot/builtin/meta/trait.ArrayElement.html"
+)]
 pub trait ArrayElement: GodotType {}
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------

--- a/godot-core/src/builtin/meta/signature.rs
+++ b/godot-core/src/builtin/meta/signature.rs
@@ -142,7 +142,7 @@ macro_rules! impl_varcall_signature_for_tuple {
         #[allow(unused_variables)]
         impl<$R, $($Pn,)*> VarcallSignatureTuple for ($R, $($Pn,)*)
             where
-                $R: ToGodot + FromGodot + FromVariantIndirect + Debug,
+                $R: ToGodot + FromGodot + Debug,
                 $(
                     $Pn: ToGodot + FromGodot + Debug,
                 )*
@@ -557,17 +557,6 @@ fn param_error<P>(call_ctx: &CallContext, index: i32, err: ConvertError) -> ! {
 fn return_error<R>(call_ctx: &CallContext, err: ConvertError) -> ! {
     let return_ty = std::any::type_name::<R>();
     panic!("in function `{call_ctx}` at return type {return_ty}: {err}");
-}
-
-/// Helper trait to support `()` which doesn't implement `FromVariant`.
-trait FromVariantIndirect {
-    fn convert(variant: Variant) -> Self;
-}
-
-impl<T: FromGodot> FromVariantIndirect for T {
-    fn convert(variant: Variant) -> Self {
-        T::from_variant(&variant)
-    }
 }
 
 unsafe fn new_from_ptrcall<T: FromGodot>(

--- a/godot-core/src/builtin/packed_array.rs
+++ b/godot-core/src/builtin/packed_array.rs
@@ -543,6 +543,9 @@ macro_rules! impl_specific_packed_array_functions {
     };
 }
 
+// TODO implement
+pub type PackedVector4Array = PackedVector2Array;
+
 impl_packed_array!(
     type_name: PackedByteArray,
     element_type: u8,

--- a/godot-core/src/obj/traits.rs
+++ b/godot-core/src/obj/traits.rs
@@ -20,6 +20,11 @@ use godot_ffi as sys;
 ///
 /// Normally, you don't need to implement this trait yourself; use [`#[derive(GodotClass)]`](../register/derive.GodotClass.html) instead.
 // Above intra-doc link to the derive-macro only works as HTML, not as symbol link.
+#[diagnostic::on_unimplemented(
+    message = "Only classes registered with Godot are allowed in this context",
+    note = "you can use `#[derive(GodotClass)]` to register your own structs with Godot",
+    note = "see also: https://godot-rust.github.io/book/register/classes.html"
+)]
 pub trait GodotClass: Bounds + 'static
 where
     Self: Sized,
@@ -206,6 +211,12 @@ pub trait IndexEnum: EngineEnum {
 ///
 /// Gives direct access to the containing `Gd<Self>` from `Self`.
 // Possible alternative for builder APIs, although even less ergonomic: Base<T> could be Base<T, Self> and return Gd<Self>.
+#[diagnostic::on_unimplemented(
+    message = "Class `{Self}` requires a `Base<T>` field",
+    label = "missing field `_base: Base<...>`",
+    note = "A base field is required to access the base from within `self`, or when using script virtual functions",
+    note = "see also: https://godot-rust.github.io/book/register/classes.html#the-base-field"
+)]
 pub trait WithBaseField: GodotClass + Bounds<Declarer = bounds::DeclUser> {
     /// Returns the `Gd` pointer containing this object.
     ///
@@ -243,7 +254,7 @@ pub trait WithBaseField: GodotClass + Bounds<Declarer = bounds::DeclUser> {
     /// # unsafe impl ExtensionLibrary for Test {}
     /// ```
     ///
-    /// However we cannot call methods that require `&mut Base`, such as
+    /// However, we cannot call methods that require `&mut Base`, such as
     /// [`Node::add_child()`](crate::engine::Node::add_child).
     ///
     /// ```compile_fail
@@ -423,6 +434,13 @@ pub mod cap {
     /// This trait is not manually implemented, and you cannot call any methods. You can use it as a bound, but typically you'd use
     /// it indirectly through [`Gd::default()`][crate::obj::Gd::default()]. Note that `Gd::default()` has an additional requirement on
     /// being reference-counted, meaning not every `GodotDefault` class can automatically be used with `Gd::default()`.
+    #[diagnostic::on_unimplemented(
+        message = "Class `{Self}` requires either an `init` constructor, or explicit opt-out",
+        label = "needs `init`",
+        note = "To provide a default constructor, use `#[class(init)]` or implement an `init` method",
+        note = "To opt out, use `#[class(no_init)]`",
+        note = "see also: https://godot-rust.github.io/book/register/constructors.html"
+    )]
     pub trait GodotDefault: GodotClass {
         /// Provides a default smart pointer instance.
         ///

--- a/godot-core/src/private.rs
+++ b/godot-core/src/private.rs
@@ -97,6 +97,11 @@ pub(crate) fn iterate_plugins(mut visitor: impl FnMut(&ClassPlugin)) {
 
 // If someone forgets #[godot_api], this causes a compile error, rather than virtual functions not being called at runtime.
 #[allow(non_camel_case_types)]
+#[diagnostic::on_unimplemented(
+    message = "`impl` blocks for Godot classes require the `#[godot_api]` attribute",
+    label = "missing `#[godot_api]` before `impl`",
+    note = "see also: https://godot-rust.github.io/book/register/functions.html#godot-special-functions"
+)]
 pub trait You_forgot_the_attribute__godot_api {}
 
 pub struct ClassConfig {

--- a/godot-core/src/property.rs
+++ b/godot-core/src/property.rs
@@ -21,6 +21,14 @@ use crate::engine::global::PropertyHint;
 ///
 /// This does not require [`FromGodot`] or [`ToGodot`], so that something can be used as a property even if it can't be used in function
 /// arguments/return types.
+
+// We also mention #[export] here, because we can't control the order of error messages. Missing Export often also means missing Var trait,
+// and so the Var error message appears first.
+#[diagnostic::on_unimplemented(
+    message = "`#[var]` properties require `Var` trait; #[export] ones require `Export` trait",
+    label = "type cannot be used as a property",
+    note = "see also: https://godot-rust.github.io/book/register/properties.html"
+)]
 pub trait Var: GodotConvert {
     fn get_property(&self) -> Self::Via;
     fn set_property(&mut self, value: Self::Via);
@@ -31,6 +39,12 @@ pub trait Var: GodotConvert {
 }
 
 /// Trait implemented for types that can be used as `#[export]` fields.
+// Mentioning both Var + Export: see above.
+#[diagnostic::on_unimplemented(
+    message = "`#[var]` properties require `Var` trait; #[export] ones require `Export` trait",
+    label = "type cannot be used as a property",
+    note = "see also: https://godot-rust.github.io/book/register/properties.html"
+)]
 pub trait Export: Var {
     /// The export info to use for an exported field of this type, if no other export info is specified.
     fn default_export_info() -> PropertyHintInfo;

--- a/godot-ffi/Cargo.toml
+++ b/godot-ffi/Cargo.toml
@@ -2,7 +2,7 @@
 name = "godot-ffi"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.77.1"
+rust-version = "1.78"
 license = "MPL-2.0"
 keywords = ["gamedev", "godot", "engine", "ffi"]
 categories = ["game-engines", "graphics"]

--- a/godot-ffi/src/extras.rs
+++ b/godot-ffi/src/extras.rs
@@ -14,6 +14,7 @@ use crate::VariantType;
 // Static checks
 
 // The impls only compile if those are different types -- ensures type safety through patch
+#[allow(dead_code)]
 trait Distinct {}
 impl Distinct for GDExtensionVariantPtr {}
 impl Distinct for GDExtensionTypePtr {}

--- a/godot-ffi/src/toolbox.rs
+++ b/godot-ffi/src/toolbox.rs
@@ -193,12 +193,14 @@ pub fn unqualified_type_name<T>() -> &'static str {
 pub(crate) trait Inner: Sized {
     type FnPtr: Sized;
 
+    #[cfg(before_api = "4.1")]
     fn extract(self, error_msg: &str) -> Self::FnPtr;
 }
 
 impl<T> Inner for Option<T> {
     type FnPtr = T;
 
+    #[cfg(before_api = "4.1")]
     fn extract(self, error_msg: &str) -> Self::FnPtr {
         self.expect(error_msg)
     }

--- a/godot-macros/Cargo.toml
+++ b/godot-macros/Cargo.toml
@@ -2,7 +2,7 @@
 name = "godot-macros"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.77.1"
+rust-version = "1.78"
 license = "MPL-2.0"
 keywords = ["gamedev", "godot", "engine", "derive", "macro"]
 categories = ["game-engines", "graphics"]

--- a/godot/Cargo.toml
+++ b/godot/Cargo.toml
@@ -2,7 +2,7 @@
 name = "godot"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.77.1"
+rust-version = "1.78"
 license = "MPL-2.0"
 keywords = ["gamedev", "godot", "engine", "2d", "3d"] # possibly: "ffi"
 categories = ["game-engines", "graphics"]

--- a/itest/rust/Cargo.toml
+++ b/itest/rust/Cargo.toml
@@ -2,7 +2,7 @@
 name = "itest"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.77.1"
+rust-version = "1.78"
 license = "MPL-2.0"
 publish = false
 


### PR DESCRIPTION
The Rust 1.78 feature released yesterday allows us to customize error messages that occur when a certain trait is not implemented. This PR applies them in some cases that are likely to cause errors at the user.

This is just a start, I'm sure we can tweak things even more over time.

Requires MSRV 1.78 (incremented from 1.77.1).