### PR TITLE
Fix native structures exposing `*mut Gd<Object>`, provide accessor

### DIFF
--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -380,6 +380,13 @@ impl<T: GodotClass> Gd<T> {
         }
     }
 
+    /// Returns a callable referencing a method from this object named `method_name`.
+    ///
+    /// This is shorter syntax for [`Callable::from_object_method(self, method_name)`][Callable::from_object_method].
+    pub fn callable<S: Into<StringName>>(&self, method_name: S) -> Callable {
+        Callable::from_object_method(self, method_name)
+    }
+
     pub(crate) unsafe fn from_obj_sys_or_none(
         ptr: sys::GDExtensionObjectPtr,
     ) -> Result<Self, ConvertError> {
@@ -418,11 +425,10 @@ impl<T: GodotClass> Gd<T> {
         self.raw.script_sys()
     }
 
-    /// Returns a callable referencing a method from this object named `method_name`.
-    ///
-    /// This is shorter syntax for [`Callable::from_object_method(self, method_name)`][Callable::from_object_method].
-    pub fn callable<S: Into<StringName>>(&self, method_name: S) -> Callable {
-        Callable::from_object_method(self, method_name)
+    pub(crate) fn with_inc_refcount(self) -> Self {
+        Self {
+            raw: self.raw.with_inc_refcount(),
+        }
     }
 }
 

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -46,7 +46,7 @@ use crate::{classes, out};
 /// - **Manual**<br>
 ///   Objects inheriting from [`Object`] which are not `RefCounted` (or inherited) are **manually-managed**.
 ///   Their destructor is not automatically called (unless they are part of the scene tree). Creating a `Gd<T>` means that
-///   you are responsible of explicitly deallocating such objects using [`free()`][Self::free].<br><br>
+///   you are responsible for explicitly deallocating such objects using [`free()`][Self::free].<br><br>
 ///
 /// - **Dynamic**<br>
 ///   For `T=Object`, the memory strategy is determined **dynamically**. Due to polymorphism, a `Gd<Object>` can point to either
@@ -77,7 +77,7 @@ use crate::{classes, out};
 /// These provide interior mutability similar to [`RefCell`][std::cell::RefCell], with the addition that `Gd` simultaneously handles reference
 /// counting (for some types `T`).
 ///
-/// When you declare a `#[func]` method on your own class and it accepts `&self` or `&mut self`, an implicit `bind()` or `bind_mut()` call
+/// When you declare a `#[func]` method on your own class, and it accepts `&self` or `&mut self`, an implicit `bind()` or `bind_mut()` call
 /// on the owning `Gd<T>` is performed. This is important to keep in mind, as you can get into situations that violate dynamic borrow rules; for
 /// example if you are inside a `&mut self` method, make a call to GDScript and indirectly call another method on the same object (re-entrancy).
 ///
@@ -423,12 +423,6 @@ impl<T: GodotClass> Gd<T> {
         T: Inherits<classes::ScriptLanguage>,
     {
         self.raw.script_sys()
-    }
-
-    pub(crate) fn with_inc_refcount(self) -> Self {
-        Self {
-            raw: self.raw.with_inc_refcount(),
-        }
     }
 }
 

--- a/godot-core/src/obj/raw.rs
+++ b/godot-core/src/obj/raw.rs
@@ -82,7 +82,8 @@ impl<T: GodotClass> RawGd<T> {
     }
 
     /// Returns `self` but with initialized ref-count.
-    fn with_inc_refcount(mut self) -> Self {
+    // Could be private if not for Gd::with_inc_refcount(), which is used by native structure setters.
+    pub(crate) fn with_inc_refcount(mut self) -> Self {
         // Note: use init_ref and not inc_ref, since this might be the first reference increment.
         // Godot expects RefCounted::init_ref to be called instead of RefCounted::reference in that case.
         // init_ref also doesn't hurt (except 1 possibly unnecessary check).

--- a/godot-core/src/obj/raw.rs
+++ b/godot-core/src/obj/raw.rs
@@ -82,8 +82,7 @@ impl<T: GodotClass> RawGd<T> {
     }
 
     /// Returns `self` but with initialized ref-count.
-    // Could be private if not for Gd::with_inc_refcount(), which is used by native structure setters.
-    pub(crate) fn with_inc_refcount(mut self) -> Self {
+    fn with_inc_refcount(mut self) -> Self {
         // Note: use init_ref and not inc_ref, since this might be the first reference increment.
         // Godot expects RefCounted::init_ref to be called instead of RefCounted::reference in that case.
         // init_ref also doesn't hurt (except 1 possibly unnecessary check).


### PR DESCRIPTION
Fixes #753.

`PhysicsServer2DExtensionShapeResult` and other similar native structures now have additional get/set methods:
```rs
pub fn get_collider(&self) -> Option<Gd<Object>>; // None if dead or unset.
pub fn set_collider(&mut self, obj: Gd<Node>);
```

Since the current cases where `Object*` is declared as a field type are all colliders, we can make the interface a bit more type-safe by using `Gd<Node>` instead of `Gd<Object>`. 

This also means that we avoid the reference-counting issue (2nd commit), where it was unclear who is in charge of ownership of ref-counted objects. That was addressed via explicit `bool` parameter, but could technically be done via custom `Drop` impl that treats the raw pointer like a `Gd<Object>`. Anyway, this is no longer relevant; I'll keep the commits in case the native structure API expands in the future though.
