### PR TITLE
Fix `Ex*` builder parameters: `ObjectArg<T>` -> `impl AsObjectArg<T>`

### DIFF
--- a/godot-codegen/src/conv/type_conversions.rs
+++ b/godot-codegen/src/conv/type_conversions.rs
@@ -236,8 +236,8 @@ fn to_rust_type_uncached(full_ty: &GodotTy, ctx: &mut Context) -> RustTy {
 
         RustTy::EngineClass {
             tokens: quote! { Gd<#qualified_class> },
-            arg_view: quote! { ObjectArg<#qualified_class> },
-            impl_as_arg: quote! { impl AsObjectArg<#qualified_class> },
+            object_arg: quote! { ObjectArg<#qualified_class> },
+            impl_as_object_arg: quote! { impl AsObjectArg<#qualified_class> },
             inner_class: ty,
         }
     }
@@ -266,7 +266,7 @@ fn to_rust_expr_inner(expr: &str, ty: &RustTy, is_inner: bool) -> TokenStream {
             return match ty {
                 RustTy::BuiltinIdent(ident) if ident == "Variant" => quote! { Variant::nil() },
                 RustTy::EngineClass { .. } => {
-                    quote! { ObjectArg::null() }
+                    quote! { Gd::null_arg() }
                 }
                 _ => panic!("null not representable in target type {ty:?}"),
             }

--- a/godot-codegen/src/generator/functions_common.rs
+++ b/godot-codegen/src/generator/functions_common.rs
@@ -320,15 +320,15 @@ pub(crate) fn make_params_exprs<'a>(
         // Objects (Gd<T>) use implicit conversions via AsObjectArg. Only use in non-virtual functions.
         match &param.type_ {
             RustTy::EngineClass {
-                arg_view,
-                impl_as_arg,
+                object_arg,
+                impl_as_object_arg,
                 ..
             } if !is_virtual => {
                 // Parameter declarations in signature: impl AsObjectArg<T>
                 if param_is_impl_asarg {
-                    params.push(quote! { #param_name: #impl_as_arg });
+                    params.push(quote! { #param_name: #impl_as_object_arg });
                 } else {
-                    params.push(quote! { #param_name: #arg_view });
+                    params.push(quote! { #param_name: #object_arg });
                 }
 
                 // Argument names in function body: arg.as_object_arg() vs. arg
@@ -338,7 +338,7 @@ pub(crate) fn make_params_exprs<'a>(
                     arg_names.push(quote! { #param_name });
                 }
 
-                param_types.push(quote! { #arg_view });
+                param_types.push(quote! { #object_arg });
             }
 
             _ => {

--- a/godot-codegen/src/models/domain.rs
+++ b/godot-codegen/src/models/domain.rs
@@ -621,10 +621,10 @@ pub enum RustTy {
         tokens: TokenStream,
 
         /// Tokens with `ObjectArg<T>` (used in `type CallSig` tuple types).
-        arg_view: TokenStream,
+        object_arg: TokenStream,
 
         /// Signature declaration with `impl AsObjectArg<T>`.
-        impl_as_arg: TokenStream,
+        impl_as_object_arg: TokenStream,
 
         /// only inner `T`
         #[allow(dead_code)] // only read in minimal config
@@ -639,9 +639,17 @@ impl RustTy {
     pub fn param_decl(&self) -> TokenStream {
         match self {
             RustTy::EngineClass {
-                arg_view: raw_gd, ..
-            } => raw_gd.clone(),
+                impl_as_object_arg, ..
+            } => impl_as_object_arg.clone(),
             other => other.to_token_stream(),
+        }
+    }
+
+    /// Returns `( <field tokens>, <needs .as_object_arg()> )`.
+    pub fn private_field_decl(&self) -> (TokenStream, bool) {
+        match self {
+            RustTy::EngineClass { object_arg, .. } => (object_arg.clone(), true),
+            other => (other.to_token_stream(), false),
         }
     }
 


### PR DESCRIPTION

Follow-up to #800 -- fixes incorrect codegen:

![image](https://github.com/user-attachments/assets/557f0a22-c84f-4a35-98f5-17b2b60bd4a6)

`ObjectArg<T>` is not part of the public API, so `impl AsObjectArg<T>` should be used instead.