### PR TITLE
Cleanup some stuff mainly related to script instance

### DIFF
--- a/godot-core/src/builtin/callable.rs
+++ b/godot-core/src/builtin/callable.rs
@@ -432,7 +432,7 @@ mod custom_callable {
         let a: &T = CallableUserdata::inner_from_raw(callable_userdata_a);
         let b: &T = CallableUserdata::inner_from_raw(callable_userdata_b);
 
-        (a == b) as sys::GDExtensionBool
+        sys::conv::bool_to_sys(a == b)
     }
 
     pub unsafe extern "C" fn rust_callable_to_string_display<T: fmt::Display>(
@@ -444,7 +444,7 @@ mod custom_callable {
         let s = crate::builtin::GString::from(c.to_string());
 
         s.move_into_string_ptr(r_out);
-        *r_is_valid = true as sys::GDExtensionBool;
+        *r_is_valid = sys::conv::SYS_TRUE;
     }
 
     pub unsafe extern "C" fn rust_callable_to_string_named<F>(
@@ -455,6 +455,6 @@ mod custom_callable {
         let w: &mut FnWrapper<F> = CallableUserdata::inner_from_raw(callable_userdata);
 
         w.name.clone().move_into_string_ptr(r_out);
-        *r_is_valid = true as sys::GDExtensionBool;
+        *r_is_valid = sys::conv::SYS_TRUE;
     }
 }

--- a/godot-core/src/builtin/string/string_name.rs
+++ b/godot-core/src/builtin/string/string_name.rs
@@ -317,7 +317,7 @@ impl From<&'static std::ffi::CStr> for StringName {
                 sys::interface_fn!(string_name_new_with_latin1_chars)(
                     ptr,
                     c_str.as_ptr(),
-                    true as sys::GDExtensionBool, // p_is_static
+                    sys::conv::SYS_TRUE, // p_is_static
                 )
             })
         };

--- a/godot-core/src/registry/class.rs
+++ b/godot-core/src/registry/class.rs
@@ -246,7 +246,7 @@ fn fill_class_info(item: PluginItem, c: &mut ClassRegistrationInfo) {
             // For some reason, certain ABCs like PhysicsBody2D are not marked "virtual" but "abstract".
             //
             // See also: https://github.com/godotengine/godot/pull/58972
-            c.godot_params.is_abstract = (!is_instantiable) as sys::GDExtensionBool;
+            c.godot_params.is_abstract = sys::conv::bool_to_sys(!is_instantiable);
             c.godot_params.free_instance_func = Some(free_fn);
 
             fill_into(
@@ -265,7 +265,7 @@ fn fill_class_info(item: PluginItem, c: &mut ClassRegistrationInfo) {
                 )
                 .expect("duplicate: recreate_instance_func (def)");
 
-                c.godot_params.is_exposed = (!is_hidden) as sys::GDExtensionBool;
+                c.godot_params.is_exposed = sys::conv::bool_to_sys(!is_hidden);
             }
 
             #[cfg(before_api = "4.2")]
@@ -276,7 +276,7 @@ fn fill_class_info(item: PluginItem, c: &mut ClassRegistrationInfo) {
             #[cfg(since_api = "4.3")]
             {
                 c.godot_params.is_runtime =
-                    crate::private::is_class_runtime(is_tool) as sys::GDExtensionBool;
+                    sys::conv::bool_to_sys(crate::private::is_class_runtime(is_tool));
             }
         }
 
@@ -498,7 +498,7 @@ fn default_creation_info() -> sys::GDExtensionClassCreationInfo2 {
     sys::GDExtensionClassCreationInfo2 {
         is_virtual: false as u8,
         is_abstract: false as u8,
-        is_exposed: true as sys::GDExtensionBool,
+        is_exposed: sys::conv::SYS_TRUE,
         set_func: None,
         get_func: None,
         get_property_list_func: None,
@@ -526,8 +526,8 @@ fn default_creation_info() -> sys::GDExtensionClassCreationInfo3 {
     sys::GDExtensionClassCreationInfo3 {
         is_virtual: false as u8,
         is_abstract: false as u8,
-        is_exposed: true as sys::GDExtensionBool,
-        is_runtime: true as sys::GDExtensionBool,
+        is_exposed: sys::conv::SYS_TRUE,
+        is_runtime: sys::conv::SYS_TRUE,
         set_func: None,
         get_func: None,
         get_property_list_func: None,

--- a/godot-core/src/registry/constant.rs
+++ b/godot-core/src/registry/constant.rs
@@ -39,7 +39,7 @@ impl IntegerConstant {
                 enum_name.string_sys(),
                 self.name.string_sys(),
                 self.value,
-                is_bitfield as sys::GDExtensionBool,
+                sys::conv::bool_to_sys(is_bitfield),
             );
         }
     }

--- a/godot-ffi/src/conv.rs
+++ b/godot-ffi/src/conv.rs
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+//! Conversions from some rust-types into appropriate Godot types.
+
+use std::mem::size_of;
+
+use crate as sys;
+use crate::static_assert;
+
+/// Infallibly convert `u32` into a `usize`.
+///
+/// gdext (and Godot in general) currently only supports targets where `u32` can be infallibly converted into a `usize`.
+pub fn u32_to_usize(i: u32) -> usize {
+    static_assert!(
+        size_of::<u32>() <= size_of::<usize>(),
+        "gdext only supports targets where u32 <= usize"
+    );
+
+    // SAFETY: The above static assert ensures that this can never fail.
+    unsafe { i.try_into().unwrap_unchecked() }
+}
+
+/// Converts a rust-bool into a sys-bool.
+pub const fn bool_to_sys(value: bool) -> sys::GDExtensionBool {
+    value as sys::GDExtensionBool
+}
+
+pub const SYS_TRUE: sys::GDExtensionBool = bool_to_sys(true);
+pub const SYS_FALSE: sys::GDExtensionBool = bool_to_sys(false);
+
+#[cfg(test)]
+mod test {
+    use crate::conv::{bool_to_sys, u32_to_usize, SYS_FALSE, SYS_TRUE};
+
+    #[test]
+    fn sys_bool() {
+        assert_eq!(bool_to_sys(true), SYS_TRUE);
+        assert_eq!(bool_to_sys(false), SYS_FALSE);
+    }
+
+    #[test]
+    fn u32_into_usize_test() {
+        const CHECKS: &[u32] = &[
+            0,
+            123,
+            4444,
+            u32::MAX,
+            u16::MAX as u32,
+            u8::MAX as u32,
+            i8::MAX as u32,
+            i16::MAX as u32,
+            i32::MAX as u32,
+        ];
+
+        for value in CHECKS {
+            assert_eq!(u32_to_usize(*value), *value as usize);
+            assert_eq!(u32_to_usize(*value) as u32, *value);
+        }
+    }
+}

--- a/godot-ffi/src/lib.rs
+++ b/godot-ffi/src/lib.rs
@@ -22,6 +22,8 @@ pub(crate) mod gen {
     include!(concat!(env!("OUT_DIR"), "/mod.rs"));
 }
 
+pub mod conv;
+
 mod compat;
 mod extras;
 mod global;

--- a/itest/godot/ManualFfiTests.gd
+++ b/itest/godot/ManualFfiTests.gd
@@ -86,13 +86,13 @@ func test_object_pass_to_user_func_ptrcall():
 
 func test_object_return_from_user_func_varcall():
 	var obj_test = ObjectTest.new()
-	var obj: MockObjRust = obj_test.return_object() 
+	var obj: MockObjRust = obj_test.return_object()
 	assert_eq(obj.i, 42)
 	obj.free()
 
 func test_object_return_from_user_func_ptrcall():
 	var obj_test: ObjectTest = ObjectTest.new()
-	var obj: MockObjRust = obj_test.return_object() 
+	var obj: MockObjRust = obj_test.return_object()
 	assert_eq(obj.i, 42)
 	obj.free()
 
@@ -124,22 +124,22 @@ func test_refcounted_as_object_pass_to_user_func_ptrcall():
 
 func test_refcounted_return_from_user_func_varcall():
 	var obj_test = ObjectTest.new()
-	var obj: MockRefCountedRust = obj_test.return_refcounted() 
+	var obj: MockRefCountedRust = obj_test.return_refcounted()
 	assert_eq(obj.i, 42)
 
 func test_refcounted_return_from_user_func_ptrcall():
 	var obj_test: ObjectTest = ObjectTest.new()
-	var obj: MockRefCountedRust = obj_test.return_refcounted() 
+	var obj: MockRefCountedRust = obj_test.return_refcounted()
 	assert_eq(obj.i, 42)
 
 func test_refcounted_as_object_return_from_user_func_varcall():
 	var obj_test = ObjectTest.new()
-	var obj: MockRefCountedRust = obj_test.return_refcounted_as_object() 
+	var obj: MockRefCountedRust = obj_test.return_refcounted_as_object()
 	assert_eq(obj.i, 42)
 
 func test_refcounted_as_object_return_from_user_func_ptrcall():
 	var obj_test: ObjectTest = ObjectTest.new()
-	var obj: MockRefCountedRust = obj_test.return_refcounted_as_object() 
+	var obj: MockRefCountedRust = obj_test.return_refcounted_as_object()
 	assert_eq(obj.i, 42)
 
 func test_custom_constructor():
@@ -263,7 +263,7 @@ func test_custom_property_wrong_values_2():
 
 	var has_property: HasCustomProperty = HasCustomProperty.new()
 	disable_error_messages()
-	has_property.not_exportable = {"a": "hello", "b": Callable()}  # Should fail.
+	has_property.not_exportable = {"a": "hello", "b": Callable()} # Should fail.
 	enable_error_messages()
 	assert_fail("HasCustomProperty.not_exportable should only accept dictionaries with float values")
 
@@ -360,4 +360,3 @@ func test_get_set():
 	assert_eq(obj.set_get, 1000)
 	assert(obj.is_set_called())
 	assert(obj.is_get_called())
-

--- a/itest/rust/src/builtin_tests/script/script_instance_tests.rs
+++ b/itest/rust/src/builtin_tests/script/script_instance_tests.rs
@@ -9,7 +9,7 @@ use std::ffi::c_void;
 
 use godot::builtin::{GString, StringName, Variant, VariantType};
 use godot::classes::{IScriptExtension, Object, Script, ScriptExtension, ScriptLanguage};
-use godot::global::{MethodFlags, PropertyHint, PropertyUsageFlags};
+use godot::global::MethodFlags;
 use godot::meta::{ClassName, FromGodot, MethodInfo, PropertyInfo, ToGodot};
 use godot::obj::script::{create_script_instance, ScriptInstance, SiMut};
 use godot::obj::{Base, Gd, WithBaseField};
@@ -46,44 +46,16 @@ impl TestScriptInstance {
         Self {
             script,
             script_property_b: false,
-            prop_list: vec![PropertyInfo {
-                variant_type: VariantType::INT,
-                property_name: StringName::from("script_property_a"),
-                class_name: ClassName::from_ascii_cstr("\0".as_bytes()),
-                hint: PropertyHint::NONE,
-                hint_string: GString::new(),
-                usage: PropertyUsageFlags::NONE,
-            }],
+            prop_list: vec![PropertyInfo::new_var::<i64>("script_property_a")],
 
             method_list: vec![MethodInfo {
                 id: 1,
                 method_name: StringName::from("script_method_a"),
                 class_name: ClassName::from_ascii_cstr("TestScript\0".as_bytes()),
-                return_type: PropertyInfo {
-                    variant_type: VariantType::STRING,
-                    class_name: ClassName::none(),
-                    property_name: StringName::from(""),
-                    hint: PropertyHint::NONE,
-                    hint_string: GString::new(),
-                    usage: PropertyUsageFlags::NONE,
-                },
+                return_type: PropertyInfo::new_var::<GString>(""),
                 arguments: vec![
-                    PropertyInfo {
-                        variant_type: VariantType::STRING,
-                        class_name: ClassName::none(),
-                        property_name: StringName::from(""),
-                        hint: PropertyHint::NONE,
-                        hint_string: GString::new(),
-                        usage: PropertyUsageFlags::NONE,
-                    },
-                    PropertyInfo {
-                        variant_type: VariantType::INT,
-                        class_name: ClassName::none(),
-                        property_name: StringName::from(""),
-                        hint: PropertyHint::NONE,
-                        hint_string: GString::new(),
-                        usage: PropertyUsageFlags::NONE,
-                    },
+                    PropertyInfo::new_var::<GString>("arg_a"),
+                    PropertyInfo::new_var::<i32>("arg_b"),
                 ],
                 default_arguments: vec![],
                 flags: MethodFlags::NORMAL,


### PR DESCRIPTION
Mainly:
- Uses `into/from_owned_sys` functions instead of storing entire property lists and such in a hashmap
- Moves functions that only operates on `ScriptInstanceData` to be methods 
- Removes several functions that are a simple wrappers around existing functions, or were only used in one place and which weren't very complicated
- Reword/correct some safety docs
- Adds a `sys::conv` module for common conversions
- Adds a dedicated `bool -> GDExtensionBool` conversion function
- Adds a true/false literal for `GDExtensionBool`
- Adds a function to infallibly convert `u32 -> usize` (this fails at compile time instead of runtime and should have no overhead, since i do not believe we (will) support any targets where `u32` <= `usize`)
- Abstracts the logic for transferring a ptrlist to and from godot, while keeping track of length, into its own struct
- Adds a `#[deny(unsafe_op_in_unsafe_fn)]` to all the ffi-functions in script instance so that we're sure all unsafe function calls are explicitly tracked and called out 

Also @TitanNano since you made a lot of this originally