### PR TITLE
Handle panics in virtual interface methods

### DIFF
--- a/godot-macros/src/class/data_models/func.rs
+++ b/godot-macros/src/class/data_models/func.rs
@@ -23,8 +23,7 @@ pub struct FuncDefinition {
 
 /// Returns a C function which acts as the callback when a virtual method of this instance is invoked.
 //
-// There are currently no virtual static methods. Additionally, virtual static methods don't really make a lot
-// of sense. Therefore, there is no need to support them.
+// Virtual methods are non-static by their nature; so there's no support for static ones.
 pub fn make_virtual_callback(
     class_name: &Ident,
     signature_info: SignatureInfo,
@@ -52,7 +51,10 @@ pub fn make_virtual_callback(
                 ret: sys::GDExtensionTypePtr,
             ) {
                 let call_ctx = #call_ctx;
-                #invocation;
+                let _success = ::godot::private::handle_ptrcall_panic(
+                    &call_ctx,
+                    || #invocation
+                );
             }
             Some(virtual_fn)
         }


### PR DESCRIPTION
Catches panics occurring in virtual calls.
Fixes #422.

Due to a [lack of error reporting in Godot's virtual call mechanism](https://github.com/godotengine/godot/blob/97b8ad1af0f2b4a216f6f1263bef4fbc69e56c7b/core/extension/gdextension_interface.h#L269), we cannot transport the errors to the user, neither as panics nor as `CallError` in `Object::try_call()`. If this is desired, we might want to work out a specific design for it in the future.