### PR TITLE
Implement `GodotConvert` for `Vec<T>`, `[T; N]` and `&[T]`

### DIFF
--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -139,7 +139,7 @@ jobs:
 
           - name: linux
             os: ubuntu-20.04
-            rust-toolchain: "1.78"
+            rust-toolchain: "1.80"
             rust-special: -msrv
 
     steps:

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -19,7 +19,7 @@ on:
 
 env:
   # Keep this a variable for easy search&replace.
-  MSRV: 1.78
+  MSRV: 1.80
 
 jobs:
   notify-docs:

--- a/examples/dodge-the-creeps/rust/Cargo.toml
+++ b/examples/dodge-the-creeps/rust/Cargo.toml
@@ -2,7 +2,7 @@
 name = "dodge-the-creeps"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.78"
+rust-version = "1.80"
 license = "MPL-2.0"
 publish = false
 

--- a/godot-bindings/Cargo.toml
+++ b/godot-bindings/Cargo.toml
@@ -2,7 +2,7 @@
 name = "godot-bindings"
 version = "0.1.3"
 edition = "2021"
-rust-version = "1.78"
+rust-version = "1.80"
 license = "MPL-2.0"
 keywords = ["gamedev", "godot", "engine", "ffi", "sys"]
 categories = ["game-engines", "graphics"]

--- a/godot-cell/Cargo.toml
+++ b/godot-cell/Cargo.toml
@@ -2,7 +2,7 @@
 name = "godot-cell"
 version = "0.1.3"
 edition = "2021"
-rust-version = "1.78"
+rust-version = "1.80"
 license = "MPL-2.0"
 keywords = ["gamedev", "godot", "engine", "ffi"]
 categories = ["game-engines", "graphics"]

--- a/godot-codegen/Cargo.toml
+++ b/godot-codegen/Cargo.toml
@@ -2,7 +2,7 @@
 name = "godot-codegen"
 version = "0.1.3"
 edition = "2021"
-rust-version = "1.78"
+rust-version = "1.80"
 license = "MPL-2.0"
 keywords = ["gamedev", "godot", "engine", "codegen"]
 categories = ["game-engines", "graphics"]

--- a/godot-core/Cargo.toml
+++ b/godot-core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "godot-core"
 version = "0.1.3"
 edition = "2021"
-rust-version = "1.78"
+rust-version = "1.80"
 license = "MPL-2.0"
 keywords = ["gamedev", "godot", "engine", "2d", "3d"] # possibly: "ffi"
 categories = ["game-engines", "graphics"]

--- a/godot-core/src/private.rs
+++ b/godot-core/src/private.rs
@@ -49,11 +49,7 @@ struct CallErrors {
 impl Default for CallErrors {
     fn default() -> Self {
         Self {
-            // [None; N] requires Clone. The following is possible once MSRV lifts to 1.79:
-            // ring_buffer: [const { None }; Self::MAX_ENTRIES as usize].into(),
-            ring_buffer: std::iter::repeat_with(|| None)
-                .take(Self::MAX_ENTRIES as usize)
-                .collect(),
+            ring_buffer: [const { None }; Self::MAX_ENTRIES as usize].into(),
             next_id: 0,
             generation: 0,
         }

--- a/godot-ffi/Cargo.toml
+++ b/godot-ffi/Cargo.toml
@@ -2,7 +2,7 @@
 name = "godot-ffi"
 version = "0.1.3"
 edition = "2021"
-rust-version = "1.78"
+rust-version = "1.80"
 license = "MPL-2.0"
 keywords = ["gamedev", "godot", "engine", "ffi"]
 categories = ["game-engines", "graphics"]

--- a/godot-macros/Cargo.toml
+++ b/godot-macros/Cargo.toml
@@ -2,7 +2,7 @@
 name = "godot-macros"
 version = "0.1.3"
 edition = "2021"
-rust-version = "1.78"
+rust-version = "1.80"
 license = "MPL-2.0"
 keywords = ["gamedev", "godot", "engine", "derive", "macro"]
 categories = ["game-engines", "graphics"]

--- a/godot/Cargo.toml
+++ b/godot/Cargo.toml
@@ -2,7 +2,7 @@
 name = "godot"
 version = "0.1.3"
 edition = "2021"
-rust-version = "1.78"
+rust-version = "1.80"
 license = "MPL-2.0"
 keywords = ["gamedev", "godot", "engine", "2d", "3d"] # possibly: "ffi"
 categories = ["game-engines", "graphics"]

--- a/itest/repo-tweak/Cargo.toml
+++ b/itest/repo-tweak/Cargo.toml
@@ -2,7 +2,7 @@
 name = "repo-tweak"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.78"
+rust-version = "1.80"
 license = "MPL-2.0"
 publish = false
 

--- a/itest/rust/Cargo.toml
+++ b/itest/rust/Cargo.toml
@@ -2,7 +2,7 @@
 name = "itest"
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.78"
+rust-version = "1.80"
 license = "MPL-2.0"
 publish = false
 

--- a/itest/rust/src/builtin_tests/convert_test.rs
+++ b/itest/rust/src/builtin_tests/convert_test.rs
@@ -6,7 +6,7 @@
  */
 
 use godot::builtin::{
-    dict, Array, Dictionary, GString, Variant, VariantArray, Vector2, Vector2Axis,
+    array, dict, Array, Dictionary, GString, Variant, VariantArray, Vector2, Vector2Axis,
 };
 use godot::classes::{Node, Resource};
 use godot::meta::error::ConvertError;
@@ -232,4 +232,84 @@ fn custom_convert_error_from_variant() {
         format!("{:?}", err.value().unwrap()),
         format!("{:?}", i64::MAX)
     );
+}
+
+#[itest]
+fn vec_to_array() {
+    let from = vec![1, 2, 3];
+    let to = from.to_variant().to::<Array<i32>>();
+    assert_eq!(to, array![1, 2, 3]);
+
+    let from = vec![GString::from("Hello"), GString::from("World")];
+    let to = from.to_variant().to::<Array<GString>>();
+    assert_eq!(to, array![GString::from("Hello"), GString::from("World")]);
+
+    // Invalid conversion.
+    let from = vec![1, 2, 3];
+    let to = from.to_variant().try_to::<Array<f32>>();
+    assert!(to.is_err());
+}
+
+#[itest]
+fn array_to_vec() {
+    let from = array![1, 2, 3];
+    let to = from.to_variant().to::<Vec<i32>>();
+    assert_eq!(to, vec![1, 2, 3]);
+
+    let from = array![GString::from("Hello"), GString::from("World")];
+    let to = from.to_variant().to::<Vec<GString>>();
+    assert_eq!(to, vec![GString::from("Hello"), GString::from("World")]);
+
+    // Invalid conversion.
+    let from = array![1, 2, 3];
+    let to = from.to_variant().try_to::<Vec<f32>>();
+    assert!(to.is_err());
+}
+
+#[itest]
+fn rust_array_to_array() {
+    let from = [1, 2, 3];
+    let to = from.to_variant().to::<Array<i32>>();
+    assert_eq!(to, array![1, 2, 3]);
+
+    let from = [GString::from("Hello"), GString::from("World")];
+    let to = from.to_variant().to::<Array<GString>>();
+    assert_eq!(to, array![GString::from("Hello"), GString::from("World")]);
+
+    // Invalid conversion.
+    let from = [1, 2, 3];
+    let to = from.to_variant().try_to::<Array<f32>>();
+    assert!(to.is_err());
+}
+
+#[itest]
+fn array_to_rust_array() {
+    let from = array![1, 2, 3];
+    let to = from.to_variant().to::<[i32; 3]>();
+    assert_eq!(to, [1, 2, 3]);
+
+    let from = array![GString::from("Hello"), GString::from("World")];
+    let to = from.to_variant().to::<[GString; 2]>();
+    assert_eq!(to, [GString::from("Hello"), GString::from("World")]);
+
+    // Invalid conversion.
+    let from = array![1, 2, 3];
+    let to = from.to_variant().try_to::<[f32; 3]>();
+    assert!(to.is_err());
+}
+
+#[itest]
+fn slice_to_array() {
+    let from = &[1, 2, 3];
+    let to = from.to_variant().to::<Array<i32>>();
+    assert_eq!(to, array![1, 2, 3]);
+
+    let from = &[GString::from("Hello"), GString::from("World")];
+    let to = from.to_variant().to::<Array<GString>>();
+    assert_eq!(to, array![GString::from("Hello"), GString::from("World")]);
+
+    // Invalid conversion.
+    let from = &[1, 2, 3];
+    let to = from.to_variant().try_to::<Array<f32>>();
+    assert!(to.is_err());
 }


### PR DESCRIPTION
Rationale:
In multithreaded contexts, I've come across a use case where it was useful to express that a multithreaded operation would return a type that implements `ToGodot`.

This is one of the cases, in my crate gdext_coroutines:
```rust
fn async_task<R>(
	&self,
	f: impl std::future::Future<Output = R> + Send + 'static,
) -> CoroutineBuilder<R>
	where
		R: 'static + ToGodot + Send;
```

Rust vectors and arrays fit all bounds of `R` except `ToGodot`, even if the element type implements `ToGodot`.

The workaround is to use wrapper types and manually implement GodotConvert for them, but I believe this blanket implementation is simple enough to be worth improving the user experience.