### PR TITLE
Emit `rustc-check-cfg`

### DIFF
--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -311,7 +311,7 @@ jobs:
             os: ubuntu-20.04
             artifact-name: linux-nightly
             godot-binary: godot.linuxbsd.editor.dev.x86_64
-            rust-extra-args: --features godot/api-custom,godot/experimental-threads,godot/serde,codegen-full-experimental
+            rust-extra-args: --features itest/experimental-threads,itest/codegen-full-experimental,godot/api-custom,godot/serde
 
           - name: linux-release
             os: ubuntu-20.04

--- a/.github/workflows/minimal-ci.yml
+++ b/.github/workflows/minimal-ci.yml
@@ -154,7 +154,7 @@ jobs:
             os: ubuntu-20.04
             artifact-name: linux-nightly
             godot-binary: godot.linuxbsd.editor.dev.x86_64
-            rust-extra-args: --features godot/api-custom,godot/experimental-threads,godot/serde,codegen-full-experimental
+            rust-extra-args: --features itest/experimental-threads,itest/codegen-full-experimental,godot/api-custom,godot/serde
 
           # Linux compat
 

--- a/godot-bindings/Cargo.toml
+++ b/godot-bindings/Cargo.toml
@@ -39,3 +39,6 @@ regex = { version = "1.5.5", default-features = false, features = ["std", "unico
 [package.metadata.docs.rs]
 features = ["experimental-godot-api"]
 rustdoc-args = ["--cfg", "published_docs"]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(published_docs)'] }

--- a/godot-cell/Cargo.toml
+++ b/godot-cell/Cargo.toml
@@ -17,3 +17,6 @@ proptest = { version = "1.4.0", optional = true }
 [package.metadata.docs.rs]
 features = ["experimental-godot-api"]
 rustdoc-args = ["--cfg", "published_docs"]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(published_docs)'] }

--- a/godot-codegen/Cargo.toml
+++ b/godot-codegen/Cargo.toml
@@ -38,6 +38,8 @@ godot-bindings = { path = "../godot-bindings" } # emit_godot_version_cfg
 features = ["experimental-godot-api"]
 rustdoc-args = ["--cfg", "published_docs"]
 
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(published_docs)'] }
 
 # To check formatter: Disabled below, since it pulls in too many dependencies during `cargo test` but is not really used.
 # Dev-dependencies cannot be optional and feature-gated. Enable manually when needed.
@@ -48,3 +50,4 @@ rustdoc-args = ["--cfg", "published_docs"]
 #
 #[dev-dependencies]
 #criterion = "0.5"
+

--- a/godot-codegen/src/generator/gdext_build_struct.rs
+++ b/godot-codegen/src/generator/gdext_build_struct.rs
@@ -53,6 +53,8 @@ pub fn make_gdext_build_struct(header: &GodotApiVersion) -> TokenStream {
                 (version.major as u8, version.minor as u8, version.patch as u8)
             }
 
+            // Duplicates code from `before_api` in `godot-bindings/lib.rs`.
+
             /// For a string `"4.x"`, returns `true` if the current Godot version is strictly less than 4.x.
             ///
             /// Runtime equivalent of `#[cfg(before_api = "4.x")]`.

--- a/godot-core/Cargo.toml
+++ b/godot-core/Cargo.toml
@@ -45,3 +45,6 @@ godot-codegen = { path = "../godot-codegen" }
 [package.metadata.docs.rs]
 features = ["experimental-godot-api"]
 rustdoc-args = ["--cfg", "published_docs"]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(published_docs)'] }

--- a/godot-ffi/Cargo.toml
+++ b/godot-ffi/Cargo.toml
@@ -37,3 +37,6 @@ godot-codegen = { path = "../godot-codegen" }
 [package.metadata.docs.rs]
 features = ["experimental-godot-api"]
 rustdoc-args = ["--cfg", "published_docs"]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(published_docs)'] }

--- a/godot-macros/Cargo.toml
+++ b/godot-macros/Cargo.toml
@@ -31,3 +31,6 @@ godot-bindings = { path = "../godot-bindings" } # emit_godot_version_cfg
 [package.metadata.docs.rs]
 features = ["experimental-godot-api"]
 rustdoc-args = ["--cfg", "published_docs"]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(published_docs)'] }

--- a/godot/Cargo.toml
+++ b/godot/Cargo.toml
@@ -34,3 +34,6 @@ godot-macros = { path = "../godot-macros" }
 [package.metadata.docs.rs]
 features = ["experimental-godot-api"]
 rustdoc-args = ["--cfg", "published_docs"]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(published_docs)'] }

--- a/itest/rust/Cargo.toml
+++ b/itest/rust/Cargo.toml
@@ -12,6 +12,7 @@ crate-type = ["cdylib"]
 [features]
 default = []
 codegen-full-experimental = ["godot/codegen-full", "godot/experimental-godot-api"]
+experimental-threads = ["godot/experimental-threads"]
 serde = ["dep:serde", "dep:serde_json", "godot/serde"]
 
 # Do not add features here that are 1:1 forwarded to the `godot` crate, unless they are needed by itest itself.

--- a/itest/rust/build.rs
+++ b/itest/rust/build.rs
@@ -148,8 +148,11 @@ fn collect_inputs() -> Vec<Input> {
     push!(inputs; PackedStringArray, PackedStringArray, PackedStringArray(), PackedStringArray::new());
     push!(inputs; PackedVector2Array, PackedVector2Array, PackedVector2Array(), PackedVector2Array::new());
     push!(inputs; PackedVector3Array, PackedVector3Array, PackedVector3Array(), PackedVector3Array::new());
-    #[cfg(since_api = "4.3")]
-    push!(inputs; PackedVector4Array, PackedVector4Array, PackedVector4Array(), PackedVector4Array::new());
+    // This is being run in a build script at the same time as other build-scripts, so the `rustc-cfg` directives haven't been run for this
+    // build-script. This means that `#[cfg(since_api = "4.3")]` wouldn't do anything.
+    if godot_bindings::since_api("4.3") {
+        push!(inputs; PackedVector4Array, PackedVector4Array, PackedVector4Array(), PackedVector4Array::new());
+    }
     push!(inputs; PackedColorArray, PackedColorArray, PackedColorArray(), PackedColorArray::new());
 
     push_newtype!(inputs; int, NewI64(i64), -922337203685477580);


### PR DESCRIPTION
In current nightly rust, cargo will complain when you use unexpected `#[cfg]` values. This mainly impacts our `since_api/before_api` cfgs. The two ways to fix this are either to use a build script to emit `cargo::rustc-check-cfg` directives, or it will be possible to add expected cfg values to the `cargo.toml` (this is currently unimplemented however).

Cargo ignores these directives in rust 1.78, and will start warning when these are missing in 1.80, see also this blog post https://blog.rust-lang.org/2024/05/06/check-cfg.html. And as mentioned previously already warns on nightly.

This solution uses a build script, where we have a const list of known api versions. I thought this was an easier solution than waiting for and using the lints field, as that would require us to manually write out all the various combinations. Whereas this way we can just write all the known api versions and use code to generate the right combinations.

Also fixes some issues pointed out by `rustc-check-cfg`, such as missing features and usage of `#[cfg(since_api)]` in a build script. 