### PR TITLE
`RawGd`: cache pointer to internal storage

### DIFF
--- a/godot-core/src/obj/rtti.rs
+++ b/godot-core/src/obj/rtti.rs
@@ -15,7 +15,7 @@ use crate::obj::{GodotClass, InstanceId};
 /// This is persisted independently of the static type system (e.g. `T` in `Gd<T>`) and can be used to perform sanity checks at runtime.
 ///
 /// See also <https://github.com/godot-rust/gdext/issues/23>.
-#[derive(Debug)]
+#[derive(Debug, Clone)] // Clone is needed to make RawGd::clone() more efficient.
 pub struct ObjectRtti {
     /// Cached instance ID. May point to dead objects.
     instance_id: InstanceId,


### PR DESCRIPTION
Avoids repeated lookups of `InstanceStorage` going through FFI `object_get_instance_binding()`, which also needs locking etc. on Godot side.

Downside is larger size of `RawGd`, however only for user-defined types. We could possibly get raw pointer access through the instance storage in the future.

cc @Ughuuu 