### PR TITLE
Make `Packed*Array` API more consistent with `Array`

### DIFF
--- a/godot-core/src/builtin/array.rs
+++ b/godot-core/src/builtin/array.rs
@@ -242,6 +242,7 @@ impl<T: ArrayElement> Array<T> {
         // SAFETY: The array has type `T` and we're writing a value of type `T` to it.
         unsafe { self.as_inner_mut() }.push_front(value.to_variant());
     }
+
     /// Removes and returns the last element of the array. Returns `None` if the array is empty.
     ///
     /// _Godot equivalent: `pop_back`_
@@ -266,7 +267,7 @@ impl<T: ArrayElement> Array<T> {
         })
     }
 
-    /// Inserts a new element before the index. The index must be valid or the end of the array (`index == len()`).
+    /// ⚠️ Inserts a new element before the index. The index must be valid or the end of the array (`index == len()`).
     ///
     /// On large arrays, this method is much slower than [`push()`][Self::push], as it will move all the array's elements after the inserted element.
     /// The larger the array, the slower `insert()` will be.
@@ -286,12 +287,13 @@ impl<T: ArrayElement> Array<T> {
 
     /// ⚠️ Removes and returns the element at the specified index. Equivalent of `pop_at` in GDScript.
     ///
-    /// On large arrays, this method is much slower than `pop_back()` as it will move all the array's
+    /// On large arrays, this method is much slower than [`pop()`][Self::pop] as it will move all the array's
     /// elements after the removed element. The larger the array, the slower `remove()` will be.
     ///
     /// # Panics
     ///
     /// If `index` is out of bounds.
+    #[doc(alias = "pop_at")]
     pub fn remove(&mut self, index: usize) -> T {
         self.check_bounds(index);
 
@@ -304,7 +306,7 @@ impl<T: ArrayElement> Array<T> {
     ///
     /// If the value does not exist in the array, nothing happens. To remove an element by index, use [`remove()`][Self::remove] instead.
     ///
-    /// On large arrays, this method is much slower than [`pop_back()`][Self::pop_back], as it will move all the array's
+    /// On large arrays, this method is much slower than [`pop()`][Self::pop], as it will move all the array's
     /// elements after the removed element.
     pub fn erase(&mut self, value: &T) {
         // SAFETY: We don't write anything to the array.

--- a/godot-core/src/builtin/packed_array.rs
+++ b/godot-core/src/builtin/packed_array.rs
@@ -9,7 +9,7 @@ use godot_ffi as sys;
 
 use crate::builtin::meta::ToGodot;
 use crate::builtin::*;
-use std::fmt;
+use std::{fmt, ops};
 use sys::types::*;
 use sys::{ffi_methods, interface_fn, GodotFfi};
 
@@ -391,6 +391,24 @@ macro_rules! impl_packed_array {
         impl_builtin_traits! {
             for $PackedArray {
                 $($trait_impls)*
+            }
+        }
+
+        impl ops::Index<usize> for $PackedArray {
+            type Output = $Element;
+
+            fn index(&self, index: usize) -> &Self::Output {
+                let ptr = self.ptr(index);
+                // SAFETY: `ptr` checked bounds.
+                unsafe { &*ptr }
+            }
+        }
+
+        impl ops::IndexMut<usize> for $PackedArray {
+            fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+                let ptr = self.ptr_mut(index);
+                // SAFETY: `ptr` checked bounds.
+                unsafe { &mut *ptr }
             }
         }
 

--- a/godot-core/src/builtin/packed_array.rs
+++ b/godot-core/src/builtin/packed_array.rs
@@ -101,13 +101,13 @@ macro_rules! impl_packed_array {
             ///
             /// _Godot equivalent: `has`_
             #[doc(alias = "has")]
-            pub fn contains(&self, value: $Element) -> bool {
-                self.as_inner().has(Self::into_arg(value))
+            pub fn contains(&self, value: &$Element) -> bool {
+                self.as_inner().has(Self::to_arg(value))
             }
 
             /// Returns the number of times a value is in the array.
-            pub fn count(&self, value: $Element) -> usize {
-                to_usize(self.as_inner().count(Self::into_arg(value)))
+            pub fn count(&self, value: &$Element) -> usize {
+                to_usize(self.as_inner().count(Self::to_arg(value)))
             }
 
             /// Returns the number of elements in the array. Equivalent of `size()` in Godot.
@@ -276,9 +276,9 @@ macro_rules! impl_packed_array {
             /// Searches the array for the first occurrence of a value and returns its index, or
             /// `None` if not found. Starts searching at index `from`; pass `None` to search the
             /// entire array.
-            pub fn find(&self, value: $Element, from: Option<usize>) -> Option<usize> {
+            pub fn find(&self, value: &$Element, from: Option<usize>) -> Option<usize> {
                 let from = to_i64(from.unwrap_or(0));
-                let index = self.as_inner().find(Self::into_arg(value), from);
+                let index = self.as_inner().find(Self::to_arg(value), from);
                 if index >= 0 {
                     Some(index.try_into().unwrap())
                 } else {
@@ -289,9 +289,9 @@ macro_rules! impl_packed_array {
             /// Searches the array backwards for the last occurrence of a value and returns its
             /// index, or `None` if not found. Starts searching at index `from`; pass `None` to
             /// search the entire array.
-            pub fn rfind(&self, value: $Element, from: Option<usize>) -> Option<usize> {
+            pub fn rfind(&self, value: &$Element, from: Option<usize>) -> Option<usize> {
                 let from = from.map(to_i64).unwrap_or(-1);
-                let index = self.as_inner().rfind(Self::into_arg(value), from);
+                let index = self.as_inner().rfind(Self::to_arg(value), from);
                 // It's not documented, but `rfind` returns -1 if not found.
                 if index >= 0 {
                     Some(to_usize(index))
@@ -305,13 +305,13 @@ macro_rules! impl_packed_array {
             /// If the value is not present in the array, returns the insertion index that would maintain sorting order.
             ///
             /// Calling `bsearch()` on an unsorted array results in unspecified (but safe) behavior.
-            pub fn bsearch(&self, value: $Element) -> usize {
-                to_usize(self.as_inner().bsearch(Self::into_arg(value), true))
+            pub fn bsearch(&self, value: &$Element) -> usize {
+                to_usize(self.as_inner().bsearch(Self::to_arg(value), true))
             }
 
             #[deprecated = "Renamed to bsearch like in Godot, to avoid confusion with Rust's slice::binary_search."]
             pub fn binary_search(&self, value: $Element) -> usize {
-                self.bsearch(value)
+                self.bsearch(&value)
             }
 
             /// Reverses the order of the elements in the array.
@@ -384,6 +384,12 @@ macro_rules! impl_packed_array {
             #[inline]
             fn into_arg(e: $Element) -> $Arg {
                 e.into()
+            }
+
+            #[inline]
+            fn to_arg(e: &$Element) -> $Arg {
+                // Once PackedArra<T> is generic, this could use a better tailored implementation that may not need to clone.
+                e.clone().into()
             }
 
             #[doc(hidden)]

--- a/godot-ffi/src/toolbox.rs
+++ b/godot-ffi/src/toolbox.rs
@@ -97,6 +97,7 @@ pub fn force_mut_ptr<T>(ptr: *const T) -> *mut T {
 pub fn to_const_ptr<T>(ptr: *mut T) -> *const T {
     ptr as *const T
 }
+
 /// If `ptr` is not null, returns `Some(mapper(ptr))`; otherwise `None`.
 #[inline]
 pub fn ptr_then<T, R, F>(ptr: *mut T, mapper: F) -> Option<R>

--- a/itest/rust/src/builtin_tests/containers/packed_array_test.rs
+++ b/itest/rust/src/builtin_tests/containers/packed_array_test.rs
@@ -67,7 +67,7 @@ fn packed_array_clone() {
     let mut array = PackedByteArray::from(&[1, 2]);
     #[allow(clippy::redundant_clone)]
     let clone = array.clone();
-    array.set(0, 3);
+    array[0] = 3;
 
     assert_eq!(clone[0], 1);
 }
@@ -159,41 +159,29 @@ fn packed_array_get() {
 fn packed_array_binary_search() {
     let array = PackedByteArray::from(&[1, 3]);
 
-    assert_eq!(array.binary_search(0), 0);
-    assert_eq!(array.binary_search(1), 0);
-    assert_eq!(array.binary_search(2), 1);
-    assert_eq!(array.binary_search(3), 1);
-    assert_eq!(array.binary_search(4), 2);
+    assert_eq!(array.bsearch(&0), 0);
+    assert_eq!(array.bsearch(&1), 0);
+    assert_eq!(array.bsearch(&2), 1);
+    assert_eq!(array.bsearch(&3), 1);
+    assert_eq!(array.bsearch(&4), 2);
 }
 
 #[itest]
 fn packed_array_find() {
     let array = PackedByteArray::from(&[1, 2, 1]);
 
-    assert_eq!(array.find(0, None), None);
-    assert_eq!(array.find(1, None), Some(0));
-    assert_eq!(array.find(1, Some(1)), Some(2));
+    assert_eq!(array.find(&0, None), None);
+    assert_eq!(array.find(&1, None), Some(0));
+    assert_eq!(array.find(&1, Some(1)), Some(2));
 }
 
 #[itest]
 fn packed_array_rfind() {
     let array = PackedByteArray::from(&[1, 2, 1]);
 
-    assert_eq!(array.rfind(0, None), None);
-    assert_eq!(array.rfind(1, None), Some(2));
-    assert_eq!(array.rfind(1, Some(1)), Some(0));
-}
-
-#[itest]
-fn packed_array_set() {
-    let mut array = PackedByteArray::from(&[1, 2]);
-
-    array.set(0, 3);
-    assert_eq!(array[0], 3);
-
-    expect_panic("Array index 2 out of bounds: length is 2", move || {
-        array.set(2, 4);
-    });
+    assert_eq!(array.rfind(&0, None), None);
+    assert_eq!(array.rfind(&1, None), Some(2));
+    assert_eq!(array.rfind(&1, Some(1)), Some(0));
 }
 
 #[itest]

--- a/itest/rust/src/builtin_tests/containers/packed_array_test.rs
+++ b/itest/rust/src/builtin_tests/containers/packed_array_test.rs
@@ -131,6 +131,31 @@ fn packed_array_as_mut_slice() {
 }
 
 #[itest]
+fn packed_array_index() {
+    let array = PackedByteArray::from(&[1, 2]);
+
+    assert_eq!(array[0], 1);
+    assert_eq!(array[1], 2);
+    expect_panic("Array index 2 out of bounds: length is 2", || {
+        let _ = array[2];
+    });
+
+    let mut array = PackedStringArray::new();
+    expect_panic("Array index 0 out of bounds: length is 0", || {
+        let _ = array[0];
+    });
+
+    array.push("first".into());
+    array.push("second".into());
+
+    assert_eq!(array[0], "first".into());
+    assert_eq!(array[1], "second".into());
+
+    array[0] = "begin".into();
+    assert_eq!(array[0], "begin".into());
+}
+
+#[itest]
 fn packed_array_get() {
     let array = PackedByteArray::from(&[1, 2]);
 

--- a/itest/rust/src/builtin_tests/containers/packed_array_test.rs
+++ b/itest/rust/src/builtin_tests/containers/packed_array_test.rs
@@ -23,17 +23,8 @@ fn packed_array_from_iterator() {
     let array = PackedByteArray::from_iter([1, 2]);
 
     assert_eq!(array.len(), 2);
-    assert_eq!(array.get(0), 1);
-    assert_eq!(array.get(1), 2);
-}
-
-#[itest]
-fn packed_array_from() {
-    let array = PackedByteArray::from(&[1, 2]);
-
-    assert_eq!(array.len(), 2);
-    assert_eq!(array.get(0), 1);
-    assert_eq!(array.get(1), 2);
+    assert_eq!(array[0], 1);
+    assert_eq!(array[1], 2);
 }
 
 #[itest]
@@ -78,7 +69,7 @@ fn packed_array_clone() {
     let clone = array.clone();
     array.set(0, 3);
 
-    assert_eq!(clone.get(0), 1);
+    assert_eq!(clone[0], 1);
 }
 
 #[itest]
@@ -159,11 +150,9 @@ fn packed_array_index() {
 fn packed_array_get() {
     let array = PackedByteArray::from(&[1, 2]);
 
-    assert_eq!(array.get(0), 1);
-    assert_eq!(array.get(1), 2);
-    expect_panic("Array index 2 out of bounds: length is 2", || {
-        array.get(2);
-    });
+    assert_eq!(array.get(0), Some(1));
+    assert_eq!(array.get(1), Some(2));
+    assert_eq!(array.get(2), None);
 }
 
 #[itest]
@@ -200,7 +189,7 @@ fn packed_array_set() {
     let mut array = PackedByteArray::from(&[1, 2]);
 
     array.set(0, 3);
-    assert_eq!(array.get(0), 3);
+    assert_eq!(array[0], 3);
 
     expect_panic("Array index 2 out of bounds: length is 2", move || {
         array.set(2, 4);
@@ -214,7 +203,7 @@ fn packed_array_push() {
     array.push(3);
 
     assert_eq!(array.len(), 3);
-    assert_eq!(array.get(2), 3);
+    assert_eq!(array[2], 3);
 }
 
 #[itest]

--- a/itest/rust/src/object_tests/virtual_methods_test.rs
+++ b/itest/rust/src/object_tests/virtual_methods_test.rs
@@ -381,20 +381,20 @@ fn test_virtual_method_with_return() {
     assert_eq!(arr.len(), arr_rust.len());
     // can't just assert_eq because the values of some floats change slightly
     assert_eq_approx!(
-        arr.at(0).to::<PackedVector3Array>().get(0),
-        arr_rust.at(0).to::<PackedVector3Array>().get(0),
+        arr.at(0).to::<PackedVector3Array>()[0],
+        arr_rust.at(0).to::<PackedVector3Array>()[0],
     );
     assert_eq_approx!(
-        real::from_f32(arr.at(2).to::<PackedFloat32Array>().get(3)),
-        real::from_f32(arr_rust.at(2).to::<PackedFloat32Array>().get(3)),
+        real::from_f32(arr.at(2).to::<PackedFloat32Array>()[3]),
+        real::from_f32(arr_rust.at(2).to::<PackedFloat32Array>()[3]),
     );
     assert_eq_approx!(
-        arr.at(3).to::<PackedColorArray>().get(0),
-        arr_rust.at(3).to::<PackedColorArray>().get(0),
+        arr.at(3).to::<PackedColorArray>()[0],
+        arr_rust.at(3).to::<PackedColorArray>()[0],
     );
     assert_eq_approx!(
-        arr.at(4).to::<PackedVector2Array>().get(0),
-        arr_rust.at(4).to::<PackedVector2Array>().get(0),
+        arr.at(4).to::<PackedVector2Array>()[0],
+        arr_rust.at(4).to::<PackedVector2Array>()[0],
     );
     assert_eq!(
         arr.at(6).to::<PackedByteArray>(),

--- a/itest/rust/src/register_tests/constant_test.rs
+++ b/itest/rust/src/register_tests/constant_test.rs
@@ -89,7 +89,7 @@ fn constants_correct_value() {
         .done();
 
     for (constant_name, constant_value) in CONSTANTS {
-        assert!(constants.contains(constant_name.into()));
+        assert!(constants.contains(&constant_name.into()));
         assert_eq!(
             ClassDb::singleton().class_get_integer_constant(
                 HasConstants::class_name().to_string_name(),
@@ -216,11 +216,11 @@ macro_rules! test_enum_export {
                 .done();
 
             for (variant_name, variant_value) in variants {
-                assert!(godot_variants.contains(variant_name.into()));
-                assert!(constants.contains(variant_name.into()));
+                let variant_name = GString::from(variant_name);
+                assert!(godot_variants.contains(&variant_name));
+                assert!(constants.contains(&variant_name));
                 assert_eq!(
-                    ClassDb::singleton()
-                        .class_get_integer_constant(class_name.to_string_name(), variant_name.into()),
+                    ClassDb::singleton().class_get_integer_constant(class_name.to_string_name(), variant_name.into()),
                     variant_value
                 );
             }


### PR DESCRIPTION
Somewhat follow-up to #720.

Adds `Index`/`IndexMut` for all packed arrays, allowing mutable/shared direct element access via `p[index]` operator.

Other changes (several breaking):
- `get()` now returns `Option<T>` instead of `T`
- deprecate `set()`
- rename `binary_search()` -> `bsearch()`
- optimize index access, since Godot already checks bounds and propagates that information
- methods that don't insert the element now take `&T` instead of `T`, consistent with `Array` 
- changed method order, consistent with `Array`
- documentation