### PR TITLE
Add `GString::chars` for 4.1

### DIFF
--- a/itest/rust/src/builtin_tests/string/gstring_test.rs
+++ b/itest/rust/src/builtin_tests/string/gstring_test.rs
@@ -68,8 +68,16 @@ fn string_clone() {
 fn empty_string_chars() {
     // Tests regression from #228: Null pointer passed to slice::from_raw_parts
     let s = GString::new();
-    assert_eq!(s.chars_checked(), &[]);
-    assert_eq!(unsafe { s.chars_unchecked() }, &[]);
+
+    #[allow(deprecated)]
+    {
+        assert_eq!(s.chars_checked(), &[]);
+        assert_eq!(unsafe { s.chars_unchecked() }, &[]);
+    }
+    #[cfg(since_api = "4.1")]
+    {
+        assert_eq!(s.chars(), &[]);
+    }
 }
 
 #[itest]
@@ -77,9 +85,15 @@ fn string_chars() {
     let string = String::from("some_string");
     let string_chars: Vec<char> = string.chars().collect();
     let gstring = GString::from(string);
-    let gstring_chars: Vec<char> = gstring.chars_checked().to_vec();
 
-    assert_eq!(gstring_chars, string_chars);
+    #[allow(deprecated)]
+    {
+        assert_eq!(string_chars, gstring.chars_checked().to_vec());
+    }
+    #[cfg(since_api = "4.1")]
+    {
+        assert_eq!(string_chars, gstring.chars().to_vec());
+    }
 }
 
 #[itest]


### PR DESCRIPTION
Adds `GString::chars` for 4.1 and hides `GString::chars_checked`/`GString::chars_unchecked`

may close  #712