### PR TITLE
Implement the `safe_ident` strategy for virtual call parameter identifier generation

### DIFF
--- a/godot-codegen/src/special_cases/codegen_special_cases.rs
+++ b/godot-codegen/src/special_cases/codegen_special_cases.rs
@@ -137,6 +137,7 @@ const SELECTED_CLASSES: &[&str] = &[
     "CollisionShape2D",
     "Control",
     "EditorPlugin",
+    "EditorExportPlugin",
     "Engine",
     "FileAccess",
     "GDScript",

--- a/godot-codegen/src/util.rs
+++ b/godot-codegen/src/util.rs
@@ -83,6 +83,7 @@ pub fn cstr_u8_slice(string: &str) -> Literal {
     Literal::byte_string(format!("{string}\0").as_bytes())
 }
 
+// This function is duplicated in godot-macros\src\util\mod.rs
 #[rustfmt::skip]
 pub fn safe_ident(s: &str) -> Ident {
     // See also: https://doc.rust-lang.org/reference/keywords.html

--- a/godot-macros/src/class/data_models/func.rs
+++ b/godot-macros/src/class/data_models/func.rs
@@ -5,7 +5,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use crate::util::{bail_fn, ident};
+use crate::util::{bail_fn, ident, safe_ident};
 use crate::{util, ParseResult};
 use proc_macro2::{Group, Ident, TokenStream, TokenTree};
 use quote::{format_ident, quote};
@@ -368,7 +368,7 @@ pub(crate) fn maybe_rename_parameter(param_ident: Ident, next_unnamed_index: &mu
         // This could technically collide with another parameter of the same name (without "_"), but that's very unlikely and not
         // something we really need to support.
         // Note that the case of a single "_" is handled above.
-        ident(remain)
+        safe_ident(remain)
     } else {
         param_ident
     }

--- a/godot-macros/src/util/mod.rs
+++ b/godot-macros/src/util/mod.rs
@@ -273,3 +273,27 @@ pub fn make_virtual_tool_check() -> TokenStream {
 pub fn make_virtual_tool_check() -> TokenStream {
     TokenStream::new()
 }
+
+// This function is duplicated in godot-codegen\src\util.rs
+#[rustfmt::skip]
+pub fn safe_ident(s: &str) -> Ident {
+    // See also: https://doc.rust-lang.org/reference/keywords.html
+    match s {
+        // Lexer
+        | "as" | "break" | "const" | "continue" | "crate" | "else" | "enum" | "extern" | "false" | "fn" | "for" | "if"
+        | "impl" | "in" | "let" | "loop" | "match" | "mod" | "move" | "mut" | "pub" | "ref" | "return" | "self" | "Self"
+        | "static" | "struct" | "super" | "trait" | "true" | "type" | "unsafe" | "use" | "where" | "while"
+
+        // Lexer 2018+
+        | "async" | "await" | "dyn"
+
+        // Reserved
+        | "abstract" | "become" | "box" | "do" | "final" | "macro" | "override" | "priv" | "typeof" | "unsized" | "virtual" | "yield"
+
+        // Reserved 2018+
+        | "try"
+           => format_ident!("{}_", s),
+
+         _ => ident(s)
+    }
+}

--- a/itest/rust/src/register_tests/keyword_parameters_test.rs
+++ b/itest/rust/src/register_tests/keyword_parameters_test.rs
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use godot::builtin::{GString, PackedStringArray};
+use godot::classes::IEditorExportPlugin;
+use godot::register::{godot_api, GodotClass};
+
+#[derive(GodotClass)]
+#[class(base=EditorExportPlugin, init)]
+struct KeywordParameterEditorExportPlugin;
+
+#[godot_api]
+impl IEditorExportPlugin for KeywordParameterEditorExportPlugin {
+    // This test requires that the second non-self parameter on `export_file`
+    // remain named `_type`.
+    fn export_file(&mut self, _path: GString, _type: GString, _features: PackedStringArray) {}
+}

--- a/itest/rust/src/register_tests/mod.rs
+++ b/itest/rust/src/register_tests/mod.rs
@@ -10,6 +10,7 @@ mod conversion_test;
 mod derive_variant_test;
 mod func_test;
 mod gdscript_ffi_test;
+mod keyword_parameters_test;
 mod option_ffi_test;
 mod var_test;
 


### PR DESCRIPTION
The behavior in [`maybe_rename_parameter`](https://github.com/godot-rust/gdext/blob/master/godot-macros/src/class/data_models/func.rs#L360) as currently implemented strips leading underscores from parameter names.

The case where `_` is stripped presents a need to sanitize identifiers where we otherwise would not have to, as the removal of the leading underscore may make the identifier match a language keyword. A concrete example someone ran into was an argument named `type` in [`IEditorExportPlugin::export_file`](https://docs.rs/godot/latest/godot/classes/trait.IEditorExportPlugin.html#method.export_file) in #817. 

There appears to be an existing approach to keyword-named parameters, as the parameter in the codegen-generated interface is named `type_`. I just implemented that exact strategy in the way `maybe_rename_parameter` generates identifiers after removing a prefixing `_`.

<details>
<summary>Codegen Comparison</summary>

With the following code from #817

```rs
use godot::{classes::{EditorExportPlugin, IEditorExportPlugin}, prelude::*};

#[derive(GodotClass)]
#[class(base=EditorExportPlugin)]
pub struct MyExportPlugin {
    base: Base<EditorExportPlugin>,
}

#[godot_api]
impl IEditorExportPlugin for MyExportPlugin {
    fn init(base: Base<EditorExportPlugin>) -> Self {
        Self {
            base,
        }
    }

    fn export_file(&mut self, _path: GString, _type: GString, _features: PackedStringArray) {
        todo!()
    }
}
```

I've included only the changed output from the expanded macro for brevity.

# Pre-Change
```rs
fn __virtual_call(name: &str) ->  ::godot::sys::GDExtensionClassCallVirtual {
    use::godot::obj::UserClass as _;
    match name {
        "_export_file" => {
            use::godot::sys;
            type Sig = ((),GString,GString,PackedStringArray);
            unsafe extern "C" fn virtual_fn(instance_ptr:sys::GDExtensionClassInstancePtr,args_ptr: *const sys::GDExtensionConstTypePtr,ret:sys::GDExtensionTypePtr,){
                let call_ctx =  ::godot::meta::CallContext::func("MyExportPlugin","export_file");
                let _success =  ::godot::private::handle_ptrcall_panic(&call_ctx, || <Sig as ::godot::meta::PtrcallSignatureTuple> ::in_ptrcall(instance_ptr, &call_ctx,args_ptr,ret, |instance_ptr,params|{
                    let(path,type,features,) = params;
                    let storage = unsafe {
                        ::godot::private::as_storage:: <MyExportPlugin>(instance_ptr)
                    };
                    let mut instance =  ::godot::private::Storage::get_mut(storage);
                    instance.export_file(path,type,features)
                },sys::PtrcallType::Virtual,));
            }
            Some(virtual_fn)
        },
// ...
```

Specific lines that cause problems:
- `let(path,type,features,) = params;`
- `instance.export_file(path,type,features)`

# Post-Change

```rs
fn __virtual_call(name: &str) -> ::godot::sys::GDExtensionClassCallVirtual {
    use ::godot::obj::UserClass as _;
    match name {
        "_export_file" => {
            use ::godot::sys;
            type Sig = ((), GString, GString, PackedStringArray);
            unsafe extern "C" fn virtual_fn(
                instance_ptr: sys::GDExtensionClassInstancePtr,
                args_ptr: *const sys::GDExtensionConstTypePtr,
                ret: sys::GDExtensionTypePtr,
            ) {
                let call_ctx =
                    ::godot::meta::CallContext::func("MyExportPlugin", "export_file");
                let _success = ::godot::private::handle_ptrcall_panic(&call_ctx, || {
                    <Sig as ::godot::meta::PtrcallSignatureTuple>::in_ptrcall(
                        instance_ptr,
                        &call_ctx,
                        args_ptr,
                        ret,
                        |instance_ptr, params| {
                            let (path, type_, features) = params;
                            let storage = unsafe {
                                ::godot::private::as_storage::<MyExportPlugin>(instance_ptr)
                            };
                            let mut instance = ::godot::private::Storage::get_mut(storage);
                            instance.export_file(path, type_, features)
                        },
                        sys::PtrcallType::Virtual,
                    )
                });
            }
            Some(virtual_fn)
        }
// ...
```
</detail>