### PR TITLE
Clean up `Array` and `Dictionary` element access APIs

### DIFF
--- a/godot-core/src/builtin/array.rs
+++ b/godot-core/src/builtin/array.rs
@@ -30,7 +30,7 @@ use super::meta::{
 /// We represent this in Rust as `VariantArray`, which is just a type alias for `Array<Variant>`.
 ///
 /// Godot also supports typed arrays, which are also just `Variant` arrays under the hood, but with
-/// runtime checks that no values of the wrong type are put into the array. We represent this as
+/// runtime checks, so that no values of the wrong type are inserted into the array. We represent this as
 /// `Array<T>`, where the type `T` must implement `ArrayElement`. Some types like `Array<T>` cannot
 /// be stored inside arrays, as Godot prevents nesting.
 ///
@@ -48,13 +48,7 @@ use super::meta::{
 /// Usage is safe if the `Array` is used on a single thread only. Concurrent reads on
 /// different threads are also safe, but any writes must be externally synchronized. The Rust
 /// compiler will enforce this as long as you use only Rust threads, but it cannot protect against
-
 /// concurrent modification on other threads (e.g. created through GDScript).
-
-// `T` must be restricted to `GodotType` in the type, because `Drop` can only be implemented
-// for `T: GodotType` because `drop()` requires `sys_mut()`, which is on the `GodotFfi`
-// trait, whose `from_sys_init()` requires `Default`, which is only implemented for `T:
-// GodotType`. Whew. This could be fixed by splitting up `GodotFfi` if desired.
 pub struct Array<T: ArrayElement> {
     // Safety Invariant: The type of all values in `opaque` matches the type `T`.
     opaque: sys::types::OpaqueArray,
@@ -104,6 +98,51 @@ impl<T: ArrayElement> Array<T> {
         }
     }
 
+    /// Constructs an empty `Array`.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// ⚠️ Returns the value at the specified index.
+    ///
+    /// This replaces the `Index` trait, which cannot be implemented for `Array` as references are not guaranteed to remain valid.
+    ///
+    /// # Panics
+    ///
+    /// If `index` is out of bounds. If you want to handle out-of-bounds access, use [`get()`](Self::get) instead.
+    pub fn at(&self, index: usize) -> T {
+        // Panics on out-of-bounds.
+        let ptr = self.ptr(index);
+
+        // SAFETY: `ptr` is a live pointer to a variant since `ptr.is_null()` just verified that the index is not out of bounds.
+        let variant = unsafe { Variant::borrow_var_sys(ptr) };
+        T::from_variant(variant)
+    }
+
+    /// Returns the value at the specified index, or `None` if the index is out-of-bounds.
+    ///
+    /// If you know the index is correct, use [`at()`](Self::at) instead.
+    pub fn get(&self, index: usize) -> Option<T> {
+        let ptr = self.ptr_or_null(index);
+        if ptr.is_null() {
+            None
+        } else {
+            // SAFETY: `ptr` is a live pointer to a variant since `ptr.is_null()` just verified that the index is not out of bounds.
+            let variant = unsafe { Variant::borrow_var_sys(ptr) };
+            Some(T::from_variant(variant))
+        }
+    }
+
+    /// Returns `true` if the array contains the given value. Equivalent of `has` in GDScript.
+    pub fn contains(&self, value: &T) -> bool {
+        self.as_inner().has(value.to_variant())
+    }
+
+    /// Returns the number of times a value is in the array.
+    pub fn count(&self, value: &T) -> usize {
+        to_usize(self.as_inner().count(value.to_variant()))
+    }
+
     /// Returns the number of elements in the array. Equivalent of `size()` in Godot.
     ///
     /// Retrieving the size incurs an FFI call. If you know the size hasn't changed, you may consider storing
@@ -132,65 +171,140 @@ impl<T: ArrayElement> Array<T> {
         self.as_inner().hash().try_into().unwrap()
     }
 
+    /// Returns the first element in the array, or `None` if the array is empty.
+    ///
+    /// Equivalent of `front()` in GDScript.
+    #[doc(alias = "front")]
+    pub fn first(&self) -> Option<T> {
+        (!self.is_empty()).then(|| {
+            let variant = self.as_inner().front();
+            T::from_variant(&variant)
+        })
+    }
+
+    /// Returns the last element in the array, or `None` if the array is empty.
+    ///
+    /// Equivalent of `back()` in GDScript.
+    #[doc(alias = "back")]
+    pub fn last(&self) -> Option<T> {
+        (!self.is_empty()).then(|| {
+            let variant = self.as_inner().back();
+            T::from_variant(&variant)
+        })
+    }
+
     /// Clears the array, removing all elements.
     pub fn clear(&mut self) {
         // SAFETY: No new values are written to the array, we only remove values from the array.
         unsafe { self.as_inner_mut() }.clear();
     }
 
-    /// Reverses the order of the elements in the array.
-    pub fn reverse(&mut self) {
-        // SAFETY: We do not write any values that don't already exist in the array, so all values have the correct type.
-        unsafe { self.as_inner_mut() }.reverse();
-    }
+    /// Sets the value at the specified index.
+    ///
+    /// # Panics
+    ///
+    /// If `index` is out of bounds.
+    pub fn set(&mut self, index: usize, value: T) {
+        let ptr_mut = self.ptr_mut(index);
 
-    /// Sorts the array.
-    ///
-    /// Note: The sorting algorithm used is not
-    /// [stable](https://en.wikipedia.org/wiki/Sorting_algorithm#Stability). This means that values
-    /// considered equal may have their order changed when using `sort_unstable`.
-    #[doc(alias = "sort")]
-    pub fn sort_unstable(&mut self) {
-        // SAFETY: We do not write any values that don't already exist in the array, so all values have the correct type.
-        unsafe { self.as_inner_mut() }.sort();
-    }
-
-    /// Sorts the array.
-    ///
-    /// Uses the provided `Callable` to determine ordering.
-    ///
-    /// Note: The sorting algorithm used is not [stable](https://en.wikipedia.org/wiki/Sorting_algorithm#Stability).
-    /// This means that values considered equal may have their order changed when using
-    /// `sort_unstable`.
-    #[doc(alias = "sort_custom")]
-    pub fn sort_unstable_custom(&mut self, func: Callable) {
-        // SAFETY: We do not write any values that don't already exist in the array, so all values have the correct type.
-        unsafe { self.as_inner_mut() }.sort_custom(func);
-    }
-
-    /// Shuffles the array such that the items will have a random order. This method uses the
-    /// global random number generator common to methods such as `randi`. Call `randomize` to
-    /// ensure that a new seed will be used each time if you want non-reproducible shuffling.
-    pub fn shuffle(&mut self) {
-        // SAFETY: We do not write any values that don't already exist in the array, so all values have the correct type.
-        unsafe { self.as_inner_mut() }.shuffle();
-    }
-
-    /// Shrinks the array down to `new_size`.
-    ///
-    /// This will only change the size of the array if `new_size` is smaller than the current size. Returns `true` if the array was shrunk.
-    ///
-    /// If you want to increase the size of the array, use [`resize_with`](Array::resize_with) instead.
-    #[doc(alias = "resize")]
-    pub fn shrink(&mut self, new_size: usize) -> bool {
-        if new_size >= self.len() {
-            return false;
+        // SAFETY: `ptr_mut` just checked that the index is not out of bounds.
+        unsafe {
+            value.to_variant().move_into_var_ptr(ptr_mut);
         }
+    }
 
-        // SAFETY: Since `new_size` is less than the current size, we'll only be removing elements from the array.
-        unsafe { self.as_inner_mut() }.resize(to_i64(new_size));
+    /// Appends an element to the end of the array.
+    ///
+    /// _Godot equivalents: `append` and `push_back`_
+    #[doc(alias = "append")]
+    #[doc(alias = "push_back")]
+    pub fn push(&mut self, value: T) {
+        // SAFETY: The array has type `T` and we're writing a value of type `T` to it.
+        unsafe { self.as_inner_mut() }.push_back(value.to_variant());
+    }
 
-        true
+    /// Adds an element at the beginning of the array, in O(n) time.
+    ///
+    /// On large arrays, this method is much slower than [`push()`][Self::push], as it will move all the array's elements.
+    /// The larger the array, the slower `push_front()` will be.
+    pub fn push_front(&mut self, value: T) {
+        // SAFETY: The array has type `T` and we're writing a value of type `T` to it.
+        unsafe { self.as_inner_mut() }.push_front(value.to_variant());
+    }
+    /// Removes and returns the last element of the array. Returns `None` if the array is empty.
+    ///
+    /// _Godot equivalent: `pop_back`_
+    #[doc(alias = "pop_back")]
+    pub fn pop(&mut self) -> Option<T> {
+        (!self.is_empty()).then(|| {
+            // SAFETY: We do not write any values to the array, we just remove one.
+            let variant = unsafe { self.as_inner_mut() }.pop_back();
+            T::from_variant(&variant)
+        })
+    }
+
+    /// Removes and returns the first element of the array. Returns `None` if the array is empty.
+    ///
+    /// Note: On large arrays, this method is much slower than `pop()` as it will move all the
+    /// array's elements. The larger the array, the slower `pop_front()` will be.
+    pub fn pop_front(&mut self) -> Option<T> {
+        (!self.is_empty()).then(|| {
+            // SAFETY: We do not write any values to the array, we just remove one.
+            let variant = unsafe { self.as_inner_mut() }.pop_front();
+            T::from_variant(&variant)
+        })
+    }
+
+    /// Inserts a new element before the index. The index must be valid or the end of the array (`index == len()`).
+    ///
+    /// On large arrays, this method is much slower than [`push()`][Self::push], as it will move all the array's elements after the inserted element.
+    /// The larger the array, the slower `insert()` will be.
+    ///
+    /// # Panics
+    /// If `index > len()`.
+    pub fn insert(&mut self, index: usize, value: T) {
+        let len = self.len();
+        assert!(
+            index <= len,
+            "Array insertion index {index} is out of bounds: length is {len}",
+        );
+
+        // SAFETY: The array has type `T` and we're writing a value of type `T` to it.
+        unsafe { self.as_inner_mut() }.insert(to_i64(index), value.to_variant());
+    }
+
+    /// ⚠️ Removes and returns the element at the specified index. Equivalent of `pop_at` in GDScript.
+    ///
+    /// On large arrays, this method is much slower than `pop_back()` as it will move all the array's
+    /// elements after the removed element. The larger the array, the slower `remove()` will be.
+    ///
+    /// # Panics
+    ///
+    /// If `index` is out of bounds.
+    pub fn remove(&mut self, index: usize) -> T {
+        self.check_bounds(index);
+
+        // SAFETY: We do not write any values to the array, we just remove one.
+        let variant = unsafe { self.as_inner_mut() }.pop_at(to_i64(index));
+        T::from_variant(&variant)
+    }
+
+    /// Removes the first occurrence of a value from the array.
+    ///
+    /// If the value does not exist in the array, nothing happens. To remove an element by index, use [`remove()`][Self::remove] instead.
+    ///
+    /// On large arrays, this method is much slower than [`pop_back()`][Self::pop_back], as it will move all the array's
+    /// elements after the removed element.
+    pub fn erase(&mut self, value: &T) {
+        // SAFETY: We don't write anything to the array.
+        unsafe { self.as_inner_mut() }.erase(value.to_variant());
+    }
+
+    /// Assigns the given value to all elements in the array. This can be used together with
+    /// `resize` to create an array with a given size and initialized elements.
+    pub fn fill(&mut self, value: &T) {
+        // SAFETY: The array has type `T` and we're writing values of type `T` to it.
+        unsafe { self.as_inner_mut() }.fill(value.to_variant());
     }
 
     /// Resizes the array to contain a different number of elements.
@@ -210,6 +324,241 @@ impl<T: ArrayElement> Array<T> {
         for i in original_size..new_size {
             self.set(i, value.to_godot());
         }
+    }
+
+    /// Shrinks the array down to `new_size`.
+    ///
+    /// This will only change the size of the array if `new_size` is smaller than the current size. Returns `true` if the array was shrunk.
+    ///
+    /// If you want to increase the size of the array, use [`resize`](Array::resize) instead.
+    #[doc(alias = "resize")]
+    pub fn shrink(&mut self, new_size: usize) -> bool {
+        if new_size >= self.len() {
+            return false;
+        }
+
+        // SAFETY: Since `new_size` is less than the current size, we'll only be removing elements from the array.
+        unsafe { self.as_inner_mut() }.resize(to_i64(new_size));
+
+        true
+    }
+
+    /// Appends another array at the end of this array. Equivalent of `append_array` in GDScript.
+    pub fn extend_array(&mut self, other: Array<T>) {
+        // SAFETY: `append_array` will only read values from `other`, and all types can be converted to `Variant`.
+        let other: VariantArray = unsafe { other.assume_type::<Variant>() };
+
+        // SAFETY: `append_array` will only write values gotten from `other` into `self`, and all values in `other` are guaranteed
+        // to be of type `T`.
+        let mut inner_self = unsafe { self.as_inner_mut() };
+        inner_self.append_array(other);
+    }
+
+    /// Returns a shallow copy of the array. All array elements are copied, but any reference types
+    /// (such as `Array`, `Dictionary` and `Object`) will still refer to the same value.
+    ///
+    /// To create a deep copy, use [`duplicate_deep()`][Self::duplicate_deep] instead.
+    /// To create a new reference to the same array data, use [`clone()`][Clone::clone].
+    pub fn duplicate_shallow(&self) -> Self {
+        // SAFETY: We never write to the duplicated array, and all values read are read as `Variant`.
+        let duplicate: VariantArray = unsafe { self.as_inner().duplicate(false) };
+
+        // SAFETY: duplicate() returns a typed array with the same type as Self, and all values are taken from `self` so have the right type.
+        unsafe { duplicate.assume_type() }
+    }
+
+    /// Returns a deep copy of the array. All nested arrays and dictionaries are duplicated and
+    /// will not be shared with the original array. Note that any `Object`-derived elements will
+    /// still be shallow copied.
+    ///
+    /// To create a shallow copy, use [`duplicate_shallow()`][Self::duplicate_shallow] instead.
+    /// To create a new reference to the same array data, use [`clone()`][Clone::clone].
+    pub fn duplicate_deep(&self) -> Self {
+        // SAFETY: We never write to the duplicated array, and all values read are read as `Variant`.
+        let duplicate: VariantArray = unsafe { self.as_inner().duplicate(true) };
+
+        // SAFETY: duplicate() returns a typed array with the same type as Self, and all values are taken from `self` so have the right type.
+        unsafe { duplicate.assume_type() }
+    }
+
+    /// Returns a sub-range `begin..end`, as a new array.
+    ///
+    /// The values of `begin` (inclusive) and `end` (exclusive) will be clamped to the array size.
+    ///
+    /// If specified, `step` is the relative index between source elements. It can be negative,
+    /// in which case `begin` must be higher than `end`. For example,
+    /// `Array::from(&[0, 1, 2, 3, 4, 5]).slice(5, 1, -2)` returns `[5, 3]`.
+    ///
+    /// Array elements are copied to the slice, but any reference types (such as `Array`,
+    /// `Dictionary` and `Object`) will still refer to the same value. To create a deep copy, use
+    /// [`subarray_deep()`][Self::subarray_deep] instead.
+    #[doc(alias = "slice")]
+    pub fn subarray_shallow(&self, begin: usize, end: usize, step: Option<isize>) -> Self {
+        self.subarray_impl(begin, end, step, false)
+    }
+
+    /// Returns a sub-range `begin..end`, as a new `Array`.
+    ///
+    /// The values of `begin` (inclusive) and `end` (exclusive) will be clamped to the array size.
+    ///
+    /// If specified, `step` is the relative index between source elements. It can be negative,
+    /// in which case `begin` must be higher than `end`. For example,
+    /// `Array::from(&[0, 1, 2, 3, 4, 5]).slice(5, 1, -2)` returns `[5, 3]`.
+    ///
+    /// All nested arrays and dictionaries are duplicated and will not be shared with the original
+    /// array. Note that any `Object`-derived elements will still be shallow copied. To create a
+    /// shallow copy, use [`subarray_shallow()`][Self::subarray_shallow] instead.
+    #[doc(alias = "slice")]
+    pub fn subarray_deep(&self, begin: usize, end: usize, step: Option<isize>) -> Self {
+        self.subarray_impl(begin, end, step, true)
+    }
+
+    fn subarray_impl(&self, begin: usize, end: usize, step: Option<isize>, deep: bool) -> Self {
+        assert_ne!(step, Some(0), "subarray: step cannot be zero");
+
+        let len = self.len();
+        let begin = begin.min(len);
+        let end = end.min(len);
+        let step = step.unwrap_or(1);
+
+        // SAFETY: The type of the array is `T` and we convert the returned array to an `Array<T>` immediately.
+        let subarray: VariantArray = unsafe {
+            self.as_inner()
+                .slice(to_i64(begin), to_i64(end), step.try_into().unwrap(), deep)
+        };
+
+        // SAFETY: slice() returns a typed array with the same type as Self
+        unsafe { subarray.assume_type() }
+    }
+
+    /// Returns an iterator over the elements of the `Array`. Note that this takes the array
+    /// by reference but returns its elements by value, since they are internally converted from
+    /// `Variant`.
+    ///
+    /// Notice that it's possible to modify the `Array` through another reference while
+    /// iterating over it. This will not result in unsoundness or crashes, but will cause the
+    /// iterator to behave in an unspecified way.
+    pub fn iter_shared(&self) -> Iter<'_, T> {
+        Iter {
+            array: self,
+            next_idx: 0,
+        }
+    }
+
+    /// Returns the minimum value contained in the array if all elements are of comparable types.
+    ///
+    /// If the elements can't be compared or the array is empty, `None` is returned.
+    pub fn min(&self) -> Option<T> {
+        let min = self.as_inner().min();
+        (!min.is_nil()).then(|| T::from_variant(&min))
+    }
+
+    /// Returns the maximum value contained in the array if all elements are of comparable types.
+    ///
+    /// If the elements can't be compared or the array is empty, `None` is returned.
+    pub fn max(&self) -> Option<T> {
+        let max = self.as_inner().max();
+        (!max.is_nil()).then(|| T::from_variant(&max))
+    }
+
+    /// Returns a random element from the array, or `None` if it is empty.
+    pub fn pick_random(&self) -> Option<T> {
+        (!self.is_empty()).then(|| {
+            let variant = self.as_inner().pick_random();
+            T::from_variant(&variant)
+        })
+    }
+
+    /// Searches the array for the first occurrence of a value and returns its index, or `None` if
+    /// not found. Starts searching at index `from`; pass `None` to search the entire array.
+    pub fn find(&self, value: &T, from: Option<usize>) -> Option<usize> {
+        let from = to_i64(from.unwrap_or(0));
+        let index = self.as_inner().find(value.to_variant(), from);
+        if index >= 0 {
+            Some(index.try_into().unwrap())
+        } else {
+            None
+        }
+    }
+
+    /// Searches the array backwards for the last occurrence of a value and returns its index, or
+    /// `None` if not found. Starts searching at index `from`; pass `None` to search the entire
+    /// array.
+    pub fn rfind(&self, value: &T, from: Option<usize>) -> Option<usize> {
+        let from = from.map(to_i64).unwrap_or(-1);
+        let index = self.as_inner().rfind(value.to_variant(), from);
+        // It's not documented, but `rfind` returns -1 if not found.
+        if index >= 0 {
+            Some(to_usize(index))
+        } else {
+            None
+        }
+    }
+
+    /// Finds the index of an existing value in a sorted array using binary search.
+    /// Equivalent of `bsearch` in GDScript.
+    ///
+    /// If the value is not present in the array, returns the insertion index that
+    /// would maintain sorting order.
+    ///
+    /// Calling `bsearch` on an unsorted array results in unspecified behavior.
+    pub fn bsearch(&self, value: &T) -> usize {
+        to_usize(self.as_inner().bsearch(value.to_variant(), true))
+    }
+
+    /// Finds the index of an existing value in a sorted array using binary search.
+    /// Equivalent of `bsearch_custom` in GDScript.
+    ///
+    /// Takes a `Callable` and uses the return value of it to perform binary search.
+    ///
+    /// If the value is not present in the array, returns the insertion index that
+    /// would maintain sorting order.
+    ///
+    /// Calling `bsearch_custom` on an unsorted array results in unspecified behavior.
+    ///
+    /// Consider using `sort_custom()` to ensure the sorting order is compatible with
+    /// your callable's ordering
+    pub fn bsearch_custom(&self, value: &T, func: Callable) -> usize {
+        to_usize(
+            self.as_inner()
+                .bsearch_custom(value.to_variant(), func, true),
+        )
+    }
+
+    /// Reverses the order of the elements in the array.
+    pub fn reverse(&mut self) {
+        // SAFETY: We do not write any values that don't already exist in the array, so all values have the correct type.
+        unsafe { self.as_inner_mut() }.reverse();
+    }
+
+    /// Sorts the array.
+    ///
+    /// Note: The sorting algorithm used is not [stable](https://en.wikipedia.org/wiki/Sorting_algorithm#Stability).
+    /// This means that values considered equal may have their order changed when using `sort_unstable`.
+    #[doc(alias = "sort")]
+    pub fn sort_unstable(&mut self) {
+        // SAFETY: We do not write any values that don't already exist in the array, so all values have the correct type.
+        unsafe { self.as_inner_mut() }.sort();
+    }
+
+    /// Sorts the array.
+    ///
+    /// Uses the provided `Callable` to determine ordering.
+    ///
+    /// Note: The sorting algorithm used is not [stable](https://en.wikipedia.org/wiki/Sorting_algorithm#Stability).
+    /// This means that values considered equal may have their order changed when using `sort_unstable_custom`.
+    #[doc(alias = "sort_custom")]
+    pub fn sort_unstable_custom(&mut self, func: Callable) {
+        // SAFETY: We do not write any values that don't already exist in the array, so all values have the correct type.
+        unsafe { self.as_inner_mut() }.sort_custom(func);
+    }
+
+    /// Shuffles the array such that the items will have a random order. This method uses the
+    /// global random number generator common to methods such as `randi`. Call `randomize` to
+    /// ensure that a new seed will be used each time if you want non-reproducible shuffling.
+    pub fn shuffle(&mut self) {
+        // SAFETY: We do not write any values that don't already exist in the array, so all values have the correct type.
+        unsafe { self.as_inner_mut() }.shuffle();
     }
 
     /// Asserts that the given index refers to an existing element.
@@ -317,101 +666,6 @@ impl<T: ArrayElement> Array<T> {
         // SAFETY: The memory layout of `Array<T>` does not depend on `T`.
         unsafe { std::mem::transmute(self) }
     }
-}
-
-impl<T: ArrayElement> Array<T> {
-    /// Constructs an empty `Array`.
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Returns a shallow copy of the array. All array elements are copied, but any reference types
-    /// (such as `Array`, `Dictionary` and `Object`) will still refer to the same value.
-    ///
-    /// To create a deep copy, use [`duplicate_deep()`][Self::duplicate_deep] instead.
-    /// To create a new reference to the same array data, use [`clone()`][Clone::clone].
-    pub fn duplicate_shallow(&self) -> Self {
-        // SAFETY: We never write to the duplicated array, and all values read are read as `Variant`.
-        let duplicate: VariantArray = unsafe { self.as_inner().duplicate(false) };
-
-        // SAFETY: duplicate() returns a typed array with the same type as Self, and all values are taken from `self` so have the right type.
-        unsafe { duplicate.assume_type() }
-    }
-
-    /// Returns a deep copy of the array. All nested arrays and dictionaries are duplicated and
-    /// will not be shared with the original array. Note that any `Object`-derived elements will
-    /// still be shallow copied.
-    ///
-    /// To create a shallow copy, use [`duplicate_shallow()`][Self::duplicate_shallow] instead.
-    /// To create a new reference to the same array data, use [`clone()`][Clone::clone].
-    pub fn duplicate_deep(&self) -> Self {
-        // SAFETY: We never write to the duplicated array, and all values read are read as `Variant`.
-        let duplicate: VariantArray = unsafe { self.as_inner().duplicate(true) };
-
-        // SAFETY: duplicate() returns a typed array with the same type as Self, and all values are taken from `self` so have the right type.
-        unsafe { duplicate.assume_type() }
-    }
-
-    /// Returns a sub-range `begin..end`, as a new array.
-    ///
-    /// The values of `begin` (inclusive) and `end` (exclusive) will be clamped to the array size.
-    ///
-    /// If specified, `step` is the relative index between source elements. It can be negative,
-    /// in which case `begin` must be higher than `end`. For example,
-    /// `Array::from(&[0, 1, 2, 3, 4, 5]).slice(5, 1, -2)` returns `[5, 3]`.
-    ///
-    /// Array elements are copied to the slice, but any reference types (such as `Array`,
-    /// `Dictionary` and `Object`) will still refer to the same value. To create a deep copy, use
-    /// [`subarray_deep()`][Self::subarray_deep] instead.
-    #[doc(alias = "slice")]
-    pub fn subarray_shallow(&self, begin: usize, end: usize, step: Option<isize>) -> Self {
-        self.subarray_impl(begin, end, step, false)
-    }
-
-    /// Returns a sub-range `begin..end`, as a new `Array`.
-    ///
-    /// The values of `begin` (inclusive) and `end` (exclusive) will be clamped to the array size.
-    ///
-    /// If specified, `step` is the relative index between source elements. It can be negative,
-    /// in which case `begin` must be higher than `end`. For example,
-    /// `Array::from(&[0, 1, 2, 3, 4, 5]).slice(5, 1, -2)` returns `[5, 3]`.
-    ///
-    /// All nested arrays and dictionaries are duplicated and will not be shared with the original
-    /// array. Note that any `Object`-derived elements will still be shallow copied. To create a
-    /// shallow copy, use [`subarray_shallow()`][Self::subarray_shallow] instead.
-    #[doc(alias = "slice")]
-    pub fn subarray_deep(&self, begin: usize, end: usize, step: Option<isize>) -> Self {
-        self.subarray_impl(begin, end, step, true)
-    }
-
-    fn subarray_impl(&self, begin: usize, end: usize, step: Option<isize>, deep: bool) -> Self {
-        assert_ne!(step, Some(0), "subarray: step cannot be zero");
-
-        let len = self.len();
-        let begin = begin.min(len);
-        let end = end.min(len);
-        let step = step.unwrap_or(1);
-
-        // SAFETY: The type of the array is `T` and we convert the returned array to an `Array<T>` immediately.
-        let subarray: VariantArray = unsafe {
-            self.as_inner()
-                .slice(to_i64(begin), to_i64(end), step.try_into().unwrap(), deep)
-        };
-
-        // SAFETY: slice() returns a typed array with the same type as Self
-        unsafe { subarray.assume_type() }
-    }
-
-    /// Appends another array at the end of this array. Equivalent of `append_array` in GDScript.
-    pub fn extend_array(&mut self, other: Array<T>) {
-        // SAFETY: `append_array` will only read values from `other`, and all types can be converted to `Variant`.
-        let other: VariantArray = unsafe { other.assume_type::<Variant>() };
-
-        // SAFETY: `append_array` will only write values gotten from `other` into `self`, and all values in `other` are guaranteed
-        // to be of type `T`.
-        let mut inner_self = unsafe { self.as_inner_mut() };
-        inner_self.append_array(other);
-    }
 
     /// Returns the runtime type info of this array.
     fn type_info(&self) -> TypeInfo {
@@ -465,262 +719,6 @@ impl<T: ArrayElement> Array<T> {
                 );
             }
         }
-    }
-}
-
-impl<T: ArrayElement + FromGodot> Array<T> {
-    /// Returns an iterator over the elements of the `Array`. Note that this takes the array
-    /// by reference but returns its elements by value, since they are internally converted from
-    /// `Variant`.
-    ///
-    /// Notice that it's possible to modify the `Array` through another reference while
-    /// iterating over it. This will not result in unsoundness or crashes, but will cause the
-    /// iterator to behave in an unspecified way.
-    pub fn iter_shared(&self) -> Iter<'_, T> {
-        Iter {
-            array: self,
-            next_idx: 0,
-        }
-    }
-
-    /// ⚠️ Returns the value at the specified index.
-    ///
-    /// This replaces the `Index` trait, which cannot be implemented for `Array` as references are not guaranteed to remain valid.
-    ///
-    /// # Panics
-    ///
-    /// If `index` is out of bounds. If you want to handle out-of-bounds access, use [`get()`](Self::get) instead.
-    pub fn at(&self, index: usize) -> T {
-        // Panics on out-of-bounds.
-        let ptr = self.ptr(index);
-
-        // SAFETY: `ptr` is a live pointer to a variant since `ptr.is_null()` just verified that the index is not out of bounds.
-        let variant = unsafe { Variant::borrow_var_sys(ptr) };
-        T::from_variant(variant)
-    }
-
-    /// Returns the value at the specified index, or `None` if the index is out-of-bounds.
-    ///
-    /// If you know the index is correct, use [`at()`](Self::at) instead.
-    pub fn get(&self, index: usize) -> Option<T> {
-        let ptr = self.ptr_or_null(index);
-        if ptr.is_null() {
-            None
-        } else {
-            // SAFETY: `ptr` is a live pointer to a variant since `ptr.is_null()` just verified that the index is not out of bounds.
-            let variant = unsafe { Variant::borrow_var_sys(ptr) };
-            Some(T::from_variant(variant))
-        }
-    }
-
-    /// Returns the first element in the array, or `None` if the array is empty. Equivalent of
-    /// `front()` in GDScript.
-    pub fn first(&self) -> Option<T> {
-        (!self.is_empty()).then(|| {
-            let variant = self.as_inner().front();
-            T::from_variant(&variant)
-        })
-    }
-
-    /// Returns the last element in the array, or `None` if the array is empty. Equivalent of
-    /// `back()` in GDScript.
-    pub fn last(&self) -> Option<T> {
-        (!self.is_empty()).then(|| {
-            let variant = self.as_inner().back();
-            T::from_variant(&variant)
-        })
-    }
-
-    /// Returns the minimum value contained in the array if all elements are of comparable types.
-    /// If the elements can't be compared or the array is empty, `None` is returned.
-    pub fn min(&self) -> Option<T> {
-        let min = self.as_inner().min();
-        (!min.is_nil()).then(|| T::from_variant(&min))
-    }
-
-    /// Returns the maximum value contained in the array if all elements are of comparable types.
-    /// If the elements can't be compared or the array is empty, `None` is returned.
-    pub fn max(&self) -> Option<T> {
-        let max = self.as_inner().max();
-        (!max.is_nil()).then(|| T::from_variant(&max))
-    }
-
-    /// Returns a random element from the array, or `None` if it is empty.
-    pub fn pick_random(&self) -> Option<T> {
-        (!self.is_empty()).then(|| {
-            let variant = self.as_inner().pick_random();
-            T::from_variant(&variant)
-        })
-    }
-
-    /// Removes and returns the last element of the array. Returns `None` if the array is empty.
-    /// Equivalent of `pop_back` in GDScript.
-    pub fn pop(&mut self) -> Option<T> {
-        (!self.is_empty()).then(|| {
-            // SAFETY: We do not write any values to the array, we just remove one.
-            let variant = unsafe { self.as_inner_mut() }.pop_back();
-            T::from_variant(&variant)
-        })
-    }
-
-    /// Removes and returns the first element of the array. Returns `None` if the array is empty.
-    ///
-    /// Note: On large arrays, this method is much slower than `pop` as it will move all the
-    /// array's elements. The larger the array, the slower `pop_front` will be.
-    pub fn pop_front(&mut self) -> Option<T> {
-        (!self.is_empty()).then(|| {
-            // SAFETY: We do not write any values to the array, we just remove one.
-            let variant = unsafe { self.as_inner_mut() }.pop_front();
-            T::from_variant(&variant)
-        })
-    }
-
-    /// Removes and returns the element at the specified index. Equivalent of `pop_at` in GDScript.
-    ///
-    /// On large arrays, this method is much slower than `pop_back` as it will move all the array's
-    /// elements after the removed element. The larger the array, the slower `remove` will be.
-    ///
-    /// # Panics
-    ///
-    /// If `index` is out of bounds.
-    pub fn remove(&mut self, index: usize) -> T {
-        self.check_bounds(index);
-
-        // SAFETY: We do not write any values to the array, we just remove one.
-        let variant = unsafe { self.as_inner_mut() }.pop_at(to_i64(index));
-        T::from_variant(&variant)
-    }
-}
-
-impl<T: ArrayElement + ToGodot> Array<T> {
-    /// Finds the index of an existing value in a sorted array using binary search.
-    /// Equivalent of `bsearch` in GDScript.
-    ///
-    /// If the value is not present in the array, returns the insertion index that
-    /// would maintain sorting order.
-    ///
-    /// Calling `bsearch` on an unsorted array results in unspecified behavior.
-    pub fn bsearch(&self, value: &T) -> usize {
-        to_usize(self.as_inner().bsearch(value.to_variant(), true))
-    }
-
-    /// Finds the index of an existing value in a sorted array using binary search.
-    /// Equivalent of `bsearch_custom` in GDScript.
-    ///
-    /// Takes a `Callable` and uses the return value of it to perform binary search.
-    ///
-    /// If the value is not present in the array, returns the insertion index that
-    /// would maintain sorting order.
-    ///
-    /// Calling `bsearch_custom` on an unsorted array results in unspecified behavior.
-    ///
-    /// Consider using `sort_custom()` to ensure the sorting order is compatible with
-    /// your callable's ordering
-    pub fn bsearch_custom(&self, value: &T, func: Callable) -> usize {
-        to_usize(
-            self.as_inner()
-                .bsearch_custom(value.to_variant(), func, true),
-        )
-    }
-
-    /// Returns the number of times a value is in the array.
-    pub fn count(&self, value: &T) -> usize {
-        to_usize(self.as_inner().count(value.to_variant()))
-    }
-
-    /// Returns `true` if the array contains the given value. Equivalent of `has` in GDScript.
-    pub fn contains(&self, value: &T) -> bool {
-        self.as_inner().has(value.to_variant())
-    }
-
-    /// Searches the array for the first occurrence of a value and returns its index, or `None` if
-    /// not found. Starts searching at index `from`; pass `None` to search the entire array.
-    pub fn find(&self, value: &T, from: Option<usize>) -> Option<usize> {
-        let from = to_i64(from.unwrap_or(0));
-        let index = self.as_inner().find(value.to_variant(), from);
-        if index >= 0 {
-            Some(index.try_into().unwrap())
-        } else {
-            None
-        }
-    }
-
-    /// Searches the array backwards for the last occurrence of a value and returns its index, or
-    /// `None` if not found. Starts searching at index `from`; pass `None` to search the entire
-    /// array.
-    pub fn rfind(&self, value: &T, from: Option<usize>) -> Option<usize> {
-        let from = from.map(to_i64).unwrap_or(-1);
-        let index = self.as_inner().rfind(value.to_variant(), from);
-        // It's not documented, but `rfind` returns -1 if not found.
-        if index >= 0 {
-            Some(to_usize(index))
-        } else {
-            None
-        }
-    }
-
-    /// Sets the value at the specified index.
-    ///
-    /// # Panics
-    ///
-    /// If `index` is out of bounds.
-    pub fn set(&mut self, index: usize, value: T) {
-        let ptr_mut = self.ptr_mut(index);
-
-        // SAFETY: `ptr_mut` just checked that the index is not out of bounds.
-        unsafe {
-            value.to_variant().move_into_var_ptr(ptr_mut);
-        }
-    }
-
-    /// Appends an element to the end of the array. Equivalent of `append` and `push_back` in
-    /// GDScript.
-    pub fn push(&mut self, value: T) {
-        // SAFETY: The array has type `T` and we're writing a value of type `T` to it.
-        unsafe { self.as_inner_mut() }.push_back(value.to_variant());
-    }
-
-    /// Adds an element at the beginning of the array. See also `push`.
-    ///
-    /// Note: On large arrays, this method is much slower than `push` as it will move all the
-    /// array's elements. The larger the array, the slower `push_front` will be.
-    pub fn push_front(&mut self, value: T) {
-        // SAFETY: The array has type `T` and we're writing a value of type `T` to it.
-        unsafe { self.as_inner_mut() }.push_front(value.to_variant());
-    }
-
-    /// Inserts a new element at a given index in the array. The index must be valid, or at the end
-    /// of the array (`index == len()`).
-    ///
-    /// Note: On large arrays, this method is much slower than `push` as it will move all the
-    /// array's elements after the inserted element. The larger the array, the slower `insert` will
-    /// be.
-    pub fn insert(&mut self, index: usize, value: T) {
-        let len = self.len();
-        assert!(
-            index <= len,
-            "Array insertion index {index} is out of bounds: length is {len}",
-        );
-
-        // SAFETY: The array has type `T` and we're writing a value of type `T` to it.
-        unsafe { self.as_inner_mut() }.insert(to_i64(index), value.to_variant());
-    }
-
-    /// Removes the first occurrence of a value from the array. If the value does not exist in the
-    /// array, nothing happens. To remove an element by index, use `remove` instead.
-    ///
-    /// On large arrays, this method is much slower than `pop_back` as it will move all the array's
-    /// elements after the removed element. The larger the array, the slower `remove` will be.
-    pub fn erase(&mut self, value: &T) {
-        // SAFETY: We don't write anything to the array.
-        unsafe { self.as_inner_mut() }.erase(value.to_variant());
-    }
-
-    /// Assigns the given value to all elements in the array. This can be used together with
-    /// `resize` to create an array with a given size and initialized elements.
-    pub fn fill(&mut self, value: &T) {
-        // SAFETY: The array has type `T` and we're writing values of type `T` to it.
-        unsafe { self.as_inner_mut() }.fill(value.to_variant());
     }
 }
 
@@ -818,7 +816,7 @@ impl<T: ArrayElement> Clone for Array<T> {
         // SAFETY: `self` is a valid array, since we have a reference that keeps it alive.
         let array = unsafe {
             Self::new_with_uninit(|self_ptr| {
-                let ctor = ::godot_ffi::builtin_fn!(array_construct_copy);
+                let ctor = sys::builtin_fn!(array_construct_copy);
                 let args = [self.sys()];
                 ctor(self_ptr, args.as_ptr());
             })
@@ -895,6 +893,9 @@ impl<T: ArrayElement> Default for Array<T> {
     }
 }
 
+// T must be GodotType (or subtrait ArrayElement), because drop() requires sys_mut(), which is on the GodotFfi trait.
+// Its sister method GodotFfi::from_sys_init() requires Default, which is only implemented for T: GodotType.
+// This could be addressed by splitting up GodotFfi if desired.
 impl<T: ArrayElement> Drop for Array<T> {
     #[inline]
     fn drop(&mut self) {
@@ -922,7 +923,7 @@ impl<T: ArrayElement> GodotType for Array<T> {
     }
 
     fn godot_type_name() -> String {
-        "Array".into()
+        "Array".to_string()
     }
 }
 
@@ -1084,7 +1085,7 @@ impl<T: ArrayElement> PartialOrd for Array<T> {
             let mut result = false;
             sys::builtin_call! {
                 array_operator_less(lhs, rhs, result.sys_mut())
-            };
+            }
             result
         };
 
@@ -1250,7 +1251,7 @@ mod serialize {
             {
                 type Value = Array<T>;
 
-                fn expecting(&self, formatter: &mut std::fmt::Formatter) -> fmt::Result {
+                fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
                     formatter.write_str(std::any::type_name::<Self::Value>())
                 }
 

--- a/godot-core/src/builtin/array.rs
+++ b/godot-core/src/builtin/array.rs
@@ -133,6 +133,11 @@ impl<T: ArrayElement> Array<T> {
         }
     }
 
+    #[deprecated = "Renamed to `get`."]
+    pub fn try_get(&self, index: usize) -> Option<T> {
+        self.get(index)
+    }
+
     /// Returns `true` if the array contains the given value. Equivalent of `has` in GDScript.
     pub fn contains(&self, value: &T) -> bool {
         self.as_inner().has(value.to_variant())
@@ -172,10 +177,8 @@ impl<T: ArrayElement> Array<T> {
     }
 
     /// Returns the first element in the array, or `None` if the array is empty.
-    ///
-    /// Equivalent of `front()` in GDScript.
-    #[doc(alias = "front")]
-    pub fn first(&self) -> Option<T> {
+    #[doc(alias = "first")]
+    pub fn front(&self) -> Option<T> {
         (!self.is_empty()).then(|| {
             let variant = self.as_inner().front();
             T::from_variant(&variant)
@@ -183,14 +186,22 @@ impl<T: ArrayElement> Array<T> {
     }
 
     /// Returns the last element in the array, or `None` if the array is empty.
-    ///
-    /// Equivalent of `back()` in GDScript.
-    #[doc(alias = "back")]
-    pub fn last(&self) -> Option<T> {
+    #[doc(alias = "last")]
+    pub fn back(&self) -> Option<T> {
         (!self.is_empty()).then(|| {
             let variant = self.as_inner().back();
             T::from_variant(&variant)
         })
+    }
+
+    #[deprecated = "Renamed to `front`, in line with GDScript method and consistent with `push_front` and `pop_front`."]
+    pub fn first(&self) -> Option<T> {
+        self.front()
+    }
+
+    #[deprecated = "Renamed to `back`, in line with GDScript method."]
+    pub fn last(&self) -> Option<T> {
+        self.back()
     }
 
     /// Clears the array, removing all elements.
@@ -223,7 +234,7 @@ impl<T: ArrayElement> Array<T> {
         unsafe { self.as_inner_mut() }.push_back(value.to_variant());
     }
 
-    /// Adds an element at the beginning of the array, in O(n) time.
+    /// Adds an element at the beginning of the array, in O(n).
     ///
     /// On large arrays, this method is much slower than [`push()`][Self::push], as it will move all the array's elements.
     /// The larger the array, the slower `push_front()` will be.
@@ -243,7 +254,7 @@ impl<T: ArrayElement> Array<T> {
         })
     }
 
-    /// Removes and returns the first element of the array. Returns `None` if the array is empty.
+    /// Removes and returns the first element of the array, in O(n). Returns `None` if the array is empty.
     ///
     /// Note: On large arrays, this method is much slower than `pop()` as it will move all the
     /// array's elements. The larger the array, the slower `pop_front()` will be.

--- a/godot-core/src/builtin/array.rs
+++ b/godot-core/src/builtin/array.rs
@@ -483,13 +483,15 @@ impl<T: ArrayElement + FromGodot> Array<T> {
         }
     }
 
-    /// Returns the value at the specified index.
+    /// ⚠️ Returns the value at the specified index.
+    ///
+    /// This replaces the `Index` trait, which cannot be implemented for `Array` as references are not guaranteed to remain valid.
     ///
     /// # Panics
     ///
-    /// If `index` is out of bounds.
-    pub fn get(&self, index: usize) -> T {
-        // Panics on out-of-bounds
+    /// If `index` is out of bounds. If you want to handle out-of-bounds access, use [`get()`](Self::get) instead.
+    pub fn at(&self, index: usize) -> T {
+        // Panics on out-of-bounds.
         let ptr = self.ptr(index);
 
         // SAFETY: `ptr` is a live pointer to a variant since `ptr.is_null()` just verified that the index is not out of bounds.
@@ -497,8 +499,10 @@ impl<T: ArrayElement + FromGodot> Array<T> {
         T::from_variant(variant)
     }
 
-    /// Returns the value at the specified index or `None` if the index is out-of-bounds.
-    pub fn try_get(&self, index: usize) -> Option<T> {
+    /// Returns the value at the specified index, or `None` if the index is out-of-bounds.
+    ///
+    /// If you know the index is correct, use [`at()`](Self::at) instead.
+    pub fn get(&self, index: usize) -> Option<T> {
         let ptr = self.ptr_or_null(index);
         if ptr.is_null() {
             None

--- a/godot-core/src/builtin/dictionary.rs
+++ b/godot-core/src/builtin/dictionary.rs
@@ -40,66 +40,6 @@ impl Dictionary {
         Self::default()
     }
 
-    /// Removes all key-value pairs from the dictionary.
-    pub fn clear(&mut self) {
-        self.as_inner().clear()
-    }
-
-    /// Returns a deep copy of the dictionary. All nested arrays and dictionaries are duplicated and
-    /// will not be shared with the original dictionary. Note that any `Object`-derived elements will
-    /// still be shallow copied.
-    ///
-    /// To create a shallow copy, use [`Self::duplicate_shallow()`] instead.
-    /// To create a new reference to the same dictionary data, use [`clone()`][Clone::clone].
-    ///
-    /// _Godot equivalent: `dict.duplicate(true)`_
-    pub fn duplicate_deep(&self) -> Self {
-        self.as_inner().duplicate(true)
-    }
-
-    /// Returns a shallow copy of the dictionary. All dictionary keys and values are copied, but
-    /// any reference types (such as `Array`, `Dictionary` and `Object`) will still refer to the
-    /// same value.
-    ///
-    /// To create a deep copy, use [`Self::duplicate_deep()`] instead.
-    /// To create a new reference to the same dictionary data, use [`clone()`][Clone::clone].
-    ///
-    /// _Godot equivalent: `dict.duplicate(false)`_
-    pub fn duplicate_shallow(&self) -> Self {
-        self.as_inner().duplicate(false)
-    }
-
-    /// Removes a key from the map, and returns the value associated with
-    /// the key if the key was in the dictionary.
-    ///
-    /// _Godot equivalent: `erase`_
-    #[doc(alias = "erase")]
-    pub fn remove<K: ToGodot>(&mut self, key: K) -> Option<Variant> {
-        let key = key.to_variant();
-        let old_value = self.get(key.clone());
-        self.as_inner().erase(key);
-        old_value
-    }
-
-    /// Reverse-search a key by its value.
-    ///
-    /// Unlike Godot, this will return `None` if the key does not exist and `Some(Variant::nil())` the key is `NIL`.
-    ///
-    /// This operation is rarely needed and very inefficient. If you find yourself needing it a lot, consider
-    /// using a `HashMap` or `Dictionary` with the inverse mapping (`V` -> `K`).
-    ///
-    /// _Godot equivalent: `find_key`_
-    #[doc(alias = "find_key")]
-    pub fn find_key_by_value<V: ToGodot>(&self, value: V) -> Option<Variant> {
-        let key = self.as_inner().find_key(value.to_variant());
-
-        if !key.is_nil() || self.contains_key(key.clone()) {
-            Some(key)
-        } else {
-            None
-        }
-    }
-
     /// ⚠️ Returns the value for the given key, or panics.
     ///
     /// If you want to check for presence, use [`get()`][Self::get] or [`get_or_nil()`][Self::get_or_nil].
@@ -166,6 +106,79 @@ impl Dictionary {
         self.as_inner().has_all(keys)
     }
 
+    /// Returns the number of entries in the dictionary.
+    ///
+    /// _Godot equivalent: `size`_
+    #[doc(alias = "size")]
+    pub fn len(&self) -> usize {
+        self.as_inner().size().try_into().unwrap()
+    }
+
+    /// Returns true if the dictionary is empty.
+    pub fn is_empty(&self) -> bool {
+        self.as_inner().is_empty()
+    }
+
+    /// Reverse-search a key by its value.
+    ///
+    /// Unlike Godot, this will return `None` if the key does not exist and `Some(Variant::nil())` the key is `NIL`.
+    ///
+    /// This operation is rarely needed and very inefficient. If you find yourself needing it a lot, consider
+    /// using a `HashMap` or `Dictionary` with the inverse mapping (`V` -> `K`).
+    ///
+    /// _Godot equivalent: `find_key`_
+    #[doc(alias = "find_key")]
+    pub fn find_key_by_value<V: ToGodot>(&self, value: V) -> Option<Variant> {
+        let key = self.as_inner().find_key(value.to_variant());
+
+        if !key.is_nil() || self.contains_key(key.clone()) {
+            Some(key)
+        } else {
+            None
+        }
+    }
+
+    /// Removes all key-value pairs from the dictionary.
+    pub fn clear(&mut self) {
+        self.as_inner().clear()
+    }
+
+    /// Set a key to a given value.
+    ///
+    /// If you are interested in the previous value, use [`insert()`][Self::insert] instead.
+    ///
+    /// _Godot equivalent: `dict[key] = value`_
+    pub fn set<K: ToGodot, V: ToGodot>(&mut self, key: K, value: V) {
+        let key = key.to_variant();
+
+        // SAFETY: `self.get_ptr_mut(key)` always returns a valid pointer to a value in the dictionary; either pre-existing or newly inserted.
+        unsafe {
+            value.to_variant().move_into_var_ptr(self.get_ptr_mut(key));
+        }
+    }
+
+    /// Insert a value at the given key, returning the previous value for that key (if available).
+    ///
+    /// If you don't need the previous value, use [`set()`][Self::set] instead.
+    pub fn insert<K: ToGodot, V: ToGodot>(&mut self, key: K, value: V) -> Option<Variant> {
+        let key = key.to_variant();
+        let old_value = self.get(key.clone());
+        self.set(key, value);
+        old_value
+    }
+
+    /// Removes a key from the map, and returns the value associated with
+    /// the key if the key was in the dictionary.
+    ///
+    /// _Godot equivalent: `erase`_
+    #[doc(alias = "erase")]
+    pub fn remove<K: ToGodot>(&mut self, key: K) -> Option<Variant> {
+        let key = key.to_variant();
+        let old_value = self.get(key.clone());
+        self.as_inner().erase(key);
+        old_value
+    }
+
     /// Returns a 32-bit integer hash value representing the dictionary and its contents.
     #[must_use]
     pub fn hash(&self) -> u32 {
@@ -188,11 +201,6 @@ impl Dictionary {
         self.as_inner().values()
     }
 
-    /// Returns true if the dictionary is empty.
-    pub fn is_empty(&self) -> bool {
-        self.as_inner().is_empty()
-    }
-
     /// Copies all keys and values from `other` into `self`.
     ///
     /// If `overwrite` is true, it will overwrite pre-existing keys.
@@ -203,36 +211,28 @@ impl Dictionary {
         self.as_inner().merge(other, overwrite)
     }
 
-    /// Returns the number of entries in the dictionary.
+    /// Returns a deep copy of the dictionary. All nested arrays and dictionaries are duplicated and
+    /// will not be shared with the original dictionary. Note that any `Object`-derived elements will
+    /// still be shallow copied.
     ///
-    /// This is equivalent to `size` in Godot.
-    #[doc(alias = "size")]
-    pub fn len(&self) -> usize {
-        self.as_inner().size().try_into().unwrap()
+    /// To create a shallow copy, use [`Self::duplicate_shallow()`] instead.
+    /// To create a new reference to the same dictionary data, use [`clone()`][Clone::clone].
+    ///
+    /// _Godot equivalent: `dict.duplicate(true)`_
+    pub fn duplicate_deep(&self) -> Self {
+        self.as_inner().duplicate(true)
     }
 
-    /// Insert a value at the given key, returning the previous value for that key (if available).
+    /// Returns a shallow copy of the dictionary. All dictionary keys and values are copied, but
+    /// any reference types (such as `Array`, `Dictionary` and `Object`) will still refer to the
+    /// same value.
     ///
-    /// If you don't need the previous value, use [`Self::set`] instead.
-    pub fn insert<K: ToGodot, V: ToGodot>(&mut self, key: K, value: V) -> Option<Variant> {
-        let key = key.to_variant();
-        let old_value = self.get(key.clone());
-        self.set(key, value);
-        old_value
-    }
-
-    /// Set a key to a given value.
+    /// To create a deep copy, use [`Self::duplicate_deep()`] instead.
+    /// To create a new reference to the same dictionary data, use [`clone()`][Clone::clone].
     ///
-    /// If you are interested in the previous value, use [`Self::insert`] instead.
-    ///
-    /// _Godot equivalent: `dict[key] = value`_
-    pub fn set<K: ToGodot, V: ToGodot>(&mut self, key: K, value: V) {
-        let key = key.to_variant();
-
-        // SAFETY: `self.get_ptr_mut(key)` always returns a valid pointer to a value in the dictionary; either pre-existing or newly inserted.
-        unsafe {
-            value.to_variant().move_into_var_ptr(self.get_ptr_mut(key));
-        }
+    /// _Godot equivalent: `dict.duplicate(false)`_
+    pub fn duplicate_shallow(&self) -> Self {
+        self.as_inner().duplicate(false)
     }
 
     /// Returns an iterator over the key-value pairs of the `Dictionary`. The pairs are each of type `(Variant, Variant)`.

--- a/itest/rust/src/builtin_tests/containers/array_test.rs
+++ b/itest/rust/src/builtin_tests/containers/array_test.rs
@@ -187,13 +187,13 @@ fn array_try_get() {
 fn array_first_last() {
     let array = array![1, 2];
 
-    assert_eq!(array.first(), Some(1));
-    assert_eq!(array.last(), Some(2));
+    assert_eq!(array.front(), Some(1));
+    assert_eq!(array.back(), Some(2));
 
     let empty_array = VariantArray::new();
 
-    assert_eq!(empty_array.first(), None);
-    assert_eq!(empty_array.last(), None);
+    assert_eq!(empty_array.front(), None);
+    assert_eq!(empty_array.back(), None);
 }
 
 #[itest]

--- a/itest/rust/src/builtin_tests/containers/array_test.rs
+++ b/itest/rust/src/builtin_tests/containers/array_test.rs
@@ -62,8 +62,8 @@ fn array_from_iterator() {
     let array = Array::from_iter([1, 2]);
 
     assert_eq!(array.len(), 2);
-    assert_eq!(array.get(0), 1);
-    assert_eq!(array.get(1), 2);
+    assert_eq!(array.at(0), 1);
+    assert_eq!(array.at(1), 2);
 }
 
 #[itest]
@@ -71,8 +71,8 @@ fn array_from_slice() {
     let array = Array::from(&[1, 2]);
 
     assert_eq!(array.len(), 2);
-    assert_eq!(array.get(0), 1);
-    assert_eq!(array.get(1), 2);
+    assert_eq!(array.at(0), 1);
+    assert_eq!(array.at(1), 2);
 }
 
 #[itest]
@@ -108,7 +108,7 @@ fn array_share() {
     let mut array = array![1, 2];
     let shared = array.clone();
     array.set(0, 3);
-    assert_eq!(shared.get(0), 3);
+    assert_eq!(shared.at(0), 3);
 }
 
 #[itest]
@@ -116,10 +116,10 @@ fn array_duplicate_shallow() {
     let subarray = array![2, 3];
     let array = varray![1, subarray];
     let duplicate = array.duplicate_shallow();
-    Array::<i64>::try_from_variant(&duplicate.get(1))
+    Array::<i64>::try_from_variant(&duplicate.at(1))
         .unwrap()
         .set(0, 4);
-    assert_eq!(subarray.get(0), 4);
+    assert_eq!(subarray.at(0), 4);
 }
 
 #[itest]
@@ -127,10 +127,10 @@ fn array_duplicate_deep() {
     let subarray = array![2, 3];
     let array = varray![1, subarray];
     let duplicate = array.duplicate_deep();
-    Array::<i64>::try_from_variant(&duplicate.get(1))
+    Array::<i64>::try_from_variant(&duplicate.at(1))
         .unwrap()
         .set(0, 4);
-    assert_eq!(subarray.get(0), 2);
+    assert_eq!(subarray.at(0), 2);
 }
 
 #[itest]
@@ -142,10 +142,10 @@ fn array_subarray_shallow() {
     let subarray = array![2, 3];
     let array = varray![1, subarray];
     let slice = array.subarray_shallow(1, 2, None);
-    Array::<i64>::try_from_variant(&slice.get(0))
+    Array::<i64>::try_from_variant(&slice.at(0))
         .unwrap()
         .set(0, 4);
-    assert_eq!(subarray.get(0), 4);
+    assert_eq!(subarray.at(0), 4);
 }
 
 #[itest]
@@ -157,20 +157,20 @@ fn array_subarray_deep() {
     let subarray = array![2, 3];
     let array = varray![1, subarray];
     let slice = array.subarray_deep(1, 2, None);
-    Array::<i64>::try_from_variant(&slice.get(0))
+    Array::<i64>::try_from_variant(&slice.at(0))
         .unwrap()
         .set(0, 4);
-    assert_eq!(subarray.get(0), 2);
+    assert_eq!(subarray.at(0), 2);
 }
 
 #[itest]
 fn array_get() {
     let array = array![1, 2];
 
-    assert_eq!(array.get(0), 1);
-    assert_eq!(array.get(1), 2);
+    assert_eq!(array.at(0), 1);
+    assert_eq!(array.at(1), 2);
     expect_panic("Array index 2 out of bounds: length is 2", || {
-        array.get(2);
+        array.at(2);
     });
 }
 
@@ -178,9 +178,9 @@ fn array_get() {
 fn array_try_get() {
     let array = array![1, 2];
 
-    assert_eq!(array.try_get(0), Some(1));
-    assert_eq!(array.try_get(1), Some(2));
-    assert_eq!(array.try_get(2), None);
+    assert_eq!(array.get(0), Some(1));
+    assert_eq!(array.get(1), Some(2));
+    assert_eq!(array.get(2), None);
 }
 
 #[itest]
@@ -254,7 +254,7 @@ fn array_set() {
     let mut array = array![1, 2];
 
     array.set(0, 3);
-    assert_eq!(array.get(0), 3);
+    assert_eq!(array.at(0), 3);
 
     expect_panic("Array index 2 out of bounds: length is 2", move || {
         array.set(2, 4);
@@ -340,34 +340,34 @@ fn array_mixed_values() {
         user_refc,
     ];
 
-    assert_eq!(i64::try_from_variant(&array.get(0)).unwrap(), int);
-    assert_eq!(GString::try_from_variant(&array.get(1)).unwrap(), string);
+    assert_eq!(i64::try_from_variant(&array.at(0)).unwrap(), int);
+    assert_eq!(GString::try_from_variant(&array.at(1)).unwrap(), string);
     assert_eq!(
-        PackedByteArray::try_from_variant(&array.get(2)).unwrap(),
+        PackedByteArray::try_from_variant(&array.at(2)).unwrap(),
         packed_array
     );
-    assert_eq!(Array::try_from_variant(&array.get(3)).unwrap(), typed_array);
+    assert_eq!(Array::try_from_variant(&array.at(3)).unwrap(), typed_array);
     assert_eq!(
-        Gd::<Object>::try_from_variant(&array.get(4))
+        Gd::<Object>::try_from_variant(&array.at(4))
             .unwrap()
             .instance_id(),
         object.instance_id()
     );
     assert_eq!(
-        Gd::<Node>::try_from_variant(&array.get(5))
+        Gd::<Node>::try_from_variant(&array.at(5))
             .unwrap()
             .instance_id(),
         node.instance_id()
     );
 
     assert_eq!(
-        Gd::<RefCounted>::try_from_variant(&array.get(6))
+        Gd::<RefCounted>::try_from_variant(&array.at(6))
             .unwrap()
             .instance_id(),
         engine_refc.instance_id()
     );
     assert_eq!(
-        Gd::<ArrayTest>::try_from_variant(&array.get(7))
+        Gd::<ArrayTest>::try_from_variant(&array.at(7))
             .unwrap()
             .instance_id(),
         user_refc.instance_id()

--- a/itest/rust/src/builtin_tests/containers/dictionary_test.rs
+++ b/itest/rust/src/builtin_tests/containers/dictionary_test.rs
@@ -219,11 +219,7 @@ fn dictionary_at() {
     };
 
     assert_eq!(dictionary.at("foo"), 0.to_variant(), "key = \"foo\"");
-    assert_eq!(
-        dictionary.at("baz"),
-        "foobar".to_variant(),
-        "key = \"baz\""
-    );
+    assert_eq!(dictionary.at("baz"), "foobar".to_variant(), "key = \"baz\"");
     assert_eq!(dictionary.at("nil"), Variant::nil(), "key = \"nil\"");
     expect_panic("key = \"bar\"", || {
         dictionary.at("bar");

--- a/itest/rust/src/builtin_tests/containers/dictionary_test.rs
+++ b/itest/rust/src/builtin_tests/containers/dictionary_test.rs
@@ -165,6 +165,7 @@ fn dictionary_duplicate_shallow() {
         "foo": 0,
         "bar": subdictionary.clone()
     };
+
     let mut clone = dictionary.duplicate_shallow();
     Dictionary::from_variant(&clone.get("bar").unwrap()).insert("baz", 4);
     assert_eq!(
@@ -172,6 +173,7 @@ fn dictionary_duplicate_shallow() {
         Some(4.to_variant()),
         "key = \"baz\""
     );
+
     clone.insert("foo", false.to_variant());
     assert_eq!(dictionary.get("foo"), Some(0.to_variant()));
     assert_eq!(clone.get("foo"), Some(false.to_variant()));
@@ -179,14 +181,12 @@ fn dictionary_duplicate_shallow() {
 
 #[itest]
 fn dictionary_get() {
-    let mut dictionary = dict! {
+    let dictionary = dict! {
         "foo": 0,
         "bar": true,
         "baz": "foobar",
         "nil": Variant::nil(),
     };
-
-    dictionary.insert("baz", "foobar");
 
     assert_eq!(dictionary.get("foo"), Some(0.to_variant()), "key = \"foo\"");
     assert_eq!(
@@ -208,6 +208,26 @@ fn dictionary_get() {
         "key = \"missing\""
     );
     assert_eq!(dictionary.get("foobar"), None, "key = \"foobar\"");
+}
+
+#[itest]
+fn dictionary_at() {
+    let dictionary = dict! {
+        "foo": 0,
+        "baz": "foobar",
+        "nil": Variant::nil(),
+    };
+
+    assert_eq!(dictionary.at("foo"), 0.to_variant(), "key = \"foo\"");
+    assert_eq!(
+        dictionary.at("baz"),
+        "foobar".to_variant(),
+        "key = \"baz\""
+    );
+    assert_eq!(dictionary.at("nil"), Variant::nil(), "key = \"nil\"");
+    expect_panic("key = \"bar\"", || {
+        dictionary.at("bar");
+    });
 }
 
 #[itest]

--- a/itest/rust/src/engine_tests/native_structures_test.rs
+++ b/itest/rust/src/engine_tests/native_structures_test.rs
@@ -137,8 +137,8 @@ fn test_native_structure_pointer_to_array_parameter() {
 
     // Check the result array.
     assert_eq!(result.len(), 2);
-    assert_eq!(result.get(0).get("start"), Some(Variant::from(99)));
-    assert_eq!(result.get(1).get("start"), Some(Variant::from(700)));
+    assert_eq!(result.at(0).get("start"), Some(Variant::from(99)));
+    assert_eq!(result.at(1).get("start"), Some(Variant::from(700)));
 }
 
 #[itest]

--- a/itest/rust/src/object_tests/virtual_methods_test.rs
+++ b/itest/rust/src/object_tests/virtual_methods_test.rs
@@ -381,28 +381,28 @@ fn test_virtual_method_with_return() {
     assert_eq!(arr.len(), arr_rust.len());
     // can't just assert_eq because the values of some floats change slightly
     assert_eq_approx!(
-        arr.get(0).to::<PackedVector3Array>().get(0),
-        arr_rust.get(0).to::<PackedVector3Array>().get(0),
+        arr.at(0).to::<PackedVector3Array>().get(0),
+        arr_rust.at(0).to::<PackedVector3Array>().get(0),
     );
     assert_eq_approx!(
-        real::from_f32(arr.get(2).to::<PackedFloat32Array>().get(3)),
-        real::from_f32(arr_rust.get(2).to::<PackedFloat32Array>().get(3)),
+        real::from_f32(arr.at(2).to::<PackedFloat32Array>().get(3)),
+        real::from_f32(arr_rust.at(2).to::<PackedFloat32Array>().get(3)),
     );
     assert_eq_approx!(
-        arr.get(3).to::<PackedColorArray>().get(0),
-        arr_rust.get(3).to::<PackedColorArray>().get(0),
+        arr.at(3).to::<PackedColorArray>().get(0),
+        arr_rust.at(3).to::<PackedColorArray>().get(0),
     );
     assert_eq_approx!(
-        arr.get(4).to::<PackedVector2Array>().get(0),
-        arr_rust.get(4).to::<PackedVector2Array>().get(0),
+        arr.at(4).to::<PackedVector2Array>().get(0),
+        arr_rust.at(4).to::<PackedVector2Array>().get(0),
     );
     assert_eq!(
-        arr.get(6).to::<PackedByteArray>(),
-        arr_rust.get(6).to::<PackedByteArray>(),
+        arr.at(6).to::<PackedByteArray>(),
+        arr_rust.at(6).to::<PackedByteArray>(),
     );
     assert_eq!(
-        arr.get(10).to::<PackedInt32Array>(),
-        arr_rust.get(10).to::<PackedInt32Array>()
+        arr.at(10).to::<PackedInt32Array>(),
+        arr_rust.at(10).to::<PackedInt32Array>()
     );
 }
 


### PR DESCRIPTION
Reorders `Array` and `Dictionary` methods in a way that makes more sense (which causes the diff to be huge).
Also gets rid of separate `impl` blocks, which were based on (meanwhile redundant) `ToGodot`/`FromGodot` bounds.

API changes for `Array`:
- Rename `get` -> `at`
- Rename `try_get` -> `get` (closer to `Vec::get`)
- ~~Add `front` + `back`, returning `T` and not `Option<T>`~~
- ~~Rename `first` -> `front_or_none`, `last` -> `back_or_none`~~
- Rename `first` -> `front`, `last` -> `back` (closer to GDScript name + `pop_back` etc)

API changes for `Dictionary`:
- Add `at`, returning a direct value or panicking

I used deprecations where possible. Unfortunately, for `Array::get` it's not possible, sorry for any inconvenience caused.