### PR TITLE
Fix: Consistent by-value and by-ref parameters for geometric types

### DIFF
--- a/godot-core/src/builtin/aabb.rs
+++ b/godot-core/src/builtin/aabb.rs
@@ -45,7 +45,7 @@ impl Aabb {
 
     /// Returns an AABB with the same geometry, with most-negative corner as `position` and non-negative `size`.
     #[inline]
-    pub fn abs(&self) -> Self {
+    pub fn abs(self) -> Self {
         Aabb {
             position: self.position + self.size.coord_min(Vector3::ZERO),
             size: self.size.abs(),
@@ -54,7 +54,7 @@ impl Aabb {
 
     /// Whether `self` covers at least the entire area of `b` (and possibly more).
     #[inline]
-    pub fn encloses(&self, b: Aabb) -> bool {
+    pub fn encloses(self, b: Aabb) -> bool {
         let end = self.end();
         let b_end = b.end();
 
@@ -71,8 +71,8 @@ impl Aabb {
     /// # Panics
     /// If `self.size` is negative.
     #[inline]
-    pub fn expand(&self, to: Vector3) -> Self {
-        self.merge(&Aabb::new(to, Vector3::ZERO))
+    pub fn expand(self, to: Vector3) -> Self {
+        self.merge(Aabb::new(to, Vector3::ZERO))
     }
 
     /// Returns a larger AABB that contains this AABB and `b`.
@@ -80,7 +80,7 @@ impl Aabb {
     /// # Panics
     /// If either `self.size` or `b.size` is negative.
     #[inline]
-    pub fn merge(&self, b: &Aabb) -> Self {
+    pub fn merge(self, b: Aabb) -> Self {
         self.assert_nonnegative();
         b.assert_nonnegative();
 
@@ -95,21 +95,21 @@ impl Aabb {
     /// # Panics
     /// If `self.size` is negative.
     #[inline]
-    pub fn volume(&self) -> real {
+    pub fn volume(self) -> real {
         self.assert_nonnegative();
         self.size.x * self.size.y * self.size.z
     }
 
     /// Returns the center of the AABB, which is equal to `position + (size / 2)`.
     #[inline]
-    pub fn center(&self) -> Vector3 {
+    pub fn center(self) -> Vector3 {
         self.position + (self.size / 2.0)
     }
 
     /// Returns a copy of the AABB grown by the specified `amount` on all sides.
     #[inline]
     #[must_use]
-    pub fn grow(&self, amount: real) -> Self {
+    pub fn grow(self, amount: real) -> Self {
         let position = self.position - Vector3::new(amount, amount, amount);
         let size = self.size + Vector3::new(amount, amount, amount) * 2.0;
 
@@ -122,7 +122,7 @@ impl Aabb {
     /// # Panics
     /// If `self.size` is negative.
     #[inline]
-    pub fn has_point(&self, point: Vector3) -> bool {
+    pub fn has_point(self, point: Vector3) -> bool {
         self.assert_nonnegative();
 
         let point = point - self.position;
@@ -135,13 +135,13 @@ impl Aabb {
 
     /// Returns `true` if the AABB has area, and `false` if the AABB is linear, empty, or has a negative size. See also `Aabb.area()`.
     #[inline]
-    pub fn has_area(&self) -> bool {
+    pub fn has_area(self) -> bool {
         ((self.size.x > 0.0) as u8 + (self.size.y > 0.0) as u8 + (self.size.z > 0.0) as u8) >= 2
     }
 
     /// Returns true if the AABB has a volume, and false if the AABB is flat, linear, empty, or has a negative size.
     #[inline]
-    pub fn has_volume(&self) -> bool {
+    pub fn has_volume(self) -> bool {
         self.size.x > 0.0 && self.size.y > 0.0 && self.size.z > 0.0
     }
 
@@ -150,14 +150,14 @@ impl Aabb {
     /// # Panics
     /// If `self.size` is negative.
     #[inline]
-    pub fn intersection(&self, b: &Aabb) -> Option<Self> {
+    pub fn intersection(self, b: Aabb) -> Option<Self> {
         self.assert_nonnegative();
 
         if !self.intersects(b) {
             return None;
         }
 
-        let mut rect = *b;
+        let mut rect = b;
         rect.position = rect.position.coord_max(self.position);
 
         let end = self.end();
@@ -169,13 +169,13 @@ impl Aabb {
 
     /// Returns `true` if this AABB is finite, by calling `@GlobalScope.is_finite` on each component.
     #[inline]
-    pub fn is_finite(&self) -> bool {
+    pub fn is_finite(self) -> bool {
         self.position.is_finite() && self.size.is_finite()
     }
 
     /// The end of the `Aabb` calculated as `position + size`.
     #[inline]
-    pub fn end(&self) -> Vector3 {
+    pub fn end(self) -> Vector3 {
         self.position + self.size
     }
 
@@ -189,7 +189,7 @@ impl Aabb {
 
     /// Returns the normalized longest axis of the AABB.
     #[inline]
-    pub fn longest_axis(&self) -> Option<Vector3> {
+    pub fn longest_axis(self) -> Option<Vector3> {
         self.longest_axis_index().map(|axis| match axis {
             Vector3Axis::X => Vector3::RIGHT,
             Vector3Axis::Y => Vector3::UP,
@@ -199,19 +199,19 @@ impl Aabb {
 
     /// Returns the index of the longest axis of the AABB (according to Vector3's AXIS_* constants).
     #[inline]
-    pub fn longest_axis_index(&self) -> Option<Vector3Axis> {
+    pub fn longest_axis_index(self) -> Option<Vector3Axis> {
         self.size.max_axis()
     }
 
     /// Returns the scalar length of the longest axis of the AABB.
     #[inline]
-    pub fn longest_axis_size(&self) -> real {
+    pub fn longest_axis_size(self) -> real {
         self.size.x.max(self.size.y.max(self.size.z))
     }
 
     /// Returns the normalized shortest axis of the AABB.
     #[inline]
-    pub fn shortest_axis(&self) -> Option<Vector3> {
+    pub fn shortest_axis(self) -> Option<Vector3> {
         self.shortest_axis_index().map(|axis| match axis {
             Vector3Axis::X => Vector3::RIGHT,
             Vector3Axis::Y => Vector3::UP,
@@ -221,19 +221,19 @@ impl Aabb {
 
     /// Returns the index of the shortest axis of the AABB (according to Vector3::AXIS* enum).
     #[inline]
-    pub fn shortest_axis_index(&self) -> Option<Vector3Axis> {
+    pub fn shortest_axis_index(self) -> Option<Vector3Axis> {
         self.size.min_axis()
     }
 
     /// Returns the scalar length of the shortest axis of the AABB.
     #[inline]
-    pub fn shortest_axis_size(&self) -> real {
+    pub fn shortest_axis_size(self) -> real {
         self.size.x.min(self.size.y.min(self.size.z))
     }
 
     /// Returns the support point in a given direction. This is useful for collision detection algorithms.
     #[inline]
-    pub fn support(&self, dir: Vector3) -> Vector3 {
+    pub fn support(self, dir: Vector3) -> Vector3 {
         let half_extents = self.size * 0.5;
         let relative_center_point = self.position + half_extents;
 
@@ -253,7 +253,7 @@ impl Aabb {
     ///
     /// _Godot equivalent: `AABB.intersects(AABB b, bool include_borders = true)`_
     #[inline]
-    pub fn intersects(&self, b: &Aabb) -> bool {
+    pub fn intersects(self, b: Aabb) -> bool {
         let end = self.end();
         let end_b = b.end();
 
@@ -271,7 +271,7 @@ impl Aabb {
     ///
     /// _Godot equivalent: `AABB.intersects(AABB b, bool include_borders = false)`_
     #[inline]
-    pub fn intersects_exclude_borders(&self, &b: &Aabb) -> bool {
+    pub fn intersects_exclude_borders(self, b: Aabb) -> bool {
         let end = self.end();
         let end_b = b.end();
 
@@ -285,7 +285,7 @@ impl Aabb {
 
     /// Returns `true` if the AABB is on both sides of a plane.
     #[inline]
-    pub fn intersects_plane(&self, plane: &Plane) -> bool {
+    pub fn intersects_plane(self, plane: Plane) -> bool {
         // The set of the edges of the AABB.
         let points = [
             self.position,
@@ -318,7 +318,7 @@ impl Aabb {
     /// # Panics
     /// If `self.size` is negative.
     #[inline]
-    pub fn intersects_ray(&self, from: Vector3, dir: Vector3) -> bool {
+    pub fn intersects_ray(self, from: Vector3, dir: Vector3) -> bool {
         self.assert_nonnegative();
 
         let tmin = (self.position - from) / dir;
@@ -338,7 +338,7 @@ impl Aabb {
     /// # Panics
     /// If `self.size` is negative.
     #[inline]
-    pub fn intersects_segment(&self, from: Vector3, to: Vector3) -> bool {
+    pub fn intersects_segment(self, from: Vector3, to: Vector3) -> bool {
         self.assert_nonnegative();
 
         let segment_dir = to - from;
@@ -371,7 +371,7 @@ impl Aabb {
     ///
     /// Most functions will fail to give a correct result if the size is negative.
     #[inline]
-    pub fn assert_nonnegative(&self) {
+    pub fn assert_nonnegative(self) {
         assert!(
             self.size.x >= 0.0 && self.size.y >= 0.0 && self.size.z >= 0.0,
             "size {:?} is negative",
@@ -467,27 +467,27 @@ mod test {
         };
 
         // Check for intersection including border
-        assert!(aabb1.intersects(&aabb2));
-        assert!(aabb2.intersects(&aabb1));
+        assert!(aabb1.intersects(aabb2));
+        assert!(aabb2.intersects(aabb1));
 
         // Check for non-intersection including border
-        assert!(!aabb1.intersects(&aabb3));
-        assert!(!aabb3.intersects(&aabb1));
+        assert!(!aabb1.intersects(aabb3));
+        assert!(!aabb3.intersects(aabb1));
 
         // Check for intersection excluding border
-        assert!(aabb1.intersects_exclude_borders(&aabb2));
-        assert!(aabb2.intersects_exclude_borders(&aabb1));
+        assert!(aabb1.intersects_exclude_borders(aabb2));
+        assert!(aabb2.intersects_exclude_borders(aabb1));
 
         // Check for non-intersection excluding border
-        assert!(!aabb1.intersects_exclude_borders(&aabb3));
-        assert!(!aabb3.intersects_exclude_borders(&aabb1));
+        assert!(!aabb1.intersects_exclude_borders(aabb3));
+        assert!(!aabb3.intersects_exclude_borders(aabb1));
 
         // Check for non-intersection excluding border
-        assert!(!aabb1.intersects_exclude_borders(&aabb4));
-        assert!(!aabb4.intersects_exclude_borders(&aabb1));
+        assert!(!aabb1.intersects_exclude_borders(aabb4));
+        assert!(!aabb4.intersects_exclude_borders(aabb1));
 
         // Check for intersection with same AABB including border
-        assert!(aabb1.intersects(&aabb1));
+        assert!(aabb1.intersects(aabb1));
     }
 
     #[test]
@@ -515,17 +515,17 @@ mod test {
 
         // Test cases
         assert_eq!(
-            aabb1.intersection(&aabb2),
+            aabb1.intersection(aabb2),
             Some(Aabb {
                 position: Vector3::new(1.0, 1.0, 1.0),
                 size: Vector3::new(1.0, 1.0, 1.0),
             })
         );
 
-        assert_eq!(aabb1.intersection(&aabb3), None);
+        assert_eq!(aabb1.intersection(aabb3), None);
 
         assert_eq!(
-            aabb1.intersection(&aabb4),
+            aabb1.intersection(aabb4),
             Some(Aabb {
                 position: Vector3::new(0.0, 0.0, 0.0),
                 size: Vector3::new(0.0, 0.0, 0.0),
@@ -620,10 +620,10 @@ mod test {
         };
 
         // Test cases
-        assert!(aabb.intersects_plane(&plane_inside));
-        assert!(!aabb.intersects_plane(&plane_outside));
-        assert!(aabb.intersects_plane(&plane_intersect));
-        assert!(!aabb.intersects_plane(&plane_parallel));
+        assert!(aabb.intersects_plane(plane_inside));
+        assert!(!aabb.intersects_plane(plane_outside));
+        assert!(aabb.intersects_plane(plane_intersect));
+        assert!(!aabb.intersects_plane(plane_parallel));
     }
 
     #[test]

--- a/godot-core/src/builtin/basis.rs
+++ b/godot-core/src/builtin/basis.rs
@@ -162,7 +162,7 @@ impl Basis {
     }
 
     /// Creates a `[Vector3; 3]` with the columns of the `Basis`.
-    pub fn to_cols(self) -> [Vector3; 3] {
+    pub fn to_cols(&self) -> [Vector3; 3] {
         self.transposed().rows
     }
 
@@ -170,7 +170,7 @@ impl Basis {
     ///
     /// _Godot equivalent: `Basis.get_rotation_quaternion()`_
     #[doc(alias = "get_rotation_quaternion")]
-    pub fn to_quat(self) -> Quaternion {
+    pub fn to_quat(&self) -> Quaternion {
         RQuat::from_mat3(&self.orthonormalized().to_glam()).to_front()
     }
 
@@ -211,7 +211,7 @@ impl Basis {
     /// The order of the angles are given by `order`.
     ///
     /// _Godot equivalent: `Basis.get_euler()`_
-    pub fn to_euler(self, order: EulerOrder) -> Vector3 {
+    pub fn to_euler(&self, order: EulerOrder) -> Vector3 {
         use glam::swizzles::Vec3Swizzles as _;
 
         let col_a = self.col_a().to_glam();
@@ -346,15 +346,15 @@ impl Basis {
     ///
     /// _Godot equivalent: `Basis.scaled()`_
     #[must_use]
-    pub fn scaled(self, scale: Vector3) -> Self {
-        Self::from_diagonal(scale.x, scale.y, scale.z) * self
+    pub fn scaled(&self, scale: Vector3) -> Self {
+        Self::from_diagonal(scale.x, scale.y, scale.z) * (*self)
     }
 
     /// Returns the inverse of the matrix.
     ///
     /// _Godot equivalent: `Basis.inverse()`_
     #[must_use]
-    pub fn inverse(self) -> Basis {
+    pub fn inverse(&self) -> Basis {
         self.glam(|mat| mat.inverse())
     }
 
@@ -362,7 +362,7 @@ impl Basis {
     ///
     /// _Godot equivalent: `Basis.transposed()`_
     #[must_use]
-    pub fn transposed(self) -> Self {
+    pub fn transposed(&self) -> Self {
         Self::from_cols(self.rows[0], self.rows[1], self.rows[2])
     }
 
@@ -376,7 +376,7 @@ impl Basis {
     ///
     /// _Godot equivalent: `Basis.orthonormalized()`_
     #[must_use]
-    pub fn orthonormalized(self) -> Self {
+    pub fn orthonormalized(&self) -> Self {
         assert!(
             !self.determinant().is_zero_approx(),
             "Determinant should not be zero."
@@ -401,8 +401,8 @@ impl Basis {
     ///
     /// _Godot equivalent: `Basis.rotated()`_
     #[must_use]
-    pub fn rotated(self, axis: Vector3, angle: real) -> Self {
-        Self::from_axis_angle(axis, angle) * self
+    pub fn rotated(&self, axis: Vector3, angle: real) -> Self {
+        Self::from_axis_angle(axis, angle) * (*self)
     }
 
     /// Assuming that the matrix is a proper rotation matrix, slerp performs
@@ -410,7 +410,7 @@ impl Basis {
     ///
     /// _Godot equivalent: `Basis.slerp()`_
     #[must_use]
-    pub fn slerp(self, other: Self, weight: real) -> Self {
+    pub fn slerp(&self, other: &Self, weight: real) -> Self {
         let from = self.to_quat();
         let to = other.to_quat();
 

--- a/godot-core/src/builtin/plane.rs
+++ b/godot-core/src/builtin/plane.rs
@@ -124,7 +124,7 @@ impl Plane {
     /// The distance will be positive if `point` is above the plane, and will be negative if
     /// `point` is below the plane.
     #[inline]
-    pub fn distance_to(&self, point: Vector3) -> real {
+    pub fn distance_to(self, point: Vector3) -> real {
         self.normal.dot(point) - self.d
     }
 
@@ -132,7 +132,7 @@ impl Plane {
     ///
     /// _Godot equivalent: `Plane.get_center()`_
     #[inline]
-    pub fn center(&self) -> Vector3 {
+    pub fn center(self) -> Vector3 {
         self.normal * self.d
     }
 
@@ -144,7 +144,7 @@ impl Plane {
     /// _Godot equivalent: `Plane.has_point(Vector3 point, float tolerance=1e-05)`_
     #[inline]
     #[doc(alias = "has_point")]
-    pub fn contains_point(&self, point: Vector3, tolerance: Option<real>) -> bool {
+    pub fn contains_point(self, point: Vector3, tolerance: Option<real>) -> bool {
         let dist: real = (self.normal.dot(point) - self.d).abs();
         dist <= tolerance.unwrap_or(real::CMP_EPSILON)
     }
@@ -153,7 +153,7 @@ impl Plane {
     ///
     /// If no intersection point is found, `None` will be returned.
     #[inline]
-    pub fn intersect_3(&self, b: &Self, c: &Self) -> Option<Vector3> {
+    pub fn intersect_3(self, b: Self, c: Self) -> Option<Vector3> {
         let normal0 = self.normal;
         let normal1 = b.normal;
         let normal2 = c.normal;
@@ -173,7 +173,7 @@ impl Plane {
     ///
     /// If no intersection is found (the ray is parallel to the plane or points away from it), `None` will be returned.
     #[inline]
-    pub fn intersect_ray(&self, from: Vector3, dir: Vector3) -> Option<Vector3> {
+    pub fn intersect_ray(self, from: Vector3, dir: Vector3) -> Option<Vector3> {
         let denom: real = self.normal.dot(dir);
         if denom.is_zero_approx() {
             return None;
@@ -191,7 +191,7 @@ impl Plane {
     ///
     /// If no intersection is found (the segment is parallel to the plane or does not intersect it), `None` will be returned.
     #[inline]
-    pub fn intersect_segment(&self, from: Vector3, to: Vector3) -> Option<Vector3> {
+    pub fn intersect_segment(self, from: Vector3, to: Vector3) -> Option<Vector3> {
         let segment = from - to;
         let denom: real = self.normal.dot(segment);
         if denom.is_zero_approx() {
@@ -206,13 +206,13 @@ impl Plane {
 
     /// Returns `true` if the plane is finite by calling `is_finite` on `normal` and `d`.
     #[inline]
-    pub fn is_finite(&self) -> bool {
+    pub fn is_finite(self) -> bool {
         self.normal.is_finite() && self.d.is_finite()
     }
 
     /// Returns `true` if `point` is located above the plane.
     #[inline]
-    pub fn is_point_over(&self, point: Vector3) -> bool {
+    pub fn is_point_over(self, point: Vector3) -> bool {
         self.normal.dot(point) > self.d
     }
 
@@ -234,7 +234,7 @@ impl Plane {
 
     /// Returns the orthogonal projection of `point` to the plane.
     #[inline]
-    pub fn project(&self, point: Vector3) -> Vector3 {
+    pub fn project(self, point: Vector3) -> Vector3 {
         point - self.normal * self.distance_to(point)
     }
 
@@ -444,53 +444,53 @@ mod test {
 
         // Planes that have 0 as its `d` would intersect in the origin point.
         assert_eq!(
-            origin_plane_a.intersect_3(&origin_plane_b, &origin_plane_c),
+            origin_plane_a.intersect_3(origin_plane_b, origin_plane_c),
             Some(vec_a)
         );
 
         // Three planes that parallel each other would not intersect in a point.
         assert_eq!(
-            origin_plane_a.intersect_3(&low_parallel_origin_a, &high_parallel_origin_a),
+            origin_plane_a.intersect_3(low_parallel_origin_a, high_parallel_origin_a),
             None
         );
 
         // Two planes that parallel each other with an unrelated third plane would not intersect in
         // a point.
         assert_eq!(
-            origin_plane_b.intersect_3(&low_parallel_origin_a, &high_parallel_origin_a),
+            origin_plane_b.intersect_3(low_parallel_origin_a, high_parallel_origin_a),
             None
         );
 
         // Three coincident planes would intersect in every point, thus no unique solution.
         assert_eq!(
-            origin_plane_a.intersect_3(&origin_plane_a, &origin_plane_a),
+            origin_plane_a.intersect_3(origin_plane_a, origin_plane_a),
             None
         );
 
         // Two coincident planes with an unrelated third plane would intersect in every point along the
         // intersection line, thus no unique solution.
         assert_eq!(
-            origin_plane_b.intersect_3(&origin_plane_b, &large_rotation_origin_a),
+            origin_plane_b.intersect_3(origin_plane_b, large_rotation_origin_a),
             None
         );
 
         // Two coincident planes with a parallel third plane would have no common intersection.
         assert_eq!(
-            origin_plane_a.intersect_3(&origin_plane_a, &low_parallel_origin_a),
+            origin_plane_a.intersect_3(origin_plane_a, low_parallel_origin_a),
             None
         );
 
         // Three planes that intersects each other in a common line would intersect in every point along
         // the line, thus no unique solution.
         assert_eq!(
-            origin_plane_a.intersect_3(&small_rotation_origin_a, &large_rotation_origin_a),
+            origin_plane_a.intersect_3(small_rotation_origin_a, large_rotation_origin_a),
             None
         );
 
         // Three planes that intersects each other in 3 parallel lines would not intersect in a common
         // point.
         assert_eq!(
-            prism_plane_a.intersect_3(&prism_plane_b, &prism_plane_c),
+            prism_plane_a.intersect_3(prism_plane_b, prism_plane_c),
             None
         );
     }

--- a/godot-core/src/builtin/rect2.rs
+++ b/godot-core/src/builtin/rect2.rs
@@ -67,7 +67,7 @@ impl Rect2 {
 
     /// Returns a rectangle with the same geometry, with top-left corner as `position` and non-negative size.
     #[inline]
-    pub fn abs(&self) -> Self {
+    pub fn abs(self) -> Self {
         Self {
             position: self.position + self.size.coord_min(Vector2::ZERO),
             size: self.size.abs(),
@@ -76,7 +76,7 @@ impl Rect2 {
 
     /// Whether `self` covers at least the entire area of `b` (and possibly more).
     #[inline]
-    pub fn encloses(&self, b: Rect2) -> bool {
+    pub fn encloses(self, b: Rect2) -> bool {
         let end = self.end();
         let b_end = b.end();
 
@@ -91,7 +91,7 @@ impl Rect2 {
     /// Note: This method is not reliable for `Rect2` with a negative size. Use [`abs`][Self::abs]
     /// to get a positive sized equivalent rectangle for expanding.
     #[inline]
-    pub fn expand(&self, to: Vector2) -> Self {
+    pub fn expand(self, to: Vector2) -> Self {
         self.merge(Rect2::new(to, Vector2::ZERO))
     }
 
@@ -100,7 +100,7 @@ impl Rect2 {
     /// Note: This method is not reliable for `Rect2` with a negative size. Use [`abs`][Self::abs]
     /// to get a positive sized equivalent rectangle for merging.
     #[inline]
-    pub fn merge(&self, b: Self) -> Self {
+    pub fn merge(self, b: Self) -> Self {
         let position = self.position.coord_min(b.position);
         let end = self.end().coord_max(b.end());
 
@@ -109,20 +109,20 @@ impl Rect2 {
 
     /// Returns the area of the rectangle.
     #[inline]
-    pub fn area(&self) -> real {
+    pub fn area(self) -> real {
         self.size.x * self.size.y
     }
 
     /// Returns the center of the Rect2, which is equal to `position + (size / 2)`.
     #[inline]
-    pub fn center(&self) -> Vector2 {
+    pub fn center(self) -> Vector2 {
         self.position + (self.size / 2.0)
     }
 
     /// Returns a copy of the Rect2 grown by the specified `amount` on all sides.
     #[inline]
     #[must_use]
-    pub fn grow(&self, amount: real) -> Self {
+    pub fn grow(self, amount: real) -> Self {
         let position = self.position - Vector2::new(amount, amount);
         let size = self.size + Vector2::new(amount, amount) * 2.0;
 
@@ -131,7 +131,7 @@ impl Rect2 {
 
     /// Returns a copy of the Rect2 grown by the specified amount on each side individually.
     #[inline]
-    pub fn grow_individual(&self, left: real, top: real, right: real, bottom: real) -> Self {
+    pub fn grow_individual(self, left: real, top: real, right: real, bottom: real) -> Self {
         Self::from_components(
             self.position.x - left,
             self.position.y - top,
@@ -145,7 +145,7 @@ impl Rect2 {
     /// `amount` may be negative, but care must be taken: If the resulting `size` has
     /// negative components the computation may be incorrect.
     #[inline]
-    pub fn grow_side(&self, side: Side, amount: real) -> Self {
+    pub fn grow_side(self, side: Side, amount: real) -> Self {
         match side {
             Side::LEFT => self.grow_individual(amount, 0.0, 0.0, 0.0),
             Side::TOP => self.grow_individual(0.0, amount, 0.0, 0.0),
@@ -156,7 +156,7 @@ impl Rect2 {
 
     /// Returns `true` if the Rect2 has area, and `false` if the Rect2 is linear, empty, or has a negative size. See also `get_area`.
     #[inline]
-    pub fn has_area(&self) -> bool {
+    pub fn has_area(self) -> bool {
         self.size.x > 0.0 && self.size.y > 0.0
     }
 
@@ -164,7 +164,7 @@ impl Rect2 {
     ///
     /// Note: This method is not reliable for Rect2 with a negative size. Use `abs` to get a positive sized equivalent rectangle to check for contained points.
     #[inline]
-    pub fn has_point(&self, point: Vector2) -> bool {
+    pub fn has_point(self, point: Vector2) -> bool {
         let point = point - self.position;
 
         point.abs() == point && point.x < self.size.x && point.y < self.size.y
@@ -172,7 +172,7 @@ impl Rect2 {
 
     /// Returns the intersection of this Rect2 and `b`. If the rectangles do not intersect, an empty Rect2 is returned.
     #[inline]
-    pub fn intersection(&self, b: Self) -> Option<Self> {
+    pub fn intersection(self, b: Self) -> Option<Self> {
         if !self.intersects(b) {
             return None;
         }
@@ -194,7 +194,7 @@ impl Rect2 {
     ///
     /// _Godot equivalent: `Rect2.intersects(Rect2 b, bool include_borders = true)`_
     #[inline]
-    pub fn intersects(&self, b: Self) -> bool {
+    pub fn intersects(self, b: Self) -> bool {
         let end = self.end();
         let end_b = b.end();
 
@@ -211,7 +211,7 @@ impl Rect2 {
     ///
     /// _Godot equivalent: `Rect2.intersects(AABB b, bool include_borders = false)`_
     #[inline]
-    pub fn intersects_exclude_borders(&self, b: Self) -> bool {
+    pub fn intersects_exclude_borders(self, b: Self) -> bool {
         let end = self.end();
         let end_b = b.end();
 
@@ -223,13 +223,13 @@ impl Rect2 {
 
     /// Returns `true` if this Rect2 is finite, by calling `@GlobalScope.is_finite` on each component.
     #[inline]
-    pub fn is_finite(&self) -> bool {
+    pub fn is_finite(self) -> bool {
         self.position.is_finite() && self.size.is_finite()
     }
 
     /// The end of the `Rect2` calculated as `position + size`.
     #[inline]
-    pub fn end(&self) -> Vector2 {
+    pub fn end(self) -> Vector2 {
         self.position + self.size
     }
 
@@ -243,7 +243,7 @@ impl Rect2 {
     ///
     /// Certain functions will fail to give a correct result if the size is negative.
     #[inline]
-    pub fn assert_nonnegative(&self) {
+    pub fn assert_nonnegative(self) {
         assert!(
             self.size.x >= 0.0 && self.size.y >= 0.0,
             "size {:?} is negative",

--- a/godot-core/src/builtin/rect2i.rs
+++ b/godot-core/src/builtin/rect2i.rs
@@ -72,7 +72,7 @@ impl Rect2i {
     /// _Godot equivalent: `Rect2i.size` property_
     #[doc(alias = "size")]
     #[inline]
-    pub const fn end(&self) -> Vector2i {
+    pub const fn end(self) -> Vector2i {
         Vector2i::new(self.position.x + self.size.x, self.position.y + self.size.y)
     }
 
@@ -98,7 +98,7 @@ impl Rect2i {
     /// Any `Rect2i` encloses itself, i.e. an enclosed `Rect2i` does is not required to be a
     /// proper sub-rect.
     #[inline]
-    pub const fn encloses(&self, other: Self) -> bool {
+    pub const fn encloses(self, other: Self) -> bool {
         self.assert_nonnegative();
         other.assert_nonnegative();
 
@@ -124,7 +124,7 @@ impl Rect2i {
     ///
     /// _Godot equivalent: `Rect2i.get_area` function_
     #[inline]
-    pub const fn area(&self) -> i32 {
+    pub const fn area(self) -> i32 {
         self.size.x * self.size.y
     }
 
@@ -134,7 +134,7 @@ impl Rect2i {
     ///
     /// _Godot equivalent: `Rect2i.get_center` function_
     #[inline]
-    pub fn center(&self) -> Vector2i {
+    pub fn center(self) -> Vector2i {
         self.position + (self.size / 2)
     }
 
@@ -176,7 +176,7 @@ impl Rect2i {
     /// Returns `true` if the `Rect2i` has area, and `false` if the `Rect2i` is linear, empty, or
     /// has a negative `size`.
     #[inline]
-    pub const fn has_area(&self) -> bool {
+    pub const fn has_area(self) -> bool {
         self.size.x > 0 && self.size.y > 0
     }
 
@@ -186,7 +186,7 @@ impl Rect2i {
     /// _Godot equivalent: `Rect2i.has_point` function_
     #[doc(alias = "has_point")]
     #[inline]
-    pub const fn contains_point(&self, point: Vector2i) -> bool {
+    pub const fn contains_point(self, point: Vector2i) -> bool {
         self.assert_nonnegative();
 
         let end = self.end();
@@ -225,7 +225,7 @@ impl Rect2i {
     /// Returns `true` if the `Rect2i` overlaps with `b` (i.e. they have at least one
     /// point in common)
     #[inline]
-    pub fn intersects(&self, b: Self) -> bool {
+    pub fn intersects(self, b: Self) -> bool {
         self.intersection(b).is_some()
     }
 
@@ -243,7 +243,7 @@ impl Rect2i {
 
     /// Returns `true` if either of the coordinates of this `Rect2i`s `size` vector is negative.
     #[inline]
-    pub const fn is_negative(&self) -> bool {
+    pub const fn is_negative(self) -> bool {
         self.size.x < 0 || self.size.y < 0
     }
 
@@ -251,7 +251,7 @@ impl Rect2i {
     ///
     /// Certain functions will fail to give a correct result if the size is negative.
     #[inline]
-    pub const fn assert_nonnegative(&self) {
+    pub const fn assert_nonnegative(self) {
         assert!(
             !self.is_negative(),
             "Rect2i size is negative" /* Uncomment once formatting in const contexts is allowed.

--- a/godot-core/src/builtin/transform2d.rs
+++ b/godot-core/src/builtin/transform2d.rs
@@ -136,7 +136,8 @@ impl Transform2D {
     }
 
     /// Create a [`Basis2D`] from the first two columns of the transform.
-    fn to_basis(self) -> Basis2D {
+    #[allow(clippy::wrong_self_convention)]
+    fn to_basis(&self) -> Basis2D {
         Basis2D::from_cols(self.a, self.b)
     }
 
@@ -145,7 +146,7 @@ impl Transform2D {
     ///
     /// _Godot equivalent: `Transform2D.affine_inverse()`_
     #[must_use]
-    pub fn affine_inverse(self) -> Self {
+    pub fn affine_inverse(&self) -> Self {
         self.glam(|aff| aff.inverse())
     }
 
@@ -177,7 +178,7 @@ impl Transform2D {
     ///
     /// _Godot equivalent: `Transform2D.interpolate_with()`_
     #[must_use]
-    pub fn interpolate_with(self, other: Self, weight: real) -> Self {
+    pub fn interpolate_with(&self, other: &Self, weight: real) -> Self {
         Self::from_angle_scale_skew_origin(
             self.rotation().lerp_angle(other.rotation(), weight),
             self.scale().lerp(other.scale(), weight),
@@ -199,7 +200,7 @@ impl Transform2D {
     ///
     /// _Godot equivalent: `Transform2D.orthonormalized()`_
     #[must_use]
-    pub fn orthonormalized(self) -> Self {
+    pub fn orthonormalized(&self) -> Self {
         Self::from_basis_origin(self.basis().orthonormalized(), self.origin)
     }
 
@@ -210,8 +211,8 @@ impl Transform2D {
     ///
     /// _Godot equivalent: `Transform2D.rotated()`_
     #[must_use]
-    pub fn rotated(self, angle: real) -> Self {
-        Self::from_angle(angle) * self
+    pub fn rotated(&self, angle: real) -> Self {
+        Self::from_angle(angle) * (*self)
     }
 
     /// Returns a copy of the transform rotated by the given `angle` (in radians).
@@ -221,8 +222,8 @@ impl Transform2D {
     ///
     /// _Godot equivalent: `Transform2D.rotated_local()`_
     #[must_use]
-    pub fn rotated_local(self, angle: real) -> Self {
-        self * Self::from_angle(angle)
+    pub fn rotated_local(&self, angle: real) -> Self {
+        (*self) * Self::from_angle(angle)
     }
 
     /// Returns a copy of the transform scaled by the given scale factor.
@@ -232,7 +233,7 @@ impl Transform2D {
     ///
     /// _Godot equivalent: `Transform2D.scaled()`_
     #[must_use]
-    pub fn scaled(self, scale: Vector2) -> Self {
+    pub fn scaled(&self, scale: Vector2) -> Self {
         let mut basis = self.to_basis();
         basis.set_row_a(basis.row_a() * scale.x);
         basis.set_row_b(basis.row_b() * scale.y);
@@ -246,7 +247,7 @@ impl Transform2D {
     ///
     /// _Godot equivalent: `Transform2D.scaled_local()`_
     #[must_use]
-    pub fn scaled_local(self, scale: Vector2) -> Self {
+    pub fn scaled_local(&self, scale: Vector2) -> Self {
         Self::from_basis_origin(self.basis().scaled(scale), self.origin)
     }
 
@@ -257,7 +258,7 @@ impl Transform2D {
     ///
     /// _Godot equivalent: `Transform2D.translated()`_
     #[must_use]
-    pub fn translated(self, offset: Vector2) -> Self {
+    pub fn translated(&self, offset: Vector2) -> Self {
         Self::from_cols(self.a, self.b, self.origin + offset)
     }
 
@@ -268,7 +269,7 @@ impl Transform2D {
     ///
     /// _Godot equivalent: `Transform2D.translated()`_
     #[must_use]
-    pub fn translated_local(self, offset: Vector2) -> Self {
+    pub fn translated_local(&self, offset: Vector2) -> Self {
         Self::from_cols(self.a, self.b, self.origin + (self.to_basis() * offset))
     }
 
@@ -670,7 +671,7 @@ mod test {
         );
 
         let interpolated: Transform2D =
-            Transform2D::IDENTITY.interpolate_with(rotate_scale_skew_pos, 0.5);
+            Transform2D::IDENTITY.interpolate_with(&rotate_scale_skew_pos, 0.5);
         assert_eq_approx!(interpolated.origin, rotate_scale_skew_pos_halfway.origin);
         assert_eq_approx!(
             interpolated.rotation(),
@@ -680,7 +681,7 @@ mod test {
         assert_eq_approx!(interpolated.skew(), rotate_scale_skew_pos_halfway.skew());
         assert_eq_approx!(interpolated, rotate_scale_skew_pos_halfway);
 
-        let interpolated = rotate_scale_skew_pos.interpolate_with(Transform2D::IDENTITY, 0.5);
+        let interpolated = rotate_scale_skew_pos.interpolate_with(&Transform2D::IDENTITY, 0.5);
         assert_eq_approx!(interpolated, rotate_scale_skew_pos_halfway);
     }
 

--- a/godot-core/src/builtin/transform3d.rs
+++ b/godot-core/src/builtin/transform3d.rs
@@ -81,7 +81,7 @@ impl Transform3D {
     /// the projection matrix.
     ///
     /// _Godot equivalent: `Transform3D(Projection from)`_
-    pub fn from_projection(proj: Projection) -> Self {
+    pub fn from_projection(proj: &Projection) -> Self {
         let a = Vector3::new(proj.cols[0].x, proj.cols[0].y, proj.cols[0].z);
         let b = Vector3::new(proj.cols[1].x, proj.cols[1].y, proj.cols[1].z);
         let c = Vector3::new(proj.cols[2].x, proj.cols[2].y, proj.cols[2].z);
@@ -114,14 +114,14 @@ impl Transform3D {
     /// Returns the inverse of the transform, under the assumption that the
     /// transformation is composed of rotation, scaling and translation.
     #[must_use]
-    pub fn affine_inverse(self) -> Self {
+    pub fn affine_inverse(&self) -> Self {
         self.glam(|aff| aff.inverse())
     }
 
     /// Returns a transform interpolated between this transform and another by
     /// a given weight (on the range of 0.0 to 1.0).
     #[must_use]
-    pub fn interpolate_with(self, other: Self, weight: real) -> Self {
+    pub fn interpolate_with(&self, other: &Self, weight: real) -> Self {
         let src_scale = self.basis.scale();
         let src_rot = self.basis.to_quat().normalized();
         let src_loc = self.origin;
@@ -151,7 +151,7 @@ impl Transform3D {
     /// See [`Basis::new_looking_at()`] for more information.
     #[cfg(before_api = "4.1")]
     #[must_use]
-    pub fn looking_at(self, target: Vector3, up: Vector3) -> Self {
+    pub fn looking_at(&self, target: Vector3, up: Vector3) -> Self {
         Self {
             basis: Basis::new_looking_at(target - self.origin, up),
             origin: self.origin,
@@ -160,7 +160,7 @@ impl Transform3D {
 
     #[cfg(since_api = "4.1")]
     #[must_use]
-    pub fn looking_at(self, target: Vector3, up: Vector3, use_model_front: bool) -> Self {
+    pub fn looking_at(&self, target: Vector3, up: Vector3, use_model_front: bool) -> Self {
         Self {
             basis: Basis::new_looking_at(target - self.origin, up, use_model_front),
             origin: self.origin,
@@ -172,7 +172,7 @@ impl Transform3D {
     ///
     /// _Godot equivalent: Transform3D.orthonormalized()_
     #[must_use]
-    pub fn orthonormalized(self) -> Self {
+    pub fn orthonormalized(&self) -> Self {
         Self {
             basis: self.basis.orthonormalized(),
             origin: self.origin,
@@ -186,7 +186,7 @@ impl Transform3D {
     ///
     /// _Godot equivalent: `Transform2D.rotated()`_
     #[must_use]
-    pub fn rotated(self, axis: Vector3, angle: real) -> Self {
+    pub fn rotated(&self, axis: Vector3, angle: real) -> Self {
         let rotation = Basis::from_axis_angle(axis, angle);
         Self {
             basis: rotation * self.basis,
@@ -200,7 +200,7 @@ impl Transform3D {
     ///
     /// _Godot equivalent: `Transform2D.rotated_local()`_
     #[must_use]
-    pub fn rotated_local(self, axis: Vector3, angle: real) -> Self {
+    pub fn rotated_local(&self, axis: Vector3, angle: real) -> Self {
         Self {
             basis: self.basis * Basis::from_axis_angle(axis, angle),
             origin: self.origin,
@@ -214,7 +214,7 @@ impl Transform3D {
     ///
     /// _Godot equivalent: `Transform2D.scaled()`_
     #[must_use]
-    pub fn scaled(self, scale: Vector3) -> Self {
+    pub fn scaled(&self, scale: Vector3) -> Self {
         Self {
             basis: Basis::from_scale(scale) * self.basis,
             origin: self.origin * scale,
@@ -228,7 +228,7 @@ impl Transform3D {
     ///
     /// _Godot equivalent: `Transform2D.scaled_local()`_
     #[must_use]
-    pub fn scaled_local(self, scale: Vector3) -> Self {
+    pub fn scaled_local(&self, scale: Vector3) -> Self {
         Self {
             basis: self.basis * Basis::from_scale(scale),
             origin: self.origin,
@@ -242,7 +242,7 @@ impl Transform3D {
     ///
     /// _Godot equivalent: `Transform2D.translated()`_
     #[must_use]
-    pub fn translated(self, offset: Vector3) -> Self {
+    pub fn translated(&self, offset: Vector3) -> Self {
         Self {
             basis: self.basis,
             origin: self.origin + offset,
@@ -256,7 +256,7 @@ impl Transform3D {
     ///
     /// _Godot equivalent: `Transform2D.translated()`_
     #[must_use]
-    pub fn translated_local(self, offset: Vector3) -> Self {
+    pub fn translated_local(&self, offset: Vector3) -> Self {
         Self {
             basis: self.basis,
             origin: self.origin + (self.basis * offset),

--- a/itest/rust/src/builtin_tests/geometry/basis_test.rs
+++ b/itest/rust/src/builtin_tests/geometry/basis_test.rs
@@ -122,12 +122,12 @@ fn basis_equiv() {
 
     #[rustfmt::skip]
     let mappings_basis = [
-        ("inverse",         inner.inverse(),                      outer.inverse()                     ),
-        ("transposed",      inner.transposed(),                   outer.transposed()                  ),
-        ("orthonormalized", inner.orthonormalized(),              outer.orthonormalized()             ),
-        ("rotated",         inner.rotated(vec.normalized(), 0.1), outer.rotated(vec.normalized(), 0.1)),
-        ("scaled",          inner.scaled(vec),                    outer.scaled(vec)                   ),
-        ("slerp",           inner.slerp(Basis::IDENTITY, 0.5),    outer.slerp(Basis::IDENTITY, 0.5)   ),
+        ("inverse",         inner.inverse(),                      outer.inverse()                      ),
+        ("transposed",      inner.transposed(),                   outer.transposed()                   ),
+        ("orthonormalized", inner.orthonormalized(),              outer.orthonormalized()              ),
+        ("rotated",         inner.rotated(vec.normalized(), 0.1), outer.rotated(vec.normalized(), 0.1) ),
+        ("scaled",          inner.scaled(vec),                    outer.scaled(vec)                    ),
+        ("slerp",           inner.slerp(Basis::IDENTITY, 0.5),    outer.slerp(&Basis::IDENTITY, 0.5)   ),
     ];
     for (name, inner, outer) in mappings_basis {
         assert_eq_approx!(inner, outer, "function: {name}\n");

--- a/itest/rust/src/builtin_tests/geometry/plane_test.rs
+++ b/itest/rust/src/builtin_tests/geometry/plane_test.rs
@@ -215,7 +215,7 @@ fn plane_intersect_3() {
     let c = Plane::new(Vector3::new(-1.0, 6.0, 0.5).normalized(), 0.0);
     check_mapping_eq(
         "intersect_3",
-        a.intersect_3(&b, &c)
+        a.intersect_3(b, c)
             .as_ref()
             .map(ToGodot::to_variant)
             .unwrap_or_default(),
@@ -228,7 +228,7 @@ fn plane_intersect_3() {
     let c = Plane::new(Vector3::new(1.5, 6.3, 2.2).normalized(), 9.5);
     check_mapping_eq(
         "intersect_3",
-        a.intersect_3(&b, &c)
+        a.intersect_3(b, c)
             .as_ref()
             .map(ToGodot::to_variant)
             .unwrap_or_default(),

--- a/itest/rust/src/builtin_tests/geometry/transform2d_test.rs
+++ b/itest/rust/src/builtin_tests/geometry/transform2d_test.rs
@@ -26,15 +26,15 @@ fn transform2d_equiv() {
 
     #[rustfmt::skip]
         let mappings_transform = [
-        ("affine_inverse",   inner.affine_inverse(),                             outer.affine_inverse()                            ),
-        ("orthonormalized",  inner.orthonormalized(),                            outer.orthonormalized()                           ),
-        ("rotated",          inner.rotated(1.0),                                 outer.rotated(1.0)                                ),
-        ("rotated_local",    inner.rotated_local(1.0),                           outer.rotated_local(1.0)                          ),
-        ("scaled",           inner.scaled(vec),                                  outer.scaled(vec)                                 ),
-        ("scaled_local",     inner.scaled_local(vec),                            outer.scaled_local(vec)                           ),
-        ("translated",       inner.translated(vec),                              outer.translated(vec)                             ),
-        ("translated_local", inner.translated_local(vec),                        outer.translated_local(vec)                       ),
-        ("interpolate_with", inner.interpolate_with(Transform2D::IDENTITY, 0.5), outer.interpolate_with(Transform2D::IDENTITY, 0.5))
+        ("affine_inverse",   inner.affine_inverse(),                             outer.affine_inverse()                             ),
+        ("orthonormalized",  inner.orthonormalized(),                            outer.orthonormalized()                            ),
+        ("rotated",          inner.rotated(1.0),                                 outer.rotated(1.0)                                 ),
+        ("rotated_local",    inner.rotated_local(1.0),                           outer.rotated_local(1.0)                           ),
+        ("scaled",           inner.scaled(vec),                                  outer.scaled(vec)                                  ),
+        ("scaled_local",     inner.scaled_local(vec),                            outer.scaled_local(vec)                            ),
+        ("translated",       inner.translated(vec),                              outer.translated(vec)                              ),
+        ("translated_local", inner.translated_local(vec),                        outer.translated_local(vec)                        ),
+        ("interpolate_with", inner.interpolate_with(Transform2D::IDENTITY, 0.5), outer.interpolate_with(&Transform2D::IDENTITY, 0.5))
     ];
     for (name, inner, outer) in mappings_transform {
         assert_eq_approx!(inner, outer, "function: {name}\n");

--- a/itest/rust/src/builtin_tests/geometry/transform3d_test.rs
+++ b/itest/rust/src/builtin_tests/geometry/transform3d_test.rs
@@ -29,15 +29,15 @@ fn transform3d_equiv() {
 
     #[rustfmt::skip]
     let mappings_transform = [
-        ("affine_inverse",   inner.affine_inverse(),                             outer.affine_inverse()                            ),
-        ("orthonormalized",  inner.orthonormalized(),                            outer.orthonormalized()                           ),
-        ("rotated",          inner.rotated(vec.normalized(), 1.0),               outer.rotated(vec.normalized(), 1.0)              ),
-        ("rotated_local",    inner.rotated_local(vec.normalized(), 1.0),         outer.rotated_local(vec.normalized(), 1.0)        ),
-        ("scaled",           inner.scaled(vec),                                  outer.scaled(vec)                                 ),
-        ("scaled_local",     inner.scaled_local(vec),                            outer.scaled_local(vec)                           ),
-        ("translated",       inner.translated(vec),                              outer.translated(vec)                             ),
-        ("translated_local", inner.translated_local(vec),                        outer.translated_local(vec)                       ),
-        ("interpolate_with", inner.interpolate_with(Transform3D::IDENTITY, 0.5), outer.interpolate_with(Transform3D::IDENTITY, 0.5))
+        ("affine_inverse",   inner.affine_inverse(),                             outer.affine_inverse()                             ),
+        ("orthonormalized",  inner.orthonormalized(),                            outer.orthonormalized()                            ),
+        ("rotated",          inner.rotated(vec.normalized(), 1.0),               outer.rotated(vec.normalized(), 1.0)               ),
+        ("rotated_local",    inner.rotated_local(vec.normalized(), 1.0),         outer.rotated_local(vec.normalized(), 1.0)         ),
+        ("scaled",           inner.scaled(vec),                                  outer.scaled(vec)                                  ),
+        ("scaled_local",     inner.scaled_local(vec),                            outer.scaled_local(vec)                            ),
+        ("translated",       inner.translated(vec),                              outer.translated(vec)                              ),
+        ("translated_local", inner.translated_local(vec),                        outer.translated_local(vec)                        ),
+        ("interpolate_with", inner.interpolate_with(Transform3D::IDENTITY, 0.5), outer.interpolate_with(&Transform3D::IDENTITY, 0.5))
     ];
     for (name, inner, outer) in mappings_transform {
         assert_eq_approx!(inner, outer, "function: {name}\n");


### PR DESCRIPTION
When finished this should close #749

So far I changed the function signature to by-value for these types:
- [x] `Aabb`
- [x] `Plane`
- [x] `Rect2`
- [x] `Rect2i`

and for these to by-ref
- [x] `Transform2D`
- [x] `Transform3D`
- [x] `Basis`

---

For `Transform2D` I ran in some problems where I don't know how you would like them to be handled. For example:

```rust
pub fn rotated(&self, angle: real) -> Self {
    Self::from_angle(angle) * self
}
```
This errors because `self` needs to be dereferenced. Would you keep passing `self` by-value, deref `self` like `(*self)` or use `self.mul(Self::from_angle(angle))`?