### PR TITLE
Fix snapped on impl_float_ext

### DIFF
--- a/godot-core/src/builtin/math/float.rs
+++ b/godot-core/src/builtin/math/float.rs
@@ -119,7 +119,7 @@ macro_rules! impl_float_ext {
 
             fn snapped(mut self, step: Self) -> Self {
                 if step != 0.0 {
-                    self = ((self / step + 0.5) * step).floor()
+                    self = (self / step + 0.5).floor() * step
                 }
                 self
             }


### PR DESCRIPTION
Fix `snapped` to work like [Godot's implementation](https://github.com/godotengine/godot/blob/master/core/math/math_funcs.cpp#L120).