### PR TITLE
Fix `Array<T>` registered without element type

### DIFF
--- a/godot-core/src/builtin/collections/array.rs
+++ b/godot-core/src/builtin/collections/array.rs
@@ -906,18 +906,6 @@ impl<T: ArrayElement> Var for Array<T> {
     fn set_property(&mut self, value: Self::Via) {
         *self = FromGodot::from_godot(value)
     }
-
-    #[cfg(since_api = "4.2")]
-    fn property_hint() -> PropertyHintInfo {
-        if T::Ffi::variant_type() == VariantType::NIL {
-            return PropertyHintInfo::with_hint_none("");
-        }
-
-        PropertyHintInfo {
-            hint: crate::global::PropertyHint::ARRAY_TYPE,
-            hint_string: T::godot_type_name().into(),
-        }
-    }
 }
 
 impl<T: ArrayElement + TypeStringHint> Export for Array<T> {
@@ -982,6 +970,20 @@ impl<T: ArrayElement> GodotType for Array<T> {
 
     fn godot_type_name() -> String {
         "Array".to_string()
+    }
+
+    #[cfg(since_api = "4.2")]
+    fn property_hint_info() -> PropertyHintInfo {
+        // Array<Variant>, aka untyped array, has no hints.
+        if T::Ffi::variant_type() == VariantType::NIL {
+            return PropertyHintInfo::none();
+        }
+
+        // Typed arrays use type hint.
+        PropertyHintInfo {
+            hint: crate::global::PropertyHint::ARRAY_TYPE,
+            hint_string: T::godot_type_name().into(),
+        }
     }
 }
 

--- a/godot-core/src/builtin/variant/impls.rs
+++ b/godot-core/src/builtin/variant/impls.rs
@@ -10,8 +10,8 @@ use crate::builtin::*;
 use crate::global;
 use crate::meta::error::{ConvertError, FromVariantError};
 use crate::meta::{ArrayElement, GodotFfiVariant, GodotType, PropertyInfo};
+use crate::registry::property::PropertyHintInfo;
 use godot_ffi as sys;
-
 // For godot-cpp, see https://github.com/godotengine/godot-cpp/blob/master/include/godot_cpp/core/type_info.hpp.
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
@@ -212,8 +212,7 @@ impl GodotType for Variant {
             variant_type: Self::variant_type(),
             class_name: Self::class_name(),
             property_name: StringName::from(property_name),
-            hint: global::PropertyHint::NONE,
-            hint_string: GString::new(),
+            hint_info: PropertyHintInfo::none(),
             usage: global::PropertyUsageFlags::DEFAULT | global::PropertyUsageFlags::NIL_IS_VARIANT,
         }
     }

--- a/godot-core/src/meta/godot_convert/impls.rs
+++ b/godot-core/src/meta/godot_convert/impls.rs
@@ -12,8 +12,8 @@ use crate::meta::{
     ToGodot,
 };
 use crate::registry::method::MethodParamOrReturnInfo;
+use crate::registry::property::PropertyHintInfo;
 use godot_ffi as sys;
-
 // The following ToGodot/FromGodot/Convert impls are auto-generated for each engine type, co-located with their definitions:
 // - enum
 // - const/mut pointer to native struct
@@ -62,6 +62,10 @@ where
 
     fn property_info(property_name: &str) -> PropertyInfo {
         T::property_info(property_name)
+    }
+
+    fn property_hint_info() -> PropertyHintInfo {
+        T::property_hint_info()
     }
 
     fn argument_info(property_name: &str) -> MethodParamOrReturnInfo {

--- a/godot-core/src/meta/mod.rs
+++ b/godot-core/src/meta/mod.rs
@@ -89,13 +89,12 @@ pub struct PropertyInfo {
     /// The name of this property in Godot.
     pub property_name: StringName,
 
-    /// How the property is meant to be edited. See also [`PropertyHint`] in the Godot docs.
+    /// Additional type information for this property, e.g. about array types or enum values. Split into `hint` and `hint_string` members.
+    ///
+    /// See also [`PropertyHint`] in the Godot docs.
     ///
     /// [`PropertyHint`]: https://docs.godotengine.org/en/latest/classes/class_%40globalscope.html#enum-globalscope-propertyhint
-    pub hint: PropertyHint,
-
-    /// Extra information passed to Godot for this property, what this means depends on the `hint` value.
-    pub hint_string: GString,
+    pub hint_info: PropertyHintInfo,
 
     /// How this property should be used. See [`PropertyUsageFlags`] in Godot for the meaning.
     ///
@@ -148,13 +147,7 @@ impl PropertyInfo {
     ///     ));
     /// ```
     pub fn with_hint_info(self, hint_info: PropertyHintInfo) -> Self {
-        let PropertyHintInfo { hint, hint_string } = hint_info;
-
-        Self {
-            hint,
-            hint_string,
-            ..self
-        }
+        Self { hint_info, ..self }
     }
 
     /// Create a new `PropertyInfo` representing a group in Godot.
@@ -166,8 +159,10 @@ impl PropertyInfo {
             variant_type: VariantType::NIL,
             class_name: ClassName::none(),
             property_name: group_name.into(),
-            hint: PropertyHint::NONE,
-            hint_string: group_prefix.into(),
+            hint_info: PropertyHintInfo {
+                hint: PropertyHint::NONE,
+                hint_string: group_prefix.into(),
+            },
             usage: PropertyUsageFlags::GROUP,
         }
     }
@@ -181,8 +176,10 @@ impl PropertyInfo {
             variant_type: VariantType::NIL,
             class_name: ClassName::none(),
             property_name: subgroup_name.into(),
-            hint: PropertyHint::NONE,
-            hint_string: subgroup_prefix.into(),
+            hint_info: PropertyHintInfo {
+                hint: PropertyHint::NONE,
+                hint_string: subgroup_prefix.into(),
+            },
             usage: PropertyUsageFlags::SUBGROUP,
         }
     }
@@ -196,8 +193,8 @@ impl PropertyInfo {
             type_: self.variant_type.sys(),
             name: sys::SysPtr::force_mut(self.property_name.string_sys()),
             class_name: sys::SysPtr::force_mut(self.class_name.string_sys()),
-            hint: u32::try_from(self.hint.ord()).expect("hint.ord()"),
-            hint_string: sys::SysPtr::force_mut(self.hint_string.string_sys()),
+            hint: u32::try_from(self.hint_info.hint.ord()).expect("hint.ord()"),
+            hint_string: sys::SysPtr::force_mut(self.hint_info.hint_string.string_sys()),
             usage: u32::try_from(self.usage.ord()).expect("usage.ord()"),
         }
     }
@@ -228,8 +225,8 @@ impl PropertyInfo {
             type_: self.variant_type.sys(),
             name: self.property_name.into_owned_string_sys(),
             class_name: sys::SysPtr::force_mut(self.class_name.string_sys()),
-            hint: u32::try_from(self.hint.ord()).expect("hint.ord()"),
-            hint_string: self.hint_string.into_owned_string_sys(),
+            hint: u32::try_from(self.hint_info.hint.ord()).expect("hint.ord()"),
+            hint_string: self.hint_info.hint_string.into_owned_string_sys(),
             usage: u32::try_from(self.usage.ord()).expect("usage.ord()"),
         }
     }

--- a/godot-core/src/meta/traits.rs
+++ b/godot-core/src/meta/traits.rs
@@ -7,13 +7,14 @@
 
 use godot_ffi as sys;
 
-use crate::builtin::{GString, StringName, Variant};
-use crate::global::{PropertyHint, PropertyUsageFlags};
+use crate::builtin::{StringName, Variant};
+use crate::global::PropertyUsageFlags;
 use crate::meta::error::ConvertError;
 use crate::meta::{sealed, ClassName, FromGodot, GodotConvert, PropertyInfo, ToGodot};
 use crate::registry::method::MethodParamOrReturnInfo;
 
 // Re-export sys traits in this module, so all are in one place.
+use crate::registry::property::PropertyHintInfo;
 pub use sys::{GodotFfi, GodotNullableFfi};
 
 /// Conversion of [`GodotFfi`] types to/from [`Variant`].
@@ -73,10 +74,14 @@ pub trait GodotType:
             variant_type: Self::Ffi::variant_type(),
             class_name: Self::class_name(),
             property_name: StringName::from(property_name),
-            hint: PropertyHint::NONE,
-            hint_string: GString::new(),
+            hint_info: Self::property_hint_info(),
             usage: PropertyUsageFlags::DEFAULT,
         }
+    }
+
+    #[doc(hidden)]
+    fn property_hint_info() -> PropertyHintInfo {
+        PropertyHintInfo::none()
     }
 
     #[doc(hidden)]

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -374,9 +374,8 @@ impl<T: GodotClass> Gd<T> {
 
     /// **Downcast:** try to convert into a smart pointer to a derived class.
     ///
-    /// If `T`'s dynamic type is not `Derived` or one of its subclasses, `None` is returned
-    /// and the reference is dropped. Otherwise, `Some` is returned and the ownership is moved
-    /// to the returned value.
+    /// If `T`'s dynamic type is not `Derived` or one of its subclasses, `Err(self)` is returned, meaning you can reuse the original
+    /// object for further casts.
     pub fn try_cast<Derived>(self) -> Result<Gd<Derived>, Self>
     where
         Derived: GodotClass + Inherits<T>,

--- a/godot-core/src/obj/onready.rs
+++ b/godot-core/src/obj/onready.rs
@@ -9,7 +9,7 @@ use crate::builtin::NodePath;
 use crate::classes::Node;
 use crate::meta::GodotConvert;
 use crate::obj::{Gd, GodotClass, Inherits};
-use crate::registry::property::{PropertyHintInfo, Var};
+use crate::registry::property::Var;
 use std::mem;
 
 /// Ergonomic late-initialization container with `ready()` support.
@@ -266,10 +266,6 @@ impl<T: Var> Var for OnReady<T> {
     fn set_property(&mut self, value: Self::Via) {
         let deref: &mut T = self;
         deref.set_property(value);
-    }
-
-    fn property_hint() -> PropertyHintInfo {
-        T::property_hint()
     }
 }
 

--- a/godot-core/src/registry/property.rs
+++ b/godot-core/src/registry/property.rs
@@ -35,8 +35,9 @@ pub trait Var: GodotConvert {
     fn get_property(&self) -> Self::Via;
     fn set_property(&mut self, value: Self::Via);
 
+    /// Specific property hints, only override if they deviate from [`GodotType::property_info`], e.g. for enums/newtypes.
     fn property_hint() -> PropertyHintInfo {
-        PropertyHintInfo::with_hint_none("")
+        Self::Via::property_hint_info()
     }
 }
 
@@ -119,6 +120,14 @@ pub struct PropertyHintInfo {
 }
 
 impl PropertyHintInfo {
+    /// Create a new `PropertyHintInfo` with a property hint of [`PROPERTY_HINT_NONE`](PropertyHint::NONE), and no hint string.
+    pub fn none() -> Self {
+        Self {
+            hint: PropertyHint::NONE,
+            hint_string: GString::new(),
+        }
+    }
+
     /// Create a new `PropertyHintInfo` with a property hint of [`PROPERTY_HINT_NONE`](PropertyHint::NONE).
     ///
     /// Starting with Godot version 4.3, the hint string will always be the empty string. Before that, the hint string is set to

--- a/godot-macros/src/class/data_models/property.rs
+++ b/godot-macros/src/class/data_models/property.rs
@@ -169,8 +169,10 @@ pub fn make_property_impl(class_name: &Ident, fields: &Fields) -> TokenStream {
                 variant_type: #field_variant_type,
                 class_name: #field_class_name,
                 property_name: #field_name.into(),
-                hint,
-                hint_string,
+                hint_info: ::godot::register::property::PropertyHintInfo {
+                    hint,
+                    hint_string,
+                },
                 usage,
             };
 

--- a/itest/rust/src/object_tests/get_property_list_test.rs
+++ b/itest/rust/src/object_tests/get_property_list_test.rs
@@ -38,8 +38,8 @@ fn property_dict_eq_property_info(dict: &Dictionary, info: &PropertyInfo) -> boo
     dict.get("name").unwrap().to::<GString>().to_string() == info.property_name.to_string()
         && dict.get("class_name").unwrap().to::<StringName>() == info.class_name.to_string_name()
         && dict.get("type").unwrap().to::<VariantType>() == info.variant_type
-        && dict.get("hint").unwrap().to::<PropertyHint>() == info.hint
-        && dict.get("hint_string").unwrap().to::<GString>() == info.hint_string
+        && dict.get("hint").unwrap().to::<PropertyHint>() == info.hint_info.hint
+        && dict.get("hint_string").unwrap().to::<GString>() == info.hint_info.hint_string
         && dict.get("usage").unwrap().to::<PropertyUsageFlags>() == info.usage
 }
 


### PR DESCRIPTION
Since it's hard to see in the diff, the actual bugfix is moving `Var::property_hint()` one level up to `GodotType::property_hint_info()`, so that it is also picked up by `#[func]` parameter/return types.

Reuses `PropertyHintInfo` inside `PropertyInfo`. More refactorings to come.

Fixes #324. 