### PR TITLE
Set null into Godot Engint APIs nullable parameters as default

### DIFF
--- a/godot-codegen/src/conv/type_conversions.rs
+++ b/godot-codegen/src/conv/type_conversions.rs
@@ -266,7 +266,7 @@ fn to_rust_expr_inner(expr: &str, ty: &RustTy, is_inner: bool) -> TokenStream {
             return match ty {
                 RustTy::BuiltinIdent(ident) if ident == "Variant" => quote! { Variant::nil() },
                 RustTy::EngineClass { .. } => {
-                    quote! { unimplemented!("see https://github.com/godot-rust/gdext/issues/156") }
+                    quote! { ObjectArg::null() }
                 }
                 _ => panic!("null not representable in target type {ty:?}"),
             }


### PR DESCRIPTION
#800 allows nullable parameters to be passed to Godot Engine API methods. This would allow the default parameters to be null as well?

Fixed to initialize them with `ObjectArg::null()`. (I tried this with the `draw_polygon()` method and it worked fine. Is this fix enough?)