### PR TITLE
Add `snapped` to integer vectors

### DIFF
--- a/godot-core/src/builtin/vectors/vector2i.rs
+++ b/godot-core/src/builtin/vectors/vector2i.rs
@@ -44,6 +44,8 @@ impl_vector_fns!(Vector2i, glam::IVec2, i32, (x, y));
 impl_vector2x_fns!(Vector2i, i32);
 
 impl Vector2i {
+    impl_integer_vector_fns!(x, y);
+
     /// Constructs a new `Vector2i` from a [`Vector2`]. The floating point coordinates will be truncated.
     #[inline]
     pub const fn from_vector2(v: Vector2) -> Self {

--- a/godot-core/src/builtin/vectors/vector3i.rs
+++ b/godot-core/src/builtin/vectors/vector3i.rs
@@ -47,6 +47,8 @@ impl_vector_fns!(Vector3i, glam::IVec3, i32, (x, y, z));
 impl_vector3x_fns!(Vector3i, i32);
 
 impl Vector3i {
+    impl_integer_vector_fns!(x, y, z);
+
     /// Constructs a new `Vector3i` from a [`Vector3`]. The floating point coordinates will be truncated.
     #[inline]
     pub const fn from_vector3(v: Vector3) -> Self {

--- a/godot-core/src/builtin/vectors/vector4i.rs
+++ b/godot-core/src/builtin/vectors/vector4i.rs
@@ -48,6 +48,8 @@ impl_vector_fns!(Vector4i, glam::IVec4, i32, (x, y, z, w));
 impl_vector4x_fns!(Vector4i, i32);
 
 impl Vector4i {
+    impl_integer_vector_fns!(x, y, z, w);
+
     /// Constructs a new `Vector4i` from a [`Vector4`]. The floating point coordinates will be
     /// truncated.
     #[inline]

--- a/itest/rust/src/builtin_tests/geometry/vector_test/vector2i_test.rs
+++ b/itest/rust/src/builtin_tests/geometry/vector_test/vector2i_test.rs
@@ -102,11 +102,13 @@ fn sign() {
     assert_eq!(b.sign(), b.as_inner().sign());
 }
 
-// TODO: implement snapped for integer vectors
-// #[itest]
-// fn snapped() {
-//     let a = Vector2i::new(12, 34);
-//     let b = Vector2i::new(5, -5);
+#[itest]
+fn snapped() {
+    let a = Vector2i::new(12, 34);
+    let b = Vector2i::new(5, -5);
+    let c = Vector2i::new(0, 0);
+    let d = Vector2i::new(3, 0);
 
-//     assert_eq!(a.snapped(b), a.as_inner().snapped(b));
-// }
+    assert_eq!(a.snapped(b), a.as_inner().snapped(b));
+    assert_eq!(c.snapped(d), c.as_inner().snapped(d));
+}

--- a/itest/rust/src/builtin_tests/geometry/vector_test/vector3i_test.rs
+++ b/itest/rust/src/builtin_tests/geometry/vector_test/vector3i_test.rs
@@ -99,11 +99,13 @@ fn sign() {
     assert_eq!(b.sign(), b.as_inner().sign());
 }
 
-// TODO: implement snapped for integer vectors
-// #[itest]
-// fn snapped() {
-//     let a = Vector3i::new(12, 34, 56);
-//     let b = Vector3i::new(5, -5, 6);
+#[itest]
+fn snapped() {
+    let a = Vector3i::new(12, 34, -56);
+    let b = Vector3i::new(5, -5, 6);
+    let c = Vector3i::new(0, 3, 0);
+    let d = Vector3i::new(3, 0, 0);
 
-//     assert_eq!(a.snapped(b), a.as_inner().snapped(b));
-// }
+    assert_eq!(a.snapped(b), a.as_inner().snapped(b));
+    assert_eq!(c.snapped(d), c.as_inner().snapped(d));
+}

--- a/itest/rust/src/builtin_tests/geometry/vector_test/vector4i_test.rs
+++ b/itest/rust/src/builtin_tests/geometry/vector_test/vector4i_test.rs
@@ -103,11 +103,13 @@ fn sign() {
     assert_eq!(b.sign(), b.as_inner().sign());
 }
 
-// TODO: implement snapped for integer vectors
-// #[itest]
-// fn snapped() {
-//     let a = Vector4i::new(12, 34, 56, 78);
-//     let b = Vector4i::new(5, -5, 6, -6);
+#[itest]
+fn snapped() {
+    let a = Vector4i::new(12, 34, 56, -78);
+    let b = Vector4i::new(5, -5, 6, 6);
+    let c = Vector4i::new(0, 3, 0, 0);
+    let d = Vector4i::new(3, 0, -3, 0);
 
-//     assert_eq!(a.snapped(b), a.as_inner().snapped(b));
-// }
+    assert_eq!(a.snapped(b), a.as_inner().snapped(b));
+    assert_eq!(c.snapped(d), c.as_inner().snapped(d));
+}


### PR DESCRIPTION
This adds  `snapped` for integer vectors based on this [code](https://github.com/godot-rust/gdext/pull/721#discussion_r1615336780).