### PR TITLE
Change logic to disable OpenXR for iOS

### DIFF
--- a/godot-codegen/src/special_cases/special_cases.rs
+++ b/godot-codegen/src/special_cases/special_cases.rs
@@ -88,9 +88,16 @@ pub fn is_godot_type_deleted(godot_ty: &str) -> bool {
     // See e.g. https://github.com/GodotVR/godot-xr-tools/issues/479.
     // OpenXR is also not available on iOS: https://github.com/godotengine/godot/blob/13ba673c42951fd7cfa6fd8a7f25ede7e9ad92bb/modules/openxr/config.py#L2
     // Do not hardcode a list of OpenXR classes, as more may be added in future Godot versions; instead use prefix.
-    #[cfg(any(all(before_api = "4.2", target_os = "macos"), target_os = "ios"))]
     if godot_ty.starts_with("OpenXR") {
-        return true;
+        let target_os = std::env::var("CARGO_CFG_TARGET_OS");
+        match target_os.as_deref() {
+            Ok("ios") => return true,
+            Ok("macos") => {
+                #[cfg(before_api = "4.2")]
+                return true;
+            }
+            _ => {}
+        }
     }
 
     // ThemeDB was previously loaded lazily


### PR DESCRIPTION
Due to `target_os = ios` not working when cross-platform building, 
use `CARGO_CFG_TARGET_OS` to check the target OS instead.