### PR TITLE
Add `get_property_list`

### DIFF
--- a/godot-codegen/src/generator/virtual_traits.rs
+++ b/godot-codegen/src/generator/virtual_traits.rs
@@ -104,6 +104,10 @@ fn special_virtual_methods(notification_enum_name: &Ident) -> TokenStream {
             unimplemented!()
         }
 
+        #[cfg(since_api = "4.3")]
+        fn get_property_list(&mut self) -> Vec<crate::builtin::meta::PropertyInfo> {
+            unimplemented!()
+        }
     }
 }
 

--- a/godot-codegen/src/generator/virtual_traits.rs
+++ b/godot-codegen/src/generator/virtual_traits.rs
@@ -115,6 +115,23 @@ fn special_virtual_methods(notification_enum_name: &Ident) -> TokenStream {
         fn get_property_list(&mut self) -> Vec<crate::builtin::meta::PropertyInfo> {
             unimplemented!()
         }
+
+        /// Called by Godot to tell if a property has a custom revert or not.
+        ///
+        /// Return `None` for no custom revert, and return `Some(value)` to specify the custom revert.
+        ///
+        /// This is a combination of Godot's [`Object::_property_get_revert`] and [`Object::_property_can_revert`]. This means that this
+        /// function will usually be called twice by Godot to find the revert.
+        ///
+        /// Note that this should be a _pure_ function. That is, it should always return the same value for a property as long as `self`
+        /// remains unchanged. Otherwise this may lead to unexpected (safe) behavior.
+        ///
+        /// [`Object::_property_get_revert`]: https://docs.godotengine.org/en/latest/classes/class_object.html#class-object-private-method-property-get-revert
+        /// [`Object::_property_can_revert`]: https://docs.godotengine.org/en/latest/classes/class_object.html#class-object-private-method-property-can-revert
+        #[doc(alias = "property_can_revert")]
+        fn property_get_revert(&self, property: StringName) -> Option<Variant> {
+            unimplemented!()
+        }
     }
 }
 

--- a/godot-codegen/src/generator/virtual_traits.rs
+++ b/godot-codegen/src/generator/virtual_traits.rs
@@ -104,6 +104,13 @@ fn special_virtual_methods(notification_enum_name: &Ident) -> TokenStream {
             unimplemented!()
         }
 
+        /// Called whenever Godot [`get_property_list()`](crate::engine::Object::get_property_list) is called, the returned vector here is
+        /// appended to the existing list of properties.
+        ///
+        /// This should mainly be used for advanced purposes, such as dynamically updating the property list in the editor.
+        ///
+        /// See also in Godot docs:
+        /// * [`Object::_get_property_list`](https://docs.godotengine.org/en/latest/classes/class_object.html#class-object-private-method-get-property-list)
         #[cfg(since_api = "4.3")]
         fn get_property_list(&mut self) -> Vec<crate::builtin::meta::PropertyInfo> {
             unimplemented!()

--- a/godot-core/src/builtin/meta/mod.rs
+++ b/godot-core/src/builtin/meta/mod.rs
@@ -324,7 +324,6 @@ impl PropertyInfo {
     ///
     /// Creating an `@export_range` property.
     ///
-
     // TODO: Make this nicer to use.
     /// ```no_run
     /// # use crate::property::export_info_function;

--- a/godot-core/src/builtin/meta/mod.rs
+++ b/godot-core/src/builtin/meta/mod.rs
@@ -20,9 +20,10 @@ pub use signature::*;
 
 pub(crate) use godot_convert::convert_error::*;
 
+use crate::builtin::*;
 use crate::engine::global::{self, PropertyHint, PropertyUsageFlags};
+use crate::property::Var;
 use crate::property::{Export, PropertyHintInfo};
-use crate::{builtin::*, property::Var};
 use godot_ffi as sys;
 use registration::method::MethodParamOrReturnInfo;
 use sys::{GodotFfi, GodotNullableFfi};
@@ -278,7 +279,7 @@ pub struct PropertyInfo {
 
     /// Which class this property is.
     ///
-    /// This should be set to [`ClassName::none()`] unless the variant type is object. You can use
+    /// This should be set to [`ClassName::none()`] unless the variant type is `Object`. You can use
     /// [`GodotClass::class_name()`](crate::obj::GodotClass::class_name()) to get the right name to use here.
     pub class_name: ClassName,
 
@@ -317,7 +318,7 @@ impl PropertyInfo {
 
     /// Change the `hint` and `hint_string` to be the given `hint_info`.
     ///
-    /// See [`export_info_functions`](crate::property::export_info_function) for functions that return appropriate `PropertyHintInfo`s for
+    /// See [`export_info_functions`](crate::property::export_info_functions) for functions that return appropriate `PropertyHintInfo`s for
     /// various Godot annotations.
     ///
     /// # Examples
@@ -326,11 +327,11 @@ impl PropertyInfo {
     ///
     // TODO: Make this nicer to use.
     /// ```no_run
-    /// # use crate::property::export_info_function;
-    /// # use crate::builtin::meta::PropertyInfo;
+    /// use godot::register::property::export_info_functions;
+    /// use godot::builtin::meta::PropertyInfo;
     ///
     /// let property = PropertyInfo::new_export::<f64>("my_range_property")
-    ///     .with_hint_info(export_info_function::export_range(
+    ///     .with_hint_info(export_info_functions::export_range(
     ///         0.0,
     ///         10.0,
     ///         Some(0.1),
@@ -340,7 +341,7 @@ impl PropertyInfo {
     ///         false,
     ///         false,
     ///         false,
-    ///     ))
+    ///     ));
     /// ```
     pub fn with_hint_info(self, hint_info: PropertyHintInfo) -> Self {
         let PropertyHintInfo { hint, hint_string } = hint_info;
@@ -415,7 +416,7 @@ impl PropertyInfo {
     /// [`free_owned_property_sys`](Self::free_owned_property_sys).
     ///
     /// This will leak memory unless used together with `free_owned_property_sys`.
-    pub fn into_owned_property_sys(self) -> sys::GDExtensionPropertyInfo {
+    pub(crate) fn into_owned_property_sys(self) -> sys::GDExtensionPropertyInfo {
         use crate::obj::EngineBitfield as _;
         use crate::obj::EngineEnum as _;
 
@@ -433,9 +434,9 @@ impl PropertyInfo {
     ///
     /// # Safety
     ///
-    /// * Must only be used on a struct returned from a call to [`into_owned_property_sys`], without modification.
+    /// * Must only be used on a struct returned from a call to `into_owned_property_sys`, without modification.
     /// * Must not be called more than once on a `sys::GDExtensionPropertyInfo` struct.
-    pub unsafe fn free_owned_property_sys(info: sys::GDExtensionPropertyInfo) {
+    pub(crate) unsafe fn free_owned_property_sys(info: sys::GDExtensionPropertyInfo) {
         // SAFETY: This function was called on a pointer returned from `into_owned_property_sys`, thus both `info.name` and
         // `info.hint_string` were created from calls to `into_owned_string_sys` on their respective types.
         // Additionally this function isn't called more than once on a struct containing the same `name` or `hint_string` pointers.

--- a/godot-core/src/builtin/string/gstring.rs
+++ b/godot-core/src/builtin/string/gstring.rs
@@ -175,6 +175,9 @@ impl GString {
         sys::static_assert_eq_size_align!(StringName, sys::types::OpaqueString);
 
         let ptr = ptr.cast::<Self>();
+
+        // SAFETY: `ptr` was returned from a call to `into_owned_string_sys`, which means it was created by a call to
+        // `Box::into_raw`, thus we can use `Box::from_raw` here. Additionally this is only called once on this pointer.
         let boxed = unsafe { Box::from_raw(ptr) };
         *boxed
     }

--- a/godot-core/src/builtin/string/gstring.rs
+++ b/godot-core/src/builtin/string/gstring.rs
@@ -158,6 +158,8 @@ impl GString {
     ///
     /// This will leak memory unless `from_owned_string_sys` is called on the returned pointer.
     pub(crate) fn into_owned_string_sys(self) -> sys::GDExtensionStringPtr {
+        sys::static_assert_eq_size_align!(StringName, sys::types::OpaqueString);
+
         let leaked = Box::into_raw(Box::new(self));
         leaked.cast()
     }
@@ -170,6 +172,8 @@ impl GString {
     /// * Must not be called more than once on the same pointer.
     #[deny(unsafe_op_in_unsafe_fn)]
     pub(crate) unsafe fn from_owned_string_sys(ptr: sys::GDExtensionStringPtr) -> Self {
+        sys::static_assert_eq_size_align!(StringName, sys::types::OpaqueString);
+
         let ptr = ptr.cast::<Self>();
         let boxed = unsafe { Box::from_raw(ptr) };
         *boxed

--- a/godot-core/src/builtin/string/string_name.rs
+++ b/godot-core/src/builtin/string/string_name.rs
@@ -131,6 +131,8 @@ impl StringName {
     /// * Must not be called more than once on the same pointer.
     #[deny(unsafe_op_in_unsafe_fn)]
     pub(crate) unsafe fn from_owned_string_sys(ptr: sys::GDExtensionStringNamePtr) -> Self {
+        sys::static_assert_eq_size_align!(StringName, sys::types::OpaqueStringName);
+
         let ptr = ptr.cast::<Self>();
         let boxed = unsafe { Box::from_raw(ptr) };
         *boxed

--- a/godot-core/src/builtin/string/string_name.rs
+++ b/godot-core/src/builtin/string/string_name.rs
@@ -134,6 +134,9 @@ impl StringName {
         sys::static_assert_eq_size_align!(StringName, sys::types::OpaqueStringName);
 
         let ptr = ptr.cast::<Self>();
+
+        // SAFETY: `ptr` was returned from a call to `into_owned_string_sys`, which means it was created by a call to
+        // `Box::into_raw`, thus we can use `Box::from_raw` here. Additionally this is only called once on this pointer.
         let boxed = unsafe { Box::from_raw(ptr) };
         *boxed
     }

--- a/godot-core/src/builtin/string/string_name.rs
+++ b/godot-core/src/builtin/string/string_name.rs
@@ -113,6 +113,29 @@ impl StringName {
         fn string_sys_mut = sys_mut;
     }
 
+    /// Consumes self and turns it into a sys-ptr, should be used together with [`from_owned_string_sys`](Self::from_owned_string_sys).
+    ///
+    /// This will leak memory unless `from_owned_string_sys` is called on the returned pointer.
+    pub(crate) fn into_owned_string_sys(self) -> sys::GDExtensionStringNamePtr {
+        sys::static_assert_eq_size_align!(StringName, sys::types::OpaqueStringName);
+
+        let leaked = Box::into_raw(Box::new(self));
+        leaked.cast()
+    }
+
+    /// Creates a `StringName` from a sys-ptr without incrementing the refcount.
+    ///
+    /// # Safety
+    ///
+    /// * Must only be used on a pointer returned from a call to [`into_owned_string_sys`](Self::into_owned_string_sys).
+    /// * Must not be called more than once on the same pointer.
+    #[deny(unsafe_op_in_unsafe_fn)]
+    pub(crate) unsafe fn from_owned_string_sys(ptr: sys::GDExtensionStringNamePtr) -> Self {
+        let ptr = ptr.cast::<Self>();
+        let boxed = unsafe { Box::from_raw(ptr) };
+        *boxed
+    }
+
     /// Convert a `StringName` sys pointer to a reference with unbounded lifetime.
     ///
     /// # Safety

--- a/godot-core/src/obj/traits.rs
+++ b/godot-core/src/obj/traits.rs
@@ -529,6 +529,12 @@ pub mod cap {
         fn __godot_get_property_list(&mut self) -> Vec<crate::builtin::meta::PropertyInfo>;
     }
 
+    #[doc(hidden)]
+    pub trait GodotPropertyGetRevert: GodotClass {
+        #[doc(hidden)]
+        fn __godot_property_get_revert(&self, property: StringName) -> Option<Variant>;
+    }
+
     /// Auto-implemented for `#[godot_api] impl MyClass` blocks
     pub trait ImplementsGodotApi: GodotClass {
         #[doc(hidden)]

--- a/godot-core/src/obj/traits.rs
+++ b/godot-core/src/obj/traits.rs
@@ -523,6 +523,12 @@ pub mod cap {
         fn __godot_set_property(&mut self, property: StringName, value: Variant) -> bool;
     }
 
+    #[doc(hidden)]
+    pub trait GodotGetPropertyList: GodotClass {
+        #[doc(hidden)]
+        fn __godot_get_property_list(&mut self) -> Vec<crate::builtin::meta::PropertyInfo>;
+    }
+
     /// Auto-implemented for `#[godot_api] impl MyClass` blocks
     pub trait ImplementsGodotApi: GodotClass {
         #[doc(hidden)]

--- a/godot-core/src/registry/mod.rs
+++ b/godot-core/src/registry/mod.rs
@@ -182,6 +182,30 @@ pub enum PluginItem {
             p_userdata: *mut std::os::raw::c_void,
             p_name: sys::GDExtensionConstStringNamePtr,
         ) -> sys::GDExtensionClassCallVirtual,
+
+        /// Callback for other virtuals.
+        user_get_property_list_fn: Option<
+            unsafe extern "C" fn(
+                p_instance: sys::GDExtensionClassInstancePtr,
+                r_count: *mut u32,
+            ) -> *const sys::GDExtensionPropertyInfo,
+        >,
+
+        #[cfg(before_api = "4.3")]
+        user_free_property_list_fn: Option<
+            unsafe extern "C" fn(
+                p_instance: sys::GDExtensionClassInstancePtr,
+                p_list: *const sys::GDExtensionPropertyInfo,
+            ),
+        >,
+        #[cfg(since_api = "4.3")]
+        user_free_property_list_fn: Option<
+            unsafe extern "C" fn(
+                p_instance: sys::GDExtensionClassInstancePtr,
+                p_list: *const sys::GDExtensionPropertyInfo,
+                p_count: u32,
+            ),
+        >,
     },
 }
 
@@ -453,6 +477,8 @@ fn fill_class_info(item: PluginItem, c: &mut ClassRegistrationInfo) {
             user_set_fn,
             user_get_fn,
             get_virtual_fn,
+            user_get_property_list_fn,
+            user_free_property_list_fn,
         } => {
             c.user_register_fn = user_register_fn;
 
@@ -473,6 +499,8 @@ fn fill_class_info(item: PluginItem, c: &mut ClassRegistrationInfo) {
             c.godot_params.notification_func = user_on_notification_fn;
             c.godot_params.set_func = user_set_fn;
             c.godot_params.get_func = user_get_fn;
+            c.godot_params.get_property_list_func = user_get_property_list_fn;
+            c.godot_params.free_property_list_func = user_free_property_list_fn;
             c.user_virtual_fn = Some(get_virtual_fn);
         }
     }

--- a/godot-core/src/registry/mod.rs
+++ b/godot-core/src/registry/mod.rs
@@ -191,6 +191,8 @@ pub enum PluginItem {
             ) -> *const sys::GDExtensionPropertyInfo,
         >,
 
+        // We do not support using this in Godot < 4.3, however it's easier to leave this in and fail elsewhere when attempting to use
+        // this in Godot < 4.3.
         #[cfg(before_api = "4.3")]
         user_free_property_list_fn: Option<
             unsafe extern "C" fn(

--- a/godot-core/src/registry/mod.rs
+++ b/godot-core/src/registry/mod.rs
@@ -206,6 +206,21 @@ pub enum PluginItem {
                 p_count: u32,
             ),
         >,
+
+        user_property_can_revert_fn: Option<
+            unsafe extern "C" fn(
+                p_instance: sys::GDExtensionClassInstancePtr,
+                p_name: sys::GDExtensionConstStringNamePtr,
+            ) -> sys::GDExtensionBool,
+        >,
+
+        user_property_get_revert_fn: Option<
+            unsafe extern "C" fn(
+                p_instance: sys::GDExtensionClassInstancePtr,
+                p_name: sys::GDExtensionConstStringNamePtr,
+                r_ret: sys::GDExtensionVariantPtr,
+            ) -> sys::GDExtensionBool,
+        >,
     },
 }
 
@@ -479,6 +494,8 @@ fn fill_class_info(item: PluginItem, c: &mut ClassRegistrationInfo) {
             get_virtual_fn,
             user_get_property_list_fn,
             user_free_property_list_fn,
+            user_property_can_revert_fn,
+            user_property_get_revert_fn,
         } => {
             c.user_register_fn = user_register_fn;
 
@@ -501,6 +518,8 @@ fn fill_class_info(item: PluginItem, c: &mut ClassRegistrationInfo) {
             c.godot_params.get_func = user_get_fn;
             c.godot_params.get_property_list_func = user_get_property_list_fn;
             c.godot_params.free_property_list_func = user_free_property_list_fn;
+            c.godot_params.property_can_revert_func = user_property_can_revert_fn;
+            c.godot_params.property_get_revert_func = user_property_get_revert_fn;
             c.user_virtual_fn = Some(get_virtual_fn);
         }
     }

--- a/godot-core/src/registry/property.rs
+++ b/godot-core/src/registry/property.rs
@@ -139,7 +139,7 @@ impl PropertyHintInfo {
 
 /// Functions used to translate user-provided arguments into export hints.
 ///
-/// Each function is named the same as the equivalent Godot annotation. E.g `@export_range` is `fn export_range`.
+/// Each function is named the same as the equivalent Godot annotation. For instance `@export_range` in Godot is `fn export_range` here.
 pub mod export_info_functions {
     use crate::builtin::GString;
     use crate::engine::global::PropertyHint;
@@ -247,7 +247,8 @@ pub mod export_info_functions {
     /// # Examples
     ///
     /// ```no_run
-    /// export_enum(&[("a", None), ("b", "Some(10)")]);
+    /// # use godot::register::property::export_info_functions::export_enum;
+    /// export_enum(&[("a", None), ("b", Some(10))]);
     /// ```
     pub fn export_enum<T>(variants: &[T]) -> PropertyHintInfo
     where
@@ -279,7 +280,8 @@ pub mod export_info_functions {
     /// # Examples
     ///
     /// ```no_run
-    /// export_flags(&[("a", None), ("b", "Some(10)")]);
+    /// # use godot::register::property::export_info_functions::export_flags;
+    /// export_flags(&[("a", None), ("b", Some(10))]);
     /// ```
     pub fn export_flags<T>(bits: &[T]) -> PropertyHintInfo
     where

--- a/godot-core/src/registry/property.rs
+++ b/godot-core/src/registry/property.rs
@@ -138,6 +138,8 @@ impl PropertyHintInfo {
 }
 
 /// Functions used to translate user-provided arguments into export hints.
+///
+/// Each function is named the same as the equivalent Godot annotation. E.g `@export_range` is `fn export_range`.
 pub mod export_info_functions {
     use crate::builtin::GString;
     use crate::engine::global::PropertyHint;
@@ -238,6 +240,15 @@ pub mod export_info_functions {
 
     type EnumVariant = ExportValueWithKey<i64>;
 
+    /// Equivalent to `@export_enum` in Godot.
+    ///
+    /// A name without a key would be represented as `(name, None)`, and a name with a key as `(name, Some(key))`.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// export_enum(&[("a", None), ("b", "Some(10)")]);
+    /// ```
     pub fn export_enum<T>(variants: &[T]) -> PropertyHintInfo
     where
         for<'a> &'a T: Into<EnumVariant>,
@@ -261,6 +272,15 @@ pub mod export_info_functions {
 
     type BitFlag = ExportValueWithKey<u32>;
 
+    /// Equivalent to `@export_flags` in Godot.
+    ///
+    /// A flag without a key would be represented as `(flag, None)`, and a flag with a key as `(flag, Some(key))`.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// export_flags(&[("a", None), ("b", "Some(10)")]);
+    /// ```
     pub fn export_flags<T>(bits: &[T]) -> PropertyHintInfo
     where
         for<'a> &'a T: Into<BitFlag>,
@@ -273,10 +293,16 @@ pub mod export_info_functions {
         }
     }
 
+    /// Equivalent to `@export_file` in Godot.
+    ///
+    /// Pass an empty string to have no filter.
     pub fn export_file<S: AsRef<str>>(filter: S) -> PropertyHintInfo {
         export_file_inner(false, filter)
     }
 
+    /// Equivalent to `@export_global_file` in Godot.
+    ///
+    /// Pass an empty string to have no filter.
     pub fn export_global_file<S: AsRef<str>>(filter: S) -> PropertyHintInfo {
         export_file_inner(true, filter)
     }

--- a/godot-macros/src/class/data_models/interface_trait_impl.rs
+++ b/godot-macros/src/class/data_models/interface_trait_impl.rs
@@ -22,6 +22,8 @@ pub fn transform_trait_impl(original_impl: venial::Impl) -> ParseResult<TokenStr
     let mut on_notification_impl = TokenStream::new();
     let mut get_property_impl = TokenStream::new();
     let mut set_property_impl = TokenStream::new();
+    let mut get_property_list_impl = TokenStream::new();
+    let mut property_get_revert_impl = TokenStream::new();
 
     let mut register_fn = None;
     let mut create_fn = None;
@@ -30,6 +32,10 @@ pub fn transform_trait_impl(original_impl: venial::Impl) -> ParseResult<TokenStr
     let mut on_notification_fn = None;
     let mut get_property_fn = None;
     let mut set_property_fn = None;
+    let mut get_property_list_fn = None;
+    let mut free_property_list_fn = None;
+    let mut property_get_revert_fn = None;
+    let mut property_can_revert_fn = None;
 
     let mut virtual_methods = vec![];
     let mut virtual_method_cfg_attrs = vec![];
@@ -204,6 +210,76 @@ pub fn transform_trait_impl(original_impl: venial::Impl) -> ParseResult<TokenStr
                 });
             }
 
+            #[cfg(before_api = "4.3")]
+            "get_property_list" => {
+                get_property_list_impl = quote! {
+                    #(#cfg_attrs)*
+                    compile_error!("`get_property_list` is only supported for Godot versions of at least 4.3");
+                };
+
+                // Set these variables otherwise rust complains that these variables arent changed in Godot < 4.3.
+                get_property_list_fn = None;
+                free_property_list_fn = None;
+            }
+
+            #[cfg(since_api = "4.3")]
+            "get_property_list" => {
+                get_property_list_impl = quote! {
+                    #(#cfg_attrs)*
+                    impl ::godot::obj::cap::GodotGetPropertyList for #class_name {
+                        fn __godot_get_property_list(&mut self) -> Vec<::godot::builtin::meta::PropertyInfo> {
+                            // Only supported in godot api > 4.3. If support is added for earlier versions this is still needed.
+                            //
+                            // use ::godot::obj::UserClass as _;
+                            //
+                            // #[cfg(before_api = "4.3")]
+                            // if ::godot::private::is_class_inactive(Self::__config().is_tool) {
+                            //     return false;
+                            // }
+
+                            <Self as #trait_path>::get_property_list(self)
+                        }
+                    }
+                };
+
+                get_property_list_fn = Some(quote! {
+                    #(#cfg_attrs)*
+                    () => Some(#prv::callbacks::get_property_list::<#class_name>),
+                });
+                free_property_list_fn = Some(quote! {
+                    #(#cfg_attrs)*
+                    () => Some(#prv::callbacks::free_property_list::<#class_name>),
+                });
+            }
+
+            "property_get_revert" => {
+                property_get_revert_impl = quote! {
+                    #(#cfg_attrs)*
+                    impl ::godot::obj::cap::GodotPropertyGetRevert for #class_name {
+                        fn __godot_property_get_revert(&self, property: StringName) -> Option<::godot::builtin::Variant> {
+                            use ::godot::obj::UserClass as _;
+
+                            #[cfg(before_api = "4.3")]
+                            if ::godot::private::is_class_inactive(Self::__config().is_tool) {
+                                return None;
+                            }
+
+                            <Self as #trait_path>::property_get_revert(self, property)
+                        }
+                    }
+                };
+
+                property_get_revert_fn = Some(quote! {
+                    #(#cfg_attrs)*
+                    () => Some(#prv::callbacks::property_get_revert::<#class_name>),
+                });
+
+                property_can_revert_fn = Some(quote! {
+                    #(#cfg_attrs)*
+                    () => Some(#prv::callbacks::property_can_revert::<#class_name>),
+                });
+            }
+
             // Other virtual methods, like ready, process etc.
             _ => {
                 let method = util::reduce_to_signature(method);
@@ -274,6 +350,10 @@ pub fn transform_trait_impl(original_impl: venial::Impl) -> ParseResult<TokenStr
     let on_notification_fn = convert_to_match_expression_or_none(on_notification_fn);
     let get_property_fn = convert_to_match_expression_or_none(get_property_fn);
     let set_property_fn = convert_to_match_expression_or_none(set_property_fn);
+    let get_property_list_fn = convert_to_match_expression_or_none(get_property_list_fn);
+    let free_property_list_fn = convert_to_match_expression_or_none(free_property_list_fn);
+    let property_get_revert_fn = convert_to_match_expression_or_none(property_get_revert_fn);
+    let property_can_revert_fn = convert_to_match_expression_or_none(property_can_revert_fn);
 
     let result = quote! {
         #original_impl
@@ -283,6 +363,8 @@ pub fn transform_trait_impl(original_impl: venial::Impl) -> ParseResult<TokenStr
         #register_class_impl
         #get_property_impl
         #set_property_impl
+        #get_property_list_impl
+        #property_get_revert_impl
 
         impl ::godot::private::You_forgot_the_attribute__godot_api for #class_name {}
 
@@ -312,6 +394,10 @@ pub fn transform_trait_impl(original_impl: venial::Impl) -> ParseResult<TokenStr
                 user_on_notification_fn: #on_notification_fn,
                 user_set_fn: #set_property_fn,
                 user_get_fn: #get_property_fn,
+                user_get_property_list_fn: #get_property_list_fn,
+                user_free_property_list_fn: #free_property_list_fn,
+                user_property_get_revert_fn: #property_get_revert_fn,
+                user_property_can_revert_fn: #property_can_revert_fn,
                 get_virtual_fn: #prv::callbacks::get_virtual::<#class_name>,
             },
             init_level: <#class_name as ::godot::obj::GodotClass>::INIT_LEVEL,

--- a/godot-macros/src/class/data_models/interface_trait_impl.rs
+++ b/godot-macros/src/class/data_models/interface_trait_impl.rs
@@ -228,7 +228,8 @@ pub fn transform_trait_impl(original_impl: venial::Impl) -> ParseResult<TokenStr
                     #(#cfg_attrs)*
                     impl ::godot::obj::cap::GodotGetPropertyList for #class_name {
                         fn __godot_get_property_list(&mut self) -> Vec<::godot::builtin::meta::PropertyInfo> {
-                            // Only supported in godot api > 4.3. If support is added for earlier versions this is still needed.
+                            // `get_property_list` is only supported in Godot API >= 4.3. If we add support for `get_property_list` to earlier
+                            // versions of Godot then this code is still needed and should be uncommented.
                             //
                             // use ::godot::obj::UserClass as _;
                             //

--- a/itest/rust/src/object_tests/get_property_list_test.rs
+++ b/itest/rust/src/object_tests/get_property_list_test.rs
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use std::collections::HashMap;
+
+use godot::builtin::meta::PropertyInfo;
+use godot::builtin::{Dictionary, GString, StringName, VariantType, Vector2, Vector3};
+use godot::engine::global::{PropertyHint, PropertyUsageFlags};
+use godot::engine::{IObject, Node};
+use godot::obj::{Gd, NewAlloc};
+use godot::register::{godot_api, GodotClass};
+use godot::test::itest;
+
+#[derive(GodotClass)]
+#[class(base = Object, init)]
+pub struct GetPropertyListTest {}
+
+#[godot_api]
+impl IObject for GetPropertyListTest {
+    fn get_property_list(&mut self) -> Vec<PropertyInfo> {
+        vec![
+            PropertyInfo::new_var::<bool>("my_property"),
+            PropertyInfo::new_export::<GString>("a_string_property"),
+            PropertyInfo::new_group("some_group", "some_group_"),
+            PropertyInfo::new_export::<Vector2>("some_group_my_vector_2"),
+            PropertyInfo::new_export::<Vector3>("some_group_my_vector_3"),
+            PropertyInfo::new_subgroup("my_subgroup", "some_subgroup_"),
+            PropertyInfo::new_export::<Option<Gd<Node>>>("some_subgroup_node"),
+        ]
+    }
+}
+
+fn property_dict_eq_property_info(dict: &Dictionary, info: &PropertyInfo) -> bool {
+    dict.get("name").unwrap().to::<GString>().to_string() == info.property_name.to_string()
+        && dict.get("class_name").unwrap().to::<StringName>() == info.class_name.to_string_name()
+        && dict.get("type").unwrap().to::<VariantType>() == info.variant_type
+        && dict.get("hint").unwrap().to::<PropertyHint>() == info.hint
+        && dict.get("hint_string").unwrap().to::<GString>() == info.hint_string
+        && dict.get("usage").unwrap().to::<PropertyUsageFlags>() == info.usage
+}
+
+#[itest]
+fn get_property_list_returns() {
+    let mut obj = GetPropertyListTest::new_alloc();
+
+    let properties = obj.get_property_list();
+
+    let mut properties_missing = HashMap::new();
+
+    properties_missing.extend(
+        obj.bind_mut()
+            .get_property_list()
+            .into_iter()
+            .map(|prop| (prop.property_name.to_string(), prop)),
+    );
+
+    for dict in properties.iter_shared() {
+        let name = dict.get("name").unwrap().to::<GString>();
+
+        let Some(prop) = properties_missing.get(&name.to_string()) else {
+            continue;
+        };
+
+        if property_dict_eq_property_info(&dict, prop) {
+            properties_missing.remove(&name.to_string());
+        }
+    }
+
+    assert!(
+        properties_missing.is_empty(),
+        "missing properties: {:?}",
+        properties_missing.keys().collect::<Vec<_>>()
+    );
+
+    obj.free();
+}

--- a/itest/rust/src/object_tests/mod.rs
+++ b/itest/rust/src/object_tests/mod.rs
@@ -8,6 +8,9 @@
 mod base_test;
 mod class_rename_test;
 mod dynamic_call_test;
+// `get_property_list` is only supported in godot 4.3+
+#[cfg(since_api = "4.3")]
+mod get_property_list_test;
 mod init_level_test;
 mod object_swap_test;
 mod object_test;

--- a/itest/rust/src/object_tests/virtual_methods_test.rs
+++ b/itest/rust/src/object_tests/virtual_methods_test.rs
@@ -282,6 +282,34 @@ impl IRefCounted for SetTest {
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 
+#[derive(GodotClass)]
+#[class(init)]
+struct RevertTest {}
+
+#[godot_api]
+impl IRefCounted for RevertTest {
+    fn property_get_revert(&self, property: StringName) -> Option<Variant> {
+        use std::sync::atomic::AtomicUsize;
+
+        static INC: AtomicUsize = AtomicUsize::new(0);
+
+        match String::from(property).as_str() {
+            "property_not_revert" => None,
+            "property_do_revert" => Some(GString::from("hello!").to_variant()),
+            "property_changes" => {
+                if INC.fetch_add(1, std::sync::atomic::Ordering::AcqRel) % 2 == 0 {
+                    None
+                } else {
+                    Some(true.to_variant())
+                }
+            }
+            _ => None,
+        }
+    }
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+
 #[itest]
 fn test_to_string() {
     let _obj = VirtualMethodTest::new_gd();
@@ -561,6 +589,32 @@ fn test_set_sets_correct() {
     obj.set("settable".into(), 500.to_variant());
     assert_eq!(obj.bind().always_set_to_100, 100);
     assert_eq!(obj.bind().settable, 500);
+}
+
+#[itest]
+fn test_revert() {
+    let revert = RevertTest::new_gd();
+
+    let not_revert = StringName::from("property_not_revert");
+    let do_revert = StringName::from("property_do_revert");
+    let changes = StringName::from("property_changes");
+
+    assert!(!revert.property_can_revert(not_revert.clone()));
+    assert_eq!(revert.property_get_revert(not_revert), Variant::nil());
+    assert!(revert.property_can_revert(do_revert.clone()));
+    assert_eq!(
+        revert.property_get_revert(do_revert),
+        GString::from("hello!").to_variant()
+    );
+
+    assert!(!revert.property_can_revert(changes.clone()));
+    assert!(revert.property_can_revert(changes.clone()));
+
+    assert_eq!(revert.property_get_revert(changes.clone()), Variant::nil());
+    assert_eq!(
+        revert.property_get_revert(changes.clone()),
+        true.to_variant()
+    );
 }
 
 // Used in `test_collision_object_2d_input_event` in `SpecialTests.gd`.

--- a/itest/rust/src/object_tests/virtual_methods_test.rs
+++ b/itest/rust/src/object_tests/virtual_methods_test.rs
@@ -296,6 +296,8 @@ impl IRefCounted for RevertTest {
         match String::from(property).as_str() {
             "property_not_revert" => None,
             "property_do_revert" => Some(GString::from("hello!").to_variant()),
+            // No UB or anything else like a crash or panic should happen when `property_can_revert` and `property_get_revert` return
+            // inconsistent values, but in case something like that happens we should be able to detect it through this function.
             "property_changes" => {
                 if INC.fetch_add(1, std::sync::atomic::Ordering::AcqRel) % 2 == 0 {
                     None


### PR DESCRIPTION
This does three main things
## Adds `get_property_list`

Also adds `property_get_revert/property_can_revert` (combined into one function).

This allows the user to fully dynamically generate the property list as well as set all relevant options for the property list. This also provides a mechanism to group exports in the editor #226, however it's not the most ergonomic way as it requires all grouped properties to be defined in the `get_property_list` method.

## Adds some convenience functions to `PropertyInfo`

This makes it easier to generate property infos corresponding to the usual property types. For instance to generate a `#[var]` declaration you can now just do `PropertyInfo::new_var::<Type>("property_name")` rather than needing to specify all the individual properties.

I also added documentation to each field of `PropertyInfo` since it's a more public facing type like this.

## Adds sys-conversions that pass ownership for `PropertyInfo`, `GString`, and `StringName`

Unlike `sys()`, these methods named `into_owned_(string/property)_sys` and `free_owned_(string/property)_sys` allow us to convert a `PropertyInfo` directly into a `sys::GDExtensionPropertyInfo` while:
- not allocating anything extra 
- not needing to keep the original values alive
- not leaking any memory (since the `free_*` function can appropriately free the value later)

This is used in `get_property_list` and `free_property_list` to pass a list of property infos to Godot and then later free the values.

closes #665 