### PR TITLE
`ClassName` now dynamic and faster

### DIFF
--- a/godot-codegen/src/generator/classes.rs
+++ b/godot-codegen/src/generator/classes.rs
@@ -76,7 +76,7 @@ fn make_class(class: &Class, ctx: &mut Context, view: &ApiView) -> GeneratedClas
 
     // Strings
     let godot_class_str = &class_name.godot_ty;
-    let class_name_cstr = util::c_str(&godot_class_str);
+    let class_name_cstr = util::c_str(godot_class_str);
     let virtual_trait_str = class_name.virtual_trait_name();
 
     // Idents and tokens

--- a/godot-codegen/src/generator/classes.rs
+++ b/godot-codegen/src/generator/classes.rs
@@ -4,7 +4,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
-
 use crate::context::{Context, NotificationEnum};
 use crate::generator::functions_common::{FnCode, FnDefinition, FnDefinitions};
 use crate::generator::method_tables::MethodTableKey;
@@ -77,7 +76,7 @@ fn make_class(class: &Class, ctx: &mut Context, view: &ApiView) -> GeneratedClas
 
     // Strings
     let godot_class_str = &class_name.godot_ty;
-    let class_name_cstr = util::cstr_u8_slice(godot_class_str);
+    let class_name_cstr = util::c_str(&godot_class_str);
     let virtual_trait_str = class_name.virtual_trait_name();
 
     // Idents and tokens
@@ -214,8 +213,13 @@ fn make_class(class: &Class, ctx: &mut Context, view: &ApiView) -> GeneratedClas
             impl crate::obj::GodotClass for #class_name {
                 type Base = #base_ty;
 
+                // Code duplicated in godot-macros.
                 fn class_name() -> ClassName {
-                    ClassName::from_ascii_cstr(#class_name_cstr)
+                    // Optimization note: instead of lazy init, could use separate static which is manually initialized during registration.
+                    static CLASS_NAME: std::sync::OnceLock<ClassName> = std::sync::OnceLock::new();
+
+                    let name: &'static ClassName = CLASS_NAME.get_or_init(|| ClassName::alloc_next(#class_name_cstr));
+                    *name
                 }
 
                 const INIT_LEVEL: crate::init::InitLevel = #init_level;

--- a/godot-codegen/src/util.rs
+++ b/godot-codegen/src/util.rs
@@ -5,6 +5,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+// Note: some code duplication with godot-macros crate.
+
 use crate::models::domain::ClassCodegenLevel;
 use crate::models::json::JsonClass;
 use crate::special_cases;
@@ -31,10 +33,14 @@ pub fn make_imports() -> TokenStream {
     }
 }
 
+pub fn c_str(string: &str) -> Literal {
+    let c_string = std::ffi::CString::new(string).expect("CString::new() failed");
+    Literal::c_string(&c_string)
+}
+
 #[cfg(since_api = "4.2")]
 pub fn make_string_name(identifier: &str) -> TokenStream {
-    let c_string = std::ffi::CString::new(identifier).expect("CString::new() failed");
-    let lit = Literal::c_string(&c_string);
+    let lit = c_str(identifier);
 
     quote! { StringName::from(#lit) }
 }
@@ -77,10 +83,6 @@ pub fn get_api_level(class: &JsonClass) -> ClassCodegenLevel {
 
 pub fn ident(s: &str) -> Ident {
     format_ident!("{}", s)
-}
-
-pub fn cstr_u8_slice(string: &str) -> Literal {
-    Literal::byte_string(format!("{string}\0").as_bytes())
 }
 
 // This function is duplicated in godot-macros\src\util\mod.rs

--- a/godot-core/src/init/mod.rs
+++ b/godot-core/src/init/mod.rs
@@ -163,6 +163,12 @@ fn gdext_on_level_deinit(level: InitLevel) {
         // If lowest level is unloaded, call global deinitialization.
         // No business logic by itself, but ensures consistency if re-initialization (hot-reload on Linux) occurs.
 
+        // Garbage-collect various statics.
+        // SAFETY: this is the last time meta APIs are used.
+        unsafe {
+            crate::meta::cleanup();
+        }
+
         // SAFETY: called after all other logic, so no concurrent access.
         // TODO: multithreading must make sure other threads are joined/stopped here.
         unsafe {

--- a/godot-core/src/meta/class_name.rs
+++ b/godot-core/src/meta/class_name.rs
@@ -26,6 +26,17 @@ use crate::obj::GodotClass;
 static CLASS_NAMES: Global<Vec<ClassNameEntry>> = Global::new(|| vec![ClassNameEntry::none()]);
 static DYNAMIC_INDEX_BY_CLASS_TYPE: Global<HashMap<TypeId, u16>> = Global::default();
 
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+
+/// # Safety
+/// Must not use any `ClassName` APIs after this call.
+pub unsafe fn cleanup() {
+    CLASS_NAMES.lock().clear();
+    DYNAMIC_INDEX_BY_CLASS_TYPE.lock().clear();
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+
 /// Entry in the class name cache.
 ///
 /// `StringName` needs to be lazy-initialized because the Godot binding may not be initialized yet.
@@ -177,6 +188,12 @@ impl ClassName {
     }
 }
 
+impl fmt::Display for ClassName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.with_string_name(|s| s.fmt(f))
+    }
+}
+
 /// Adds a new class name to the cache, returning its index.
 fn insert_class(name: ClassNameSource) -> u16 {
     let mut names = CLASS_NAMES.lock();
@@ -187,10 +204,4 @@ fn insert_class(name: ClassNameSource) -> u16 {
 
     names.push(ClassNameEntry::new(name));
     index
-}
-
-impl fmt::Display for ClassName {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.with_string_name(|s| s.fmt(f))
-    }
 }

--- a/godot-core/src/meta/mod.rs
+++ b/godot-core/src/meta/mod.rs
@@ -384,3 +384,11 @@ impl MethodInfo {
         }
     }
 }
+
+/// Clean up various resources at end of usage.
+///
+/// # Safety
+/// Must not use meta facilities (e.g. `ClassName`) after this call.
+pub(crate) unsafe fn cleanup() {
+    class_name::cleanup();
+}

--- a/godot-core/src/meta/signature.rs
+++ b/godot-core/src/meta/signature.rs
@@ -637,7 +637,11 @@ impl<'a> CallContext<'a> {
 
     /// Outbound call from Rust into the engine, via Gd methods.
     pub fn gd<T: GodotClass>(function_name: &'a str) -> Self {
-        let class_name = T::class_name().as_str();
+        let class_name = T::class_name();
+
+        // FIXME no leaks
+        let class_name = class_name.to_string().leak();
+
         Self {
             class_name,
             function_name,

--- a/godot-core/src/meta/signature.rs
+++ b/godot-core/src/meta/signature.rs
@@ -4,7 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
-
+use std::borrow::Cow;
 use std::fmt;
 use std::fmt::Debug;
 
@@ -614,15 +614,15 @@ impl_ptrcall_signature_for_tuple!(R, (p0, 0): P0, (p1, 1): P1, (p2, 2): P2, (p3,
 #[derive(Clone)]
 #[doc(hidden)] // currently exposed in godot::meta
 pub struct CallContext<'a> {
-    pub class_name: &'a str,
-    pub function_name: &'a str,
+    pub(crate) class_name: Cow<'a, str>,
+    pub(crate) function_name: &'a str,
 }
 
 impl<'a> CallContext<'a> {
     /// Call from Godot into a user-defined #[func] function.
     pub const fn func(class_name: &'a str, function_name: &'a str) -> Self {
         Self {
-            class_name,
+            class_name: Cow::Borrowed(class_name),
             function_name,
         }
     }
@@ -630,20 +630,15 @@ impl<'a> CallContext<'a> {
     /// Outbound call from Rust into the engine, class/builtin APIs.
     pub const fn outbound(class_name: &'a str, function_name: &'a str) -> Self {
         Self {
-            class_name,
+            class_name: Cow::Borrowed(class_name),
             function_name,
         }
     }
 
     /// Outbound call from Rust into the engine, via Gd methods.
     pub fn gd<T: GodotClass>(function_name: &'a str) -> Self {
-        let class_name = T::class_name();
-
-        // FIXME no leaks
-        let class_name = class_name.to_string().leak();
-
         Self {
-            class_name,
+            class_name: T::class_name().to_cow_str(),
             function_name,
         }
     }

--- a/godot-core/src/obj/bounds.rs
+++ b/godot-core/src/obj/bounds.rs
@@ -117,7 +117,7 @@ pub(super) mod private {
     ///     type Base = Node;
     ///
     ///     fn class_name() -> ClassName {
-    ///         ClassName::from_ascii_cstr(b"MyClass\0")
+    ///         ClassName::new_cached::<MyClass>(|| "MyClass".to_string())
     ///     }
     /// }
     ///

--- a/godot-core/src/private.rs
+++ b/godot-core/src/private.rs
@@ -121,7 +121,12 @@ pub(crate) fn call_error_remove(in_error: &sys::GDExtensionCallError) -> Option<
 }
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
-// Plugin handling
+// Plugin and global state handling
+
+pub fn next_class_id() -> u16 {
+    static NEXT_CLASS_ID: atomic::AtomicU16 = atomic::AtomicU16::new(0);
+    NEXT_CLASS_ID.fetch_add(1, atomic::Ordering::Relaxed)
+}
 
 pub(crate) fn iterate_plugins(mut visitor: impl FnMut(&ClassPlugin)) {
     sys::plugin_foreach!(__GODOT_PLUGIN_REGISTRY; visitor);

--- a/godot-core/src/registry/class.rs
+++ b/godot-core/src/registry/class.rs
@@ -122,7 +122,7 @@ pub fn register_class<
     };
 
     assert!(
-        !T::class_name().is_empty(),
+        !T::class_name().is_none(),
         "cannot register () or unnamed class"
     );
 

--- a/godot-ffi/src/toolbox.rs
+++ b/godot-ffi/src/toolbox.rs
@@ -363,8 +363,7 @@ mod manual_init_cell {
     /// Similar to a [`OnceLock`](std::sync::OnceLock), but without the overhead of locking for initialization. In most cases the compiler
     /// seems able to optimize `OnceLock` to equivalent code. But this guaranteed does not have any overhead at runtime.
     ///
-    /// This cell additionally allows to deinitialize the value, which is useful in scenarios where the state needs to be reset (e.g.
-    /// hot-reloading on Linux).
+    /// This cell additionally allows to deinitialize the value. Access to uninitialized values is UB, but checked in Debug mode.
     pub(crate) struct ManualInitCell<T> {
         // Invariant: Is `None` until initialized, and then never modified after (except, possibly, through interior mutability).
         cell: UnsafeCell<Option<T>>,

--- a/godot-macros/src/util/mod.rs
+++ b/godot-macros/src/util/mod.rs
@@ -5,7 +5,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-// Note: some code duplication with codegen crate
+// Note: some code duplication with godot-codegen crate.
 
 use crate::ParseResult;
 use proc_macro2::{Delimiter, Group, Ident, Literal, TokenStream, TokenTree};
@@ -22,8 +22,9 @@ pub fn ident(s: &str) -> Ident {
     format_ident!("{}", s)
 }
 
-pub fn cstr_u8_slice(string: &str) -> Literal {
-    Literal::byte_string(format!("{string}\0").as_bytes())
+pub fn c_str(string: &str) -> Literal {
+    let c_string = std::ffi::CString::new(string).expect("CString::new() failed");
+    Literal::c_string(&c_string)
 }
 
 pub fn class_name_obj(class: &impl ToTokens) -> TokenStream {

--- a/itest/rust/src/builtin_tests/script/script_instance_tests.rs
+++ b/itest/rust/src/builtin_tests/script/script_instance_tests.rs
@@ -51,7 +51,7 @@ impl TestScriptInstance {
             method_list: vec![MethodInfo {
                 id: 1,
                 method_name: StringName::from("script_method_a"),
-                class_name: ClassName::from_ascii_cstr("TestScript\0".as_bytes()),
+                class_name: ClassName::new_cached::<TestScript>(|| "TestScript".to_string()),
                 return_type: PropertyInfo::new_var::<GString>(""),
                 arguments: vec![
                     PropertyInfo::new_var::<GString>("arg_a"),

--- a/itest/rust/src/object_tests/class_name_test.rs
+++ b/itest/rust/src/object_tests/class_name_test.rs
@@ -10,6 +10,7 @@ use godot::meta::ClassName;
 use godot::obj::bounds::implement_godot_bounds;
 use godot::obj::GodotClass;
 use godot::sys;
+use std::borrow::Cow;
 
 struct A;
 
@@ -34,6 +35,5 @@ fn class_name_dynamic() {
     assert_eq!(a.to_string(), "A");
     assert_eq!(a.to_gstring(), GString::from("A"));
     assert_eq!(a.to_string_name(), StringName::from("A"));
-
-    a.with_str(|s| assert_eq!(s, "A"));
+    assert_eq!(a.to_cow_str(), Cow::<'static, str>::Owned("A".to_string()));
 }

--- a/itest/rust/src/object_tests/class_name_test.rs
+++ b/itest/rust/src/object_tests/class_name_test.rs
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+use crate::framework::itest;
+use godot::builtin::{GString, StringName};
+use godot::meta::ClassName;
+use godot::obj::bounds::implement_godot_bounds;
+use godot::obj::GodotClass;
+use godot::sys;
+
+struct A;
+
+implement_godot_bounds!(A);
+
+impl GodotClass for A {
+    type Base = godot::classes::Object;
+
+    fn class_name() -> ClassName {
+        ClassName::new_cached::<A>(|| "A".to_string())
+    }
+}
+
+#[itest]
+fn class_name_dynamic() {
+    let a = A::class_name();
+    let b = A::class_name();
+
+    assert_eq!(a, b);
+    assert_eq!(sys::hash_value(&a), sys::hash_value(&b));
+
+    assert_eq!(a.to_string(), "A");
+    assert_eq!(a.to_gstring(), GString::from("A"));
+    assert_eq!(a.to_string_name(), StringName::from("A"));
+
+    a.with_str(|s| assert_eq!(s, "A"));
+}

--- a/itest/rust/src/object_tests/class_rename_test.rs
+++ b/itest/rust/src/object_tests/class_rename_test.rs
@@ -30,6 +30,6 @@ fn renaming_changes_the_name() {
         dont_rename::RepeatMe::class_name(),
         rename::RepeatMe::class_name()
     );
-    assert_eq!(dont_rename::RepeatMe::class_name().as_str(), "RepeatMe");
-    assert_eq!(rename::RepeatMe::class_name().as_str(), "NoRepeat");
+    assert_eq!(dont_rename::RepeatMe::class_name().to_string(), "RepeatMe");
+    assert_eq!(rename::RepeatMe::class_name().to_string(), "NoRepeat");
 }

--- a/itest/rust/src/object_tests/mod.rs
+++ b/itest/rust/src/object_tests/mod.rs
@@ -6,6 +6,7 @@
  */
 
 mod base_test;
+mod class_name_test;
 mod class_rename_test;
 mod dynamic_call_test;
 // `get_property_list` is only supported in Godot 4.3+


### PR DESCRIPTION
Reworks `ClassName` to be faster and more versatile.

It now supports arbitrary `String` values, not just literals. At the same time, `ClassName` is still `Copy`. Names of Godot classes or user ones created via `#[derive(Godot)]` should now resolve their name very quickly, not even hash is needed anymore.

Closes #792. At least the direct suspect is related to `ClassName`, and I think that should (hopefully) be out of the way now. If there are remaining performance problems in this context, please provide profiling information.