### PR TITLE
Added implementation to convert Vec<$Element> into $PackedArray types.

### DIFF
--- a/godot-core/src/builtin/collections/packed_array.rs
+++ b/godot-core/src/builtin/collections/packed_array.rs
@@ -455,6 +455,13 @@ macro_rules! impl_packed_array {
             }
         }
 
+        #[doc = concat!("Creates a `", stringify!($PackedArray), "` from the given Rust vec.")]
+        impl From<Vec<$Element>> for $PackedArray {
+            fn from(vec: Vec<$Element>) -> Self{
+                vec.into_iter().collect()
+            }
+        }
+
         #[doc = concat!("Creates a `", stringify!($PackedArray), "` from an iterator.")]
         impl FromIterator<$Element> for $PackedArray {
             fn from_iter<I: IntoIterator<Item = $Element>>(iter: I) -> Self {

--- a/itest/rust/src/builtin_tests/containers/packed_array_test.rs
+++ b/itest/rust/src/builtin_tests/containers/packed_array_test.rs
@@ -6,7 +6,7 @@
  */
 
 use crate::framework::{expect_panic, itest};
-use godot::builtin::{PackedByteArray, PackedFloat32Array, PackedStringArray};
+use godot::builtin::{PackedByteArray, PackedFloat32Array, PackedInt32Array, PackedStringArray};
 
 #[itest]
 fn packed_array_default() {
@@ -25,6 +25,24 @@ fn packed_array_from_iterator() {
     assert_eq!(array.len(), 2);
     assert_eq!(array[0], 1);
     assert_eq!(array[1], 2);
+}
+
+#[itest]
+fn packed_array_from_vec_str() {
+    let string_array = PackedStringArray::from(vec!["hello".into(), "world".into()]);
+
+    assert_eq!(string_array.len(), 2);
+    assert_eq!(string_array[0], "hello".into());
+    assert_eq!(string_array[1], "world".into());
+}
+
+#[itest]
+fn packed_array_from_vec_i32() {
+    let int32_array = PackedInt32Array::from(vec![1, 2]);
+
+    assert_eq!(int32_array.len(), 2);
+    assert_eq!(int32_array[0], 1);
+    assert_eq!(int32_array[1], 2);
 }
 
 #[itest]


### PR DESCRIPTION
Enables easy creation of Packed*Array from Vec<$Element>.

```rust 
let byte_array: PackedByteArray = PackedByteArray::from(vec![11, 46, 255]);
let color_array: PackedColorArray = PackedColorArray::from(vec![
    Color { r: 0.1, g: 0.2, b: 0.3, a: 1.0, }, Color { r: 0.4, g: 0.5, b: 0.6, a: 1.0, },
]);
let float32_array: PackedFloat32Array = PackedFloat32Array::from(vec![1., 2., 3., 4.]);
let float64_array: PackedFloat64Array = PackedFloat64Array::from(vec![9., 8., 7., 6.]);
let int32_array: PackedInt32Array = PackedInt32Array::from(vec![1, 2, 3, 4]);
let int64_array: PackedInt64Array = PackedInt64Array::from(vec![9, 8, 7, 6]);
let string_array: PackedStringArray = PackedStringArray::from(vec!["hello".into(), "mundo".into()]);
let vector2_array: PackedVector2Array = PackedVector2Array::from(vec![
    Vector2 { x: 12.0, y: 34.0, }, Vector2 { x: 56.0, y: 78.0, },
]);
let vector3_array: PackedVector3Array = PackedVector3Array::from(vec![
    Vector3 { x: 12.0, y: 34.0, z: 56.0, }, Vector3 { x: 78.0, y: 90.0, z: 12.0, },
]);