### PR TITLE
Map `Vector3i.Axis` enum to builtin `Vector3Axis`

### DIFF
--- a/godot-codegen/src/conv/type_conversions.rs
+++ b/godot-codegen/src/conv/type_conversions.rs
@@ -76,6 +76,7 @@ fn to_hardcoded_rust_enum(ty: &str) -> Option<&str> {
         "enum::Variant.Type" => "VariantType",
         "enum::Variant.Operator" => "VariantOperator",
         "enum::Vector3.Axis" => "Vector3Axis",
+        "enum::Vector3i.Axis" => "Vector3Axis",
         _ => return None,
     };
     Some(result)

--- a/itest/rust/src/engine_tests/utilities_test.rs
+++ b/itest/rust/src/engine_tests/utilities_test.rs
@@ -8,7 +8,9 @@
 use crate::framework::itest;
 
 use godot::builtin::{GString, Variant};
+use godot::classes::Node3D;
 use godot::global::*;
+use godot::obj::NewAlloc;
 
 #[itest]
 fn utilities_abs() {
@@ -69,4 +71,15 @@ fn utilities_max() {
         &[Variant::from(-5.0), Variant::from(-7.0)],
     );
     assert_eq!(output, Variant::from(-1.0));
+}
+
+// Checks that godot-rust is not susceptible to the godot-cpp issue https://github.com/godotengine/godot-cpp/issues/1390.
+#[itest]
+fn utilities_is_instance_valid() {
+    let node = Node3D::new_alloc();
+    let variant = Variant::from(node.clone());
+    assert!(is_instance_valid(variant.clone()));
+
+    node.free();
+    assert!(!is_instance_valid(variant));
 }


### PR DESCRIPTION
Other extensions which reference the **integer** axis type should now be able to use the builtin enum `Vector3Axis`.

An example that caused problems, with the GodotVoxel plugin:
```rs
info: component 'rust-std' for target 'x86_64-pc-windows-gnu' is up to date
   Compiling godot-ffi v0.1.1 (https://github.com/godot-rust/gdext?branch=master#4dc2720f)
   Compiling godot-core v0.1.1 (https://github.com/godot-rust/gdext?branch=master#4dc2720f)
error[E0433]: failed to resolve: could not find `vector3i` in `classes`
   --> C:\...\GodotVoxelSteam\voxel_generator\target\x86_64-pc-windows-gnu\debug\build\godot-core-00312bf968325b83\out\classes\voxel_blocky_model.rs:256:59
    |
256 | ...: crate::classes::vector3i::Axis, clockwise: bool,) {
    |                      ^^^^^^^^ could not find `vector3i` in `classes`
    |
note: module `crate::gen::builtin_classes::vector3i` exists but is inaccessible
   --> C:\...\GodotVoxelSteam\voxel_generator\target\x86_64-pc-windows-gnu\debug\build\godot-core-00312bf968325b83\out\builtin_classes\mod.rs:13:1
    |
13  | mod vector3i;
    | ^^^^^^^^^^^^^ not accessible

error[E0433]: failed to resolve: could not find `vector3i` in `classes`
   --> C:\...\GodotVoxelSteam\voxel_generator\target\x86_64-pc-windows-gnu\debug\build\godot-core-00312bf968325b83\out\classes\voxel_blocky_model.rs:257:49
    |
257 |             type CallSig = ((), crate::classes::vector3i::Axis, bool);
    |                                                 ^^^^^^^^ could not find `vector3i` in `classes`
    |
note: module `crate::gen::builtin_classes::vector3i` exists but is inaccessible
   --> C:\...\GodotVoxelSteam\voxel_generator\target\x86_64-pc-windows-gnu\debug\build\godot-core-00312bf968325b83\out\builtin_classes\mod.rs:13:1
    |
13  | mod vector3i;
    | ^^^^^^^^^^^^^ not accessible

For more information about this error, try `rustc --explain E0433`.
error: could not compile `godot-core` (lib) due to 2 previous errors
```