### PR TITLE
Update type strings according to how godot 4.3 exports them currently

### DIFF
--- a/godot-core/src/builtin/array.rs
+++ b/godot-core/src/builtin/array.rs
@@ -834,7 +834,11 @@ impl<T: ArrayElement + TypeStringHint> TypeStringHint for Array<T> {
 
 impl TypeStringHint for VariantArray {
     fn type_string() -> String {
-        format!("{}:Array", VariantType::Array as i32)
+        if sys::GdextBuild::since_api("4.3") {
+            format!("{}:", VariantType::Array as i32)
+        } else {
+            format!("{}:Array", VariantType::Array as i32)
+        }
     }
 }
 

--- a/godot-core/src/builtin/dictionary.rs
+++ b/godot-core/src/builtin/dictionary.rs
@@ -330,7 +330,11 @@ impl Var for Dictionary {
 
 impl TypeStringHint for Dictionary {
     fn type_string() -> String {
-        format!("{}:Dictionary", sys::VariantType::Dictionary as i32)
+        if sys::GdextBuild::since_api("4.3") {
+            format!("{}:", sys::VariantType::Dictionary as i32)
+        } else {
+            format!("{}:Dictionary", sys::VariantType::Dictionary as i32)
+        }
     }
 }
 


### PR DESCRIPTION
Makes our exports match what https://github.com/godotengine/godot/pull/90716 does

i am now wondering if we have some code-duplication with the type string hint impl, but i guess we can look into that at some other point