### PR TITLE
Fix `#[var]` not overriding `#[export]`

### DIFF
--- a/godot-macros/src/class/data_models/field_export.rs
+++ b/godot-macros/src/class/data_models/field_export.rs
@@ -9,7 +9,6 @@ use proc_macro2::{Ident, TokenStream};
 use quote::quote;
 use std::collections::HashSet;
 
-use crate::class::FieldHint;
 use crate::util::{KvParser, ListParser};
 use crate::ParseResult;
 
@@ -353,16 +352,16 @@ impl FieldExport {
 
 macro_rules! quote_export_func {
     ($function_name:ident($($tt:tt)*)) => {
-        FieldHint::HintFromExportFunction(quote! {
+        Some(quote! {
             ::godot::register::property::export_info_functions::$function_name($($tt)*)
         })
     }
 }
 
 impl FieldExport {
-    pub fn to_field_hint(&self) -> FieldHint {
+    pub fn to_export_hint(&self) -> Option<TokenStream> {
         match self {
-            FieldExport::Default => FieldHint::Inferred,
+            FieldExport::Default => None,
 
             FieldExport::Range {
                 min,


### PR DESCRIPTION
Currently if you use `#[export]` alongside `#[var]` then the `hint` and `hint_string` fields will be overriden by `#[export]` regardless of what you set them to in `#[var]`. this fixes that.