### PR TITLE
Fix validation for `api-*` mutual exclusivity

### DIFF
--- a/godot-bindings/build.rs
+++ b/godot-bindings/build.rs
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+// `api-*` validation is required here because otherwise, user gets confusing error about conflicting module imports.
+// We can also not use this in dependent crates, e.g. in godot/build.rs, since this crate is compiled before and already causes the error.
+// It's the only purpose of this build.rs file. If a better solution is found, this file can be removed.
+
+#[rustfmt::skip]
+fn main() {    
+    let mut count = 0;
+    if cfg!(feature = "api-custom") { count += 1; }
+
+    // [version-sync] [[
+    //  [line] \tif cfg!(feature = "api-$kebabVersion") { count += 1; }
+    if cfg!(feature = "api-4-0") { count += 1; }
+    if cfg!(feature = "api-4-0-1") { count += 1; }
+    if cfg!(feature = "api-4-0-2") { count += 1; }
+    if cfg!(feature = "api-4-0-3") { count += 1; }
+    if cfg!(feature = "api-4-0-4") { count += 1; }
+    if cfg!(feature = "api-4-1") { count += 1; }
+    if cfg!(feature = "api-4-1-1") { count += 1; }
+    if cfg!(feature = "api-4-1-2") { count += 1; }
+    if cfg!(feature = "api-4-1-3") { count += 1; }
+    if cfg!(feature = "api-4-1-4") { count += 1; }
+    if cfg!(feature = "api-4-2") { count += 1; }
+    if cfg!(feature = "api-4-2-1") { count += 1; }
+    if cfg!(feature = "api-4-2-2") { count += 1; }
+    // ]]
+
+    assert!(count <= 1, "ERROR: at most one `api-*` feature can be enabled");
+}

--- a/godot-cell/src/borrow_state.rs
+++ b/godot-cell/src/borrow_state.rs
@@ -10,10 +10,10 @@
 /// This state upholds these invariants:
 /// - You can only take a shared borrow when there is no accessible mutable borrow.
 /// - You can only take a mutable borrow when there is neither an accessible mutable borrow, nor a shared
-/// borrow.
+///   borrow.
 /// - You can only set a mutable borrow as inaccessible when an accessible mutable borrow exists.
 /// - You can only unset a mutable borrow as inaccessible when there is no accessible mutable borrow and no
-/// shared borrows.  
+///   shared borrows.
 ///
 /// If a catastrophic error occurs, then the state will be poisoned. If the state is poisoned then that's
 /// almost certainly an implementation bug, and should never happen. But in an abundance of caution it is

--- a/godot-core/src/lib.rs
+++ b/godot-core/src/lib.rs
@@ -33,6 +33,12 @@ mod storage;
 pub use godot_ffi as sys;
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
+// Validations (see also godot/lib.rs)
+
+#[cfg(all(feature = "docs", before_api = "4.3"))]
+compile_error!("Generating editor docs for Rust symbols requires at least Godot 4.3.");
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
 // Generated code
 
 // Output of generated code. Mimics the file structure, symbols are re-exported.

--- a/godot/src/lib.rs
+++ b/godot/src/lib.rs
@@ -151,24 +151,6 @@ compile_error!("The feature `double-precision` currently requires `api-custom` d
 #[cfg(all(feature = "register-docs", before_api = "4.3"))]
 compile_error!("Generating editor docs for Rust symbols requires at least Godot 4.3.");
 
-const fn _validate_features() {
-    let mut count = 0;
-
-    if cfg!(feature = "api-4-0") {
-        count += 1;
-    }
-    if cfg!(feature = "api-4-1") {
-        count += 1;
-    }
-    if cfg!(feature = "api-custom") {
-        count += 1;
-    }
-
-    assert!(count <= 1, "at most one `api-*` feature can be enabled");
-}
-
-const _: () = _validate_features();
-
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Modules
 

--- a/godot/src/lib.rs
+++ b/godot/src/lib.rs
@@ -148,8 +148,7 @@ compile_error!("Must opt-in using `experimental-wasm` Cargo feature; keep in min
 #[cfg(all(feature = "double-precision", not(feature = "api-custom")))]
 compile_error!("The feature `double-precision` currently requires `api-custom` due to incompatibilities in the GDExtension API JSON.");
 
-#[cfg(all(feature = "register-docs", before_api = "4.3"))]
-compile_error!("Generating editor docs for Rust symbols requires at least Godot 4.3.");
+// Note: #[cfg]s are not emitted in this crate, so move checks for those up to godot-core.
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Modules


### PR DESCRIPTION
Turns out this was already disallowed, because `prebuilt` imports would lead to conflicts.

Anyway, I've improved the error messages, and also fixed a `#[cfg(before_api = "4.3")]` warning because the corresponding `cfg` wasn't emitted in the `godot` crate.