### PR TITLE
`delta` parameter in `process()` + `physics_process()` is now `f32` instead of `f64`

### DIFF
--- a/examples/dodge-the-creeps/rust/src/player.rs
+++ b/examples/dodge-the-creeps/rust/src/player.rs
@@ -56,7 +56,7 @@ impl IArea2D for Player {
         self.base_mut().hide();
     }
 
-    fn process(&mut self, delta: f64) {
+    fn process(&mut self, delta: f32) {
         let mut animated_sprite = self
             .base()
             .get_node_as::<AnimatedSprite2D>("AnimatedSprite2D");
@@ -99,7 +99,7 @@ impl IArea2D for Player {
             animated_sprite.stop();
         }
 
-        let change = velocity * real::from_f64(delta);
+        let change = velocity * delta;
         let position = self.base().get_global_position() + change;
         let position = Vector2::new(
             position.x.clamp(0.0, self.screen_size.x),

--- a/godot-codegen/src/generator/functions_common.rs
+++ b/godot-codegen/src/generator/functions_common.rs
@@ -90,7 +90,7 @@ pub fn make_function_definition(
     let has_default_params = default_parameters::function_uses_default_params(sig);
     let vis = if has_default_params {
         // Public API mapped by separate function.
-        // Needs to be crate-public because default-arg builder lives outside of the module.
+        // Needs to be crate-public because default-arg builder lives outside the module.
         quote! { pub(crate) }
     } else {
         make_vis(sig.is_private())

--- a/godot-codegen/src/models/domain.rs
+++ b/godot-codegen/src/models/domain.rs
@@ -477,10 +477,14 @@ pub struct FnParam {
 }
 
 impl FnParam {
-    pub fn new_range(method_args: &Option<Vec<JsonMethodArg>>, ctx: &mut Context) -> Vec<FnParam> {
+    pub fn new_range(
+        method_args: &Option<Vec<JsonMethodArg>>,
+        meta_overrides: &HashMap<String, String>,
+        ctx: &mut Context,
+    ) -> Vec<FnParam> {
         option_as_slice(method_args)
             .iter()
-            .map(|arg| Self::new(arg, ctx))
+            .map(|arg| Self::new(arg, ctx, meta_overrides))
             .collect()
     }
 
@@ -494,9 +498,18 @@ impl FnParam {
             .collect()
     }
 
-    pub fn new(method_arg: &JsonMethodArg, ctx: &mut Context) -> FnParam {
+    pub fn new(
+        method_arg: &JsonMethodArg,
+        ctx: &mut Context,
+        meta_overrides: &HashMap<String, String>,
+    ) -> FnParam {
+        // Some methods like _process(f64) have manual overrides to f32.
+        let forced_meta = meta_overrides.get(&method_arg.name);
+        let meta = forced_meta.or(method_arg.meta.as_ref());
+
         let name = safe_ident(&method_arg.name);
-        let type_ = conv::to_rust_type(&method_arg.type_, method_arg.meta.as_ref(), ctx);
+
+        let type_ = conv::to_rust_type(&method_arg.type_, meta, ctx);
         let default_value = method_arg
             .default_value
             .as_ref()

--- a/godot-codegen/src/models/domain_mapping.rs
+++ b/godot-codegen/src/models/domain_mapping.rs
@@ -438,7 +438,6 @@ impl ClassMethod {
         }
 
         let is_private = special_cases::is_method_private(class_name, &method.name);
-
         let godot_method_name = method.name.clone();
 
         let qualifier = {
@@ -451,11 +450,14 @@ impl ClassMethod {
             FnQualifier::from_const_static(is_actually_const, method.is_static)
         };
 
+        let param_meta_overrides =
+            special_cases::get_class_method_meta_overrides(class_name, &method.name);
+
         Some(Self {
             common: FunctionCommon {
                 name: rust_method_name.to_string(),
                 godot_name: godot_method_name,
-                parameters: FnParam::new_range(&method.arguments, ctx),
+                parameters: FnParam::new_range(&method.arguments, &param_meta_overrides, ctx),
                 return_value: FnReturn::new(&method.return_value, ctx),
                 is_vararg: method.is_vararg,
                 is_private,
@@ -494,7 +496,7 @@ impl UtilityFunction {
             common: FunctionCommon {
                 name: rust_method_name,
                 godot_name: godot_method_name,
-                parameters: FnParam::new_range(&function.arguments, ctx),
+                parameters: FnParam::new_range(&function.arguments, &HashMap::new(), ctx),
                 return_value: FnReturn::new(&return_value, ctx),
                 is_vararg: function.is_vararg,
                 is_private: false,

--- a/godot-core/src/obj/traits.rs
+++ b/godot-core/src/obj/traits.rs
@@ -242,7 +242,7 @@ pub trait WithBaseField: GodotClass + Bounds<Declarer = bounds::DeclUser> {
     ///
     /// #[godot_api]
     /// impl INode for MyClass {
-    ///     fn process(&mut self, _delta: f64) {
+    ///     fn process(&mut self, _delta: f32) {
     ///         let name = self.base().get_name();
     ///         godot_print!("name is {name}");
     ///     }
@@ -268,7 +268,7 @@ pub trait WithBaseField: GodotClass + Bounds<Declarer = bounds::DeclUser> {
     ///
     /// #[godot_api]
     /// impl INode for MyClass {
-    ///     fn process(&mut self, _delta: f64) {
+    ///     fn process(&mut self, _delta: f32) {
     ///         let node = Node::new_alloc();
     ///         // fails because `add_child` requires a mutable reference.
     ///         self.base().add_child(node);
@@ -306,7 +306,7 @@ pub trait WithBaseField: GodotClass + Bounds<Declarer = bounds::DeclUser> {
     ///
     /// #[godot_api]
     /// impl INode for MyClass {
-    ///     fn process(&mut self, _delta: f64) {
+    ///     fn process(&mut self, _delta: f32) {
     ///         let node = Node::new_alloc();
     ///         self.base_mut().add_child(node);
     ///     }
@@ -331,7 +331,7 @@ pub trait WithBaseField: GodotClass + Bounds<Declarer = bounds::DeclUser> {
     ///
     /// #[godot_api]
     /// impl INode for MyClass {
-    ///     fn process(&mut self, _delta: f64) {
+    ///     fn process(&mut self, _delta: f32) {
     ///         self.base_mut().call("other_method".into(), &[]);
     ///     }
     /// }

--- a/itest/rust/src/engine_tests/codegen_test.rs
+++ b/itest/rust/src/engine_tests/codegen_test.rs
@@ -93,7 +93,7 @@ impl IHttpRequest for CodegenTest {
     }
 
     // Test unnamed parameter in virtual function
-    fn process(&mut self, _: f64) {}
+    fn process(&mut self, _: real) {}
 }
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------

--- a/itest/rust/src/object_tests/onready_test.rs
+++ b/itest/rust/src/object_tests/onready_test.rs
@@ -6,12 +6,12 @@
  */
 
 use crate::framework::{expect_panic, itest};
+use godot::builtin::meta::ToGodot;
+use godot::builtin::real;
 use godot::engine::notify::NodeNotification;
 use godot::engine::INode;
-use godot::register::{godot_api, GodotClass};
-
 use godot::obj::{Gd, OnReady};
-use godot::prelude::ToGodot;
+use godot::register::{godot_api, GodotClass};
 
 #[itest]
 fn onready_deref() {
@@ -232,5 +232,5 @@ impl OnReadyWithImplWithoutReady {
 #[godot_api]
 impl INode for OnReadyWithoutImpl {
     // Declare another function to ensure virtual getter must be provided.
-    fn process(&mut self, _delta: f64) {}
+    fn process(&mut self, _delta: real) {}
 }


### PR DESCRIPTION
For virtual functions `Node::process()` and `Node::physics_process()`, this changes parameter `delta`'s type from `f64` to `f32` in single-precision builds. In double-precision, they stay `f64`. Effectively, the type becomes `real`.

Reasons:
- Reduces the amount of casting boilerplate. Even the cliché example `pos += vel * delta` currently needs a cast. Most code doesn't benefit from the extra precision. 
- Reduces complexity for beginners; this has come up repeatedly as an obstacle ([1](https://discord.com/channels/723850269347283004/1197987849962803290/1197987849962803290), [2](https://discord.com/channels/723850269347283004/1043514894198255737/1179679802177900594), [3](https://discord.com/channels/723850269347283004/1043514894198255737/1127345569115938867)).
- People who need the precision can still use [`Node::get_[physics_]process_delta_time()`](https://godot-rust.github.io/docs/gdext/master/godot/engine/struct.Node.html#method.get_process_delta_time), which keeps returning `f64`.

Closes #510. See there for extended discussion.