### PR TITLE
Fix doc comments not showing up if only some class members are documented

### DIFF
--- a/godot-core/src/docs.rs
+++ b/godot-core/src/docs.rs
@@ -23,20 +23,27 @@ pub struct StructDocs {
     pub members: &'static str,
 }
 
-/// Created for documentation on
+/// Keeps documentation for inherent `impl` blocks, such as:
 /// ```ignore
 /// #[godot_api]
 /// impl Struct {
-///     #[func]
 ///     /// This function panics!
+///     #[func]
 ///     fn panic() -> f32 { panic!() }
+///     /// this signal signals
+///     #[signal]
+///     fn documented_signal(p: Vector3, w: f64);
+///     /// this constant consts
+///     #[constant]
+///     const CON: i64 = 42;
+///
 /// }
 /// ```
 #[derive(Clone, Copy, Debug, Default)]
 pub struct InherentImplDocs {
     pub methods: &'static str,
-    pub signals: &'static str,
-    pub constants: &'static str,
+    pub signals_block: &'static str,
+    pub constants_block: &'static str,
 }
 
 #[derive(Default)]
@@ -46,17 +53,25 @@ struct DocPieces {
     virtual_methods: &'static str,
 }
 
-#[doc(hidden)]
 /// This function scours the registered plugins to find their documentation pieces,
 /// and strings them together.
 ///
-/// It returns an iterator over XML documents.
+/// Returns an iterator over XML documents.
+///
+/// Documentation for signals and constants is being processed at compile time
+/// and can take the form of an already formatted XML `<block><doc></doc>…</block>`, or an
+/// empty string if no such attribute has been documented.
+///
+/// Since documentation for methods comes from two different sources
+/// -- inherent implementations (`methods`) and `I*` trait implementations (`virtual_method_docs`) --
+/// it is undesirable to merge them at compile time. Instead, they are being kept as a
+/// strings of not-yet-parented XML tags (or empty string if no method has been documented).
 pub fn gather_xml_docs() -> impl Iterator<Item = String> {
     let mut map = HashMap::<&'static str, DocPieces>::new();
     crate::private::iterate_plugins(|x| match x.item {
-        PluginItem::InherentImpl {
-            docs: Some(docs), ..
-        } => map.entry(x.class_name.as_str()).or_default().inherent = docs,
+        PluginItem::InherentImpl { docs, .. } => {
+            map.entry(x.class_name.as_str()).or_default().inherent = docs
+        }
         PluginItem::ITraitImpl {
             virtual_method_docs,
             ..
@@ -70,7 +85,9 @@ pub fn gather_xml_docs() -> impl Iterator<Item = String> {
         } => map.entry(x.class_name.as_str()).or_default().definition = docs,
         _ => (),
     });
-    map.into_iter().map(|(class, pieces)| {
+    map
+        .into_iter()
+        .map(|(class, pieces)| {
             let StructDocs {
                 base,
                 description,
@@ -79,24 +96,32 @@ pub fn gather_xml_docs() -> impl Iterator<Item = String> {
 
             let InherentImplDocs {
                 methods,
-                signals,
-                constants,
+                signals_block,
+                constants_block,
             } = pieces.inherent;
 
             let virtual_methods = pieces.virtual_methods;
-            let brief = description.split_once("[br]").map(|(x, _)| x).unwrap_or_default();
-format!(r#"
+            let methods_block = (virtual_methods.is_empty() && methods.is_empty())
+                .then(String::new)
+                .unwrap_or_else(|| format!("<methods>{methods}{virtual_methods}</methods>"));
+
+            let brief = description
+                .split_once("[br]")
+                .map(|(x, _)| x)
+                .unwrap_or_default();
+
+            format!(r#"
 <?xml version="1.0" encoding="UTF-8"?>
 <class name="{class}" inherits="{base}" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 <brief_description>{brief}</brief_description>
 <description>{description}</description>
-<methods>{methods}{virtual_methods}</methods>
-<constants>{constants}</constants>
-<signals>{signals}</signals>
+{methods_block}
+{constants_block}
+{signals_block}
 <members>{members}</members>
 </class>"#)
         },
-    )
+        )
 }
 
 /// # Safety

--- a/godot-core/src/registry/plugin.rs
+++ b/godot-core/src/registry/plugin.rs
@@ -108,7 +108,7 @@ pub enum PluginItem {
         /// Always present since that's the entire point of this `impl` block.
         register_methods_constants_fn: ErasedRegisterFn,
         #[cfg(all(since_api = "4.3", feature = "docs"))]
-        docs: Option<InherentImplDocs>,
+        docs: InherentImplDocs,
     },
 
     /// Collected from `#[godot_api] impl I... for MyClass`.

--- a/godot/tests/docs.rs
+++ b/godot/tests/docs.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "register-docs")]
 /*
  * Copyright (c) godot-rust; Bromeon and contributors.
  * This Source Code Form is subject to the terms of the Mozilla Public
@@ -75,10 +76,13 @@ use godot::prelude::*;
 /// these
 #[derive(GodotClass)]
 #[class(base=Node)]
-pub struct ExtremelyDocumented {
+pub struct FairlyDocumented {
     #[doc = r#"this is very documented"#]
     #[var]
     item: f32,
+    /// is it documented?
+    #[var]
+    item_2: i64,
     /// this isnt documented
     _other_item: (),
     /// nor this
@@ -86,46 +90,78 @@ pub struct ExtremelyDocumented {
 }
 
 #[godot_api]
-impl INode for ExtremelyDocumented {
+impl INode for FairlyDocumented {
     /// initialize this
     fn init(base: Base<Node>) -> Self {
         Self {
             base,
             item: 883.0,
+            item_2: 25,
             _other_item: {},
         }
     }
 }
 
 #[godot_api]
-impl ExtremelyDocumented {
-    #[constant]
+impl FairlyDocumented {
     /// Documentation.
+    #[constant]
     const RANDOM: i64 = 4;
 
+    #[constant]
+    const PURPOSE: i64 = 42;
+
     #[func]
+    fn totally_undocumented_function(&self) -> i64 {
+        5
+    }
+
     /// huh
+    #[func]
     fn ye(&self) -> f32 {
         self.item
     }
 
-    #[func]
+    #[func(gd_self, virtual)]
+    fn virtual_undocumented(_s: Gd<Self>) {
+        panic!("no implementation")
+    }
+
+    /// some virtual function that should be overridden by a user
+    ///
+    /// some multiline doc
+    #[func(gd_self, virtual)]
+    fn virtual_documented(_s: Gd<Self>) {
+        panic!("please provide user implementation")
+    }
+
     /// wow
+    ///
+    /// some multiline doc
+    #[func]
     fn ne(_x: f32) -> Gd<Self> {
         panic!()
     }
+
+    #[signal]
+    fn undocumented_signal(p: Vector3, w: f64);
+
+    /// some user signal
+    ///
+    /// some multiline doc
+    #[signal]
+    fn documented_signal(p: Vector3, w: f64);
 }
 
 #[test]
-#[cfg(feature = "register-docs")]
 fn correct() {
     // Uncomment if implementation changes and expected output file should be rewritten.
     // std::fs::write(
-    //     "tests/docs.xml",
+    //     "tests/test_data/docs.xml",
     //     godot_core::docs::gather_xml_docs().next().unwrap(),
     // );
     assert_eq!(
-        include_str!("docs.xml"),
+        include_str!("test_data/docs.xml"),
         godot_core::docs::gather_xml_docs().next().unwrap()
     );
 }

--- a/godot/tests/test_data/docs.xml
+++ b/godot/tests/test_data/docs.xml
@@ -1,6 +1,6 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
-<class name="ExtremelyDocumented" inherits="Node" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+<class name="FairlyDocumented" inherits="Node" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 <brief_description>[i]documented[/i] ~ [b]documented[/b] ~ [AABB] [url=https://github.com/godot-rust/gdext/pull/748]pr[/url]</brief_description>
 <description>[i]documented[/i] ~ [b]documented[/b] ~ [AABB] [url=https://github.com/godot-rust/gdext/pull/748]pr[/url][br][br]a few tests:[br][br]headings:[br][br]Some heading[br][br]lists:[br][br][br][br][br][br]links with back-references:[br][br]Blah blah [br][br][br][br]footnotes:[br][br]We cannot florbinate the glorb[br][br][br][br]task lists:[br][br]We must ensure that we've completed[br][br][br][br]tables:[br][br][br][br]images:[br][br][img]http://url/a.png[/img][br][br]blockquotes:[br][br][br][br]ordered list:[br][br][br][br]Something here < this is technically header syntax[br][br]And here[br][br]smart punctuation[br][br]codeblocks:[br][br][codeblock]#![no_main]
 #[link_section=\".text\"]
@@ -16,11 +16,19 @@ these</description>
   </description>
 </method>
 
+<method name="virtual_documented">
+  <return type="()" />
+  
+  <description>
+  some virtual function that should be overridden by a user[br][br]some multiline doc
+  </description>
+</method>
+
 <method name="ne">
-  <return type="Gd < ExtremelyDocumented >" />
+  <return type="Gd < FairlyDocumented >" />
   <param index="0" name="x" type="f32" />
   <description>
-  wow
+  wow[br][br]some multiline doc
   </description>
 </method>
 
@@ -33,6 +41,13 @@ these</description>
 </method>
 </methods>
 <constants><constant name="RANDOM" value="4">Documentation.</constant></constants>
-<signals></signals>
-<members><member name="item" type="f32" default="">this is very documented</member></members>
+<signals>
+<signal name="documented_signal">
+  <param index="0" name="p" type="Vector3" /><param index="1" name="w" type="f64" />
+  <description>
+  some user signal[br][br]some multiline doc
+  </description>
+</signal>
+</signals>
+<members><member name="item" type="f32" default="">this is very documented</member><member name="item_2" type="i64" default="">is it documented?</member></members>
 </class>

--- a/itest/rust/src/register_tests/constant_test.rs
+++ b/itest/rust/src/register_tests/constant_test.rs
@@ -176,7 +176,7 @@ godot::sys::plugin_add!(
                 raw: ::godot::private::callbacks::register_user_methods_constants::<HasOtherConstants>,
             },
             #[cfg(all(since_api = "4.3", feature = "register-docs"))]
-            docs: None,
+            docs: ::godot::docs::InherentImplDocs::default(),
         },
         init_level: HasOtherConstants::INIT_LEVEL,
     }


### PR DESCRIPTION
closes #810 

- Extend test case to feature some undocumented members of godot instances
- Change map&unwrap in docs.rs to filter_map (allow to document only subset of all the properties of a given class)
- ~~Add "docs" feature to plugin in constant_tests~~
- Generate documentation blocks for signals & constants on compile-time