### PR TITLE
Vector conversion functions

### DIFF
--- a/godot-core/src/builtin/rect2.rs
+++ b/godot-core/src/builtin/rect2.rs
@@ -23,6 +23,8 @@ use crate::builtin::{real, Rect2i, Side, Vector2};
 /// | 2D        | **`Rect2`**     | [`Rect2i`]   |
 /// | 3D        | [`Aabb`]        |              |
 ///
+/// <br>You can convert to `Rect2i` using [`cast_int()`][Self::cast_int].
+///
 /// [`Aabb`]: crate::builtin::Aabb
 ///
 /// # Godot docs
@@ -63,14 +65,20 @@ impl Rect2 {
         }
     }
 
-    /// Create a new `Rect2` from a `Rect2i`, using `as` for `i32` to `real` conversions.
-    ///
-    /// _Godot equivalent: `Rect2(Rect2i from)`_
+    #[deprecated = "Moved to `Rect2i::cast_float()`"]
     #[inline]
     pub const fn from_rect2i(rect: Rect2i) -> Self {
-        Self {
-            position: Vector2::from_vector2i(rect.position),
-            size: Vector2::from_vector2i(rect.size),
+        rect.cast_float()
+    }
+
+    /// Create a new `Rect2i` from a `Rect2`, using `as` for `real` to `i32` conversions.
+    ///
+    /// _Godot equivalent: `Rect2i(Rect2 from)`_
+    #[inline]
+    pub const fn cast_int(self) -> Rect2i {
+        Rect2i {
+            position: self.position.cast_int(),
+            size: self.size.cast_int(),
         }
     }
 

--- a/godot-core/src/builtin/rect2i.rs
+++ b/godot-core/src/builtin/rect2i.rs
@@ -24,6 +24,8 @@ use sys::{ffi_methods, GodotFfi};
 /// | 2D        | [`Rect2`]       | **`Rect2i`** |
 /// | 3D        | [`Aabb`]        |              |
 ///
+/// <br>You can convert to `Rect2` using [`cast_float()`][Self::cast_float].
+///
 /// [`Aabb`]: crate::builtin::Aabb
 ///
 /// # Godot docs
@@ -60,23 +62,29 @@ impl Rect2i {
         }
     }
 
-    /// Create a new `Rect2i` from a `Rect2`, using `as` for `real` to `i32` conversions.
-    ///
-    /// _Godot equivalent: `Rect2i(Rect2 from)`_
-    #[inline]
-    pub const fn from_rect2(rect: Rect2) -> Self {
-        Self {
-            position: Vector2i::from_vector2(rect.position),
-            size: Vector2i::from_vector2(rect.size),
-        }
-    }
-
     /// Create a new `Rect2i` with the first corner at `position` and the opposite corner at `end`.
     #[inline]
     pub fn from_corners(position: Vector2i, end: Vector2i) -> Self {
         Self {
             position,
             size: end - position,
+        }
+    }
+
+    #[deprecated = "Moved to `Rect2::cast_int()`"]
+    #[inline]
+    pub const fn from_rect2(rect: Rect2) -> Self {
+        rect.cast_int()
+    }
+
+    /// Create a new `Rect2` from a `Rect2i`, using `as` for `i32` to `real` conversions.
+    ///
+    /// _Godot equivalent: `Rect2(Rect2i from)`_
+    #[inline]
+    pub const fn cast_float(self) -> Rect2 {
+        Rect2 {
+            position: self.position.cast_float(),
+            size: self.size.cast_float(),
         }
     }
 
@@ -312,7 +320,7 @@ mod test {
         let zero = Rect2i::default();
         let new = Rect2i::new(Vector2i::new(0, 100), Vector2i::new(1280, 720));
         let from_components = Rect2i::from_components(0, 100, 1280, 720);
-        let from_rect2 = Rect2i::from_rect2(Rect2::from_components(0.1, 100.3, 1280.1, 720.42));
+        let from_rect2 = Rect2::from_components(0.1, 100.3, 1280.1, 720.42).cast_int();
         let from_corners = Rect2i::from_corners(Vector2i::new(0, 100), Vector2i::new(1280, 820));
 
         assert_eq!(zero.position.x, 0);

--- a/godot-core/src/builtin/vectors/vector2.rs
+++ b/godot-core/src/builtin/vectors/vector2.rs
@@ -11,7 +11,7 @@ use sys::{ffi_methods, GodotFfi};
 
 use crate::builtin::math::{FloatExt, GlamConv, GlamType};
 use crate::builtin::vectors::Vector2Axis;
-use crate::builtin::{inner, real, RAffine2, RVec2, Vector2i};
+use crate::builtin::{inner, real, RAffine2, RVec2, Vector2i, Vector3};
 
 use std::fmt;
 
@@ -165,7 +165,7 @@ impl Vector2 {
 }
 
 impl_float_vector_fns!(Vector2, (x, y));
-impl_vector2x_fns!(Vector2, real);
+impl_vector2x_fns!(Vector2, Vector3, real);
 impl_vector2_vector3_fns!(Vector2, (x, y));
 
 impl_vector_operators!(Vector2, real, (x, y));

--- a/godot-core/src/builtin/vectors/vector2.rs
+++ b/godot-core/src/builtin/vectors/vector2.rs
@@ -44,6 +44,8 @@ use std::fmt;
 /// | 3D        | [`Vector3`][crate::builtin::Vector3] | [`Vector3i`][crate::builtin::Vector3i] |
 /// | 4D        | [`Vector4`][crate::builtin::Vector4] | [`Vector4i`][crate::builtin::Vector4i] |
 ///
+/// <br>You can convert to 3D vectors using [`to_3d(z)`][Self::to_3d], and to `Vector2i` using [`cast_int()`][Self::cast_int].
+///
 /// # Godot docs
 ///
 /// [`Vector2` (stable)](https://docs.godotengine.org/en/stable/classes/class_vector2.html)
@@ -69,13 +71,10 @@ impl_vector_fns!(Vector2, RVec2, real, (x, y));
 
 /// # Specialized `Vector2` functions
 impl Vector2 {
-    /// Constructs a new `Vector2` from a [`Vector2i`].
+    #[deprecated = "Moved to `Vector2i::cast_float()`"]
     #[inline]
     pub const fn from_vector2i(v: Vector2i) -> Self {
-        Self {
-            x: v.x as real,
-            y: v.y as real,
-        }
+        v.cast_float()
     }
 
     /// Returns this vector's angle with respect to the positive X axis, or `(1.0, 0.0)` vector, in radians.
@@ -164,7 +163,7 @@ impl Vector2 {
     }
 }
 
-impl_float_vector_fns!(Vector2, (x, y));
+impl_float_vector_fns!(Vector2, Vector2i, (x, y));
 impl_vector2x_fns!(Vector2, Vector3, real);
 impl_vector2_vector3_fns!(Vector2, (x, y));
 

--- a/godot-core/src/builtin/vectors/vector2.rs
+++ b/godot-core/src/builtin/vectors/vector2.rs
@@ -24,6 +24,8 @@ use std::fmt;
 /// is always 64-bit. The engine can be compiled with the option `precision=double` to use 64-bit
 /// vectors; use the gdext library with the `double-precision` feature in that case.
 ///
+#[doc = shared_vector_docs!()]
+///
 /// ### Navigation to `impl` blocks within this page
 ///
 /// - [Constants](#constants)

--- a/godot-core/src/builtin/vectors/vector2i.rs
+++ b/godot-core/src/builtin/vectors/vector2i.rs
@@ -10,7 +10,7 @@ use std::cmp::Ordering;
 use sys::{ffi_methods, GodotFfi};
 
 use crate::builtin::math::{GlamConv, GlamType};
-use crate::builtin::{inner, real, RVec2, Vector2, Vector2Axis};
+use crate::builtin::{inner, real, RVec2, Vector2, Vector2Axis, Vector3i};
 
 use std::fmt;
 
@@ -91,7 +91,7 @@ impl Vector2i {
 }
 
 impl_vector_fns!(Vector2i, glam::IVec2, i32, (x, y));
-impl_vector2x_fns!(Vector2i, i32);
+impl_vector2x_fns!(Vector2i, Vector3i, i32);
 
 impl_vector_operators!(Vector2i, i32, (x, y));
 

--- a/godot-core/src/builtin/vectors/vector2i.rs
+++ b/godot-core/src/builtin/vectors/vector2i.rs
@@ -42,6 +42,8 @@ use std::fmt;
 /// | 3D        | [`Vector3`][crate::builtin::Vector3] | [`Vector3i`][crate::builtin::Vector3i] |
 /// | 4D        | [`Vector4`][crate::builtin::Vector4] | [`Vector4i`][crate::builtin::Vector4i] |
 ///
+/// <br>You can convert to 3D vectors using [`to_3d(z)`][Self::to_3d], and to `Vector2` using [`cast_float()`][Self::cast_float].
+///
 /// # Godot docs
 ///
 /// [`Vector2i` (stable)](https://docs.godotengine.org/en/stable/classes/class_vector2i.html)
@@ -65,15 +67,12 @@ impl Vector2i {
 
 /// # Specialized `Vector2i` functions
 impl Vector2i {
-    inline_impl_integer_vector_fns!(x, y);
+    inline_impl_integer_vector_fns!(Vector2, x, y);
 
-    /// Constructs a new `Vector2i` from a [`Vector2`]. The floating point coordinates will be truncated.
+    #[deprecated = "Moved to `Vector2::cast_int()`"]
     #[inline]
     pub const fn from_vector2(v: Vector2) -> Self {
-        Self {
-            x: v.x as i32,
-            y: v.y as i32,
-        }
+        v.cast_int()
     }
 
     /// Converts `self` to the corresponding [`real`] `glam` type.

--- a/godot-core/src/builtin/vectors/vector2i.rs
+++ b/godot-core/src/builtin/vectors/vector2i.rs
@@ -19,10 +19,12 @@ use std::fmt;
 /// 2-element structure that can be used to represent discrete positions or directions in 2D space,
 /// as well as any other pair of numeric values.
 ///
-/// It uses integer coordinates and is therefore preferable to [`Vector2`] when exact precision is
+/// `Vector2i` uses integer coordinates and is therefore preferable to [`Vector2`] when exact precision is
 /// required. Note that the values are limited to 32 bits, and unlike `Vector2` this cannot be
 /// configured with an engine build option. Use `i64` or [`PackedInt64Array`][crate::builtin::PackedInt64Array]
 /// if 64-bit values are needed.
+///
+#[doc = shared_vector_docs!()]
 ///
 /// ### Navigation to `impl` blocks within this page
 ///

--- a/godot-core/src/builtin/vectors/vector3.rs
+++ b/godot-core/src/builtin/vectors/vector3.rs
@@ -45,6 +45,8 @@ use std::fmt;
 /// | 3D        | **`Vector3`**                        | [`Vector3i`][crate::builtin::Vector3i] |
 /// | 4D        | [`Vector4`][crate::builtin::Vector4] | [`Vector4i`][crate::builtin::Vector4i] |
 ///
+/// <br>You can convert to 2D vectors using [`to_2d()`][Self::to_2d], and to `Vector3i` using [`cast_int()`][Self::cast_int].
+///
 /// # Godot docs
 ///
 /// [`Vector3` (stable)](https://docs.godotengine.org/en/stable/classes/class_vector3.html)
@@ -67,12 +69,7 @@ impl Vector3 {
     impl_vector_consts!(real);
     impl_float_vector_consts!();
     impl_vector3x_consts!(real);
-}
 
-impl_vector_fns!(Vector3, RVec3, real, (x, y, z));
-
-/// # Specialized `Vector3` functions
-impl Vector3 {
     /// Unit vector pointing towards the left side of imported 3D assets.
     pub const MODEL_LEFT: Self = Self::new(1.0, 0.0, 0.0);
 
@@ -90,15 +87,16 @@ impl Vector3 {
 
     /// Unit vector pointing towards the rear side (back) of imported 3D assets.
     pub const MODEL_REAR: Self = Self::new(0.0, 0.0, -1.0);
+}
 
-    /// Constructs a new `Vector3` from a [`Vector3i`].
+impl_vector_fns!(Vector3, RVec3, real, (x, y, z));
+
+/// # Specialized `Vector3` functions
+impl Vector3 {
+    #[deprecated = "Moved to `Vector3i::cast_float()`"]
     #[inline]
     pub const fn from_vector3i(v: Vector3i) -> Self {
-        Self {
-            x: v.x as real,
-            y: v.y as real,
-            z: v.z as real,
-        }
+        v.cast_float()
     }
 
     #[doc(hidden)]
@@ -231,7 +229,7 @@ impl Vector3 {
     }
 }
 
-impl_float_vector_fns!(Vector3, (x, y, z));
+impl_float_vector_fns!(Vector3, Vector3i, (x, y, z));
 impl_vector3x_fns!(Vector3, Vector2, real);
 impl_vector2_vector3_fns!(Vector3, (x, y, z));
 impl_vector3_vector4_fns!(Vector3, (x, y, z));

--- a/godot-core/src/builtin/vectors/vector3.rs
+++ b/godot-core/src/builtin/vectors/vector3.rs
@@ -232,7 +232,7 @@ impl Vector3 {
 }
 
 impl_float_vector_fns!(Vector3, (x, y, z));
-impl_vector3x_fns!(Vector3, real);
+impl_vector3x_fns!(Vector3, Vector2, real);
 impl_vector2_vector3_fns!(Vector3, (x, y, z));
 impl_vector3_vector4_fns!(Vector3, (x, y, z));
 

--- a/godot-core/src/builtin/vectors/vector3.rs
+++ b/godot-core/src/builtin/vectors/vector3.rs
@@ -24,6 +24,8 @@ use std::fmt;
 /// is always 64-bit. The engine can be compiled with the option `precision=double` to use 64-bit
 /// vectors instead; use the gdext library with the `double-precision` feature in that case.
 ///
+#[doc = shared_vector_docs!()]
+///
 /// ### Navigation to `impl` blocks within this page
 ///
 /// - [Constants](#constants)

--- a/godot-core/src/builtin/vectors/vector3i.rs
+++ b/godot-core/src/builtin/vectors/vector3i.rs
@@ -42,6 +42,8 @@ use crate::builtin::{inner, real, RVec3, Vector2i, Vector3, Vector3Axis};
 /// | 3D        | [`Vector3`][crate::builtin::Vector3] | **`Vector3i`**                         |
 /// | 4D        | [`Vector4`][crate::builtin::Vector4] | [`Vector4i`][crate::builtin::Vector4i] |
 ///
+/// <br>You can convert to 2D vectors using [`to_2d()`][Self::to_2d], and to `Vector3` using [`cast_float()`][Self::cast_float].
+///
 /// # Godot docs
 ///
 /// [`Vector3i` (stable)](https://docs.godotengine.org/en/stable/classes/class_vector3i.html)
@@ -70,17 +72,13 @@ impl_vector_fns!(Vector3i, glam::IVec3, i32, (x, y, z));
 
 /// # Specialized `Vector3i` functions
 impl Vector3i {
-    /// Constructs a new `Vector3i` from a [`Vector3`]. The floating point coordinates will be truncated.
+    #[deprecated = "Moved to `Vector3::cast_int()`"]
     #[inline]
     pub const fn from_vector3(v: Vector3) -> Self {
-        Self {
-            x: v.x as i32,
-            y: v.y as i32,
-            z: v.z as i32,
-        }
+        v.cast_int()
     }
 
-    inline_impl_integer_vector_fns!(x, y, z);
+    inline_impl_integer_vector_fns!(Vector3, x, y, z);
 
     /// Converts `self` to the corresponding [`real`] `glam` type.
     #[doc(hidden)]

--- a/godot-core/src/builtin/vectors/vector3i.rs
+++ b/godot-core/src/builtin/vectors/vector3i.rs
@@ -19,10 +19,12 @@ use crate::builtin::{inner, real, RVec3, Vector3, Vector3Axis};
 /// 3-element structure that can be used to represent discrete positions or directions in 3D space,
 /// as well as any other triple of numeric values.
 ///
-/// It uses integer coordinates and is therefore preferable to [`Vector3`] when exact precision is
+/// `Vector3i` uses integer coordinates and is therefore preferable to [`Vector3`] when exact precision is
 /// required. Note that the values are limited to 32 bits, and unlike `Vector3` this cannot be
 /// configured with an engine build option. Use `i64` or [`PackedInt64Array`][crate::builtin::PackedInt64Array]
 /// if 64-bit values are needed.
+///
+#[doc = shared_vector_docs!()]
 ///
 /// ### Navigation to `impl` blocks within this page
 ///

--- a/godot-core/src/builtin/vectors/vector3i.rs
+++ b/godot-core/src/builtin/vectors/vector3i.rs
@@ -12,7 +12,7 @@ use godot_ffi as sys;
 use sys::{ffi_methods, GodotFfi};
 
 use crate::builtin::math::{GlamConv, GlamType};
-use crate::builtin::{inner, real, RVec3, Vector3, Vector3Axis};
+use crate::builtin::{inner, real, RVec3, Vector2i, Vector3, Vector3Axis};
 
 /// Vector used for 3D math using integer coordinates.
 ///
@@ -96,7 +96,7 @@ impl Vector3i {
     }
 }
 
-impl_vector3x_fns!(Vector3i, i32);
+impl_vector3x_fns!(Vector3i, Vector2i, i32);
 
 impl_vector_operators!(Vector3i, i32, (x, y, z));
 

--- a/godot-core/src/builtin/vectors/vector4.rs
+++ b/godot-core/src/builtin/vectors/vector4.rs
@@ -72,14 +72,9 @@ impl_vector_fns!(Vector4, RVec4, real, (x, y, z, w));
 
 /// # Specialized `Vector4` functions
 impl Vector4 {
-    /// Constructs a new `Vector4` from a [`Vector4i`][crate::builtin::Vector4i].
+    #[deprecated = "Moved to `Vector4i::cast_float()`"]
     pub const fn from_vector4i(v: Vector4i) -> Self {
-        Self {
-            x: v.x as real,
-            y: v.y as real,
-            z: v.z as real,
-            w: v.w as real,
-        }
+        v.cast_float()
     }
 
     #[doc(hidden)]
@@ -89,7 +84,7 @@ impl Vector4 {
     }
 }
 
-impl_float_vector_fns!(Vector4, (x, y, z, w));
+impl_float_vector_fns!(Vector4, Vector4i, (x, y, z, w));
 impl_vector4x_fns!(Vector4, real);
 impl_vector3_vector4_fns!(Vector4, (x, y, z, w));
 

--- a/godot-core/src/builtin/vectors/vector4.rs
+++ b/godot-core/src/builtin/vectors/vector4.rs
@@ -22,6 +22,8 @@ use std::fmt;
 /// is always 64-bit. The engine can be compiled with the option `precision=double` to use 64-bit
 /// vectors; use the gdext library with the `double-precision` feature in that case.
 ///
+#[doc = shared_vector_docs!()]
+///
 /// ### Navigation to `impl` blocks within this page
 ///
 /// - [Constants](#constants)

--- a/godot-core/src/builtin/vectors/vector4i.rs
+++ b/godot-core/src/builtin/vectors/vector4i.rs
@@ -18,10 +18,12 @@ use std::fmt;
 ///
 /// 4-element structure that can be used to represent 4D grid coordinates or sets of integers.
 ///
-/// It uses integer coordinates and is therefore preferable to [`Vector4`] when exact precision is
+/// `Vector4i` uses integer coordinates and is therefore preferable to [`Vector4`] when exact precision is
 /// required. Note that the values are limited to 32 bits, and unlike `Vector4` this cannot be
 /// configured with an engine build option. Use `i64` or [`PackedInt64Array`][crate::builtin::PackedInt64Array]
 /// if 64-bit values are needed.
+///
+#[doc = shared_vector_docs!()]
 ///
 /// ### Navigation to `impl` blocks within this page
 ///

--- a/godot-core/src/builtin/vectors/vector4i.rs
+++ b/godot-core/src/builtin/vectors/vector4i.rs
@@ -71,18 +71,12 @@ impl_vector_fns!(Vector4i, glam::IVec4, i32, (x, y, z, w));
 
 /// # Specialized `Vector4i` functions
 impl Vector4i {
-    inline_impl_integer_vector_fns!(x, y, z, w);
+    inline_impl_integer_vector_fns!(Vector4, x, y, z, w);
 
-    /// Constructs a new `Vector4i` from a [`Vector4`]. The floating point coordinates will be
-    /// truncated.
+    #[deprecated = "Moved to `Vector4::cast_int()`"]
     #[inline]
     pub const fn from_vector4(v: Vector4) -> Self {
-        Self {
-            x: v.x as i32,
-            y: v.y as i32,
-            z: v.z as i32,
-            w: v.w as i32,
-        }
+        v.cast_int()
     }
 
     /// Converts `self` to the corresponding [`real`] `glam` type.

--- a/godot-core/src/builtin/vectors/vector_macros.rs
+++ b/godot-core/src/builtin/vectors/vector_macros.rs
@@ -330,6 +330,37 @@ macro_rules! impl_vector3x_consts {
     };
 }
 
+macro_rules! shared_vector_docs {
+    () => {
+        "Conversions are provided via various `from_*` and `to_*` functions, not via the `From` trait. This encourages `new()` as the main \
+         way to construct vectors, is explicit about the conversion taking place, needs no type inference, and works in `const` contexts."
+    };
+}
+
+macro_rules! tuple_type {
+    ($Scalar:ty; $x:ident, $y:ident) => {
+        ($Scalar, $Scalar)
+    };
+    ($Scalar:ty; $x:ident, $y:ident, $z:ident) => {
+        ($Scalar, $Scalar, $Scalar)
+    };
+    ($Scalar:ty; $x:ident, $y:ident, $z:ident, $w:ident) => {
+        ($Scalar, $Scalar, $Scalar, $Scalar)
+    };
+}
+
+macro_rules! array_type {
+    ($Scalar:ty; $x:ident, $y:ident) => {
+        [$Scalar; 2]
+    };
+    ($Scalar:ty; $x:ident, $y:ident, $z:ident) => {
+        [$Scalar; 3]
+    };
+    ($Scalar:ty; $x:ident, $y:ident, $z:ident, $w:ident) => {
+        [$Scalar; 4]
+    };
+}
+
 /// Implements functions that are present on floating-point and integer vectors.
 macro_rules! impl_vector_fns {
     (
@@ -345,18 +376,46 @@ macro_rules! impl_vector_fns {
         /// # Constructors and general vector functions
         /// The following associated functions and methods are available on all vectors (2D, 3D, 4D; float and int).
         impl $Vector {
-            /// Returns a vector with the given components.
+            /// Creates a vector with the given components.
+            #[inline]
             pub const fn new($($comp: $Scalar),*) -> Self {
                 Self {
                     $( $comp ),*
                 }
             }
 
-            /// Returns a new vector with all components set to `v`.
+            /// Creates a vector with all components set to `v`.
+            #[inline]
             pub const fn splat(v: $Scalar) -> Self {
                 Self {
                     $( $comp: v ),*
                 }
+            }
+
+            /// Creates a vector from the given tuple.
+            #[inline]
+            pub const fn from_tuple(tuple: tuple_type!($Scalar; $($comp),*)) -> Self {
+                let ( $($comp,)* ) = tuple;
+                Self::new( $($comp),* )
+            }
+
+            /// Creates a vector from the given array.
+            #[inline]
+            pub const fn from_array(array: array_type!($Scalar; $($comp),*)) -> Self {
+                let [ $($comp,)* ] = array;
+                Self::new( $($comp),* )
+            }
+
+            /// Returns a tuple with the components of the vector.
+            #[inline]
+            pub const fn to_tuple(&self) -> tuple_type!($Scalar; $($comp),*) {
+                ( $(self.$comp,)* )
+            }
+
+            /// Returns an array with the components of the vector.
+            #[inline]
+            pub const fn to_array(&self) -> array_type!($Scalar; $($comp),*) {
+                [ $(self.$comp,)* ]
             }
 
             /// Converts the corresponding `glam` type to `Self`.

--- a/godot-core/src/builtin/vectors/vector_macros.rs
+++ b/godot-core/src/builtin/vectors/vector_macros.rs
@@ -766,12 +766,20 @@ macro_rules! impl_vector2x_fns {
     (
         // Name of the vector type.
         $Vector:ty,
+        // Name of the 3D-equivalent vector type.
+        $Vector3D:ty,
         // Type of target component, for example `real`.
         $Scalar:ty
     ) => {
         /// # 2D functions
         /// The following methods are only available on 2D vectors (for both float and int).
         impl $Vector {
+            /// Increases dimension to 3D, accepting a new value for the Z component.
+            #[inline]
+            pub fn to_3d(self, z: $Scalar) -> $Vector3D {
+                <$Vector3D>::new(self.x, self.y, z)
+            }
+
             /// Returns the aspect ratio of this vector, the ratio of [`Self::x`] to [`Self::y`].
             #[inline]
             pub fn aspect(self) -> real {
@@ -820,12 +828,23 @@ macro_rules! impl_vector3x_fns {
     (
         // Name of the vector type.
         $Vector:ty,
+        // Name of the vector type.
+        $Vector2D:ty,
         // Type of target component, for example `real`.
         $Scalar:ty
     ) => {
         /// # 3D functions
         /// The following methods are only available on 3D vectors (for both float and int).
         impl $Vector {
+            /// Reduces dimension to 2D, discarding the Z component.
+            ///
+            /// See also [`swizzle!`][crate::builtin::swizzle] for a more general way to extract components.
+            /// `self.to_2d()` is equivalent to `swizzle!(self => x, y)`.
+            #[inline]
+            pub fn to_2d(self) -> $Vector2D {
+                <$Vector2D>::new(self.x, self.y)
+            }
+
             /// Returns the axis of the vector's highest value. See [`Vector3Axis`] enum. If all components are equal, this method returns [`None`].
             ///
             /// To mimic Godot's behavior, unwrap this function's result with `unwrap_or(Vector3Axis::X)`.


### PR DESCRIPTION
### Additions 

- Different representations
  - `from_tuple()` + `to_tuple()`
  - `from_array()` + `to_array()`
- Dimension
  - `to_2d()` 
  - `to_3d(z)`
- Component type (also for `Rect2/Rect2i`)
  - `cast_int()`
  - `cast_float()`
  - inspiration for naming: `ptr::cast_const()`, `ptr::cast_mut()`

### Deprecations
  - deprecate `from_vector2i()` and similar constructors