### PR TITLE
Streamline modules - part II: `godot::extra`, notifications

### DIFF
--- a/godot-codegen/src/conv/name_conversions.rs
+++ b/godot-codegen/src/conv/name_conversions.rs
@@ -77,6 +77,7 @@ pub fn to_pascal_case(ty_name: &str) -> String {
         .replace("Sdfgiy", "SdfgiY")
 }
 
+#[allow(dead_code)] // Keep around in case we need it later.
 pub fn shout_to_pascal(shout_case: &str) -> String {
     // TODO use heck?
 

--- a/godot-codegen/src/conv/type_conversions.rs
+++ b/godot-codegen/src/conv/type_conversions.rs
@@ -172,7 +172,7 @@ fn to_rust_type_uncached(full_ty: &GodotTy, ctx: &mut Context) -> RustTy {
             let bitfield_ty = conv::make_enum_name(bitfield);
 
             RustTy::EngineBitfield {
-                tokens: quote! { crate::engine::global::#bitfield_ty },
+                tokens: quote! { crate::global::#bitfield_ty },
                 surrounding_class: None,
             }
         };
@@ -193,7 +193,7 @@ fn to_rust_type_uncached(full_ty: &GodotTy, ctx: &mut Context) -> RustTy {
             let enum_ty = conv::make_enum_name(qualified_enum);
 
             RustTy::EngineEnum {
-                tokens: quote! { crate::engine::global::#enum_ty },
+                tokens: quote! { crate::global::#enum_ty },
                 surrounding_class: None,
             }
         };

--- a/godot-codegen/src/generator/notifications.rs
+++ b/godot-codegen/src/generator/notifications.rs
@@ -97,6 +97,8 @@ pub fn make_notification_enum(
         ///
         /// Makes it easier to keep an overview all possible notification variants for a given class, including
         /// notifications defined in base classes.
+        ///
+        /// Contains the [`Unknown`] variant for forward compatibility.
         #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
         #[repr(i32)]
         #cfg_attributes

--- a/godot-core/src/builtin/array.rs
+++ b/godot-core/src/builtin/array.rs
@@ -870,7 +870,7 @@ impl<T: ArrayElement> Var for Array<T> {
         }
 
         PropertyHintInfo {
-            hint: crate::engine::global::PropertyHint::ARRAY_TYPE,
+            hint: crate::global::PropertyHint::ARRAY_TYPE,
             hint_string: T::godot_type_name().into(),
         }
     }
@@ -879,7 +879,7 @@ impl<T: ArrayElement> Var for Array<T> {
 impl<T: ArrayElement + TypeStringHint> Export for Array<T> {
     fn default_export_info() -> PropertyHintInfo {
         PropertyHintInfo {
-            hint: crate::engine::global::PropertyHint::TYPE_STRING,
+            hint: crate::global::PropertyHint::TYPE_STRING,
             hint_string: T::type_string().into(),
         }
     }

--- a/godot-core/src/builtin/basis.rs
+++ b/godot-core/src/builtin/basis.rs
@@ -10,9 +10,7 @@ use sys::{ffi_methods, GodotFfi};
 
 use crate::builtin::math::{ApproxEq, FloatExt, GlamConv, GlamType};
 use crate::builtin::real_consts::FRAC_PI_2;
-use crate::builtin::{real, Quaternion, RMat3, RQuat, RVec2, RVec3, Vector3};
-
-use crate::engine::global::EulerOrder;
+use crate::builtin::{real, EulerOrder, Quaternion, RMat3, RQuat, RVec2, RVec3, Vector3};
 use std::cmp::Ordering;
 use std::fmt::Display;
 use std::ops::{Mul, MulAssign};

--- a/godot-core/src/builtin/meta/registration/method.rs
+++ b/godot-core/src/builtin/meta/registration/method.rs
@@ -10,7 +10,7 @@ use sys::interface_fn;
 
 use crate::builtin::meta::{ClassName, PropertyInfo, VarcallSignatureTuple};
 use crate::builtin::{StringName, Variant};
-use crate::engine::global::MethodFlags;
+use crate::global::MethodFlags;
 
 /// Info relating to an argument or return type in a method.
 pub struct MethodParamOrReturnInfo {

--- a/godot-core/src/builtin/packed_array.rs
+++ b/godot-core/src/builtin/packed_array.rs
@@ -514,7 +514,7 @@ macro_rules! impl_packed_array {
                 // In 4.3 Godot can (and does) use type hint strings for packed arrays, see https://github.com/godotengine/godot/pull/82952.
                 if sys::GdextBuild::since_api("4.3") {
                     $crate::property::PropertyHintInfo {
-                        hint: $crate::engine::global::PropertyHint::TYPE_STRING,
+                        hint: $crate::global::PropertyHint::TYPE_STRING,
                         hint_string: <$Element as $crate::property::TypeStringHint>::type_string().into(),
                     }
                 } else {

--- a/godot-core/src/builtin/quaternion.rs
+++ b/godot-core/src/builtin/quaternion.rs
@@ -9,9 +9,7 @@ use godot_ffi as sys;
 use sys::{ffi_methods, GodotFfi};
 
 use crate::builtin::math::{ApproxEq, FloatExt, GlamConv, GlamType};
-use crate::builtin::{inner, real, Basis, RQuat, RealConv, Vector3};
-
-use crate::engine::global::EulerOrder;
+use crate::builtin::{inner, real, Basis, EulerOrder, RQuat, RealConv, Vector3};
 use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use super::meta::impl_godot_as_self;

--- a/godot-core/src/builtin/rect2.rs
+++ b/godot-core/src/builtin/rect2.rs
@@ -9,8 +9,7 @@ use godot_ffi as sys;
 use sys::{ffi_methods, GodotFfi};
 
 use crate::builtin::math::ApproxEq;
-use crate::builtin::{real, Rect2i, Vector2};
-use crate::engine::global::Side;
+use crate::builtin::{real, Rect2i, Side, Vector2};
 
 use super::meta::impl_godot_as_self;
 

--- a/godot-core/src/builtin/rect2i.rs
+++ b/godot-core/src/builtin/rect2i.rs
@@ -7,11 +7,10 @@
 
 use std::cmp;
 
-use crate::engine::global::Side;
+use crate::builtin::meta::impl_godot_as_self;
+use crate::builtin::{Rect2, Side, Vector2i};
 use godot_ffi as sys;
 use sys::{ffi_methods, GodotFfi};
-
-use super::{meta::impl_godot_as_self, Rect2, Vector2i};
 
 /// 2D axis-aligned integer bounding box.
 ///

--- a/godot-core/src/builtin/signal.rs
+++ b/godot-core/src/builtin/signal.rs
@@ -10,10 +10,10 @@ use std::ptr;
 
 use godot_ffi as sys;
 
-use super::meta::{impl_godot_as_self, FromGodot, GodotType};
-use crate::builtin::meta::ToGodot;
+use crate::builtin::meta::{impl_godot_as_self, FromGodot, GodotType, ToGodot};
 use crate::builtin::{inner, Array, Callable, Dictionary, StringName, Variant};
-use crate::engine::{global::Error, Object};
+use crate::engine::Object;
+use crate::global::Error;
 use crate::obj::bounds::DynMemory;
 use crate::obj::{Bounds, Gd, GodotClass, InstanceId};
 use sys::{ffi_methods, GodotFfi};

--- a/godot-core/src/engine/mod.rs
+++ b/godot-core/src/engine/mod.rs
@@ -12,25 +12,12 @@ use crate::obj::{bounds, Bounds, Gd, GodotClass, InstanceId};
 
 // Re-exports of generated symbols
 
-#[deprecated = "Enums have been moved to `godot::global`."]
-pub mod global {
-    pub use crate::builtin::{Corner, EulerOrder, Side};
-    pub use crate::global::*;
-}
-
-#[deprecated = "Utility functions have been moved to `godot::global`."]
-pub mod utilities {
-    pub use crate::global::*;
-}
-
 pub use crate::gen::classes::*;
-pub use io::*;
 pub use script_instance::{create_script_instance, ScriptInstance, SiMut};
 
 use crate::builtin::meta::CallContext;
 use crate::sys;
 
-mod io;
 mod manual_extensions;
 mod script_instance;
 pub mod translate;
@@ -48,6 +35,38 @@ use crate::builtin::meta::ClassName;
 pub mod native {
     pub use crate::gen::native::*;
 }
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// Deprecations
+
+// #[deprecated = "Enums have been moved to `godot::global`."]
+// pub mod global {
+//     pub use crate::builtin::{Corner, EulerOrder, Side};
+//     pub use crate::global::*;
+// }
+//
+// #[deprecated = "Utility functions have been moved to `godot::global`."]
+// pub mod utilities {
+//     pub use crate::global::*;
+// }
+//
+// #[deprecated = "`GFile` has been moved to `godot::extras`."]
+// pub use crate::extras::GFile;
+//
+// #[deprecated = "`IoError` has been moved to `godot::extras`."]
+// pub use crate::extras::IoError;
+//
+// #[deprecated = "`save` has been moved to `godot::global`."]
+// pub use crate::global::save;
+//
+// #[deprecated = "`try_save` has been moved to `godot::global`."]
+// pub use crate::global::try_save;
+//
+// #[deprecated = "`load` has been moved to `godot::global`."]
+// pub use crate::global::load;
+//
+// #[deprecated = "`try_load` has been moved to `godot::global`."]
+// pub use crate::global::try_load;
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Utilities for crate

--- a/godot-core/src/engine/mod.rs
+++ b/godot-core/src/engine/mod.rs
@@ -13,14 +13,11 @@ use crate::obj::{bounds, Bounds, Gd, GodotClass, InstanceId};
 // Re-exports of generated symbols
 
 pub use crate::gen::classes::*;
-pub use script_instance::{create_script_instance, ScriptInstance, SiMut};
 
 use crate::builtin::meta::CallContext;
 use crate::sys;
 
 mod manual_extensions;
-mod script_instance;
-pub mod translate;
 
 #[cfg(debug_assertions)]
 use crate::builtin::meta::ClassName;
@@ -49,6 +46,20 @@ pub mod global {
 pub mod utilities {
     pub use crate::global::*;
 }
+
+#[deprecated = "`godot::engine::translate` has been moved to `godot::extras`."]
+pub mod translate {
+    pub use crate::extras::{tr, tr_n};
+}
+
+#[deprecated = "`create_script_instance` has been moved to `godot::extras`."]
+pub use crate::extras::create_script_instance;
+
+#[deprecated = "`ScriptInstance` has been moved to `godot::extras`."]
+pub use crate::extras::ScriptInstance;
+
+#[deprecated = "`SiMut` has been moved to `godot::extras`."]
+pub use crate::extras::SiMut;
 
 #[deprecated = "`GFile` has been moved to `godot::extras`."]
 pub use crate::extras::GFile;

--- a/godot-core/src/engine/mod.rs
+++ b/godot-core/src/engine/mod.rs
@@ -39,34 +39,34 @@ pub mod native {
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Deprecations
 
-// #[deprecated = "Enums have been moved to `godot::global`."]
-// pub mod global {
-//     pub use crate::builtin::{Corner, EulerOrder, Side};
-//     pub use crate::global::*;
-// }
-//
-// #[deprecated = "Utility functions have been moved to `godot::global`."]
-// pub mod utilities {
-//     pub use crate::global::*;
-// }
-//
-// #[deprecated = "`GFile` has been moved to `godot::extras`."]
-// pub use crate::extras::GFile;
-//
-// #[deprecated = "`IoError` has been moved to `godot::extras`."]
-// pub use crate::extras::IoError;
-//
-// #[deprecated = "`save` has been moved to `godot::global`."]
-// pub use crate::global::save;
-//
-// #[deprecated = "`try_save` has been moved to `godot::global`."]
-// pub use crate::global::try_save;
-//
-// #[deprecated = "`load` has been moved to `godot::global`."]
-// pub use crate::global::load;
-//
-// #[deprecated = "`try_load` has been moved to `godot::global`."]
-// pub use crate::global::try_load;
+#[deprecated = "Enums have been moved to `godot::global`."]
+pub mod global {
+    pub use crate::builtin::{Corner, EulerOrder, Side};
+    pub use crate::global::*;
+}
+
+#[deprecated = "Utility functions have been moved to `godot::global`."]
+pub mod utilities {
+    pub use crate::global::*;
+}
+
+#[deprecated = "`GFile` has been moved to `godot::extras`."]
+pub use crate::extras::GFile;
+
+#[deprecated = "`IoError` has been moved to `godot::extras`."]
+pub use crate::extras::IoError;
+
+#[deprecated = "`save` has been moved to `godot::global`."]
+pub use crate::global::save;
+
+#[deprecated = "`try_save` has been moved to `godot::global`."]
+pub use crate::global::try_save;
+
+#[deprecated = "`load` has been moved to `godot::global`."]
+pub use crate::global::load;
+
+#[deprecated = "`try_load` has been moved to `godot::global`."]
+pub use crate::global::try_load;
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Utilities for crate

--- a/godot-core/src/extras/gfile.rs
+++ b/godot-core/src/extras/gfile.rs
@@ -7,11 +7,10 @@
 
 use crate::builtin::{real, GString, PackedByteArray, PackedStringArray, Variant};
 use crate::engine::file_access::{CompressionMode, ModeFlags};
-use crate::gen::classes::FileAccess;
+use crate::engine::FileAccess;
+use crate::extras::IoError;
 use crate::global::Error;
 use crate::obj::Gd;
-
-use crate::engine::io::IoError;
 
 use std::cmp;
 use std::io::{BufRead, ErrorKind, Read, Seek, SeekFrom, Write};
@@ -49,9 +48,9 @@ use std::io::{BufRead, ErrorKind, Read, Seek, SeekFrom, Write};
 /// ## Examples
 ///
 /// ```no_run
-/// use godot::engine::GFile;
+/// use godot::builtin::GString;
 /// use godot::engine::file_access::ModeFlags;
-/// use godot::builtin::{GString};
+/// use godot::extras::GFile;
 ///
 /// fn save_game() -> Result<(), std::io::Error> {
 ///

--- a/godot-core/src/extras/io_error.rs
+++ b/godot-core/src/extras/io_error.rs
@@ -7,8 +7,8 @@
 
 use std::error::Error;
 
-use crate::engine::global::Error as GodotError;
 use crate::gen::classes::FileAccess;
+use crate::global::Error as GodotError;
 use crate::obj::{Gd, NotUniqueError};
 
 /// Error that can occur while using `gdext` IO utilities.

--- a/godot-core/src/extras/mod.rs
+++ b/godot-core/src/extras/mod.rs
@@ -7,8 +7,6 @@
 
 mod gfile;
 mod io_error;
-mod resources;
 
-pub use gfile::GFile;
+pub use gfile::*;
 pub use io_error::*;
-pub use resources::{load, save, try_load, try_save};

--- a/godot-core/src/extras/mod.rs
+++ b/godot-core/src/extras/mod.rs
@@ -7,6 +7,10 @@
 
 mod gfile;
 mod io_error;
+mod script_instance;
+mod translate;
 
 pub use gfile::*;
 pub use io_error::*;
+pub use script_instance::*;
+pub use translate::*;

--- a/godot-core/src/extras/script_instance.rs
+++ b/godot-core/src/extras/script_instance.rs
@@ -15,10 +15,9 @@ use godot_cell::{GdCell, MutGuard};
 
 use crate::builtin::meta::{MethodInfo, PropertyInfo};
 use crate::builtin::{GString, StringName, Variant, VariantType};
+use crate::engine::{Script, ScriptLanguage};
 use crate::obj::{Base, Gd, GodotClass, ScriptBaseMut, ScriptBaseRef};
 use crate::sys;
-
-use super::{Script, ScriptLanguage};
 
 /// Implement custom scripts that can be attached to objects in Godot.
 ///

--- a/godot-core/src/extras/translate.rs
+++ b/godot-core/src/extras/translate.rs
@@ -22,7 +22,7 @@ pub use crate::{tr, tr_n};
 /// # let a = Vector2i { x: 0, y: 0 };
 /// # let b = Vector2i { x: 0, y: 0 };
 /// # let context = "context";
-/// use godot::engine::translate::tr;
+/// use godot::extras::tr;
 ///
 /// // Good.
 /// tr!(context; "{a} is a {b}"); // inlined, with context
@@ -65,7 +65,7 @@ macro_rules! tr {
 /// # let b = Vector2i { x: 0, y: 0 };
 /// # let context = "context";
 /// # let n = 2;
-/// use godot::engine::translate::tr_n;
+/// use godot::extras::tr_n;
 ///
 /// // Good.
 /// tr_n!(n, context; "{a} is a {b}", "{a}s are {b}s"); // inlined, with context

--- a/godot-core/src/global/mod.rs
+++ b/godot-core/src/global/mod.rs
@@ -19,13 +19,16 @@
 //! - Rectangle: [`Side`][crate::builtin::Side], [`Corner`][crate::builtin::Corner] <sub>(godot-generated)</sub>
 //! - Rotation: [`EulerOrder`][crate::builtin::EulerOrder] <sub>(godot-generated)</sub>
 //! - Variant: [`VariantType`][crate::builtin::VariantType], [`VariantOperator`][crate::builtin::VariantOperator]
-//! - Vector: [`Vector2Axis`](crate::builtin::Vector2Axis), [`Vector3Axis`](crate::builtin::Vector3Axis), [`Vector4Axis`](crate::builtin::Vector4Axis)
+//! - Vector: [`Vector2Axis`][crate::builtin::Vector2Axis], [`Vector3Axis`][crate::builtin::Vector3Axis], [`Vector4Axis`][crate::builtin::Vector4Axis]
 //!
 
 mod print;
+mod save_load;
 
 pub use crate::{godot_error, godot_print, godot_print_rich, godot_script_error, godot_warn};
 
 // Some enums are directly re-exported from crate::builtin.
 pub use crate::gen::central::global_enums::*;
 pub use crate::gen::utilities::*;
+
+pub use save_load::*;

--- a/godot-core/src/global/mod.rs
+++ b/godot-core/src/global/mod.rs
@@ -32,3 +32,7 @@ pub use crate::gen::central::global_enums::*;
 pub use crate::gen::utilities::*;
 
 pub use save_load::*;
+
+// This is needed for generated classes to find symbols, even those that have been moved to crate::builtin.
+#[allow(unused_imports)] // micromanaging imports for generated code is not fun
+pub(crate) use crate::builtin::{Corner, EulerOrder, Side};

--- a/godot-core/src/global/save_load.rs
+++ b/godot-core/src/global/save_load.rs
@@ -6,11 +6,10 @@
  */
 
 use crate::builtin::GString;
-use crate::engine::global::Error as GodotError;
-use crate::gen::classes::{Resource, ResourceLoader, ResourceSaver};
+use crate::engine::{Resource, ResourceLoader, ResourceSaver};
+use crate::extras::IoError;
+use crate::global::Error as GodotError;
 use crate::obj::{Gd, Inherits};
-
-use super::IoError;
 
 /// ⚠️ Loads a resource from the filesystem located at `path`, panicking on error.
 ///

--- a/godot-core/src/lib.rs
+++ b/godot-core/src/lib.rs
@@ -40,11 +40,15 @@ pub use registry::*;
 /// * Enum/flag modules: `canvas_item`, etc.
 ///
 /// Noteworthy sub-modules are:
-/// * [`notify`][crate::engine::notify]: all notification types, used when working with the virtual callback to handle lifecycle notifications.
-/// * [`global`][crate::engine::global]: global enums not belonging to a specific class.
-/// * [`utilities`][crate::engine::utilities]: utility methods that are global in Godot.
-/// * [`translate`][crate::engine::translate]: convenience macros for translation.
+/// * [`notify`][crate::engine::notify]: all notification enums, used when working with the virtual callback to handle lifecycle notifications.
+/// * [`native`][crate::engine::native]: definition of _native structure_ types.
 pub mod engine;
+
+/// Higher-level additions to the Godot engine API.
+///
+/// Contains functionality that extends existing Godot classes and functions, to make them more versatile
+/// or better integrated with Rust.
+pub mod extras;
 
 // Output of generated code. Mimics the file structure, symbols are re-exported.
 #[rustfmt::skip]

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -17,12 +17,14 @@ use crate::builtin::meta::{
     ToGodot,
 };
 use crate::builtin::{Callable, NodePath, StringName, Variant};
+use crate::global::PropertyHint;
 use crate::obj::raw::RawGd;
 use crate::obj::{
     bounds, cap, Bounds, EngineEnum, GdDerefTarget, GdMut, GdRef, GodotClass, Inherits, InstanceId,
 };
+use crate::private::callbacks;
 use crate::property::{Export, PropertyHintInfo, TypeStringHint, Var};
-use crate::{callbacks, engine, out};
+use crate::{engine, out};
 
 /// Smart pointer to objects owned by the Godot engine.
 ///
@@ -649,7 +651,7 @@ impl<T: GodotClass> Clone for Gd<T> {
 
 impl<T: GodotClass> TypeStringHint for Gd<T> {
     fn type_string() -> String {
-        use engine::global::PropertyHint;
+        use crate::global::PropertyHint;
 
         match Self::default_export_info().hint {
             hint @ (PropertyHint::RESOURCE_TYPE | PropertyHint::NODE_TYPE) => {
@@ -680,11 +682,11 @@ impl<T: GodotClass> Var for Gd<T> {
 impl<T: GodotClass> Export for Gd<T> {
     fn default_export_info() -> PropertyHintInfo {
         let hint = if T::inherits::<engine::Resource>() {
-            engine::global::PropertyHint::RESOURCE_TYPE
+            PropertyHint::RESOURCE_TYPE
         } else if T::inherits::<engine::Node>() {
-            engine::global::PropertyHint::NODE_TYPE
+            PropertyHint::NODE_TYPE
         } else {
-            engine::global::PropertyHint::NONE
+            PropertyHint::NONE
         };
 
         // Godot does this by default too; the hint is needed when the class is a resource/node,

--- a/godot-core/src/obj/guards.rs
+++ b/godot-core/src/obj/guards.rs
@@ -11,9 +11,8 @@ use godot_ffi::out;
 use std::fmt::Debug;
 use std::ops::{Deref, DerefMut};
 
-use crate::engine::ScriptInstance;
-
-use super::{Gd, GodotClass};
+use crate::extras::ScriptInstance;
+use crate::obj::{Gd, GodotClass};
 
 /// Immutably/shared bound reference guard for a [`Gd`][crate::obj::Gd] smart pointer.
 ///

--- a/godot-core/src/obj/raw.rs
+++ b/godot-core/src/obj/raw.rs
@@ -19,7 +19,7 @@ use crate::obj::bounds::DynMemory as _;
 use crate::obj::rtti::ObjectRtti;
 use crate::obj::{bounds, Bounds, GdDerefTarget, GdMut, GdRef, GodotClass, InstanceId};
 use crate::storage::{InstanceStorage, Storage};
-use crate::{engine, out};
+use crate::{engine, global, out};
 
 /// Low-level bindings for object pointers in Godot.
 ///
@@ -105,7 +105,7 @@ impl<T: GodotClass> RawGd<T> {
     pub(crate) fn is_instance_valid(&self) -> bool {
         self.cached_rtti
             .as_ref()
-            .map(|rtti| engine::utilities::is_instance_id_valid(rtti.instance_id().to_i64()))
+            .map(|rtti| global::is_instance_id_valid(rtti.instance_id().to_i64()))
             .unwrap_or(false)
     }
 

--- a/godot-core/src/registry/property.rs
+++ b/godot-core/src/registry/property.rs
@@ -11,7 +11,7 @@ use godot_ffi as sys;
 
 use crate::builtin::meta::{FromGodot, GodotConvert, GodotType, ToGodot};
 use crate::builtin::GString;
-use crate::engine::global::PropertyHint;
+use crate::global::PropertyHint;
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Trait definitions
@@ -142,7 +142,7 @@ impl PropertyHintInfo {
 /// Each function is named the same as the equivalent Godot annotation. For instance `@export_range` in Godot is `fn export_range` here.
 pub mod export_info_functions {
     use crate::builtin::GString;
-    use crate::engine::global::PropertyHint;
+    use crate::global::PropertyHint;
 
     use super::PropertyHintInfo;
 

--- a/godot-macros/src/class/data_models/func.rs
+++ b/godot-macros/src/class/data_models/func.rs
@@ -379,7 +379,7 @@ fn make_method_flags(
     method_type: ReceiverType,
     is_script_virtual: bool,
 ) -> Result<TokenStream, String> {
-    let flags = quote! { ::godot::engine::global::MethodFlags };
+    let flags = quote! { ::godot::global::MethodFlags };
 
     let base_flags = match method_type {
         ReceiverType::Ref => {

--- a/godot-macros/src/class/data_models/property.rs
+++ b/godot-macros/src/class/data_models/property.rs
@@ -89,14 +89,14 @@ pub fn make_property_impl(class_name: &Ident, fields: &Fields) -> TokenStream {
 
         let usage_flags = match usage_flags {
             UsageFlags::Inferred => {
-                quote! { ::godot::engine::global::PropertyUsageFlags::NONE }
+                quote! { ::godot::global::PropertyUsageFlags::NONE }
             }
             UsageFlags::InferredExport => {
-                quote! { ::godot::engine::global::PropertyUsageFlags::DEFAULT }
+                quote! { ::godot::global::PropertyUsageFlags::DEFAULT }
             }
             UsageFlags::Custom(flags) => quote! {
                 #(
-                    ::godot::engine::global::PropertyUsageFlags::#flags
+                    ::godot::global::PropertyUsageFlags::#flags
                 )|*
             },
         };
@@ -135,14 +135,14 @@ pub fn make_property_impl(class_name: &Ident, fields: &Fields) -> TokenStream {
 
                 quote! {
                     (
-                        ::godot::engine::global::PropertyHint::#hint,
+                        ::godot::global::PropertyHint::#hint,
                         #hint_string
                     )
                 }
             }
             FieldHint::HintWithString { hint, hint_string } => quote! {
                 (
-                    ::godot::engine::global::PropertyHint::#hint,
+                    ::godot::global::PropertyHint::#hint,
                     ::godot::builtin::GString::from(#hint_string)
                 )
             },

--- a/godot-macros/src/derive/derive_var.rs
+++ b/godot-macros/src/derive/derive_var.rs
@@ -61,7 +61,7 @@ fn create_property_hint_impl(convert: &GodotConvert) -> TokenStream {
 
             quote! {
                 ::godot::register::property::PropertyHintInfo {
-                    hint: ::godot::engine::global::PropertyHint::ENUM,
+                    hint: ::godot::global::PropertyHint::ENUM,
                     hint_string: #hint_string.into(),
                 }
             }

--- a/godot/src/lib.rs
+++ b/godot/src/lib.rs
@@ -223,7 +223,7 @@ const _: () = _validate_features();
 // Modules
 
 #[doc(inline)]
-pub use godot_core::{builtin, engine, global, obj};
+pub use godot_core::{builtin, engine, extras, global, obj};
 
 #[allow(deprecated)]
 pub use godot_core::log;

--- a/godot/src/prelude.rs
+++ b/godot/src/prelude.rs
@@ -15,14 +15,15 @@ pub use super::builtin::math::FloatExt as _;
 pub use super::builtin::meta::{FromGodot, ToGodot};
 
 pub use super::engine::{
-    load, try_load, AudioStreamPlayer, Camera2D, Camera3D, GFile, IAudioStreamPlayer, ICamera2D,
-    ICamera3D, INode, INode2D, INode3D, IObject, IPackedScene, IRefCounted, IResource, ISceneTree,
-    Input, Node, Node2D, Node3D, Object, PackedScene, RefCounted, Resource, SceneTree,
+    AudioStreamPlayer, Camera2D, Camera3D, IAudioStreamPlayer, ICamera2D, ICamera3D, INode,
+    INode2D, INode3D, IObject, IPackedScene, IRefCounted, IResource, ISceneTree, Input, Node,
+    Node2D, Node3D, Object, PackedScene, RefCounted, Resource, SceneTree,
 };
+pub use super::extras::{GFile, IoError};
 pub use super::global::{
-    godot_error, godot_print, godot_print_rich, godot_script_error, godot_warn,
+    godot_error, godot_print, godot_print_rich, godot_script_error, godot_warn, load, save,
+    try_load, try_save,
 };
-/* ProjectionEye etc */
 
 pub use super::init::{gdextension, ExtensionLibrary, InitLevel};
 pub use super::obj::{Base, Gd, GdMut, GdRef, GodotClass, Inherits, InstanceId, OnReady};

--- a/itest/rust/build.rs
+++ b/itest/rust/build.rs
@@ -216,7 +216,7 @@ fn main() {
         use godot::builtin::meta::*;
         use godot::log::godot_error;
         use godot::obj::{Gd, InstanceId};
-        use godot::engine::global::Error;
+        use godot::global::Error;
         use godot::engine::{Node, Resource};
 
         #[derive(godot::register::GodotClass)]

--- a/itest/rust/src/benchmarks/mod.rs
+++ b/itest/rust/src/benchmarks/mod.rs
@@ -74,7 +74,7 @@ fn class_singleton_access() -> Gd<Os> {
 
 #[bench]
 fn utilities_allocate_rid() -> i64 {
-    godot::engine::utilities::rid_allocate_id()
+    godot::global::rid_allocate_id()
 }
 
 #[bench]
@@ -90,7 +90,7 @@ fn utilities_ffi_call() -> f64 {
     let base = black_box(5.678);
     let exponent = black_box(3.456);
 
-    godot::engine::utilities::pow(base, exponent)
+    godot::global::pow(base, exponent)
 }
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------

--- a/itest/rust/src/builtin_tests/containers/array_test.rs
+++ b/itest/rust/src/builtin_tests/containers/array_test.rs
@@ -406,9 +406,9 @@ fn untyped_array_return_from_godot_func() {
 // ancestors in the list.
 #[itest]
 fn typed_array_pass_to_godot_func() {
-    use godot::engine::global::Error;
     use godot::engine::image::Format;
     use godot::engine::{Image, Texture2DArray};
+    use godot::global::Error;
 
     let mut image = Image::new_gd();
     image.set_data(

--- a/itest/rust/src/builtin_tests/geometry/basis_test.rs
+++ b/itest/rust/src/builtin_tests/geometry/basis_test.rs
@@ -8,8 +8,7 @@
 use godot::builtin::inner::InnerBasis;
 use godot::builtin::math::assert_eq_approx;
 use godot::builtin::meta::ToGodot;
-use godot::builtin::{real, Basis, RealConv, VariantOperator, Vector3};
-use godot::engine::global::EulerOrder;
+use godot::builtin::{real, Basis, EulerOrder, RealConv, VariantOperator, Vector3};
 
 use crate::framework::itest;
 

--- a/itest/rust/src/builtin_tests/geometry/rect2_test.rs
+++ b/itest/rust/src/builtin_tests/geometry/rect2_test.rs
@@ -9,8 +9,7 @@ use crate::framework::itest;
 
 use godot::builtin::inner::InnerRect2;
 use godot::builtin::math::assert_eq_approx;
-use godot::builtin::{real, reals, RealConv, Rect2, Vector2};
-use godot::engine::global::Side;
+use godot::builtin::{real, reals, RealConv, Rect2, Side, Vector2};
 
 #[itest]
 fn rect2_inner_equivalence() {

--- a/itest/rust/src/builtin_tests/geometry/rect2i_test.rs
+++ b/itest/rust/src/builtin_tests/geometry/rect2i_test.rs
@@ -9,8 +9,7 @@ use std::fmt::Debug;
 
 use crate::framework::itest;
 use godot::builtin::inner::InnerRect2i;
-use godot::builtin::{Rect2i, Vector2i};
-use godot::engine::global::Side;
+use godot::builtin::{Rect2i, Side, Vector2i};
 use godot::obj::EngineEnum;
 
 #[itest]

--- a/itest/rust/src/builtin_tests/script/script_instance_tests.rs
+++ b/itest/rust/src/builtin_tests/script/script_instance_tests.rs
@@ -9,11 +9,11 @@ use std::ffi::c_void;
 
 use godot::builtin::meta::{ClassName, FromGodot, MethodInfo, PropertyInfo, ToGodot};
 use godot::builtin::{GString, StringName, Variant, VariantType};
-use godot::engine::global::{MethodFlags, PropertyHint, PropertyUsageFlags};
 use godot::engine::{
     create_script_instance, IScriptExtension, Object, Script, ScriptExtension, ScriptInstance,
     ScriptLanguage, SiMut,
 };
+use godot::global::{MethodFlags, PropertyHint, PropertyUsageFlags};
 use godot::obj::{Base, Gd, WithBaseField};
 use godot::register::{godot_api, GodotClass};
 use godot::sys;

--- a/itest/rust/src/builtin_tests/script/script_instance_tests.rs
+++ b/itest/rust/src/builtin_tests/script/script_instance_tests.rs
@@ -9,10 +9,8 @@ use std::ffi::c_void;
 
 use godot::builtin::meta::{ClassName, FromGodot, MethodInfo, PropertyInfo, ToGodot};
 use godot::builtin::{GString, StringName, Variant, VariantType};
-use godot::engine::{
-    create_script_instance, IScriptExtension, Object, Script, ScriptExtension, ScriptInstance,
-    ScriptLanguage, SiMut,
-};
+use godot::engine::{IScriptExtension, Object, Script, ScriptExtension, ScriptLanguage};
+use godot::extras::{create_script_instance, ScriptInstance, SiMut};
 use godot::global::{MethodFlags, PropertyHint, PropertyUsageFlags};
 use godot::obj::{Base, Gd, WithBaseField};
 use godot::register::{godot_api, GodotClass};

--- a/itest/rust/src/engine_tests/gfile_test.rs
+++ b/itest/rust/src/engine_tests/gfile_test.rs
@@ -9,7 +9,8 @@ use std::io::{BufRead, BufReader, BufWriter, Read, Seek, SeekFrom, Write};
 
 use crate::framework::itest;
 use godot::builtin::GString;
-use godot::engine::{file_access::ModeFlags, GFile};
+use godot::engine::file_access::ModeFlags;
+use godot::extras::GFile;
 
 const TEST_FULL_PATH: &str = "res://file_tests";
 

--- a/itest/rust/src/engine_tests/save_load_test.rs
+++ b/itest/rust/src/engine_tests/save_load_test.rs
@@ -5,7 +5,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use godot::engine::{load, save, try_load, try_save};
+use godot::global::{load, save, try_load, try_save};
 use godot::obj::NewGd;
 use godot::register::GodotClass;
 

--- a/itest/rust/src/engine_tests/translate_test.rs
+++ b/itest/rust/src/engine_tests/translate_test.rs
@@ -7,7 +7,7 @@
 
 use crate::framework::itest;
 use godot::builtin::Vector2;
-use godot::engine::translate::{tr, tr_n};
+use godot::extras::{tr, tr_n};
 
 #[itest]
 fn tr_macro_format() {

--- a/itest/rust/src/object_tests/get_property_list_test.rs
+++ b/itest/rust/src/object_tests/get_property_list_test.rs
@@ -9,8 +9,8 @@ use std::collections::HashMap;
 
 use godot::builtin::meta::PropertyInfo;
 use godot::builtin::{Dictionary, GString, StringName, VariantType, Vector2, Vector3};
-use godot::engine::global::{PropertyHint, PropertyUsageFlags};
 use godot::engine::{IObject, Node};
+use godot::global::{PropertyHint, PropertyUsageFlags};
 use godot::obj::{Gd, NewAlloc};
 use godot::register::{godot_api, GodotClass};
 use godot::test::itest;

--- a/itest/rust/src/object_tests/object_test.rs
+++ b/itest/rust/src/object_tests/object_test.rs
@@ -11,11 +11,11 @@ use std::rc::Rc;
 use godot::builtin::meta::GodotType;
 use godot::builtin::meta::{FromGodot, ToGodot};
 use godot::builtin::{GString, StringName, Variant, Vector3};
-use godot::engine::utilities::instance_from_id;
 use godot::engine::{
     file_access, Area2D, Camera3D, Engine, FileAccess, IRefCounted, Node, Node3D, Object,
     RefCounted,
 };
+use godot::global::instance_from_id;
 use godot::obj::{Base, Gd, Inherits, InstanceId, NewAlloc, NewGd, RawGd};
 use godot::register::{godot_api, GodotClass};
 use godot::sys::{self, interface_fn, GodotFfi};

--- a/itest/rust/src/object_tests/onready_test.rs
+++ b/itest/rust/src/object_tests/onready_test.rs
@@ -58,7 +58,7 @@ fn onready_lifecycle_forget() {
     expect_panic(
         "Forgetting to initialize OnReady during ready() panics",
         move || {
-            forgetful.notify(NodeNotification::Ready);
+            forgetful.notify(NodeNotification::READY);
         },
     );
 
@@ -69,7 +69,7 @@ fn onready_lifecycle_forget() {
 fn onready_lifecycle() {
     let mut obj = OnReadyWithImpl::create(true);
 
-    obj.notify(NodeNotification::Ready);
+    obj.notify(NodeNotification::READY);
 
     {
         let mut obj = obj.bind_mut();
@@ -87,7 +87,7 @@ fn onready_lifecycle() {
 fn onready_lifecycle_without_impl() {
     let mut obj = OnReadyWithoutImpl::create();
 
-    obj.notify(NodeNotification::Ready);
+    obj.notify(NodeNotification::READY);
 
     {
         let mut obj = obj.bind_mut();
@@ -104,7 +104,7 @@ fn onready_lifecycle_without_impl() {
 fn onready_lifecycle_with_impl_without_ready() {
     let mut obj = OnReadyWithImplWithoutReady::create();
 
-    obj.notify(NodeNotification::Ready);
+    obj.notify(NodeNotification::READY);
 
     {
         let mut obj = obj.bind_mut();
@@ -123,7 +123,7 @@ fn onready_lifecycle_with_impl_without_ready() {
 #[itest]
 fn onready_property_access() {
     let mut obj = OnReadyWithImpl::create(true);
-    obj.notify(NodeNotification::Ready);
+    obj.notify(NodeNotification::READY);
 
     obj.set("auto".into(), 33.to_variant());
     obj.set("manual".into(), 44.to_variant());

--- a/itest/rust/src/object_tests/property_template_test.rs
+++ b/itest/rust/src/object_tests/property_template_test.rs
@@ -13,7 +13,7 @@
 use std::collections::HashMap;
 
 use crate::framework::itest;
-use godot::engine::global::PropertyUsageFlags;
+use godot::global::PropertyUsageFlags;
 use godot::prelude::*;
 use godot::sys::GdextBuild;
 

--- a/itest/rust/src/object_tests/property_test.rs
+++ b/itest/rust/src/object_tests/property_test.rs
@@ -7,8 +7,8 @@
 
 use godot::builtin::meta::{GodotConvert, ToGodot};
 use godot::builtin::{dict, Color, Dictionary, GString, Variant, VariantType};
-use godot::engine::global::{PropertyHint, PropertyUsageFlags};
 use godot::engine::{INode, IRefCounted, Node, Object, RefCounted, Resource, Texture};
+use godot::global::{PropertyHint, PropertyUsageFlags};
 use godot::obj::{Base, EngineBitfield, EngineEnum, Gd, NewAlloc, NewGd};
 use godot::register::property::{Export, PropertyHintInfo, Var};
 use godot::register::{godot_api, Export, GodotClass, GodotConvert, Var};

--- a/itest/rust/src/object_tests/virtual_methods_test.rs
+++ b/itest/rust/src/object_tests/virtual_methods_test.rs
@@ -523,19 +523,19 @@ fn test_input_event_multiple(test_context: &TestContext) {
 fn test_notifications() {
     let obj = NotificationTest::new_alloc();
     let mut node = obj.clone().upcast::<Node>();
-    node.notify(NodeNotification::Unpaused);
-    node.notify(NodeNotification::EditorPostSave);
-    node.notify(NodeNotification::Ready);
-    node.notify_reversed(NodeNotification::WmSizeChanged);
+    node.notify(NodeNotification::UNPAUSED);
+    node.notify(NodeNotification::EDITOR_POST_SAVE);
+    node.notify(NodeNotification::READY);
+    node.notify_reversed(NodeNotification::WM_SIZE_CHANGED);
 
     assert_eq!(
         obj.bind().sequence,
         vec![
-            ReceivedEvent::Notification(NodeNotification::Unpaused),
-            ReceivedEvent::Notification(NodeNotification::EditorPostSave),
+            ReceivedEvent::Notification(NodeNotification::UNPAUSED),
+            ReceivedEvent::Notification(NodeNotification::EDITOR_POST_SAVE),
             ReceivedEvent::Ready,
-            ReceivedEvent::Notification(NodeNotification::Ready),
-            ReceivedEvent::Notification(NodeNotification::WmSizeChanged),
+            ReceivedEvent::Notification(NodeNotification::READY),
+            ReceivedEvent::Notification(NodeNotification::WM_SIZE_CHANGED),
         ]
     );
     obj.free();


### PR DESCRIPTION
Sequel of #729.
- Adds `godot::extras` module with all the higher-level engine functionality, such as `ScriptInstance` and `GFile`
- Changes notification constants to `SHOUT_CASE`, consistent with all other enums/constants
- Simplify `NODE_RECACHE_REQUESTED` workaround, also on older API levels (see [Godot issue](https://github.com/godotengine/godot/issues/75839))