### PR TITLE
Disable main_thread_id assertion for Android debug build

### DIFF
--- a/godot-ffi/src/binding/single_threaded.rs
+++ b/godot-ffi/src/binding/single_threaded.rs
@@ -147,7 +147,8 @@ impl BindingStorage {
 
         // We only check if we are in the main thread in debug builds if we aren't building for a non-threaded Godot build,
         // since we could otherwise assume there won't be multi-threading.
-        #[cfg(all(debug_assertions, not(wasm_nothreads)))]
+        // TODO: figure out why the panic happens on Android, and how to resolve it. See https://github.com/godot-rust/gdext/pull/780.
+        #[cfg(all(debug_assertions, not(wasm_nothreads), not(target_os = "android")))]
         {
             let main_thread_id = storage.main_thread_id.get().expect(
                 "Godot engine not available; make sure you are not calling it from unit/doc tests",


### PR DESCRIPTION
This assertion block was previously commented out and reactivated without a clear reason in git history
It causes a runtime panic in debug builds for Android
If this assertion is required, please implement logic that also considers Android