### PR TITLE
More thoroughly document `unsafe` in `godot-ffi`

### DIFF
--- a/godot-codegen/src/generator/extension_interface.rs
+++ b/godot-codegen/src/generator/extension_interface.rs
@@ -84,6 +84,9 @@ fn generate_proc_address_funcs(h_path: &Path) -> TokenStream {
         }
 
         impl GDExtensionInterface {
+            // TODO: Figure out the right safety preconditions. This currently does not have any because incomplete safety docs
+            // can cause issues with people assuming they are sufficient.
+            #[allow(clippy::missing_safety_doc)]
             pub(crate) unsafe fn load(
                 get_proc_address: crate::GDExtensionInterfaceGetProcAddress,
             ) -> Self {

--- a/godot-codegen/src/generator/method_tables.rs
+++ b/godot-codegen/src/generator/method_tables.rs
@@ -286,7 +286,10 @@ fn make_named_method_table(info: NamedMethodTable) -> TokenStream {
             pub const CLASS_COUNT: usize = #class_count;
             pub const METHOD_COUNT: usize = #method_count;
 
-            pub fn load(
+            // TODO: Figure out the right safety preconditions. This currently does not have any because incomplete safety docs
+            // can cause issues with people assuming they are sufficient.
+            #[allow(clippy::missing_safety_doc)]
+            pub unsafe fn load(
                 #ctor_parameters
             ) -> Self {
                 #pre_init_code
@@ -383,8 +386,11 @@ fn make_method_table(info: IndexedMethodTable) -> TokenStream {
             pub const CLASS_COUNT: usize = #class_count;
             pub const METHOD_COUNT: usize = #method_count;
 
+            // TODO: Figure out the right safety preconditions. This currently does not have any because incomplete safety docs
+            // can cause issues with people assuming they are sufficient.
+            #[allow(clippy::missing_safety_doc)]
             #unused_attr
-            pub fn load(
+            pub unsafe fn load(
                 #ctor_parameters
             ) -> Self {
                 #pre_init_code
@@ -455,8 +461,11 @@ fn make_method_table(info: IndexedMethodTable) -> TokenStream {
             pub const CLASS_COUNT: usize = #class_count;
             pub const METHOD_COUNT: usize = #method_count;
 
+            // TODO: Figure out the right safety preconditions. This currently does not have any because incomplete safety docs
+            // can cause issues with people assuming they are sufficient.
+            #[allow(clippy::missing_safety_doc)]
             #unused_attr
-            pub fn load() -> Self {
+            pub unsafe fn load() -> Self {
                 // SAFETY: interface and lifecycle tables are initialized at this point, so we can get 'static references to them.
                 let (interface, lifecycle_table) = unsafe {
                     (crate::get_interface(), crate::builtin_lifecycle_api())

--- a/godot-ffi/src/binding/mod.rs
+++ b/godot-ffi/src/binding/mod.rs
@@ -80,6 +80,27 @@ unsafe impl Sync for ClassLibraryPtr {}
 unsafe impl Send for ClassLibraryPtr {}
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
+
+/// # Safety
+/// The table must not have been initialized yet.
+unsafe fn initialize_table<T>(table: &ManualInitCell<T>, value: T, what: &str) {
+    debug_assert!(
+        !table.is_initialized(),
+        "method table for {what} should only be initialized once"
+    );
+
+    table.set(value)
+}
+
+/// # Safety
+/// The table must have been initialized.
+unsafe fn get_table<T>(table: &'static ManualInitCell<T>, msg: &str) -> &'static T {
+    debug_assert!(table.is_initialized(), "{msg}");
+
+    table.get_unchecked()
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
 // Public API
 
 /// # Safety
@@ -152,25 +173,6 @@ pub unsafe fn class_editor_api() -> &'static ClassEditorMethodTable {
         &get_binding().class_editor_method_table,
         "cannot fetch classes; init level 'Editor' not yet loaded",
     )
-}
-
-/// # Safety
-/// The table must not have been initialized yet.
-unsafe fn initialize_table<T>(table: &ManualInitCell<T>, value: T, what: &str) {
-    debug_assert!(
-        !table.is_initialized(),
-        "method table for {what} should only be initialized once"
-    );
-
-    table.set(value)
-}
-
-/// # Safety
-/// The table must have been initialized.
-unsafe fn get_table<T>(table: &'static ManualInitCell<T>, msg: &str) -> &'static T {
-    debug_assert!(table.is_initialized(), "{msg}");
-
-    table.get_unchecked()
 }
 
 /// # Safety

--- a/godot-ffi/src/binding/single_threaded.rs
+++ b/godot-ffi/src/binding/single_threaded.rs
@@ -143,7 +143,9 @@ impl BindingStorage {
     /// - The binding must be initialized.
     #[inline(always)]
     pub unsafe fn get_binding_unchecked() -> &'static GodotBinding {
-        let storage = Self::storage();
+        // SAFETY: The bindings were initialized on the main thread because `initialize` must be called from the main thread,
+        // and this function is called from the main thread.
+        let storage = unsafe { Self::storage() };
 
         // We only check if we are in the main thread in debug builds if we aren't building for a non-threaded Godot build,
         // since we could otherwise assume there won't be multi-threading.

--- a/godot-ffi/src/compat/compat_4_0.rs
+++ b/godot-ffi/src/compat/compat_4_0.rs
@@ -15,7 +15,8 @@ use crate::compat::BindingCompat;
 
 pub type InitCompat = *const sys::GDExtensionInterface;
 
-impl BindingCompat for *const sys::GDExtensionInterface {
+// SAFETY: If `ensure_static_runtime_compatibility` succeeds then the other two functions should be safe to call.
+unsafe impl BindingCompat for *const sys::GDExtensionInterface {
     fn ensure_static_runtime_compatibility(&self) {
         // We try to read the first fields of the GDExtensionInterface struct, which are version numbers.
         // If those are unrealistic numbers, chances are high that `self` is in fact a function pointer (used for Godot 4.1.x).
@@ -40,7 +41,7 @@ impl BindingCompat for *const sys::GDExtensionInterface {
         );
     }
 
-    fn runtime_version(&self) -> sys::GDExtensionGodotVersion {
+    unsafe fn runtime_version(&self) -> sys::GDExtensionGodotVersion {
         // SAFETY: this method is only invoked after the static compatibility check has passed.
         // We thus know that Godot 4.0.x runs, and *self is a GDExtensionInterface pointer.
         let interface = unsafe { &**self };
@@ -52,7 +53,7 @@ impl BindingCompat for *const sys::GDExtensionInterface {
         }
     }
 
-    fn load_interface(&self) -> sys::GDExtensionInterface {
+    unsafe fn load_interface(&self) -> sys::GDExtensionInterface {
         unsafe { **self }
     }
 }

--- a/godot-ffi/src/compat/mod.rs
+++ b/godot-ffi/src/compat/mod.rs
@@ -21,7 +21,12 @@ pub use compat_4_0::*;
 ///
 /// Provides a compatibility layer to be able to use 4.0.x extensions under Godot versions >= 4.1.
 /// Also performs deterministic checks and expressive errors for cases where compatibility cannot be provided.
-pub(crate) trait BindingCompat {
+///
+/// # Safety
+///
+/// [`ensure_static_runtime_compatibility`](BindingCompat::ensure_static_runtime_compatibility) succeeding should be sufficient to ensure that
+/// both [`runtime_version`](BindingCompat::runtime_version) and [`load_interface`](BindingCompat::load_interface) can be called safely.
+pub(crate) unsafe trait BindingCompat {
     // Implementation note: these methods could be unsafe, but that would remove any `unsafe` statements _inside_
     // the function bodies, making reasoning about them harder. Also, the call site is already an unsafe function,
     // so it would not add safety there, either.
@@ -42,8 +47,16 @@ pub(crate) trait BindingCompat {
     fn ensure_static_runtime_compatibility(&self);
 
     /// Return version dynamically passed via `gdextension_interface.h` file.
-    fn runtime_version(&self) -> sys::GDExtensionGodotVersion;
+    ///
+    /// # Safety
+    ///
+    /// `self` must be a valid interface or get proc address pointer.
+    unsafe fn runtime_version(&self) -> sys::GDExtensionGodotVersion;
 
     /// Return the interface, either as-is from the header (legacy) or code-generated (modern API).
-    fn load_interface(&self) -> sys::GDExtensionInterface;
+    ///
+    /// # Safety
+    ///
+    /// `self` must be a valid interface or get proc address pointer.
+    unsafe fn load_interface(&self) -> sys::GDExtensionInterface;
 }

--- a/godot-ffi/src/godot_ffi.rs
+++ b/godot-ffi/src/godot_ffi.rs
@@ -106,22 +106,26 @@ pub unsafe trait GodotFfi {
 
 /// # Safety
 ///
-/// See [`GodotFfi::new_with_uninit`] and [`GodotFfi::new_with_init`].
+/// - For Godot version 4.0 see [`GodotFfi::new_with_init`].
+/// - For Godot versions >= 4.1 see [`GodotFfi::new_with_uninit`].
 #[cfg(before_api = "4.1")]
 pub unsafe fn new_with_uninit_or_init<T: GodotFfi>(
     init_fn: impl FnOnce(sys::GDExtensionTypePtr),
 ) -> T {
-    T::new_with_init(init_fn)
+    // SAFETY: `before_api = "4.1"` so the user must fulfil the safety preconditions of `new_with_init`.
+    unsafe { T::new_with_init(init_fn) }
 }
 
 /// # Safety
 ///
-/// See [`GodotFfi::new_with_uninit`] and [`GodotFfi::new_with_init`].
+/// - For Godot version 4.0 see [`GodotFfi::new_with_init`].
+/// - For Godot versions >= 4.1 see [`GodotFfi::new_with_uninit`].
 #[cfg(since_api = "4.1")]
 pub unsafe fn new_with_uninit_or_init<T: GodotFfi>(
     init_fn: impl FnOnce(sys::GDExtensionUninitializedTypePtr),
 ) -> T {
-    T::new_with_uninit(init_fn)
+    // SAFETY: `since_api = "4.1"` so the user must fulfil the safety preconditions of `new_with_uninit`.
+    unsafe { T::new_with_uninit(init_fn) }
 }
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
@@ -170,6 +174,7 @@ pub enum PtrcallType {
 // or a free-standing `impl` for concrete sys pointers such as GDExtensionObjectPtr.
 // See doc comment of `ffi_methods!` for information
 
+// TODO: explicitly document safety invariants.
 #[macro_export]
 #[doc(hidden)]
 macro_rules! ffi_methods_one {

--- a/godot-ffi/src/linux_reload_workaround.rs
+++ b/godot-ffi/src/linux_reload_workaround.rs
@@ -70,7 +70,8 @@ pub unsafe fn thread_atexit(func: *mut c_void, obj: *mut c_void, dso_symbol: *mu
     } else if let Some(system_thread_atexit) = *system_thread_atexit() {
         // Hot reloading is disabled, and system provides `__cxa_thread_atexit_impl`,
         // so forward the call to it.
-        system_thread_atexit(func, obj, dso_symbol);
+        // SAFETY: Is only called by the system when thread_atexit should be called.
+        unsafe { system_thread_atexit(func, obj, dso_symbol) };
     } else {
         // Hot reloading is disabled *and* we don't have `__cxa_thread_atexit_impl`,
         // throw hands up in the air and leak memory.

--- a/godot-ffi/src/string_cache.rs
+++ b/godot-ffi/src/string_cache.rs
@@ -129,30 +129,30 @@ fn box_to_sname_ptr(
 
 #[cfg(before_api = "4.2")]
 unsafe fn string_type_ptr(opaque_ptr: *mut sys::types::OpaqueString) -> sys::GDExtensionTypePtr {
-    ptr::addr_of_mut!(*opaque_ptr) as sys::GDExtensionTypePtr
+    opaque_ptr as sys::GDExtensionTypePtr
 }
 
 #[cfg(before_api = "4.2")]
 unsafe fn string_uninit_ptr(
     opaque_ptr: *mut sys::types::OpaqueString,
 ) -> sys::GDExtensionUninitializedStringPtr {
-    ptr::addr_of_mut!(*opaque_ptr) as sys::GDExtensionUninitializedStringPtr
+    opaque_ptr as sys::GDExtensionUninitializedStringPtr
 }
 
 #[cfg(since_api = "4.2")]
 unsafe fn sname_uninit_ptr(
     opaque_ptr: *mut sys::types::OpaqueStringName,
 ) -> sys::GDExtensionUninitializedStringNamePtr {
-    ptr::addr_of_mut!(*opaque_ptr) as sys::GDExtensionUninitializedStringNamePtr
+    opaque_ptr as sys::GDExtensionUninitializedStringNamePtr
 }
 
 unsafe fn sname_type_ptr(opaque_ptr: *mut sys::types::OpaqueStringName) -> sys::GDExtensionTypePtr {
-    ptr::addr_of_mut!(*opaque_ptr) as sys::GDExtensionTypePtr
+    opaque_ptr as sys::GDExtensionTypePtr
 }
 
 #[cfg(before_api = "4.2")]
 unsafe fn sname_uninit_type_ptr(
     opaque_ptr: *mut sys::types::OpaqueStringName,
 ) -> sys::GDExtensionUninitializedTypePtr {
-    ptr::addr_of_mut!(*opaque_ptr) as sys::GDExtensionUninitializedTypePtr
+    opaque_ptr as sys::GDExtensionUninitializedTypePtr
 }

--- a/godot-ffi/src/toolbox.rs
+++ b/godot-ffi/src/toolbox.rs
@@ -67,12 +67,19 @@ macro_rules! out {
 ///  let get_godot_version = get_proc_address(sys::c_str(b"get_godot_version\0"));
 ///  let get_godot_version = sys::cast_fn_ptr!(get_godot_version as sys::GDExtensionInterfaceGetGodotVersion);
 /// ```
+///
+/// # Safety
+///
+/// `$ToType` must be an option of an `unsafe extern "C"` function pointer.
 #[allow(unused)]
 #[macro_export]
 macro_rules! cast_fn_ptr {
-    ($option:ident as $ToType:ty) => {{
-        let ptr = $option.expect("null function pointer");
-        std::mem::transmute::<unsafe extern "C" fn(), <$ToType as $crate::Inner>::FnPtr>(ptr)
+    (unsafe { $option:ident as $ToType:ty }) => {{
+        // SAFETY: `$ToType` is an `unsafe extern "C"` function pointer and is thus compatible with `unsafe extern "C" fn()`.
+        // And `Option<T>` is compatible with `Option<U>` when both `T` and `U` are compatible function pointers.
+        #[allow(unused_unsafe)]
+        let ptr: Option<_> = unsafe { std::mem::transmute::<Option<unsafe extern "C" fn()>, $ToType>($option) };
+        ptr.expect("null function pointer")
     }};
 }
 
@@ -133,16 +140,6 @@ pub fn hash_value<T: std::hash::Hash>(t: &T) -> u64 {
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
     t.hash(&mut hasher);
     hasher.finish()
-}
-
-/// Check whether contents of `lhs` and `rhs` are bitwise equal.
-///
-/// # Safety
-/// Requires valid pointers, properly aligned.
-pub unsafe fn bitwise_equal<T>(lhs: *const T, rhs: *const T) -> bool {
-    // Convert to raw parts
-    std::slice::from_raw_parts(lhs as *const u8, std::mem::size_of::<T>())
-        == std::slice::from_raw_parts(rhs as *const u8, std::mem::size_of::<T>())
 }
 
 pub fn join<T, I>(iter: I) -> String
@@ -246,6 +243,9 @@ pub type UtilityFunctionBind = unsafe extern "C" fn(
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Utility functions
+
+// TODO: Most of these should be `unsafe` since the caller passes an `unsafe extern "C"` function pointer which it must be legal to call.
+// But for now we can just rely on knowing that these aren't called in the wrong context.
 
 pub(crate) fn load_class_method(
     get_method_bind: GetClassMethod,


### PR DESCRIPTION
This shouldn't change any behavior.

Mainly makes `unsafe_op_in_unsafe_fn` a warn lint in `godot-ffi`, but allows it again in a couple of places where it'd just be tedious to add in all the unsafe blocks. Such as codegen and the various interface APIs. Also the `ffi_methods` macro has an allow since properly documenting the safety invariants there is actually _very tricky_.

Also removes `bitwise_equal`, expands a bit on lacking safety docs of some functions, and makes some functions unsafe that should be.