### PR TITLE
added packed vector4 support

### DIFF
--- a/godot-core/src/builtin/array.rs
+++ b/godot-core/src/builtin/array.rs
@@ -88,6 +88,7 @@ impl_builtin_froms!(VariantArray;
     PackedStringArray => array_from_packed_string_array,
     PackedVector2Array => array_from_packed_vector2_array,
     PackedVector3Array => array_from_packed_vector3_array,
+    PackedVector4Array => array_from_packed_vector4_array,
 );
 
 impl<T: ArrayElement> Array<T> {

--- a/godot-core/src/builtin/meta/mod.rs
+++ b/godot-core/src/builtin/meta/mod.rs
@@ -69,6 +69,7 @@ mod sealed {
     impl Sealed for PackedStringArray {}
     impl Sealed for PackedVector2Array {}
     impl Sealed for PackedVector3Array {}
+    impl Sealed for PackedVector4Array {}
     impl Sealed for PackedColorArray {}
     impl Sealed for Plane {}
     impl Sealed for Projection {}

--- a/godot-core/src/builtin/packed_array.rs
+++ b/godot-core/src/builtin/packed_array.rs
@@ -688,6 +688,24 @@ impl_packed_array!(
 );
 
 impl_packed_array!(
+    type_name: PackedVector4Array,
+    element_type: Vector4,
+    opaque_type: OpaquePackedVector4Array,
+    inner_type: InnerPackedVector4Array,
+    argument_type: Vector4,
+    return_type: __GdextType,
+    from_array: packed_vector4_array_from_array,
+    operator_index: packed_vector4_array_operator_index,
+    operator_index_const: packed_vector4_array_operator_index_const,
+    trait_impls: {
+        Default => packed_vector4_array_construct_default;
+        Clone => packed_vector4_array_construct_copy;
+        Drop => packed_vector4_array_destroy;
+        PartialEq => packed_vector4_array_operator_equal;
+    },
+);
+
+impl_packed_array!(
     type_name: PackedColorArray,
     element_type: Color,
     opaque_type: OpaquePackedColorArray,

--- a/godot-core/src/builtin/variant/impls.rs
+++ b/godot-core/src/builtin/variant/impls.rs
@@ -135,6 +135,7 @@ mod impls {
     impl_ffi_variant!(PackedStringArray, packed_string_array_to_variant, packed_string_array_from_variant);
     impl_ffi_variant!(PackedVector2Array, packed_vector2_array_to_variant, packed_vector2_array_from_variant);
     impl_ffi_variant!(PackedVector3Array, packed_vector3_array_to_variant, packed_vector3_array_from_variant);
+    impl_ffi_variant!(PackedVector4Array, packed_vector4_array_to_variant, packed_vector4_array_from_variant);
     impl_ffi_variant!(PackedColorArray, packed_color_array_to_variant, packed_color_array_from_variant);
     impl_ffi_variant!(Plane, plane_to_variant, plane_from_variant);
     impl_ffi_variant!(Projection, projection_to_variant, projection_from_variant);

--- a/godot-core/src/property.rs
+++ b/godot-core/src/property.rs
@@ -400,6 +400,7 @@ mod export_impls {
     impl_property_by_godot_convert!(PackedStringArray, no_export);
     impl_property_by_godot_convert!(PackedVector2Array, no_export);
     impl_property_by_godot_convert!(PackedVector3Array, no_export);
+    impl_property_by_godot_convert!(PackedVector4Array, no_export);
     impl_property_by_godot_convert!(PackedColorArray, no_export);
 
     // Primitives

--- a/itest/rust/build.rs
+++ b/itest/rust/build.rs
@@ -148,6 +148,7 @@ fn collect_inputs() -> Vec<Input> {
     push!(inputs; PackedStringArray, PackedStringArray, PackedStringArray(), PackedStringArray::new());
     push!(inputs; PackedVector2Array, PackedVector2Array, PackedVector2Array(), PackedVector2Array::new());
     push!(inputs; PackedVector3Array, PackedVector3Array, PackedVector3Array(), PackedVector3Array::new());
+    push!(inputs; PackedVector4Array, PackedVector4Array, PackedVector4Array(), PackedVector4Array::new());
     push!(inputs; PackedColorArray, PackedColorArray, PackedColorArray(), PackedColorArray::new());
 
     push_newtype!(inputs; int, NewI64(i64), -922337203685477580);

--- a/itest/rust/src/object_tests/virtual_methods_test.rs
+++ b/itest/rust/src/object_tests/virtual_methods_test.rs
@@ -12,7 +12,7 @@ use crate::framework::{itest, TestContext};
 use godot::builtin::meta::ToGodot;
 use godot::builtin::{
     real, varray, Color, GString, PackedByteArray, PackedColorArray, PackedFloat32Array,
-    PackedInt32Array, PackedStringArray, PackedVector2Array, PackedVector3Array, RealConv,
+    PackedInt32Array, PackedStringArray, PackedVector2Array, PackedVector3Array, PackedVector4Array, RealConv,
     StringName, Variant, VariantArray, Vector2, Vector3,
 };
 use godot::engine::notify::NodeNotification;
@@ -120,7 +120,7 @@ impl IPrimitiveMesh for VirtualReturnTest {
     fn create_mesh_array(&self) -> VariantArray {
         varray![
             PackedVector3Array::from_iter([Vector3::LEFT]),
-            PackedVector3Array::from_iter([Vector3::LEFT]),
+            PackedVector4Array::from_iter([Vector3::LEFT]),
             PackedFloat32Array::from_iter([0.0, 0.0, 0.0, 1.0]),
             PackedColorArray::from_iter([Color::from_rgb(1.0, 1.0, 1.0)]),
             PackedVector2Array::from_iter([Vector2::LEFT]),
@@ -383,6 +383,10 @@ fn test_virtual_method_with_return() {
     assert_eq_approx!(
         arr.get(0).to::<PackedVector3Array>().get(0),
         arr_rust.get(0).to::<PackedVector3Array>().get(0),
+    );
+    assert_eq_approx!(
+        arr.get(0).to::<PackedVector4Array>().get(0),
+        arr_rust.get(0).to::<PackedVector4Array>().get(0),
     );
     assert_eq_approx!(
         real::from_f32(arr.get(2).to::<PackedFloat32Array>().get(3)),


### PR DESCRIPTION
Godot recently added PackedVector4Array support to the engine.  This adds the same types to gdext as well