### PR TITLE
Add determinant to Transform2D

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ gen
 *.bat
 config.toml
 exp.rs
+
+# Mac specific
+.DS_Store

--- a/godot-core/src/builtin/transform2d.rs
+++ b/godot-core/src/builtin/transform2d.rs
@@ -150,6 +150,18 @@ impl Transform2D {
         self.glam(|aff| aff.inverse())
     }
 
+    /// Returns the determinant of the basis matrix.
+    ///
+    /// If the basis is uniformly scaled, then its determinant equals the square of the scale factor.
+    ///
+    /// A negative determinant means the basis was flipped, so one part of the scale is negative.
+    /// A zero determinant means the basis isn't invertible, and is usually considered invalid.
+    ///
+    /// _Godot equivalent: `Transform2D.determinant()`_
+    pub fn determinant(&self) -> real {
+        self.basis().determinant()
+    }
+
     /// Returns the transform's rotation (in radians).
     ///
     /// _Godot equivalent: `Transform2D.get_rotation()`_
@@ -443,7 +455,7 @@ impl Basis2D {
     }
 
     /// Returns the determinant of the matrix.
-    pub(crate) fn determinant(&self) -> real {
+    pub fn determinant(&self) -> real {
         self.glam(|mat| mat.determinant())
     }
 

--- a/itest/rust/src/builtin_tests/geometry/transform2d_test.rs
+++ b/itest/rust/src/builtin_tests/geometry/transform2d_test.rs
@@ -57,6 +57,19 @@ fn transform2d_equiv() {
     );
 }
 
+#[cfg(since_api = "4.1")]
+#[itest]
+fn transform2d_determinant() {
+    let inner = InnerTransform2D::from_outer(&TEST_TRANSFORM);
+    let outer = TEST_TRANSFORM;
+
+    assert_eq_approx!(
+        real::from_f64(inner.determinant()),
+        outer.determinant(),
+        "function: determinant\n"
+    );
+}
+
 #[itest]
 fn transform2d_xform_equiv() {
     let vec = Vector2::new(1.0, 2.0);


### PR DESCRIPTION
Would be nice to have this function. It's also available and public in Godot, as can be seen here: [Transform2D](https://docs.godotengine.org/en/stable/classes/class_transform2d.html). Also, the function can be used to check for Transform2D invalid so that you don't call eg. affine_inverse on an invalid matrix and get an assert.