### PR TITLE
Builtin docs (impl blocks, navigation table, link to Godot)

### DIFF
--- a/godot-core/src/builtin/aabb.rs
+++ b/godot-core/src/builtin/aabb.rs
@@ -27,6 +27,10 @@ use crate::builtin::{real, Plane, Vector3, Vector3Axis};
 ///
 /// [`Rect2`]: crate::builtin::Rect2
 /// [`Rect2i`]: crate::builtin::Rect2i
+///
+/// # Godot docs
+///
+/// [`AABB`](https://docs.godotengine.org/en/stable/classes/class_aabb.html)
 #[derive(Default, Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(C)]

--- a/godot-core/src/builtin/aabb.rs
+++ b/godot-core/src/builtin/aabb.rs
@@ -18,7 +18,15 @@ use crate::builtin::{real, Plane, Vector3, Vector3Axis};
 ///
 /// Currently most methods are only available through [`InnerAabb`](super::inner::InnerAabb).
 ///
-/// The 2D counterpart to `Aabb` is [`Rect2`](super::Rect2).
+/// # All bounding-box types
+///
+/// | Dimension | Floating-point | Integer      |
+/// |-----------|----------------|--------------|
+/// | 2D        | [`Rect2`]      | [`Rect2i`]   |
+/// | 3D        | **`Aabb`**       |              |
+///
+/// [`Rect2`]: crate::builtin::Rect2
+/// [`Rect2i`]: crate::builtin::Rect2i
 #[derive(Default, Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(C)]

--- a/godot-core/src/builtin/basis.rs
+++ b/godot-core/src/builtin/basis.rs
@@ -40,6 +40,10 @@ use std::ops::{Mul, MulAssign};
 /// [`Transform2D`]: crate::builtin::Transform2D
 /// [`Transform3D`]: crate::builtin::Transform3D
 /// [`Projection`]: crate::builtin::Projection
+///
+/// # Godot docs
+///
+/// [`Basis` (stable)](https://docs.godotengine.org/en/stable/classes/class_basis.html)
 #[derive(Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(C)]

--- a/godot-core/src/builtin/basis.rs
+++ b/godot-core/src/builtin/basis.rs
@@ -29,6 +29,17 @@ use std::ops::{Mul, MulAssign};
 /// the _transformed_ unit vectors of X/Y/Z axes, they have no direct relation to those axes in the _transformed_ coordinate system. Thus, an
 /// independent notion of a, b, c does not suggest such a relation.  Furthermore, there are sometimes expressions such as `x.x`, `x.y`, `y.x`
 /// etc. They are typically hard to read and error-prone to write. Having `a.x`, `a.y`, `b.x` makes things more understandable.
+///
+/// # All matrix types
+///
+/// | Dimension | Orthogonal basis   | Affine transform      | Projective transform |
+/// |-----------|--------------------|-----------------------|----------------------|
+/// | 2D        |                    | [`Transform2D`] (2x3) |                      |
+/// | 3D        | **`Basis`** (3x3)  | [`Transform3D`] (3x4) | [`Projection`] (4x4) |
+///
+/// [`Transform2D`]: crate::builtin::Transform2D
+/// [`Transform3D`]: crate::builtin::Transform3D
+/// [`Projection`]: crate::builtin::Projection
 #[derive(Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(C)]

--- a/godot-core/src/builtin/callable.rs
+++ b/godot-core/src/builtin/callable.rs
@@ -25,6 +25,10 @@ use sys::{ffi_methods, GodotFfi};
 /// Currently, it is impossible to use `bind` and `unbind` in GDExtension, see [godot-cpp#802].
 ///
 /// [godot-cpp#802]: https://github.com/godotengine/godot-cpp/issues/802
+///
+/// # Godot docs
+///
+/// [`Callable` (stable)](https://docs.godotengine.org/en/stable/classes/class_callable.html)
 pub struct Callable {
     opaque: sys::types::OpaqueCallable,
 }

--- a/godot-core/src/builtin/collections/array.rs
+++ b/godot-core/src/builtin/collections/array.rs
@@ -105,6 +105,10 @@ use sys::{ffi_methods, interface_fn, GodotFfi};
 /// different threads are also safe, but any writes must be externally synchronized. The Rust
 /// compiler will enforce this as long as you use only Rust threads, but it cannot protect against
 /// concurrent modification on other threads (e.g. created through GDScript).
+///
+/// # Godot docs
+///
+/// [`Array[T]` (stable)](https://docs.godotengine.org/en/stable/classes/class_array.html)
 pub struct Array<T: ArrayElement> {
     // Safety Invariant: The type of all values in `opaque` matches the type `T`.
     opaque: sys::types::OpaqueArray,

--- a/godot-core/src/builtin/collections/dictionary.rs
+++ b/godot-core/src/builtin/collections/dictionary.rs
@@ -73,6 +73,10 @@ use std::{fmt, ptr};
 /// # Thread safety
 ///
 /// The same principles apply as for [`VariantArray`]. Consult its documentation for details.
+///
+/// # Godot docs
+///
+/// [`Dictionary` (stable)](https://docs.godotengine.org/en/stable/classes/class_dictionary.html)
 pub struct Dictionary {
     opaque: OpaqueDictionary,
 }

--- a/godot-core/src/builtin/color.rs
+++ b/godot-core/src/builtin/color.rs
@@ -20,6 +20,10 @@ use sys::{ffi_methods, GodotFfi};
 /// values outside this range are explicitly allowed for e.g. High Dynamic Range (HDR).
 ///
 /// To access its [**HSVA**](ColorHsv) representation, use [`Color::to_hsv`].
+///
+/// # Godot docs
+///
+/// [`Color` (stable)](https://docs.godotengine.org/en/stable/classes/class_color.html)
 #[repr(C)]
 #[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/godot-core/src/builtin/plane.rs
+++ b/godot-core/src/builtin/plane.rs
@@ -22,6 +22,10 @@ use std::ops::Neg;
 /// Note: almost all methods on `Plane` require that the `normal` vector have
 /// unit length and will panic if this invariant is violated. This is not separately
 /// annotated for each method.
+///
+/// # Godot docs
+///
+/// [Plane (stable)](https://docs.godotengine.org/en/stable/classes/class_plane.html)
 #[derive(Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(C)]

--- a/godot-core/src/builtin/projection.rs
+++ b/godot-core/src/builtin/projection.rs
@@ -36,6 +36,10 @@ use super::{Aabb, Rect2, Vector3};
 /// [`Basis`]: crate::builtin::Basis
 /// [`Transform2D`]: crate::builtin::Transform2D
 /// [`Transform3D`]: Transform3D
+///
+/// # Godot docs
+///
+/// [`Projection` (stable)](https://docs.godotengine.org/en/stable/classes/class_projection.html)
 #[derive(Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(C)]

--- a/godot-core/src/builtin/projection.rs
+++ b/godot-core/src/builtin/projection.rs
@@ -25,6 +25,17 @@ use super::{Aabb, Rect2, Vector3};
 /// more performant and has a lower memory footprint.
 ///
 /// This builtin comes with two related types [`ProjectionEye`] and [`ProjectionPlane`], that are type-safe pendants to Godot's integers.
+///
+/// # All matrix types
+///
+/// | Dimension | Orthogonal basis | Affine transform      | Projective transform   |
+/// |-----------|------------------|-----------------------|------------------------|
+/// | 2D        |                  | [`Transform2D`] (2x3) |                        |
+/// | 3D        | [`Basis`] (3x3)  | [`Transform3D`] (3x4) | **`Projection`** (4x4) |
+///
+/// [`Basis`]: crate::builtin::Basis
+/// [`Transform2D`]: crate::builtin::Transform2D
+/// [`Transform3D`]: Transform3D
 #[derive(Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(C)]

--- a/godot-core/src/builtin/quaternion.rs
+++ b/godot-core/src/builtin/quaternion.rs
@@ -15,6 +15,10 @@ use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssi
 /// Unit quaternion to represent 3D rotations.
 ///
 /// See also [`Quaternion`](https://docs.godotengine.org/en/stable/classes/class_quaternion.html) in the Godot documentation.
+///
+/// # Godot docs
+///
+/// [`Quaternion` (stable)](https://docs.godotengine.org/en/stable/classes/class_quaternion.html)
 #[derive(Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(C)]

--- a/godot-core/src/builtin/rect2.rs
+++ b/godot-core/src/builtin/rect2.rs
@@ -16,9 +16,14 @@ use crate::builtin::{real, Rect2i, Side, Vector2};
 /// `Rect2` consists of a position, a size, and several utility functions. It is typically used for
 /// fast overlap tests.
 ///
-/// Currently most methods are only available through [`InnerRect2`](super::inner::InnerRect2).
+/// # All bounding-box types
 ///
-/// The 3D counterpart to `Rect2` is [`Aabb`](super::Aabb).
+/// | Dimension | Floating-point  | Integer      |
+/// |-----------|-----------------|--------------|
+/// | 2D        | **`Rect2`**     | [`Rect2i`]   |
+/// | 3D        | [`Aabb`]        |              |
+///
+/// [`Aabb`]: crate::builtin::Aabb
 #[derive(Default, Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(C)]

--- a/godot-core/src/builtin/rect2.rs
+++ b/godot-core/src/builtin/rect2.rs
@@ -24,6 +24,10 @@ use crate::builtin::{real, Rect2i, Side, Vector2};
 /// | 3D        | [`Aabb`]        |              |
 ///
 /// [`Aabb`]: crate::builtin::Aabb
+///
+/// # Godot docs
+///
+/// [`Rect2` (stable)](https://docs.godotengine.org/en/stable/classes/class_rect2.html)
 #[derive(Default, Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(C)]

--- a/godot-core/src/builtin/rect2i.rs
+++ b/godot-core/src/builtin/rect2i.rs
@@ -16,6 +16,15 @@ use sys::{ffi_methods, GodotFfi};
 ///
 /// `Rect2i` consists of a position, a size, and several utility functions. It is typically used for
 /// fast overlap tests.
+///
+/// # All bounding-box types
+///
+/// | Dimension | Floating-point  | Integer      |
+/// |-----------|-----------------|--------------|
+/// | 2D        | [`Rect2`]       | **`Rect2i`** |
+/// | 3D        | [`Aabb`]        |              |
+///
+/// [`Aabb`]: crate::builtin::Aabb
 #[derive(Default, Copy, Clone, Eq, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(C)]

--- a/godot-core/src/builtin/rect2i.rs
+++ b/godot-core/src/builtin/rect2i.rs
@@ -25,6 +25,10 @@ use sys::{ffi_methods, GodotFfi};
 /// | 3D        | [`Aabb`]        |              |
 ///
 /// [`Aabb`]: crate::builtin::Aabb
+///
+/// # Godot docs
+///
+/// [`Rect2i` (stable)](https://docs.godotengine.org/en/stable/classes/class_rect2i.html)
 #[derive(Default, Copy, Clone, Eq, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(C)]

--- a/godot-core/src/builtin/rid.rs
+++ b/godot-core/src/builtin/rid.rs
@@ -26,6 +26,10 @@ use sys::{ffi_methods, static_assert, static_assert_eq_size_align, GodotFfi};
 ///
 /// [servers]: https://docs.godotengine.org/en/stable/tutorials/optimization/using_servers.html
 /// [docs]: https://docs.godotengine.org/en/stable/classes/class_rid.html
+///
+/// # Godot docs
+///
+/// [`RID` (stable)](https://docs.godotengine.org/en/stable/classes/class_rid.html)
 
 // Using normal Rust repr to take advantage of the nullable pointer optimization. As this enum is
 // eligible for it, it is also guaranteed to have it. Meaning the layout of this type is identical to `u64`.

--- a/godot-core/src/builtin/signal.rs
+++ b/godot-core/src/builtin/signal.rs
@@ -21,6 +21,10 @@ use sys::{ffi_methods, GodotFfi};
 /// A `Signal` represents a signal of an Object instance in Godot.
 ///
 /// Signals are composed of a reference to an `Object` and the name of the signal on this object.
+///
+/// # Godot docs
+///
+/// [`Signal` (stable)](https://docs.godotengine.org/en/stable/classes/class_signal.html)
 pub struct Signal {
     opaque: sys::types::OpaqueSignal,
 }

--- a/godot-core/src/builtin/string/gstring.rs
+++ b/godot-core/src/builtin/string/gstring.rs
@@ -44,14 +44,18 @@ use crate::builtin::{inner, NodePath, StringName};
 /// * you have a large number of method calls per string instance (which are more expensive due to indirectly calling into Godot)
 /// * you need UTF-8 encoding (`GString`'s encoding is platform-dependent and unspecified)
 ///
-/// # Other string types
-///
-/// Godot also provides two separate string classes with slightly different semantics: [`StringName`] and [`NodePath`].
-///
 /// # Null bytes
 ///
 /// Note that Godot ignores any bytes after a null-byte. This means that for instance `"hello, world!"` and `"hello, world!\0 ignored by Godot"`
 /// will be treated as the same string if converted to a `GString`.
+///
+/// # All string types
+///
+/// | Intended use case | String type                                |
+/// |-------------------|--------------------------------------------|
+/// | General purpose   | **`GString`**                              |
+/// | Interned names    | [`StringName`][crate::builtin::StringName] |
+/// | Scene-node paths  | [`NodePath`][crate::builtin::NodePath]     |
 #[doc(alias = "String")]
 // #[repr] is needed on GString itself rather than the opaque field, because PackedStringArray::as_slice() relies on a packed representation.
 #[repr(transparent)]

--- a/godot-core/src/builtin/string/node_path.rs
+++ b/godot-core/src/builtin/string/node_path.rs
@@ -20,6 +20,14 @@ use super::{GString, StringName};
 ///
 /// Note that Godot ignores any bytes after a null-byte. This means that for instance `"hello, world!"` and `"hello, world!\0 ignored by Godot"`
 /// will be treated as the same string if converted to a `NodePath`.
+///
+/// # All string types
+///
+/// | Intended use case | String type                                |
+/// |-------------------|--------------------------------------------|
+/// | General purpose   | [`GString`][crate::builtin::GString]       |
+/// | Interned names    | [`StringName`][crate::builtin::StringName] |
+/// | Scene-node paths  | **`NodePath`**                             |
 pub struct NodePath {
     opaque: sys::types::OpaqueNodePath,
 }

--- a/godot-core/src/builtin/string/string_name.rs
+++ b/godot-core/src/builtin/string/string_name.rs
@@ -36,6 +36,14 @@ use crate::builtin::{GString, NodePath};
 /// The fastest way to create string names is by using null-terminated C-string literals such as `c"MyClass"`. These have `'static` lifetime and
 /// can be used directly by Godot, without allocation or conversion. The encoding is limited to Latin-1, however. See the corresponding
 /// [`From<&'static CStr>` impl](#impl-From<%26CStr>-for-StringName).
+///
+/// # All string types
+///
+/// | Intended use case | String type                                |
+/// |-------------------|--------------------------------------------|
+/// | General purpose   | [`GString`][crate::builtin::GString]       |
+/// | Interned names    | **`StringName`**                           |
+/// | Scene-node paths  | [`NodePath`][crate::builtin::NodePath]     |
 // Currently we rely on `transparent` for `borrow_string_sys`.
 #[repr(transparent)]
 pub struct StringName {

--- a/godot-core/src/builtin/transform2d.rs
+++ b/godot-core/src/builtin/transform2d.rs
@@ -25,6 +25,17 @@ use std::ops::{Mul, MulAssign};
 /// [ a.x  b.x  origin.x ]
 /// [ a.y  b.y  origin.y ]
 /// ```
+///
+/// # All matrix types
+///
+/// | Dimension | Orthogonal basis | Affine transform        | Projective transform |
+/// |-----------|------------------|-------------------------|----------------------|
+/// | 2D        |                  | **`Transform2D`** (2x3) |                      |
+/// | 3D        | [`Basis`] (3x3)  | [`Transform3D`] (3x4)   | [`Projection`] (4x4) |
+///
+/// [`Basis`]: crate::builtin::Basis
+/// [`Transform3D`]: crate::builtin::Transform3D
+/// [`Projection`]: crate::builtin::Projection
 #[derive(Default, Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(C)]

--- a/godot-core/src/builtin/transform2d.rs
+++ b/godot-core/src/builtin/transform2d.rs
@@ -36,6 +36,10 @@ use std::ops::{Mul, MulAssign};
 /// [`Basis`]: crate::builtin::Basis
 /// [`Transform3D`]: crate::builtin::Transform3D
 /// [`Projection`]: crate::builtin::Projection
+///
+/// # Godot docs
+///
+/// [`Transform2D` (stable)](https://docs.godotengine.org/en/stable/classes/class_transform2d.html)
 #[derive(Default, Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(C)]

--- a/godot-core/src/builtin/transform3d.rs
+++ b/godot-core/src/builtin/transform3d.rs
@@ -25,6 +25,17 @@ use std::ops::Mul;
 /// [ a.y  b.y  c.y  o.y ]
 /// [ a.z  b.z  c.z  o.z ]
 /// ```
+///
+/// # All matrix types
+///
+/// | Dimension | Orthogonal basis | Affine transform        | Projective transform |
+/// |-----------|------------------|-------------------------|----------------------|
+/// | 2D        |                  | [`Transform2D`] (2x3)   |                      |
+/// | 3D        | [`Basis`] (3x3)  | **`Transform3D`** (3x4) | [`Projection`] (4x4) |
+///
+/// [`Basis`]: Basis
+/// [`Transform2D`]: crate::builtin::Transform2D
+/// [`Projection`]: Projection
 #[derive(Default, Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(C)]

--- a/godot-core/src/builtin/transform3d.rs
+++ b/godot-core/src/builtin/transform3d.rs
@@ -36,6 +36,10 @@ use std::ops::Mul;
 /// [`Basis`]: Basis
 /// [`Transform2D`]: crate::builtin::Transform2D
 /// [`Projection`]: Projection
+///
+/// # Godot docs
+///
+/// [`Transform3D` (stable)](https://docs.godotengine.org/en/stable/classes/class_transform3d.html)
 #[derive(Default, Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(C)]

--- a/godot-core/src/builtin/variant/mod.rs
+++ b/godot-core/src/builtin/variant/mod.rs
@@ -21,6 +21,10 @@ mod impls;
 /// value.  
 ///
 /// See also [Godot documentation for `Variant`](https://docs.godotengine.org/en/stable/classes/class_variant.html).
+///
+/// # Godot docs
+///
+/// [`Variant` (stable)](https://docs.godotengine.org/en/stable/classes/class_variant.html)
 // We rely on the layout of `Variant` being the same as Godot's layout in `borrow_slice` and `borrow_slice_mut`.
 #[repr(transparent)]
 pub struct Variant {

--- a/godot-core/src/builtin/vectors/vector2.rs
+++ b/godot-core/src/builtin/vectors/vector2.rs
@@ -17,14 +17,24 @@ use std::fmt;
 
 /// Vector used for 2D math using floating point coordinates.
 ///
-/// 2-element structure that can be used to represent positions in 2D space or any other pair of
-/// numeric values.
+/// 2-element structure that can be used to represent continuous positions or directions in 2D space,
+/// as well as any other pair of numeric values.
 ///
 /// It uses floating-point coordinates of 32-bit precision, unlike the engine's `float` type which
 /// is always 64-bit. The engine can be compiled with the option `precision=double` to use 64-bit
 /// vectors; use the gdext library with the `double-precision` feature in that case.
 ///
 /// See [`Vector2i`] for its integer counterpart.
+///
+/// ### Navigation to `impl` blocks within this page
+///
+/// - [Constants](#constants)
+/// - [Constructors and general vector functions](#constructors-and-general-vector-functions)
+/// - [Specialized `Vector2` functions](#specialized-vector2-functions)
+/// - [Float-specific functions](#float-specific-functions)
+/// - [2D functions](#2d-functions)
+/// - [2D and 3D functions](#2d-and-3d-functions)
+/// - [Trait impls + operators](#trait-implementations)
 #[derive(Default, Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(C)]
@@ -36,17 +46,16 @@ pub struct Vector2 {
     pub y: real,
 }
 
-impl_vector_operators!(Vector2, real, (x, y));
-
-impl_vector_consts!(Vector2, real);
-impl_float_vector_consts!(Vector2);
-impl_vector2x_consts!(Vector2, real);
+/// # Constants
+impl Vector2 {
+    impl_vector_consts!(real);
+    impl_float_vector_consts!();
+    impl_vector2x_consts!(real);
+}
 
 impl_vector_fns!(Vector2, RVec2, real, (x, y));
-impl_float_vector_fns!(Vector2, (x, y));
-impl_vector2x_fns!(Vector2, real);
-impl_vector2_vector3_fns!(Vector2, (x, y));
 
+/// # Specialized `Vector2` functions
 impl Vector2 {
     /// Constructs a new `Vector2` from a [`Vector2i`].
     #[inline]
@@ -55,12 +64,6 @@ impl Vector2 {
             x: v.x as real,
             y: v.y as real,
         }
-    }
-
-    #[doc(hidden)]
-    #[inline]
-    pub fn as_inner(&self) -> inner::InnerVector2 {
-        inner::InnerVector2::from_outer(self)
     }
 
     /// Returns this vector's angle with respect to the positive X axis, or `(1.0, 0.0)` vector, in radians.
@@ -141,7 +144,19 @@ impl Vector2 {
         let angle = self.angle_to(to);
         self.rotated(angle * weight) * (result_length / start_length)
     }
+
+    #[doc(hidden)]
+    #[inline]
+    pub fn as_inner(&self) -> inner::InnerVector2 {
+        inner::InnerVector2::from_outer(self)
+    }
 }
+
+impl_float_vector_fns!(Vector2, (x, y));
+impl_vector2x_fns!(Vector2, real);
+impl_vector2_vector3_fns!(Vector2, (x, y));
+
+impl_vector_operators!(Vector2, real, (x, y));
 
 /// Formats the vector like Godot: `(x, y)`.
 impl fmt::Display for Vector2 {

--- a/godot-core/src/builtin/vectors/vector2.rs
+++ b/godot-core/src/builtin/vectors/vector2.rs
@@ -41,6 +41,10 @@ use std::fmt;
 /// | 2D        | **`Vector2`**                        | [`Vector2i`][crate::builtin::Vector2i] |
 /// | 3D        | [`Vector3`][crate::builtin::Vector3] | [`Vector3i`][crate::builtin::Vector3i] |
 /// | 4D        | [`Vector4`][crate::builtin::Vector4] | [`Vector4i`][crate::builtin::Vector4i] |
+///
+/// # Godot docs
+///
+/// [`Vector2` (stable)](https://docs.godotengine.org/en/stable/classes/class_vector2.html)
 #[derive(Default, Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(C)]

--- a/godot-core/src/builtin/vectors/vector2.rs
+++ b/godot-core/src/builtin/vectors/vector2.rs
@@ -24,8 +24,6 @@ use std::fmt;
 /// is always 64-bit. The engine can be compiled with the option `precision=double` to use 64-bit
 /// vectors; use the gdext library with the `double-precision` feature in that case.
 ///
-/// See [`Vector2i`] for its integer counterpart.
-///
 /// ### Navigation to `impl` blocks within this page
 ///
 /// - [Constants](#constants)
@@ -35,6 +33,14 @@ use std::fmt;
 /// - [2D functions](#2d-functions)
 /// - [2D and 3D functions](#2d-and-3d-functions)
 /// - [Trait impls + operators](#trait-implementations)
+///
+/// # All vector types
+///
+/// | Dimension | Floating-point                       | Integer                                |
+/// |-----------|--------------------------------------|----------------------------------------|
+/// | 2D        | **`Vector2`**                        | [`Vector2i`][crate::builtin::Vector2i] |
+/// | 3D        | [`Vector3`][crate::builtin::Vector3] | [`Vector3i`][crate::builtin::Vector3i] |
+/// | 4D        | [`Vector4`][crate::builtin::Vector4] | [`Vector4i`][crate::builtin::Vector4i] |
 #[derive(Default, Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(C)]

--- a/godot-core/src/builtin/vectors/vector2i.rs
+++ b/godot-core/src/builtin/vectors/vector2i.rs
@@ -20,7 +20,7 @@ use std::fmt;
 /// as well as any other pair of numeric values.
 ///
 /// It uses integer coordinates and is therefore preferable to [`Vector2`] when exact precision is
-/// required. Note that the values are limited to 32 bits, and unlike [`Vector2`] this cannot be
+/// required. Note that the values are limited to 32 bits, and unlike `Vector2` this cannot be
 /// configured with an engine build option. Use `i64` or [`PackedInt64Array`][crate::builtin::PackedInt64Array]
 /// if 64-bit values are needed.
 ///
@@ -31,6 +31,14 @@ use std::fmt;
 /// - [Specialized `Vector2i` functions](#specialized-vector2i-functions)
 /// - [2D functions](#2d-functions)
 /// - [Trait impls + operators](#trait-implementations)
+///
+/// # All vector types
+///
+/// | Dimension | Floating-point                       | Integer                                |
+/// |-----------|--------------------------------------|----------------------------------------|
+/// | 2D        | [`Vector2`][crate::builtin::Vector2] | **`Vector2i`**                         |
+/// | 3D        | [`Vector3`][crate::builtin::Vector3] | [`Vector3i`][crate::builtin::Vector3i] |
+/// | 4D        | [`Vector4`][crate::builtin::Vector4] | [`Vector4i`][crate::builtin::Vector4i] |
 #[derive(Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(C)]

--- a/godot-core/src/builtin/vectors/vector2i.rs
+++ b/godot-core/src/builtin/vectors/vector2i.rs
@@ -16,13 +16,21 @@ use std::fmt;
 
 /// Vector used for 2D math using integer coordinates.
 ///
-/// 2-element structure that can be used to represent positions in 2D space or any other pair of
-/// numeric values.
+/// 2-element structure that can be used to represent discrete positions or directions in 2D space,
+/// as well as any other pair of numeric values.
 ///
 /// It uses integer coordinates and is therefore preferable to [`Vector2`] when exact precision is
 /// required. Note that the values are limited to 32 bits, and unlike [`Vector2`] this cannot be
 /// configured with an engine build option. Use `i64` or [`PackedInt64Array`][crate::builtin::PackedInt64Array]
 /// if 64-bit values are needed.
+///
+/// ### Navigation to `impl` blocks within this page
+///
+/// - [Constants](#constants)
+/// - [Constructors and general vector functions](#constructors-and-general-vector-functions)
+/// - [Specialized `Vector2i` functions](#specialized-vector2i-functions)
+/// - [2D functions](#2d-functions)
+/// - [Trait impls + operators](#trait-implementations)
 #[derive(Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(C)]
@@ -34,17 +42,16 @@ pub struct Vector2i {
     pub y: i32,
 }
 
-impl_vector_operators!(Vector2i, i32, (x, y));
-
-impl_vector_consts!(Vector2i, i32);
-impl_integer_vector_consts!(Vector2i);
-impl_vector2x_consts!(Vector2i, i32);
-
-impl_vector_fns!(Vector2i, glam::IVec2, i32, (x, y));
-impl_vector2x_fns!(Vector2i, i32);
-
+/// # Constants
 impl Vector2i {
-    impl_integer_vector_fns!(x, y);
+    impl_vector_consts!(i32);
+    impl_integer_vector_consts!();
+    impl_vector2x_consts!(i32);
+}
+
+/// # Specialized `Vector2i` functions
+impl Vector2i {
+    inline_impl_integer_vector_fns!(x, y);
 
     /// Constructs a new `Vector2i` from a [`Vector2`]. The floating point coordinates will be truncated.
     #[inline]
@@ -68,6 +75,11 @@ impl Vector2i {
         inner::InnerVector2i::from_outer(self)
     }
 }
+
+impl_vector_fns!(Vector2i, glam::IVec2, i32, (x, y));
+impl_vector2x_fns!(Vector2i, i32);
+
+impl_vector_operators!(Vector2i, i32, (x, y));
 
 /// Formats the vector like Godot: `(x, y)`.
 impl fmt::Display for Vector2i {

--- a/godot-core/src/builtin/vectors/vector2i.rs
+++ b/godot-core/src/builtin/vectors/vector2i.rs
@@ -39,6 +39,10 @@ use std::fmt;
 /// | 2D        | [`Vector2`][crate::builtin::Vector2] | **`Vector2i`**                         |
 /// | 3D        | [`Vector3`][crate::builtin::Vector3] | [`Vector3i`][crate::builtin::Vector3i] |
 /// | 4D        | [`Vector4`][crate::builtin::Vector4] | [`Vector4i`][crate::builtin::Vector4i] |
+///
+/// # Godot docs
+///
+/// [`Vector2i` (stable)](https://docs.godotengine.org/en/stable/classes/class_vector2i.html)
 #[derive(Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(C)]

--- a/godot-core/src/builtin/vectors/vector3.rs
+++ b/godot-core/src/builtin/vectors/vector3.rs
@@ -17,14 +17,25 @@ use std::fmt;
 
 /// Vector used for 3D math using floating point coordinates.
 ///
-/// 3-element structure that can be used to represent positions in 3D space or any other triple of
-/// numeric values.
+/// 3-element structure that can be used to represent continuous positions or directions in 3D space,
+/// as well as any other triple of numeric values.
 ///
 /// It uses floating-point coordinates of 32-bit precision, unlike the engine's `float` type which
 /// is always 64-bit. The engine can be compiled with the option `precision=double` to use 64-bit
-/// vectors; use the gdext library with the `double-precision` feature in that case.
+/// vectors instead; use the gdext library with the `double-precision` feature in that case.
 ///
 /// See [`Vector3i`] for its integer counterpart.
+///
+/// ### Navigation to `impl` blocks within this page
+///
+/// - [Constants](#constants)
+/// - [Constructors and general vector functions](#constructors-and-general-vector-functions)
+/// - [Specialized `Vector3` functions](#specialized-vector3-functions)
+/// - [Float-specific functions](#float-specific-functions)
+/// - [3D functions](#3d-functions)
+/// - [2D and 3D functions](#2d-and-3d-functions)
+/// - [3D and 4D functions](#3d-and-4d-functions)
+/// - [Trait impls + operators](#trait-implementations)
 #[derive(Default, Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(C)]
@@ -39,18 +50,16 @@ pub struct Vector3 {
     pub z: real,
 }
 
-impl_vector_operators!(Vector3, real, (x, y, z));
-
-impl_vector_consts!(Vector3, real);
-impl_float_vector_consts!(Vector3);
-impl_vector3x_consts!(Vector3, real);
+/// # Constants
+impl Vector3 {
+    impl_vector_consts!(real);
+    impl_float_vector_consts!();
+    impl_vector3x_consts!(real);
+}
 
 impl_vector_fns!(Vector3, RVec3, real, (x, y, z));
-impl_float_vector_fns!(Vector3, (x, y, z));
-impl_vector3x_fns!(Vector3, real);
-impl_vector2_vector3_fns!(Vector3, (x, y, z));
-impl_vector3_vector4_fns!(Vector3, (x, y, z));
 
+/// # Specialized `Vector3` functions
 impl Vector3 {
     /// Unit vector pointing towards the left side of imported 3D assets.
     pub const MODEL_LEFT: Self = Self::new(1.0, 0.0, 0.0);
@@ -209,6 +218,13 @@ impl Vector3 {
         self.rotated(unit_axis, angle * weight) * (result_length / start_length)
     }
 }
+
+impl_float_vector_fns!(Vector3, (x, y, z));
+impl_vector3x_fns!(Vector3, real);
+impl_vector2_vector3_fns!(Vector3, (x, y, z));
+impl_vector3_vector4_fns!(Vector3, (x, y, z));
+
+impl_vector_operators!(Vector3, real, (x, y, z));
 
 /// Formats the vector like Godot: `(x, y, z)`.
 impl fmt::Display for Vector3 {

--- a/godot-core/src/builtin/vectors/vector3.rs
+++ b/godot-core/src/builtin/vectors/vector3.rs
@@ -24,8 +24,6 @@ use std::fmt;
 /// is always 64-bit. The engine can be compiled with the option `precision=double` to use 64-bit
 /// vectors instead; use the gdext library with the `double-precision` feature in that case.
 ///
-/// See [`Vector3i`] for its integer counterpart.
-///
 /// ### Navigation to `impl` blocks within this page
 ///
 /// - [Constants](#constants)
@@ -36,6 +34,14 @@ use std::fmt;
 /// - [2D and 3D functions](#2d-and-3d-functions)
 /// - [3D and 4D functions](#3d-and-4d-functions)
 /// - [Trait impls + operators](#trait-implementations)
+///
+/// # All vector types
+///
+/// | Dimension | Floating-point                       | Integer                                |
+/// |-----------|--------------------------------------|----------------------------------------|
+/// | 2D        | [`Vector2`][crate::builtin::Vector2] | [`Vector2i`][crate::builtin::Vector2i] |
+/// | 3D        | **`Vector3`**                        | [`Vector3i`][crate::builtin::Vector3i] |
+/// | 4D        | [`Vector4`][crate::builtin::Vector4] | [`Vector4i`][crate::builtin::Vector4i] |
 #[derive(Default, Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(C)]

--- a/godot-core/src/builtin/vectors/vector3.rs
+++ b/godot-core/src/builtin/vectors/vector3.rs
@@ -42,6 +42,10 @@ use std::fmt;
 /// | 2D        | [`Vector2`][crate::builtin::Vector2] | [`Vector2i`][crate::builtin::Vector2i] |
 /// | 3D        | **`Vector3`**                        | [`Vector3i`][crate::builtin::Vector3i] |
 /// | 4D        | [`Vector4`][crate::builtin::Vector4] | [`Vector4i`][crate::builtin::Vector4i] |
+///
+/// # Godot docs
+///
+/// [`Vector3` (stable)](https://docs.godotengine.org/en/stable/classes/class_vector3.html)
 #[derive(Default, Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(C)]

--- a/godot-core/src/builtin/vectors/vector3i.rs
+++ b/godot-core/src/builtin/vectors/vector3i.rs
@@ -39,6 +39,10 @@ use crate::builtin::{inner, real, RVec3, Vector3, Vector3Axis};
 /// | 2D        | [`Vector2`][crate::builtin::Vector2] | [`Vector2i`][crate::builtin::Vector2i] |
 /// | 3D        | [`Vector3`][crate::builtin::Vector3] | **`Vector3i`**                         |
 /// | 4D        | [`Vector4`][crate::builtin::Vector4] | [`Vector4i`][crate::builtin::Vector4i] |
+///
+/// # Godot docs
+///
+/// [`Vector3i` (stable)](https://docs.godotengine.org/en/stable/classes/class_vector3i.html)
 #[derive(Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(C)]

--- a/godot-core/src/builtin/vectors/vector3i.rs
+++ b/godot-core/src/builtin/vectors/vector3i.rs
@@ -16,13 +16,21 @@ use crate::builtin::{inner, real, RVec3, Vector3, Vector3Axis};
 
 /// Vector used for 3D math using integer coordinates.
 ///
-/// 3-element structure that can be used to represent positions in 3D space or any other triple of
-/// numeric values.
+/// 3-element structure that can be used to represent discrete positions or directions in 3D space,
+/// as well as any other triple of numeric values.
 ///
 /// It uses integer coordinates and is therefore preferable to [`Vector3`] when exact precision is
 /// required. Note that the values are limited to 32 bits, and unlike [`Vector3`] this cannot be
 /// configured with an engine build option. Use `i64` or [`PackedInt64Array`][crate::builtin::PackedInt64Array]
 /// if 64-bit values are needed.
+///
+/// ### Navigation to `impl` blocks within this page
+///
+/// - [Constants](#constants)
+/// - [Constructors and general vector functions](#constructors-and-general-vector-functions)
+/// - [Specialized `Vector3i` functions](#specialized-vector3i-functions)
+/// - [3D functions](#3d-functions)
+/// - [Trait impls + operators](#trait-implementations)
 #[derive(Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(C)]
@@ -37,18 +45,17 @@ pub struct Vector3i {
     pub z: i32,
 }
 
-impl_vector_operators!(Vector3i, i32, (x, y, z));
-
-impl_vector_consts!(Vector3i, i32);
-impl_integer_vector_consts!(Vector3i);
-impl_vector3x_consts!(Vector3i, i32);
+/// # Constants
+impl Vector3i {
+    impl_vector_consts!(i32);
+    impl_integer_vector_consts!();
+    impl_vector3x_consts!(i32);
+}
 
 impl_vector_fns!(Vector3i, glam::IVec3, i32, (x, y, z));
-impl_vector3x_fns!(Vector3i, i32);
 
+/// # Specialized `Vector3i` functions
 impl Vector3i {
-    impl_integer_vector_fns!(x, y, z);
-
     /// Constructs a new `Vector3i` from a [`Vector3`]. The floating point coordinates will be truncated.
     #[inline]
     pub const fn from_vector3(v: Vector3) -> Self {
@@ -58,6 +65,8 @@ impl Vector3i {
             z: v.z as i32,
         }
     }
+
+    inline_impl_integer_vector_fns!(x, y, z);
 
     /// Converts `self` to the corresponding [`real`] `glam` type.
     #[doc(hidden)]
@@ -72,6 +81,10 @@ impl Vector3i {
         inner::InnerVector3i::from_outer(self)
     }
 }
+
+impl_vector3x_fns!(Vector3i, i32);
+
+impl_vector_operators!(Vector3i, i32, (x, y, z));
 
 /// Formats the vector like Godot: `(x, y, z)`.
 impl fmt::Display for Vector3i {

--- a/godot-core/src/builtin/vectors/vector3i.rs
+++ b/godot-core/src/builtin/vectors/vector3i.rs
@@ -20,7 +20,7 @@ use crate::builtin::{inner, real, RVec3, Vector3, Vector3Axis};
 /// as well as any other triple of numeric values.
 ///
 /// It uses integer coordinates and is therefore preferable to [`Vector3`] when exact precision is
-/// required. Note that the values are limited to 32 bits, and unlike [`Vector3`] this cannot be
+/// required. Note that the values are limited to 32 bits, and unlike `Vector3` this cannot be
 /// configured with an engine build option. Use `i64` or [`PackedInt64Array`][crate::builtin::PackedInt64Array]
 /// if 64-bit values are needed.
 ///
@@ -31,6 +31,14 @@ use crate::builtin::{inner, real, RVec3, Vector3, Vector3Axis};
 /// - [Specialized `Vector3i` functions](#specialized-vector3i-functions)
 /// - [3D functions](#3d-functions)
 /// - [Trait impls + operators](#trait-implementations)
+///
+/// # All vector types
+///
+/// | Dimension | Floating-point                       | Integer                                |
+/// |-----------|--------------------------------------|----------------------------------------|
+/// | 2D        | [`Vector2`][crate::builtin::Vector2] | [`Vector2i`][crate::builtin::Vector2i] |
+/// | 3D        | [`Vector3`][crate::builtin::Vector3] | **`Vector3i`**                         |
+/// | 4D        | [`Vector4`][crate::builtin::Vector4] | [`Vector4i`][crate::builtin::Vector4i] |
 #[derive(Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(C)]

--- a/godot-core/src/builtin/vectors/vector4.rs
+++ b/godot-core/src/builtin/vectors/vector4.rs
@@ -23,6 +23,16 @@ use std::fmt;
 /// vectors; use the gdext library with the `double-precision` feature in that case.
 ///
 /// See [`Vector4i`] for its integer counterpart.
+///
+/// ### Navigation to `impl` blocks within this page
+///
+/// - [Constants](#constants)
+/// - [Constructors and general vector functions](#constructors-and-general-vector-functions)
+/// - [Specialized `Vector4` functions](#specialized-vector4-functions)
+/// - [Float-specific functions](#float-specific-functions)
+/// - [4D functions](#4d-functions)
+/// - [3D and 4D functions](#3d-and-4d-functions)
+/// - [Trait impls + operators](#trait-implementations)
 #[derive(Default, Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(C)]
@@ -40,16 +50,15 @@ pub struct Vector4 {
     pub w: real,
 }
 
-impl_vector_operators!(Vector4, real, (x, y, z, w));
-
-impl_vector_consts!(Vector4, real);
-impl_float_vector_consts!(Vector4);
+/// # Constants
+impl Vector4 {
+    impl_vector_consts!(real);
+    impl_float_vector_consts!();
+}
 
 impl_vector_fns!(Vector4, RVec4, real, (x, y, z, w));
-impl_float_vector_fns!(Vector4, (x, y, z, w));
-impl_vector4x_fns!(Vector4, real);
-impl_vector3_vector4_fns!(Vector4, (x, y, z, w));
 
+/// # Specialized `Vector4` functions
 impl Vector4 {
     /// Constructs a new `Vector4` from a [`Vector4i`][crate::builtin::Vector4i].
     pub const fn from_vector4i(v: Vector4i) -> Self {
@@ -67,6 +76,12 @@ impl Vector4 {
         inner::InnerVector4::from_outer(self)
     }
 }
+
+impl_float_vector_fns!(Vector4, (x, y, z, w));
+impl_vector4x_fns!(Vector4, real);
+impl_vector3_vector4_fns!(Vector4, (x, y, z, w));
+
+impl_vector_operators!(Vector4, real, (x, y, z, w));
 
 /// Formats the vector like Godot: `(x, y, z, w)`.
 impl fmt::Display for Vector4 {

--- a/godot-core/src/builtin/vectors/vector4.rs
+++ b/godot-core/src/builtin/vectors/vector4.rs
@@ -22,8 +22,6 @@ use std::fmt;
 /// is always 64-bit. The engine can be compiled with the option `precision=double` to use 64-bit
 /// vectors; use the gdext library with the `double-precision` feature in that case.
 ///
-/// See [`Vector4i`] for its integer counterpart.
-///
 /// ### Navigation to `impl` blocks within this page
 ///
 /// - [Constants](#constants)
@@ -33,6 +31,14 @@ use std::fmt;
 /// - [4D functions](#4d-functions)
 /// - [3D and 4D functions](#3d-and-4d-functions)
 /// - [Trait impls + operators](#trait-implementations)
+///
+/// # All vector types
+///
+/// | Dimension | Floating-point                       | Integer                                |
+/// |-----------|--------------------------------------|----------------------------------------|
+/// | 2D        | [`Vector2`][crate::builtin::Vector2] | [`Vector2i`][crate::builtin::Vector2i] |
+/// | 3D        | [`Vector3`][crate::builtin::Vector3] | [`Vector3i`][crate::builtin::Vector3i] |
+/// | 4D        | **`Vector4`**                        | [`Vector4i`][crate::builtin::Vector4i] |
 #[derive(Default, Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(C)]

--- a/godot-core/src/builtin/vectors/vector4.rs
+++ b/godot-core/src/builtin/vectors/vector4.rs
@@ -39,6 +39,10 @@ use std::fmt;
 /// | 2D        | [`Vector2`][crate::builtin::Vector2] | [`Vector2i`][crate::builtin::Vector2i] |
 /// | 3D        | [`Vector3`][crate::builtin::Vector3] | [`Vector3i`][crate::builtin::Vector3i] |
 /// | 4D        | **`Vector4`**                        | [`Vector4i`][crate::builtin::Vector4i] |
+///
+/// # Godot docs
+///
+/// [`Vector4` (stable)](https://docs.godotengine.org/en/stable/classes/class_vector4.html)
 #[derive(Default, Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(C)]

--- a/godot-core/src/builtin/vectors/vector4i.rs
+++ b/godot-core/src/builtin/vectors/vector4i.rs
@@ -38,6 +38,10 @@ use std::fmt;
 /// | 2D        | [`Vector2`][crate::builtin::Vector2] | [`Vector2i`][crate::builtin::Vector2i] |
 /// | 3D        | [`Vector3`][crate::builtin::Vector3] | [`Vector3i`][crate::builtin::Vector3i] |
 /// | 4D        | [`Vector4`][crate::builtin::Vector4] | **`Vector4i`**                         |
+///
+/// # Godot docs
+///
+/// [`Vector4i` (stable)](https://docs.godotengine.org/en/stable/classes/class_vector4i.html)
 #[derive(Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(C)]

--- a/godot-core/src/builtin/vectors/vector4i.rs
+++ b/godot-core/src/builtin/vectors/vector4i.rs
@@ -19,7 +19,7 @@ use std::fmt;
 /// 4-element structure that can be used to represent 4D grid coordinates or sets of integers.
 ///
 /// It uses integer coordinates and is therefore preferable to [`Vector4`] when exact precision is
-/// required. Note that the values are limited to 32 bits, and unlike [`Vector4`] this cannot be
+/// required. Note that the values are limited to 32 bits, and unlike `Vector4` this cannot be
 /// configured with an engine build option. Use `i64` or [`PackedInt64Array`][crate::builtin::PackedInt64Array]
 /// if 64-bit values are needed.
 ///
@@ -30,6 +30,14 @@ use std::fmt;
 /// - [Specialized `Vector4i` functions](#specialized-vector4i-functions)
 /// - [4D functions](#4d-functions)
 /// - [Trait impls + operators](#trait-implementations)
+///
+/// # All vector types
+///
+/// | Dimension | Floating-point                       | Integer                                |
+/// |-----------|--------------------------------------|----------------------------------------|
+/// | 2D        | [`Vector2`][crate::builtin::Vector2] | [`Vector2i`][crate::builtin::Vector2i] |
+/// | 3D        | [`Vector3`][crate::builtin::Vector3] | [`Vector3i`][crate::builtin::Vector3i] |
+/// | 4D        | [`Vector4`][crate::builtin::Vector4] | **`Vector4i`**                         |
 #[derive(Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(C)]

--- a/godot-core/src/builtin/vectors/vector4i.rs
+++ b/godot-core/src/builtin/vectors/vector4i.rs
@@ -22,6 +22,14 @@ use std::fmt;
 /// required. Note that the values are limited to 32 bits, and unlike [`Vector4`] this cannot be
 /// configured with an engine build option. Use `i64` or [`PackedInt64Array`][crate::builtin::PackedInt64Array]
 /// if 64-bit values are needed.
+///
+/// ### Navigation to `impl` blocks within this page
+///
+/// - [Constants](#constants)
+/// - [Constructors and general vector functions](#constructors-and-general-vector-functions)
+/// - [Specialized `Vector4i` functions](#specialized-vector4i-functions)
+/// - [4D functions](#4d-functions)
+/// - [Trait impls + operators](#trait-implementations)
 #[derive(Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(C)]
@@ -39,16 +47,17 @@ pub struct Vector4i {
     pub w: i32,
 }
 
-impl_vector_operators!(Vector4i, i32, (x, y, z, w));
-
-impl_vector_consts!(Vector4i, i32);
-impl_integer_vector_consts!(Vector4i);
+/// # Constants
+impl Vector4i {
+    impl_vector_consts!(i32);
+    impl_integer_vector_consts!();
+}
 
 impl_vector_fns!(Vector4i, glam::IVec4, i32, (x, y, z, w));
-impl_vector4x_fns!(Vector4i, i32);
 
+/// # Specialized `Vector4i` functions
 impl Vector4i {
-    impl_integer_vector_fns!(x, y, z, w);
+    inline_impl_integer_vector_fns!(x, y, z, w);
 
     /// Constructs a new `Vector4i` from a [`Vector4`]. The floating point coordinates will be
     /// truncated.
@@ -80,6 +89,9 @@ impl Vector4i {
         inner::InnerVector4i::from_outer(self)
     }
 }
+
+impl_vector4x_fns!(Vector4i, i32);
+impl_vector_operators!(Vector4i, i32, (x, y, z, w));
 
 /// Formats the vector like Godot: `(x, y, z, w)`.
 impl fmt::Display for Vector4i {

--- a/godot-core/src/builtin/vectors/vector_macros.rs
+++ b/godot-core/src/builtin/vectors/vector_macros.rs
@@ -254,101 +254,79 @@ macro_rules! impl_vector_index {
 /// Implements constants that are present on floating-point and integer vectors.
 macro_rules! impl_vector_consts {
     (
-        // Name of the vector type.
-        $Vector:ty,
         // Type of target component, for example `real`.
         $Scalar:ty
     ) => {
-        impl $Vector {
-            /// Zero vector, a vector with all components set to `0`.
-            pub const ZERO: Self = Self::splat(0 as $Scalar);
+        /// Zero vector, a vector with all components set to `0`.
+        pub const ZERO: Self = Self::splat(0 as $Scalar);
 
-            /// One vector, a vector with all components set to `1`.
-            pub const ONE: Self = Self::splat(1 as $Scalar);
-        }
+        /// One vector, a vector with all components set to `1`.
+        pub const ONE: Self = Self::splat(1 as $Scalar);
     };
 }
 
 /// Implements constants that are present only on floating-point vectors.
 macro_rules! impl_float_vector_consts {
-    (
-        // Name of the vector type.
-        $Vector:ty
-    ) => {
-        impl $Vector {
-            /// Infinity vector, a vector with all components set to `real::INFINITY`.
-            pub const INF: Self = Self::splat(real::INFINITY);
-        }
+    () => {
+        /// Infinity vector, a vector with all components set to `real::INFINITY`.
+        pub const INF: Self = Self::splat(real::INFINITY);
     };
 }
 
 /// Implements constants that are present only on integer vectors.
 macro_rules! impl_integer_vector_consts {
-    (
-        // Name of the vector type.
-        $Vector:ty
-    ) => {
-        impl $Vector {
-            /// Min vector, a vector with all components equal to [`i32::MIN`]. Can be used as a negative integer equivalent of `real::INF`.
-            pub const MIN: Self = Self::splat(i32::MIN);
+    () => {
+        /// Min vector, a vector with all components equal to [`i32::MIN`]. Can be used as a negative integer equivalent of `real::INF`.
+        pub const MIN: Self = Self::splat(i32::MIN);
 
-            /// Max vector, a vector with all components equal to [`i32::MAX`]. Can be used as an integer equivalent of `real::INF`.
-            pub const MAX: Self = Self::splat(i32::MAX);
-        }
+        /// Max vector, a vector with all components equal to [`i32::MAX`]. Can be used as an integer equivalent of `real::INF`.
+        pub const MAX: Self = Self::splat(i32::MAX);
     };
 }
 
 /// Implements constants present on 2D vectors.
 macro_rules! impl_vector2x_consts {
     (
-        // Name of the vector type.
-        $Vector:ty,
         // Type of target component, for example `real`.
         $Scalar:ty
     ) => {
-        impl $Vector {
-            /// Left unit vector. Represents the direction of left.
-            pub const LEFT: Self = Self::new(-1 as $Scalar, 0 as $Scalar);
+        /// Left unit vector. Represents the direction of left.
+        pub const LEFT: Self = Self::new(-1 as $Scalar, 0 as $Scalar);
 
-            /// Right unit vector. Represents the direction of right.
-            pub const RIGHT: Self = Self::new(1 as $Scalar, 0 as $Scalar);
+        /// Right unit vector. Represents the direction of right.
+        pub const RIGHT: Self = Self::new(1 as $Scalar, 0 as $Scalar);
 
-            /// Up unit vector. Y is down in 2D, so this vector points -Y.
-            pub const UP: Self = Self::new(0 as $Scalar, -1 as $Scalar);
+        /// Up unit vector. Y is down in 2D, so this vector points -Y.
+        pub const UP: Self = Self::new(0 as $Scalar, -1 as $Scalar);
 
-            /// Down unit vector. Y is down in 2D, so this vector points +Y.
-            pub const DOWN: Self = Self::new(0 as $Scalar, 1 as $Scalar);
-        }
+        /// Down unit vector. Y is down in 2D, so this vector points +Y.
+        pub const DOWN: Self = Self::new(0 as $Scalar, 1 as $Scalar);
     };
 }
 
 /// Implements constants present on 3D vectors.
 macro_rules! impl_vector3x_consts {
     (
-        // Name of the vector type.
-        $Vector:ty,
         // Type of target component, for example `real`.
         $Scalar:ty
     ) => {
-        impl $Vector {
-            /// Unit vector in -X direction. Can be interpreted as left in an untransformed 3D world.
-            pub const LEFT: Self = Self::new(-1 as $Scalar, 0 as $Scalar, 0 as $Scalar);
+        /// Unit vector in -X direction. Can be interpreted as left in an untransformed 3D world.
+        pub const LEFT: Self = Self::new(-1 as $Scalar, 0 as $Scalar, 0 as $Scalar);
 
-            /// Unit vector in +X direction. Can be interpreted as right in an untransformed 3D world.
-            pub const RIGHT: Self = Self::new(1 as $Scalar, 0 as $Scalar, 0 as $Scalar);
+        /// Unit vector in +X direction. Can be interpreted as right in an untransformed 3D world.
+        pub const RIGHT: Self = Self::new(1 as $Scalar, 0 as $Scalar, 0 as $Scalar);
 
-            /// Unit vector in +Y direction. Typically interpreted as up in a 3D world.
-            pub const UP: Self = Self::new(0 as $Scalar, 1 as $Scalar, 0 as $Scalar);
+        /// Unit vector in +Y direction. Typically interpreted as up in a 3D world.
+        pub const UP: Self = Self::new(0 as $Scalar, 1 as $Scalar, 0 as $Scalar);
 
-            /// Unit vector in -Y direction. Typically interpreted as down in a 3D world.
-            pub const DOWN: Self = Self::new(0 as $Scalar, -1 as $Scalar, 0 as $Scalar);
+        /// Unit vector in -Y direction. Typically interpreted as down in a 3D world.
+        pub const DOWN: Self = Self::new(0 as $Scalar, -1 as $Scalar, 0 as $Scalar);
 
-            /// Unit vector in -Z direction. Can be interpreted as “into the screen” in an untransformed 3D world.
-            pub const FORWARD: Self = Self::new(0 as $Scalar, 0 as $Scalar, -1 as $Scalar);
+        /// Unit vector in -Z direction. Can be interpreted as “into the screen” in an untransformed 3D world.
+        pub const FORWARD: Self = Self::new(0 as $Scalar, 0 as $Scalar, -1 as $Scalar);
 
-            /// Unit vector in +Z direction. Can be interpreted as “out of the screen” in an untransformed 3D world.
-            pub const BACK: Self = Self::new(0 as $Scalar, 0 as $Scalar, 1 as $Scalar);
-        }
+        /// Unit vector in +Z direction. Can be interpreted as “out of the screen” in an untransformed 3D world.
+        pub const BACK: Self = Self::new(0 as $Scalar, 0 as $Scalar, 1 as $Scalar);
     };
 }
 
@@ -364,6 +342,8 @@ macro_rules! impl_vector_fns {
         // Names of the components, with parentheses, for example `(x, y)`.
         ($($comp:ident),*)
     ) => {
+        /// # Constructors and general vector functions
+        /// The following associated functions and methods are available on all vectors (2D, 3D, 4D; float and int).
         impl $Vector {
             /// Returns a vector with the given components.
             pub const fn new($($comp: $Scalar),*) -> Self {
@@ -418,7 +398,7 @@ macro_rules! impl_vector_fns {
 
             /// Squared length (squared magnitude) of this vector.
             ///
-            /// Runs faster than [`Self::length`], so prefer it if you need to compare vectors or need the
+            /// Runs faster than [`length()`][Self::length], so prefer it if you need to compare vectors or need the
             /// squared distance for some formula.
             #[inline]
             pub fn length_squared(self) -> $Scalar {
@@ -426,18 +406,22 @@ macro_rules! impl_vector_fns {
             }
 
             /// Returns a new vector containing the minimum of the two vectors, component-wise.
+            ///
+            #[doc = concat!("You may consider using the fully-qualified syntax `", stringify!($Vector), "::coord_min(a, b)` for symmetry.")]
             #[inline]
             pub fn coord_min(self, other: Self) -> Self {
                 self.glam2(&other, |a, b| a.min(b))
             }
 
             /// Returns a new vector containing the maximum of the two vectors, component-wise.
+            ///
+            #[doc = concat!("You may consider using the fully-qualified syntax `", stringify!($Vector), "::coord_max(a, b)` for symmetry.")]
             #[inline]
             pub fn coord_max(self, other: Self) -> Self {
                 self.glam2(&other, |a, b| a.max(b))
             }
 
-            /// Returns a new vector with each component set to 1 if it's positive, -1 if it's negative, and 0 if it's zero.
+            /// Returns a new vector with each component set to 1 if the component is positive, -1 if negative, and 0 if zero.
             #[inline]
             pub fn sign(self) -> Self {
                 #[inline]
@@ -487,7 +471,7 @@ pub(super) fn snap_one(mut value: i32, step: i32) -> i32 {
 }
 
 /// Implements functions that are present only on integer vectors.
-macro_rules! impl_integer_vector_fns {
+macro_rules! inline_impl_integer_vector_fns {
     (
         // Names of the components, for example `x, y`.
         $($comp:ident),*
@@ -511,7 +495,6 @@ macro_rules! impl_integer_vector_fns {
     };
 }
 
-/// Implements functions that are present only on floating-point vectors.
 macro_rules! impl_float_vector_fns {
     (
         // Name of the vector type.
@@ -519,6 +502,9 @@ macro_rules! impl_float_vector_fns {
         // Names of the components, with parentheses, for example `(x, y)`.
         ($($comp:ident),*)
     ) => {
+        /// # Float-specific functions
+        ///
+        /// The following methods are only available on floating-point vectors.
         impl $Vector {
             /// Returns a new vector with all components rounded up (towards positive infinity).
             #[inline]
@@ -526,7 +512,7 @@ macro_rules! impl_float_vector_fns {
                 Self::from_glam(self.to_glam().ceil())
             }
 
-            /// Performs a cubic interpolation between this vector and `b` using `pre_a` and `post_b` as handles,
+            /// Cubic interpolation between `self` and `b` using `pre_a` and `post_b` as handles,
             /// and returns the result at position `weight`.
             ///
             /// `weight` is on the range of 0.0 to 1.0, representing the amount of interpolation.
@@ -539,11 +525,11 @@ macro_rules! impl_float_vector_fns {
                 )
             }
 
-            /// Performs a cubic interpolation between this vector and `b` using `pre_a` and `post_b` as handles,
+            /// Cubic interpolation between `self` and `b` using `pre_a` and `post_b` as handles,
             /// and returns the result at position `weight`.
             ///
             /// `weight` is on the range of 0.0 to 1.0, representing the amount of interpolation.
-            /// It can perform smoother interpolation than [`Self::cubic_interpolate`] by the time values.
+            /// It can perform smoother interpolation than [`cubic_interpolate()`][Self::cubic_interpolate] by the time values.
             #[inline]
             #[allow(clippy::too_many_arguments)]
             pub fn cubic_interpolate_in_time(
@@ -672,7 +658,7 @@ macro_rules! impl_float_vector_fns {
                 self.try_normalized().unwrap_or_default()
             }
 
-            /// Returns a vector composed of the [`FloatExt::fposmod`] of this vector's components and `pmod`.
+            /// Returns a vector composed of the [`FloatExt::fposmod()`] of this vector's components and `pmod`.
             #[inline]
             pub fn posmod(self, pmod: real) -> Self {
                 Self::new(
@@ -680,7 +666,7 @@ macro_rules! impl_float_vector_fns {
                 )
             }
 
-            /// Returns a vector composed of the [`FloatExt::fposmod`] of this vector's components and `modv`'s components.
+            /// Returns a vector composed of the [`FloatExt::fposmod()`] of this vector's components and `modv`'s components.
             #[inline]
             pub fn posmodv(self, modv: Self) -> Self {
                 Self::new(
@@ -717,7 +703,6 @@ macro_rules! impl_float_vector_fns {
     };
 }
 
-/// Implements functions present on 2D vectors.
 macro_rules! impl_vector2x_fns {
     (
         // Name of the vector type.
@@ -725,6 +710,8 @@ macro_rules! impl_vector2x_fns {
         // Type of target component, for example `real`.
         $Scalar:ty
     ) => {
+        /// # 2D functions
+        /// The following methods are only available on 2D vectors (for both float and int).
         impl $Vector {
             /// Returns the aspect ratio of this vector, the ratio of [`Self::x`] to [`Self::y`].
             #[inline]
@@ -770,7 +757,6 @@ macro_rules! impl_vector2x_fns {
     };
 }
 
-/// Implements functions present on 3D vectors.
 macro_rules! impl_vector3x_fns {
     (
         // Name of the vector type.
@@ -778,6 +764,8 @@ macro_rules! impl_vector3x_fns {
         // Type of target component, for example `real`.
         $Scalar:ty
     ) => {
+        /// # 3D functions
+        /// The following methods are only available on 3D vectors (for both float and int).
         impl $Vector {
             /// Returns the axis of the vector's highest value. See [`Vector3Axis`] enum. If all components are equal, this method returns [`None`].
             ///
@@ -843,7 +831,6 @@ macro_rules! impl_vector3x_fns {
     };
 }
 
-/// Implements functions present on 4D vectors.
 macro_rules! impl_vector4x_fns {
     (
         // Name of the vector type.
@@ -851,6 +838,8 @@ macro_rules! impl_vector4x_fns {
         // Type of target component, for example `real`.
         $Scalar:ty
     ) => {
+        /// # 4D functions
+        /// The following methods are only available on 4D vectors (for both float and int).
         impl $Vector {
             /// Returns the axis of the vector's highest value. See [`Vector4Axis`] enum. If all components are equal, this method returns [`None`].
             ///
@@ -916,7 +905,6 @@ macro_rules! impl_vector4x_fns {
     };
 }
 
-/// Implements functions present on floating-point 2D and 3D vectors.
 macro_rules! impl_vector2_vector3_fns {
     (
         // Name of the vector type.
@@ -924,6 +912,8 @@ macro_rules! impl_vector2_vector3_fns {
         // Names of the components, with parentheses, for example `(x, y, z, w)`.
         ($($comp:ident),*)
     ) => {
+        /// # 2D and 3D functions
+        /// The following methods are available on both 2D and 3D float vectors.
         impl $Vector {
             /// Returns the angle to the given vector, in radians.
             #[inline]
@@ -1007,7 +997,6 @@ macro_rules! impl_vector2_vector3_fns {
     };
 }
 
-/// Implements functions present on floating-point 3D and 4D vectors.
 macro_rules! impl_vector3_vector4_fns {
     (
         // Name of the vector type.
@@ -1015,6 +1004,8 @@ macro_rules! impl_vector3_vector4_fns {
         // Names of the components, with parentheses, for example `(x, y, z, w)`.
         ($($comp:ident),*)
     ) => {
+        /// # 3D and 4D functions
+        /// The following methods are available on both 3D and 4D float vectors.
         impl $Vector {
             /// Returns the reciprocal (inverse) of the vector. This is the same as `1.0/n` for each component.
             #[inline]


### PR DESCRIPTION
Changes:
- Vector types now have fewer useless `impl` blocks (e.g. separating constants).
- The remaining `impl`s are named and anchor-linked from struct docs.
- For vectors, matrices, bounding boxes and strings, there is a new table with links to the other entries in the same category.
- Every builtin type (except packed arrays) now has a link to Godot doc page.