### PR TITLE
Exhaustive enums

### DIFF
--- a/godot-codegen/src/models/domain/enums.rs
+++ b/godot-codegen/src/models/domain/enums.rs
@@ -18,6 +18,7 @@ pub struct Enum {
     pub name: Ident,
     pub godot_name: String,
     pub is_bitfield: bool,
+    pub is_exhaustive: bool,
     pub enumerators: Vec<Enumerator>,
 }
 

--- a/godot-codegen/src/models/domain_mapping.rs
+++ b/godot-codegen/src/models/domain_mapping.rs
@@ -517,6 +517,7 @@ impl Enum {
     pub fn from_json(json_enum: &JsonEnum, surrounding_class: Option<&TyName>) -> Self {
         let godot_name = &json_enum.name;
         let is_bitfield = json_enum.is_bitfield;
+        let is_exhaustive = special_cases::is_enum_exhaustive(surrounding_class, godot_name);
 
         let rust_enum_name = conv::make_enum_name_str(godot_name);
         let rust_enumerator_names = {
@@ -550,6 +551,7 @@ impl Enum {
             name: ident(&rust_enum_name),
             godot_name: godot_name.clone(),
             is_bitfield,
+            is_exhaustive,
             enumerators,
         }
     }

--- a/godot-codegen/src/special_cases/special_cases.rs
+++ b/godot-codegen/src/special_cases/special_cases.rs
@@ -354,3 +354,27 @@ pub fn is_class_level_server(class_name: &str) -> bool {
         => true, _ => false
     }
 }
+
+/// Certain enums that are extremely unlikely to get new identifiers in the future.
+/// 
+/// `class_name` = None for global enums.
+/// 
+/// Very conservative, only includes a few enums. Even `VariantType` was extended over time.
+/// Also does not work for any enums containing duplicate ordinals.
+#[rustfmt::skip]
+pub fn is_enum_exhaustive(class_name: Option<&TyName>, enum_name: &str) -> bool {
+    // Adding new enums here should generally not break existing code:
+    // * match _ patterns are still allowed, but cause a warning
+    // * Enum::CONSTANT access looks the same for proper enum and newtype+const
+    // Obviously, removing them will.
+
+    match (class_name, enum_name) {
+        | (None, "ClockDirection")
+        | (None, "Corner")
+        | (None, "EulerOrder")
+        | (None, "Side")
+        | (None, "Orientation")
+
+        => true, _ => false
+    }
+}

--- a/godot-core/src/builtin/basis.rs
+++ b/godot-core/src/builtin/basis.rs
@@ -12,6 +12,7 @@ use crate::builtin::math::{ApproxEq, FloatExt, GlamConv, GlamType};
 use crate::builtin::real_consts::FRAC_PI_2;
 use crate::builtin::{real, Quaternion, RMat3, RQuat, RVec2, RVec3, Vector3};
 
+use crate::engine::global::EulerOrder;
 use std::cmp::Ordering;
 use std::fmt::Display;
 use std::ops::{Mul, MulAssign};
@@ -322,6 +323,7 @@ impl Basis {
         ))
     }
 
+    #[allow(clippy::wrong_self_convention)]
     fn to_euler_inner(major: real, pair0: RVec2, pair1: RVec2, pair2: RVec2) -> RVec3 {
         match Self::is_between_neg1_1(major) {
             // It's -1
@@ -605,19 +607,6 @@ unsafe impl GodotFfi for Basis {
 }
 
 impl_godot_as_self!(Basis);
-
-/// The ordering used to interpret a set of euler angles as extrinsic
-/// rotations.
-#[derive(Copy, Clone, Eq, PartialEq, Debug)]
-#[repr(C)]
-pub enum EulerOrder {
-    XYZ = 0,
-    XZY = 1,
-    YXZ = 2,
-    YZX = 3,
-    ZXY = 4,
-    ZYX = 5,
-}
 
 #[cfg(test)]
 mod test {

--- a/godot-core/src/builtin/color.rs
+++ b/godot-core/src/builtin/color.rs
@@ -368,31 +368,43 @@ impl ApproxEq for Color {
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub enum ColorChannelOrder {
     /// RGBA channel order. Godot's default.
-    Rgba,
+    RGBA,
 
     /// ABGR channel order. Reverse of the default RGBA order.
-    Abgr,
+    ABGR,
 
     /// ARGB channel order. More compatible with DirectX.
-    Argb,
+    ARGB,
+}
+
+#[allow(non_upper_case_globals)]
+impl ColorChannelOrder {
+    #[deprecated(note = "Renamed to `ColorChannelOrder::RGBA`.")]
+    pub const Rgba: Self = Self::RGBA;
+
+    #[deprecated(note = "Renamed to `ColorChannelOrder::ABGR`.")]
+    pub const Abgr: Self = Self::ABGR;
+
+    #[deprecated(note = "Renamed to `ColorChannelOrder::ARGB`.")]
+    pub const Argb: Self = Self::ARGB;
 }
 
 impl ColorChannelOrder {
     fn pack<T>(self, rgba: [T; 4]) -> [T; 4] {
         let [r, g, b, a] = rgba;
         match self {
-            ColorChannelOrder::Rgba => [r, g, b, a],
-            ColorChannelOrder::Abgr => [a, b, g, r],
-            ColorChannelOrder::Argb => [a, r, g, b],
+            ColorChannelOrder::RGBA => [r, g, b, a],
+            ColorChannelOrder::ABGR => [a, b, g, r],
+            ColorChannelOrder::ARGB => [a, r, g, b],
         }
     }
 
     fn unpack<T>(self, xyzw: [T; 4]) -> [T; 4] {
         let [x, y, z, w] = xyzw;
         match self {
-            ColorChannelOrder::Rgba => [x, y, z, w],
-            ColorChannelOrder::Abgr => [w, z, y, x],
-            ColorChannelOrder::Argb => [y, z, w, x],
+            ColorChannelOrder::RGBA => [x, y, z, w],
+            ColorChannelOrder::ABGR => [w, z, y, x],
+            ColorChannelOrder::ARGB => [y, z, w, x],
         }
     }
 }

--- a/godot-core/src/builtin/mod.rs
+++ b/godot-core/src/builtin/mod.rs
@@ -88,6 +88,8 @@ pub mod strings {
     pub use super::string::TransientStringNameOrd;
 }
 
+use crate::engine::global::Side;
+
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Implementation
 
@@ -151,14 +153,22 @@ pub(crate) fn u8_to_bool(u: u8) -> bool {
 /// The side of a [`Rect2`] or [`Rect2i`].
 ///
 /// _Godot equivalent: `@GlobalScope.Side`_
-#[doc(alias = "Side")]
-#[derive(Copy, Clone, Debug)]
-#[repr(C)]
-pub enum RectSide {
-    Left = 0,
-    Top = 1,
-    Right = 2,
-    Bottom = 3,
+#[deprecated(note = "Merged with `godot::global::Side`.")]
+pub type RectSide = Side;
+
+#[allow(non_upper_case_globals)]
+impl Side {
+    #[deprecated(note = "Renamed to `Side::LEFT`.")]
+    pub const Left: Side = Side::LEFT;
+
+    #[deprecated(note = "Renamed to `Side::TOP`.")]
+    pub const Top: Side = Side::TOP;
+
+    #[deprecated(note = "Renamed to `Side::RIGHT`.")]
+    pub const Right: Side = Side::RIGHT;
+
+    #[deprecated(note = "Renamed to `Side::BOTTOM`.")]
+    pub const Bottom: Side = Side::BOTTOM;
 }
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------

--- a/godot-core/src/builtin/mod.rs
+++ b/godot-core/src/builtin/mod.rs
@@ -88,8 +88,6 @@ pub mod strings {
     pub use super::string::TransientStringNameOrd;
 }
 
-use crate::engine::global::Side;
-
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Implementation
 
@@ -154,7 +152,12 @@ pub(crate) fn u8_to_bool(u: u8) -> bool {
 ///
 /// _Godot equivalent: `@GlobalScope.Side`_
 #[deprecated(note = "Merged with `godot::global::Side`.")]
-pub type RectSide = Side;
+pub type RectSide = crate::engine::global::Side;
+use crate::engine::global::Side;
+
+/// The ordering used to interpret a set of euler angles as extrinsic rotations.
+#[deprecated(note = "Merged with `godot::global::EulerOrder`.")]
+pub type EulerOrder = crate::engine::global::EulerOrder;
 
 #[allow(non_upper_case_globals)]
 impl Side {

--- a/godot-core/src/builtin/projection.rs
+++ b/godot-core/src/builtin/projection.rs
@@ -122,8 +122,8 @@ impl Projection {
         f2 = (f2 + add) * near;
 
         match eye {
-            ProjectionEye::Left => Self::create_frustum(-f2, f1, -f3, f3, near, far),
-            ProjectionEye::Right => Self::create_frustum(-f1, f2, -f3, f3, near, far),
+            ProjectionEye::LEFT => Self::create_frustum(-f2, f1, -f3, f3, near, far),
+            ProjectionEye::RIGHT => Self::create_frustum(-f1, f2, -f3, f3, near, far),
         }
     }
 
@@ -302,12 +302,12 @@ impl Projection {
         let frustumshift = (intraocular_dist * near * 0.5) / convergence_dist;
 
         let (left, right, model_translation) = match eye {
-            ProjectionEye::Left => (
+            ProjectionEye::LEFT => (
                 frustumshift - xmax,
                 xmax + frustumshift,
                 intraocular_dist / 2.0,
             ),
-            ProjectionEye::Right => (
+            ProjectionEye::RIGHT => (
                 -frustumshift - xmax,
                 xmax - frustumshift,
                 intraocular_dist / -2.0,
@@ -544,24 +544,45 @@ impl_godot_as_self!(Projection);
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
 #[repr(C)]
 pub enum ProjectionPlane {
-    Near = 0,
-    Far = 1,
-    Left = 2,
-    Top = 3,
-    Right = 4,
-    Bottom = 5,
+    NEAR = 0,
+    FAR = 1,
+    LEFT = 2,
+    TOP = 3,
+    RIGHT = 4,
+    BOTTOM = 5,
+}
+
+#[allow(non_upper_case_globals)]
+impl ProjectionPlane {
+    #[deprecated(note = "Renamed to `ProjectionPlane::NEAR`")]
+    pub const Near: Self = Self::NEAR;
+
+    #[deprecated(note = "Renamed to `ProjectionPlane::FAR`")]
+    pub const Far: Self = Self::FAR;
+
+    #[deprecated(note = "Renamed to `ProjectionPlane::LEFT`")]
+    pub const Left: Self = Self::LEFT;
+
+    #[deprecated(note = "Renamed to `ProjectionPlane::TOP`")]
+    pub const Top: Self = Self::TOP;
+
+    #[deprecated(note = "Renamed to `ProjectionPlane::RIGHT`")]
+    pub const Right: Self = Self::RIGHT;
+
+    #[deprecated(note = "Renamed to `ProjectionPlane::BOTTOM`")]
+    pub const Bottom: Self = Self::BOTTOM;
 }
 
 impl ProjectionPlane {
     /// Convert from one of GDScript's `Projection.PLANE_*` integer constants.
     pub fn try_from_ord(ord: i64) -> Option<Self> {
         match ord {
-            0 => Some(Self::Near),
-            1 => Some(Self::Far),
-            2 => Some(Self::Left),
-            3 => Some(Self::Top),
-            4 => Some(Self::Right),
-            5 => Some(Self::Bottom),
+            0 => Some(Self::NEAR),
+            1 => Some(Self::FAR),
+            2 => Some(Self::LEFT),
+            3 => Some(Self::TOP),
+            4 => Some(Self::RIGHT),
+            5 => Some(Self::BOTTOM),
             _ => None,
         }
     }
@@ -571,16 +592,25 @@ impl ProjectionPlane {
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
 #[repr(C)]
 pub enum ProjectionEye {
-    Left = 1,
-    Right = 2,
+    LEFT = 1,
+    RIGHT = 2,
+}
+
+#[allow(non_upper_case_globals)]
+impl ProjectionEye {
+    #[deprecated(note = "Renamed to `ProjectionEye::LEFT`")]
+    pub const Left: Self = Self::LEFT;
+
+    #[deprecated(note = "Renamed to `ProjectionEye::RIGHT`")]
+    pub const Right: Self = Self::RIGHT;
 }
 
 impl ProjectionEye {
     /// Convert from numbers `1` and `2`.
     pub fn try_from_ord(ord: i64) -> Option<Self> {
         match ord {
-            1 => Some(Self::Left),
-            2 => Some(Self::Right),
+            1 => Some(Self::LEFT),
+            2 => Some(Self::RIGHT),
             _ => None,
         }
     }

--- a/godot-core/src/builtin/quaternion.rs
+++ b/godot-core/src/builtin/quaternion.rs
@@ -9,8 +9,9 @@ use godot_ffi as sys;
 use sys::{ffi_methods, GodotFfi};
 
 use crate::builtin::math::{ApproxEq, FloatExt, GlamConv, GlamType};
-use crate::builtin::{inner, real, Basis, EulerOrder, RQuat, RealConv, Vector3};
+use crate::builtin::{inner, real, Basis, RQuat, RealConv, Vector3};
 
+use crate::engine::global::EulerOrder;
 use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use super::meta::impl_godot_as_self;

--- a/godot-core/src/builtin/rect2.rs
+++ b/godot-core/src/builtin/rect2.rs
@@ -9,7 +9,8 @@ use godot_ffi as sys;
 use sys::{ffi_methods, GodotFfi};
 
 use crate::builtin::math::ApproxEq;
-use crate::builtin::{real, Rect2i, RectSide, Vector2};
+use crate::builtin::{real, Rect2i, Vector2};
+use crate::engine::global::Side;
 
 use super::meta::impl_godot_as_self;
 
@@ -147,12 +148,12 @@ impl Rect2 {
     /// `amount` may be negative, but care must be taken: If the resulting `size` has
     /// negative components the computation may be incorrect.
     #[inline]
-    pub fn grow_side(&self, side: RectSide, amount: real) -> Self {
+    pub fn grow_side(&self, side: Side, amount: real) -> Self {
         match side {
-            RectSide::Left => self.grow_individual(amount, 0.0, 0.0, 0.0),
-            RectSide::Top => self.grow_individual(0.0, amount, 0.0, 0.0),
-            RectSide::Right => self.grow_individual(0.0, 0.0, amount, 0.0),
-            RectSide::Bottom => self.grow_individual(0.0, 0.0, 0.0, amount),
+            Side::LEFT => self.grow_individual(amount, 0.0, 0.0, 0.0),
+            Side::TOP => self.grow_individual(0.0, amount, 0.0, 0.0),
+            Side::RIGHT => self.grow_individual(0.0, 0.0, amount, 0.0),
+            Side::BOTTOM => self.grow_individual(0.0, 0.0, 0.0, amount),
         }
     }
 

--- a/godot-core/src/builtin/rect2i.rs
+++ b/godot-core/src/builtin/rect2i.rs
@@ -7,10 +7,11 @@
 
 use std::cmp;
 
+use crate::engine::global::Side;
 use godot_ffi as sys;
 use sys::{ffi_methods, GodotFfi};
 
-use super::{meta::impl_godot_as_self, Rect2, RectSide, Vector2i};
+use super::{meta::impl_godot_as_self, Rect2, Vector2i};
 
 /// 2D axis-aligned integer bounding box.
 ///
@@ -164,12 +165,12 @@ impl Rect2i {
     /// `amount` may be negative, but care must be taken: If the resulting `size` has
     /// negative components the computation may be incorrect.
     #[inline]
-    pub fn grow_side(self, side: RectSide, amount: i32) -> Self {
+    pub fn grow_side(self, side: Side, amount: i32) -> Self {
         match side {
-            RectSide::Left => self.grow_individual(amount, 0, 0, 0),
-            RectSide::Top => self.grow_individual(0, amount, 0, 0),
-            RectSide::Right => self.grow_individual(0, 0, amount, 0),
-            RectSide::Bottom => self.grow_individual(0, 0, 0, amount),
+            Side::LEFT => self.grow_individual(amount, 0, 0, 0),
+            Side::TOP => self.grow_individual(0, amount, 0, 0),
+            Side::RIGHT => self.grow_individual(0, 0, amount, 0),
+            Side::BOTTOM => self.grow_individual(0, 0, 0, amount),
         }
     }
 
@@ -502,25 +503,25 @@ mod test {
         assert!(end.encloses(begin));
 
         let now = begin.grow_individual(3, 0, 0, 0);
-        let now_side = begin.grow_side(RectSide::Left, 3);
+        let now_side = begin.grow_side(Side::LEFT, 3);
         assert_ne!(now, end);
         assert_eq!(now, now_side);
         assert!(end.encloses(now));
 
         let now = now.grow_individual(0, 3, 0, 0);
-        let now_side = now_side.grow_side(RectSide::Top, 3);
+        let now_side = now_side.grow_side(Side::TOP, 3);
         assert_ne!(now, end);
         assert_eq!(now, now_side);
         assert!(end.encloses(now));
 
         let now = now.grow_individual(0, 0, 3, 0);
-        let now_side = now_side.grow_side(RectSide::Right, 3);
+        let now_side = now_side.grow_side(Side::RIGHT, 3);
         assert_ne!(now, end);
         assert_eq!(now, now_side);
         assert!(end.encloses(now));
 
         let now = now.grow_individual(0, 0, 0, 3);
-        let now_side = now_side.grow_side(RectSide::Bottom, 3);
+        let now_side = now_side.grow_side(Side::BOTTOM, 3);
         assert_eq!(now, end);
         assert_eq!(now, now_side);
     }

--- a/itest/rust/src/builtin_tests/color_test.rs
+++ b/itest/rust/src/builtin_tests/color_test.rs
@@ -21,15 +21,15 @@ fn color_from_rgba8() {
 fn color_from_u32() {
     const D: f32 = 255.0;
     assert_eq!(
-        Color::from_u32_rgba(0x01020304, ColorChannelOrder::Rgba),
+        Color::from_u32_rgba(0x01020304, ColorChannelOrder::RGBA),
         Color::from_rgba(1.0 / D, 2.0 / D, 3.0 / D, 4.0 / D)
     );
     assert_eq!(
-        Color::from_u32_rgba(0x01020304, ColorChannelOrder::Abgr),
+        Color::from_u32_rgba(0x01020304, ColorChannelOrder::ABGR),
         Color::from_rgba(4.0 / D, 3.0 / D, 2.0 / D, 1.0 / D)
     );
     assert_eq!(
-        Color::from_u32_rgba(0x01020304, ColorChannelOrder::Argb),
+        Color::from_u32_rgba(0x01020304, ColorChannelOrder::ARGB),
         Color::from_rgba(2.0 / D, 3.0 / D, 4.0 / D, 1.0 / D)
     );
 }
@@ -38,15 +38,15 @@ fn color_from_u32() {
 fn color_from_u64() {
     const D: f32 = 65535.0;
     assert_eq!(
-        Color::from_u64_rgba(0x0001000200030004, ColorChannelOrder::Rgba),
+        Color::from_u64_rgba(0x0001000200030004, ColorChannelOrder::RGBA),
         Color::from_rgba(1.0 / D, 2.0 / D, 3.0 / D, 4.0 / D)
     );
     assert_eq!(
-        Color::from_u64_rgba(0x0001000200030004, ColorChannelOrder::Abgr),
+        Color::from_u64_rgba(0x0001000200030004, ColorChannelOrder::ABGR),
         Color::from_rgba(4.0 / D, 3.0 / D, 2.0 / D, 1.0 / D)
     );
     assert_eq!(
-        Color::from_u64_rgba(0x0001000200030004, ColorChannelOrder::Argb),
+        Color::from_u64_rgba(0x0001000200030004, ColorChannelOrder::ARGB),
         Color::from_rgba(2.0 / D, 3.0 / D, 4.0 / D, 1.0 / D)
     );
 }
@@ -100,17 +100,17 @@ fn color_blend() {
 #[itest]
 fn color_to_u32() {
     let c = Color::from_html("#01020304").unwrap();
-    assert_eq!(c.to_u32(ColorChannelOrder::Rgba), 0x01020304);
-    assert_eq!(c.to_u32(ColorChannelOrder::Abgr), 0x04030201);
-    assert_eq!(c.to_u32(ColorChannelOrder::Argb), 0x04010203);
+    assert_eq!(c.to_u32(ColorChannelOrder::RGBA), 0x01020304);
+    assert_eq!(c.to_u32(ColorChannelOrder::ABGR), 0x04030201);
+    assert_eq!(c.to_u32(ColorChannelOrder::ARGB), 0x04010203);
 }
 
 #[itest]
 fn color_to_u64() {
     let c = Color::from_html("#01020304").unwrap();
-    assert_eq!(c.to_u64(ColorChannelOrder::Rgba), 0x0101_0202_0303_0404);
-    assert_eq!(c.to_u64(ColorChannelOrder::Abgr), 0x0404_0303_0202_0101);
-    assert_eq!(c.to_u64(ColorChannelOrder::Argb), 0x0404_0101_0202_0303);
+    assert_eq!(c.to_u64(ColorChannelOrder::RGBA), 0x0101_0202_0303_0404);
+    assert_eq!(c.to_u64(ColorChannelOrder::ABGR), 0x0404_0303_0202_0101);
+    assert_eq!(c.to_u64(ColorChannelOrder::ARGB), 0x0404_0101_0202_0303);
 }
 
 // Multiple specific cases because HSV->RGB conversion algorithm used is very dependent on Hue value, taking into account different values

--- a/itest/rust/src/builtin_tests/geometry/basis_test.rs
+++ b/itest/rust/src/builtin_tests/geometry/basis_test.rs
@@ -8,7 +8,8 @@
 use godot::builtin::inner::InnerBasis;
 use godot::builtin::math::assert_eq_approx;
 use godot::builtin::meta::ToGodot;
-use godot::builtin::{real, Basis, EulerOrder, RealConv, VariantOperator, Vector3};
+use godot::builtin::{real, Basis, RealConv, VariantOperator, Vector3};
+use godot::engine::global::EulerOrder;
 
 use crate::framework::itest;
 

--- a/itest/rust/src/builtin_tests/geometry/rect2_test.rs
+++ b/itest/rust/src/builtin_tests/geometry/rect2_test.rs
@@ -9,7 +9,8 @@ use crate::framework::itest;
 
 use godot::builtin::inner::InnerRect2;
 use godot::builtin::math::assert_eq_approx;
-use godot::builtin::{real, reals, RealConv, Rect2, RectSide, Vector2};
+use godot::builtin::{real, reals, RealConv, Rect2, Vector2};
+use godot::engine::global::Side;
 
 #[itest]
 fn rect2_inner_equivalence() {
@@ -29,12 +30,7 @@ fn rect2_inner_equivalence() {
     ];
     let reals = reals![0.0, 1.0, 32.0];
     let grow_values = reals![-1.0, 0.0, 7.0];
-    let sides = [
-        RectSide::Left,
-        RectSide::Top,
-        RectSide::Right,
-        RectSide::Bottom,
-    ];
+    let sides = [Side::LEFT, Side::TOP, Side::RIGHT, Side::BOTTOM];
 
     for rect in rects {
         let inner_rect = InnerRect2::from_outer(&rect);

--- a/itest/rust/src/builtin_tests/geometry/rect2i_test.rs
+++ b/itest/rust/src/builtin_tests/geometry/rect2i_test.rs
@@ -9,7 +9,9 @@ use std::fmt::Debug;
 
 use crate::framework::itest;
 use godot::builtin::inner::InnerRect2i;
-use godot::builtin::{Rect2i, RectSide, Vector2i};
+use godot::builtin::{Rect2i, Vector2i};
+use godot::engine::global::Side;
+use godot::obj::EngineEnum;
 
 #[itest]
 fn rect2i_equiv_unary() {
@@ -28,12 +30,7 @@ fn rect2i_equiv_unary() {
         Vector2i::new(10, 10),
     ];
     let test_ints = [0, 1, 10, 32];
-    let test_sides = [
-        RectSide::Left,
-        RectSide::Top,
-        RectSide::Right,
-        RectSide::Bottom,
-    ];
+    let test_sides = [Side::LEFT, Side::TOP, Side::RIGHT, Side::BOTTOM];
 
     fn evaluate_mappings<T>(key: &str, a: T, b: T)
     where
@@ -87,7 +84,7 @@ fn rect2i_equiv_unary() {
                 evaluate_mappings(
                     "grow_side",
                     a.grow_side(b, c),
-                    inner_a.grow_side(b as i64, c as i64),
+                    inner_a.grow_side(b.ord() as i64, c as i64),
                 );
             }
         }


### PR DESCRIPTION
Allows a hardcoded list of Godot enums to be treated as exhaustive. This means that it's extremely unlikely that Godot will add new enumerators in the future; it's thus reasonably safe to build forward-compatible extensions by not handling any enumerators that aren't currently defined.

 This is for concepts like:
- `ClockDirection`: CW + CCW
- `Side`: always 4
- `Orientation`: always vertical + horizontal

We treat this very conservatively, "probably won't change" isn't enough. We have seen that even `VariantType` was changed with the `PackedVector4Array` addition.

Exhaustive enums are now mapped as proper Rust enums, instead of the newtype struct + associated constants. This allows exhaustive matching in `match`. (We may promote non-exhaustive ones to use `enum` as well, but this would need handling of future values, and duplicates would still need to be defined as constants).


---

Apart from that, this PR also renames more enumerators to `SHOUT_CASE`. It deprecates the following manually defined enums and merges them with their Godot equivalent:
- `RectSide` -> `Side`
- `EulerOrder`