### PR TITLE
Support `#[export(range = (radians_as_degrees, suffix="XX"))]`

### DIFF
--- a/godot-core/src/deprecated.rs
+++ b/godot-core/src/deprecated.rs
@@ -20,6 +20,13 @@ pub const fn base_attribute() {}
         More information on https://github.com/godot-rust/gdext/pull/702."]
 pub const fn feature_custom_godot() {}
 
+#[cfg_attr(
+    since_api = "4.2",
+    deprecated = "Use #[export(range = (radians_as_degrees))] and not #[export(range = (radians))]. \n\
+	More information on https://github.com/godotengine/godot/pull/82195."
+)]
+pub const fn export_range_radians() {}
+
 #[macro_export]
 macro_rules! emit_deprecated_warning {
     ($warning_fn:ident) => {

--- a/godot-core/src/meta/mod.rs
+++ b/godot-core/src/meta/mod.rs
@@ -117,6 +117,7 @@ impl PropertyInfo {
     ///         false,
     ///         false,
     ///         false,
+    ///         Some("mm".to_string()),
     ///     ));
     /// ```
     pub fn with_hint_info(self, hint_info: PropertyHintInfo) -> Self {

--- a/godot-macros/src/util/kv_parser.rs
+++ b/godot-macros/src/util/kv_parser.rs
@@ -6,7 +6,7 @@
  */
 
 use crate::ParseResult;
-use proc_macro2::{Delimiter, Ident, Spacing, Span, TokenStream, TokenTree};
+use proc_macro2::{Delimiter, Ident, Literal, Spacing, Span, TokenStream, TokenTree};
 use quote::ToTokens;
 use std::collections::HashMap;
 
@@ -288,6 +288,17 @@ impl KvValue {
         match &self.tokens[0] {
             TokenTree::Ident(id) => Ok(id.clone()),
             other => bail!(other, "expected identifier"),
+        }
+    }
+
+    pub fn as_literal(&self) -> ParseResult<Literal> {
+        if self.tokens.len() > 1 {
+            return bail!(&self.tokens[1], "expected a single literal");
+        }
+
+        match &self.tokens[0] {
+            TokenTree::Literal(literal) => Ok(literal.clone()),
+            other => bail!(other, "expected literal"),
         }
     }
 }

--- a/itest/rust/src/object_tests/property_test.rs
+++ b/itest/rust/src/object_tests/property_test.rs
@@ -239,10 +239,11 @@ struct CheckAllExports {
     #[export]
     normal: GString,
 
-    #[export(range = (0.0, 10.0, or_greater, or_less, exp, radians, hide_slider))]
+    // `suffix = "px"` should be in the third slot to test that key-value pairs in that position no longer error.
+    #[export(range = (0.0, 10.0, suffix = "px", or_greater, or_less, exp, degrees, hide_slider))]
     range_exported: f64,
 
-    #[export(range = (0.0, 10.0, 0.2, or_greater, or_less, exp, radians, hide_slider))]
+    #[export(range = (0.0, 10.0, 0.2, or_greater, or_less, exp, radians_as_degrees, hide_slider))]
     range_exported_with_step: f64,
 
     #[export(enum = (A = 10, B, C, D = 20))]


### PR DESCRIPTION
`radians_as_degrees` was added in Godot [4.2][1] to replace `radians` with identical functionality and a better name.  `suffix` was added in [4.0][2] and was seemingly missed when `#[export(range)]` was first implemented.

This is the first instance where Godot has deprecated an API and gdext has needed to implement it.  Hopefully this will serve as a useful template for future work.

This also fixes a previously unknown bug where a `KEY=VALUE` expression in the third slot of `range = (...)` would yield strange error messages.

[1]: https://github.com/godotengine/godot/pull/82195
[2]: https://github.com/godotengine/godot/pull/50009

Resolves https://github.com/godot-rust/gdext/issues/731