### PR TITLE
Add helpful error for renamed Wasm module

### DIFF
--- a/godot-macros/src/gdextension.rs
+++ b/godot-macros/src/gdextension.rs
@@ -54,6 +54,11 @@ pub fn attribute_gdextension(item: venial::Item) -> ParseResult<TokenStream> {
             let script = std::ffi::CString::new(concat!(
                 "var pkgName = '", env!("CARGO_PKG_NAME"), "';", r#"
                 var libName = pkgName.replaceAll('-', '_') + '.wasm';
+                if (!(libName in LDSO.loadedLibsByName)) {
+                    // Always print to console, even if the error is suppressed.
+                    console.error(`godot-rust could not find the Wasm module '${libName}', needed to load the '${pkgName}' crate. Please ensure a file named '${libName}' exists in the game's web export files. This may require updating Wasm paths in the crate's corresponding '.gdextension' file, or just renaming the Wasm file to the correct name otherwise.`);
+                    throw new Error(`Wasm module '${libName}' not found. Check the console for more information.`);
+                }
                 var dso = LDSO.loadedLibsByName[libName];
                 // This property was renamed as of emscripten 3.1.34
                 var dso_exports = "module" in dso ? dso["module"] : dso["exports"];


### PR DESCRIPTION
An initial countermeasure for the problem at https://github.com/godot-rust/gdext/issues/438#issuecomment-2227222843 - we just throw an error if `${crate_name_with_underscores}.wasm` doesn't exist when it should. The error message needs some improvement, but at least I could test this approach and it produces the result below.

![image](https://github.com/user-attachments/assets/2e7c190b-3915-473b-9cfb-181819004a4f)

Right now, I just throw an error with a summarized description of the problem and print a longer error to console. But I think there's some improvement to be had here, I'm open for suggestions. Maybe we can just throw the error with the full message anyway, or we can append "Check the browser console for more details" to the error message.