### PR TITLE
Simplify property hint APIs

### DIFF
--- a/godot-core/src/builtin/collections/array.rs
+++ b/godot-core/src/builtin/collections/array.rs
@@ -895,8 +895,21 @@ impl<T: ArrayElement> Var for Array<T> {
     fn get_property(&self) -> Self::Via {
         self.to_godot()
     }
+
     fn set_property(&mut self, value: Self::Via) {
         *self = FromGodot::from_godot(value)
+    }
+
+    fn property_hint() -> PropertyHintInfo {
+        // For array #[var], the hint string is "PackedInt32Array", "Node" etc. for typed arrays, and "" for untyped arrays.
+        if Self::has_variant_t() {
+            PropertyHintInfo::none()
+        } else if sys::GdextBuild::since_api("4.2") {
+            PropertyHintInfo::var_array_element::<T>()
+        } else {
+            // Godot 4.1 was missing PropertyHint::ARRAY_TYPE, so we use the type name instead.
+            PropertyHintInfo::none()
+        }
     }
 }
 
@@ -906,7 +919,7 @@ impl<T: ArrayElement> Export for Array<T> {
         if Self::has_variant_t() {
             PropertyHintInfo::with_type_name::<VariantArray>()
         } else {
-            PropertyHintInfo::with_array_element::<T>()
+            PropertyHintInfo::export_array_element::<T>()
         }
     }
 }

--- a/godot-core/src/builtin/collections/array.rs
+++ b/godot-core/src/builtin/collections/array.rs
@@ -900,7 +900,7 @@ impl<T: ArrayElement> Var for Array<T> {
         *self = FromGodot::from_godot(value)
     }
 
-    fn property_hint() -> PropertyHintInfo {
+    fn var_hint() -> PropertyHintInfo {
         // For array #[var], the hint string is "PackedInt32Array", "Node" etc. for typed arrays, and "" for untyped arrays.
         if Self::has_variant_t() {
             PropertyHintInfo::none()
@@ -914,10 +914,10 @@ impl<T: ArrayElement> Var for Array<T> {
 }
 
 impl<T: ArrayElement> Export for Array<T> {
-    fn default_export_info() -> PropertyHintInfo {
+    fn export_hint() -> PropertyHintInfo {
         // If T == Variant, then we return "Array" builtin type hint.
         if Self::has_variant_t() {
-            PropertyHintInfo::with_type_name::<VariantArray>()
+            PropertyHintInfo::type_name::<VariantArray>()
         } else {
             PropertyHintInfo::export_array_element::<T>()
         }

--- a/godot-core/src/builtin/collections/array.rs
+++ b/godot-core/src/builtin/collections/array.rs
@@ -11,9 +11,10 @@ use std::marker::PhantomData;
 use crate::builtin::*;
 use crate::meta::error::{ConvertError, FromGodotError, FromVariantError};
 use crate::meta::{
-    ArrayElement, ArrayTypeInfo, FromGodot, GodotConvert, GodotFfiVariant, GodotType, ToGodot,
+    ArrayElement, ArrayTypeInfo, FromGodot, GodotConvert, GodotFfiVariant, GodotType,
+    PropertyHintInfo, ToGodot,
 };
-use crate::registry::property::{Export, PropertyHintInfo, Var};
+use crate::registry::property::{Export, Var};
 use godot_ffi as sys;
 use sys::{ffi_methods, interface_fn, GodotFfi};
 
@@ -907,7 +908,7 @@ impl<T: ArrayElement> Var for Array<T> {
         } else if sys::GdextBuild::since_api("4.2") {
             PropertyHintInfo::var_array_element::<T>()
         } else {
-            // Godot 4.1 was missing PropertyHint::ARRAY_TYPE, so we use the type name instead.
+            // Godot 4.1 was not using PropertyHint::ARRAY_TYPE, but the empty hint instead.
             PropertyHintInfo::none()
         }
     }

--- a/godot-core/src/builtin/collections/dictionary.rs
+++ b/godot-core/src/builtin/collections/dictionary.rs
@@ -9,7 +9,6 @@ use godot_ffi as sys;
 
 use crate::builtin::{inner, Variant, VariantArray};
 use crate::meta::{FromGodot, ToGodot};
-use crate::registry::property::{Export, PropertyHintInfo, Var};
 use sys::types::OpaqueDictionary;
 use sys::{ffi_methods, interface_fn, GodotFfi};
 
@@ -397,22 +396,6 @@ impl Clone for Dictionary {
                 ctor(self_ptr, args.as_ptr());
             })
         }
-    }
-}
-
-impl Var for Dictionary {
-    fn get_property(&self) -> Self::Via {
-        self.to_godot()
-    }
-
-    fn set_property(&mut self, value: Self::Via) {
-        *self = FromGodot::from_godot(value)
-    }
-}
-
-impl Export for Dictionary {
-    fn default_export_info() -> PropertyHintInfo {
-        PropertyHintInfo::with_hint_none("Dictionary")
     }
 }
 

--- a/godot-core/src/builtin/collections/dictionary.rs
+++ b/godot-core/src/builtin/collections/dictionary.rs
@@ -9,9 +9,7 @@ use godot_ffi as sys;
 
 use crate::builtin::{inner, Variant, VariantArray};
 use crate::meta::{FromGodot, ToGodot};
-use crate::registry::property::{
-    builtin_type_string, Export, PropertyHintInfo, TypeStringHint, Var,
-};
+use crate::registry::property::{Export, PropertyHintInfo, Var};
 use sys::types::OpaqueDictionary;
 use sys::{ffi_methods, interface_fn, GodotFfi};
 
@@ -409,12 +407,6 @@ impl Var for Dictionary {
 
     fn set_property(&mut self, value: Self::Via) {
         *self = FromGodot::from_godot(value)
-    }
-}
-
-impl TypeStringHint for Dictionary {
-    fn type_string() -> String {
-        builtin_type_string::<Dictionary>()
     }
 }
 

--- a/godot-core/src/builtin/collections/packed_array.rs
+++ b/godot-core/src/builtin/collections/packed_array.rs
@@ -548,7 +548,7 @@ macro_rules! impl_packed_array {
             fn default_export_info() -> $crate::registry::property::PropertyHintInfo {
                 // In 4.3 Godot can (and does) use type hint strings for packed arrays, see https://github.com/godotengine/godot/pull/82952.
                 if sys::GdextBuild::since_api("4.3") {
-                    $crate::registry::property::PropertyHintInfo::with_array_element::<$Element>()
+                    $crate::registry::property::PropertyHintInfo::export_array_element::<$Element>()
                 } else {
                     $crate::registry::property::PropertyHintInfo::with_type_name::<$PackedArray>()
                 }

--- a/godot-core/src/builtin/collections/packed_array.rs
+++ b/godot-core/src/builtin/collections/packed_array.rs
@@ -548,14 +548,9 @@ macro_rules! impl_packed_array {
             fn default_export_info() -> $crate::registry::property::PropertyHintInfo {
                 // In 4.3 Godot can (and does) use type hint strings for packed arrays, see https://github.com/godotengine/godot/pull/82952.
                 if sys::GdextBuild::since_api("4.3") {
-                    $crate::registry::property::PropertyHintInfo {
-                        hint: $crate::global::PropertyHint::TYPE_STRING,
-                        hint_string: <$Element as $crate::registry::property::TypeStringHint>::type_string().into(),
-                    }
+                    $crate::registry::property::PropertyHintInfo::with_array_element::<$Element>()
                 } else {
-                    $crate::registry::property::PropertyHintInfo::with_hint_none(
-                        <$PackedArray as $crate::meta::GodotType>::godot_type_name()
-                    )
+                    $crate::registry::property::PropertyHintInfo::with_type_name::<$PackedArray>()
                 }
             }
         }

--- a/godot-core/src/builtin/collections/packed_array.rs
+++ b/godot-core/src/builtin/collections/packed_array.rs
@@ -545,12 +545,12 @@ macro_rules! impl_packed_array {
         $crate::meta::impl_godot_as_self!($PackedArray);
 
         impl $crate::registry::property::Export for $PackedArray {
-            fn export_hint() -> $crate::registry::property::PropertyHintInfo {
+            fn export_hint() -> $crate::meta::PropertyHintInfo {
                 // In 4.3 Godot can (and does) use type hint strings for packed arrays, see https://github.com/godotengine/godot/pull/82952.
                 if sys::GdextBuild::since_api("4.3") {
-                    $crate::registry::property::PropertyHintInfo::export_array_element::<$Element>()
+                    $crate::meta::PropertyHintInfo::export_array_element::<$Element>()
                 } else {
-                    $crate::registry::property::PropertyHintInfo::type_name::<$PackedArray>()
+                    $crate::meta::PropertyHintInfo::type_name::<$PackedArray>()
                 }
             }
         }

--- a/godot-core/src/builtin/collections/packed_array.rs
+++ b/godot-core/src/builtin/collections/packed_array.rs
@@ -545,12 +545,12 @@ macro_rules! impl_packed_array {
         $crate::meta::impl_godot_as_self!($PackedArray);
 
         impl $crate::registry::property::Export for $PackedArray {
-            fn default_export_info() -> $crate::registry::property::PropertyHintInfo {
+            fn export_hint() -> $crate::registry::property::PropertyHintInfo {
                 // In 4.3 Godot can (and does) use type hint strings for packed arrays, see https://github.com/godotengine/godot/pull/82952.
                 if sys::GdextBuild::since_api("4.3") {
                     $crate::registry::property::PropertyHintInfo::export_array_element::<$Element>()
                 } else {
-                    $crate::registry::property::PropertyHintInfo::with_type_name::<$PackedArray>()
+                    $crate::registry::property::PropertyHintInfo::type_name::<$PackedArray>()
                 }
             }
         }

--- a/godot-core/src/builtin/variant/impls.rs
+++ b/godot-core/src/builtin/variant/impls.rs
@@ -9,8 +9,7 @@ use super::*;
 use crate::builtin::*;
 use crate::global;
 use crate::meta::error::{ConvertError, FromVariantError};
-use crate::meta::{ArrayElement, GodotFfiVariant, GodotType, PropertyInfo};
-use crate::registry::property::PropertyHintInfo;
+use crate::meta::{ArrayElement, GodotFfiVariant, GodotType, PropertyHintInfo, PropertyInfo};
 use godot_ffi as sys;
 // For godot-cpp, see https://github.com/godotengine/godot-cpp/blob/master/include/godot_cpp/core/type_info.hpp.
 

--- a/godot-core/src/meta/godot_convert/impls.rs
+++ b/godot-core/src/meta/godot_convert/impls.rs
@@ -8,12 +8,12 @@
 use crate::builtin::Variant;
 use crate::meta::error::{ConvertError, FromFfiError, FromVariantError};
 use crate::meta::{
-    ArrayElement, ClassName, FromGodot, GodotConvert, GodotNullableFfi, GodotType, PropertyInfo,
-    ToGodot,
+    ArrayElement, ClassName, FromGodot, GodotConvert, GodotNullableFfi, GodotType,
+    PropertyHintInfo, PropertyInfo, ToGodot,
 };
 use crate::registry::method::MethodParamOrReturnInfo;
-use crate::registry::property::PropertyHintInfo;
 use godot_ffi as sys;
+
 // The following ToGodot/FromGodot/Convert impls are auto-generated for each engine type, co-located with their definitions:
 // - enum
 // - const/mut pointer to native struct

--- a/godot-core/src/meta/method_info.rs
+++ b/godot-core/src/meta/method_info.rs
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+use crate::builtin::{StringName, Variant};
+use crate::global::MethodFlags;
+use crate::meta::{ClassName, PropertyInfo};
+use crate::sys;
+use godot_ffi::conv::u32_to_usize;
+
+/// Describes a method in Godot.
+///
+/// Abstraction of the low-level `sys::GDExtensionMethodInfo`.
+// Currently used for ScriptInstance.
+// TODO check overlap with (private) ClassMethodInfo.
+#[derive(Debug, Clone)]
+pub struct MethodInfo {
+    pub id: i32,
+    pub method_name: StringName,
+    pub class_name: ClassName,
+    pub return_type: PropertyInfo,
+    pub arguments: Vec<PropertyInfo>,
+    pub default_arguments: Vec<Variant>,
+    pub flags: MethodFlags,
+}
+
+impl MethodInfo {
+    /// Consumes self and turns it into a `sys::GDExtensionMethodInfo`, should be used together with
+    /// [`free_owned_method_sys`](Self::free_owned_method_sys).
+    ///
+    /// This will leak memory unless used together with `free_owned_method_sys`.
+    pub fn into_owned_method_sys(self) -> sys::GDExtensionMethodInfo {
+        use crate::obj::EngineBitfield as _;
+
+        // Destructure self to ensure all fields are used.
+        let Self {
+            id,
+            method_name,
+            // TODO: Do we need this?
+            class_name: _class_name,
+            return_type,
+            arguments,
+            default_arguments,
+            flags,
+        } = self;
+
+        let argument_count: u32 = arguments
+            .len()
+            .try_into()
+            .expect("cannot have more than `u32::MAX` arguments");
+        let arguments = arguments
+            .into_iter()
+            .map(|arg| arg.into_owned_property_sys())
+            .collect::<Box<[_]>>();
+        let arguments = Box::leak(arguments).as_mut_ptr();
+
+        let default_argument_count: u32 = default_arguments
+            .len()
+            .try_into()
+            .expect("cannot have more than `u32::MAX` default arguments");
+        let default_argument = default_arguments
+            .into_iter()
+            .map(|arg| arg.into_owned_var_sys())
+            .collect::<Box<[_]>>();
+        let default_arguments = Box::leak(default_argument).as_mut_ptr();
+
+        sys::GDExtensionMethodInfo {
+            id,
+            name: method_name.into_owned_string_sys(),
+            return_value: return_type.into_owned_property_sys(),
+            argument_count,
+            arguments,
+            default_argument_count,
+            default_arguments,
+            flags: flags.ord().try_into().expect("flags should be valid"),
+        }
+    }
+
+    /// Properly frees a `sys::GDExtensionMethodInfo` created by [`into_owned_method_sys`](Self::into_owned_method_sys).
+    ///
+    /// # Safety
+    ///
+    /// * Must only be used on a struct returned from a call to `into_owned_method_sys`, without modification.
+    /// * Must not be called more than once on a `sys::GDExtensionMethodInfo` struct.
+    #[deny(unsafe_op_in_unsafe_fn)]
+    pub unsafe fn free_owned_method_sys(info: sys::GDExtensionMethodInfo) {
+        // Destructure info to ensure all fields are used.
+        let sys::GDExtensionMethodInfo {
+            name,
+            return_value,
+            flags: _flags,
+            id: _id,
+            argument_count,
+            arguments,
+            default_argument_count,
+            default_arguments,
+        } = info;
+
+        // SAFETY: `name` is a pointer that was returned from `StringName::into_owned_string_sys`, and has not been freed before this.
+        let _name = unsafe { StringName::from_owned_string_sys(name) };
+
+        // SAFETY: `return_value` is a pointer that was returned from `PropertyInfo::into_owned_property_sys`, and has not been freed before
+        // this.
+        unsafe { PropertyInfo::free_owned_property_sys(return_value) };
+
+        // SAFETY:
+        // - `from_raw_parts_mut`: `arguments` comes from `as_mut_ptr()` on a mutable slice of length `argument_count`, and no other
+        //    accesses to the pointer happens for the lifetime of the slice.
+        // - `Box::from_raw`: The slice was returned from a call to `Box::leak`, and we have ownership of the value behind this pointer.
+        let arguments = unsafe {
+            let slice = std::slice::from_raw_parts_mut(arguments, u32_to_usize(argument_count));
+
+            Box::from_raw(slice)
+        };
+
+        for info in arguments.iter() {
+            // SAFETY: These infos were originally created from a call to `PropertyInfo::into_owned_property_sys`, and this method
+            // will not be called again on this pointer.
+            unsafe { PropertyInfo::free_owned_property_sys(*info) }
+        }
+
+        // SAFETY:
+        // - `from_raw_parts_mut`: `default_arguments` comes from `as_mut_ptr()` on a mutable slice of length `default_argument_count`, and no
+        //    other accesses to the pointer happens for the lifetime of the slice.
+        // - `Box::from_raw`: The slice was returned from a call to `Box::leak`, and we have ownership of the value behind this pointer.
+        let default_arguments = unsafe {
+            let slice = std::slice::from_raw_parts_mut(
+                default_arguments,
+                u32_to_usize(default_argument_count),
+            );
+
+            Box::from_raw(slice)
+        };
+
+        for variant in default_arguments.iter() {
+            // SAFETY: These pointers were originally created from a call to `Variant::into_owned_var_sys`, and this method will not be
+            // called again on this pointer.
+            let _variant = unsafe { Variant::from_owned_var_sys(*variant) };
+        }
+    }
+}

--- a/godot-core/src/meta/mod.rs
+++ b/godot-core/src/meta/mod.rs
@@ -107,15 +107,14 @@ impl PropertyInfo {
     ///
     /// This will generate property info equivalent to what a `#[var]` attribute would.
     pub fn new_var<T: Var>(property_name: &str) -> Self {
-        <T as GodotConvert>::Via::property_info(property_name).with_hint_info(T::property_hint())
+        <T as GodotConvert>::Via::property_info(property_name).with_hint_info(T::var_hint())
     }
 
     /// Create a new `PropertyInfo` representing an exported property named `property_name` with type `T`.
     ///
     /// This will generate property info equivalent to what an `#[export]` attribute would.
     pub fn new_export<T: Export>(property_name: &str) -> Self {
-        <T as GodotConvert>::Via::property_info(property_name)
-            .with_hint_info(T::default_export_info())
+        <T as GodotConvert>::Via::property_info(property_name).with_hint_info(T::export_hint())
     }
 
     /// Change the `hint` and `hint_string` to be the given `hint_info`.

--- a/godot-core/src/meta/mod.rs
+++ b/godot-core/src/meta/mod.rs
@@ -24,9 +24,9 @@
 //!
 //! ## Variants
 //!
-//! [`ToGodot`] and [`FromGodot`] also implement a conversion to/from [`Variant`], which is the most versatile Godot type. This conversion is
-//! available via `to_variant()` and `from_variant()` methods. These methods are also available directly on `Variant` itself, via `to()`,
-//! `try_to()` and `from()` functions.
+//! [`ToGodot`] and [`FromGodot`] also implement a conversion to/from [`Variant`][crate::builtin::Variant], which is the most versatile Godot
+//! type. This conversion is available via `to_variant()` and `from_variant()` methods. These methods are also available directly on `Variant`
+//! itself, via `to()`, `try_to()` and `from()` functions.
 //!
 //! ## Class conversions
 //!
@@ -37,6 +37,8 @@
 mod array_type_info;
 mod class_name;
 mod godot_convert;
+mod method_info;
+mod property_info;
 mod sealed;
 mod signature;
 mod traits;
@@ -44,18 +46,13 @@ mod traits;
 pub mod error;
 pub use class_name::ClassName;
 pub use godot_convert::{FromGodot, GodotConvert, ToGodot};
-use sys::conv::u32_to_usize;
 pub use traits::{ArrayElement, GodotType};
 
 pub(crate) use crate::impl_godot_as_self;
 pub(crate) use array_type_info::ArrayTypeInfo;
 pub(crate) use traits::{GodotFfiVariant, GodotNullableFfi};
 
-use crate::builtin::*;
-use crate::global::{MethodFlags, PropertyHint, PropertyUsageFlags};
 use crate::registry::method::MethodParamOrReturnInfo;
-use crate::registry::property::{Export, PropertyHintInfo, Var};
-use godot_ffi as sys;
 
 #[doc(hidden)]
 pub use signature::*;
@@ -63,323 +60,10 @@ pub use signature::*;
 #[cfg(feature = "trace")]
 pub use signature::trace;
 
-// ----------------------------------------------------------------------------------------------------------------------------------------------
-
-/// Describes a property in Godot.
-///
-/// Abstraction of the low-level `sys::GDExtensionPropertyInfo`.
-///
-/// Keeps the actual allocated values (the `sys` equivalent only keeps pointers, which fall out of scope).
-#[derive(Debug, Clone)]
-// Note: is not #[non_exhaustive], so adding fields is a breaking change. Mostly used internally at the moment though.
-pub struct PropertyInfo {
-    /// Which type this property has.
-    ///
-    /// For objects this should be set to [`VariantType::OBJECT`], and the `class_name` field to the actual name of the class.
-    ///
-    /// For [`Variant`] this should be set to [`VariantType::NIL`].
-    pub variant_type: VariantType,
-
-    /// Which class this property is.
-    ///
-    /// This should be set to [`ClassName::none()`] unless the variant type is `Object`. You can use
-    /// [`GodotClass::class_name()`](crate::obj::GodotClass::class_name()) to get the right name to use here.
-    pub class_name: ClassName,
-
-    /// The name of this property in Godot.
-    pub property_name: StringName,
-
-    /// Additional type information for this property, e.g. about array types or enum values. Split into `hint` and `hint_string` members.
-    ///
-    /// See also [`PropertyHint`] in the Godot docs.
-    ///
-    /// [`PropertyHint`]: https://docs.godotengine.org/en/latest/classes/class_%40globalscope.html#enum-globalscope-propertyhint
-    pub hint_info: PropertyHintInfo,
-
-    /// How this property should be used. See [`PropertyUsageFlags`] in Godot for the meaning.
-    ///
-    /// [`PropertyUsageFlags`]: https://docs.godotengine.org/en/latest/classes/class_%40globalscope.html#enum-globalscope-propertyusageflags
-    pub usage: PropertyUsageFlags,
-}
-
-impl PropertyInfo {
-    /// Create a new `PropertyInfo` representing a property named `property_name` with type `T`.
-    ///
-    /// This will generate property info equivalent to what a `#[var]` attribute would.
-    pub fn new_var<T: Var>(property_name: &str) -> Self {
-        <T as GodotConvert>::Via::property_info(property_name).with_hint_info(T::var_hint())
-    }
-
-    /// Create a new `PropertyInfo` representing an exported property named `property_name` with type `T`.
-    ///
-    /// This will generate property info equivalent to what an `#[export]` attribute would.
-    pub fn new_export<T: Export>(property_name: &str) -> Self {
-        <T as GodotConvert>::Via::property_info(property_name).with_hint_info(T::export_hint())
-    }
-
-    /// Change the `hint` and `hint_string` to be the given `hint_info`.
-    ///
-    /// See [`export_info_functions`](crate::registry::property::export_info_functions) for functions that return appropriate `PropertyHintInfo`s for
-    /// various Godot annotations.
-    ///
-    /// # Examples
-    ///
-    /// Creating an `@export_range` property.
-    ///
-    // TODO: Make this nicer to use.
-    /// ```no_run
-    /// use godot::register::property::export_info_functions;
-    /// use godot::meta::PropertyInfo;
-    ///
-    /// let property = PropertyInfo::new_export::<f64>("my_range_property")
-    ///     .with_hint_info(export_info_functions::export_range(
-    ///         0.0,
-    ///         10.0,
-    ///         Some(0.1),
-    ///         false,
-    ///         false,
-    ///         false,
-    ///         false,
-    ///         false,
-    ///         false,
-    ///         Some("mm".to_string()),
-    ///     ));
-    /// ```
-    pub fn with_hint_info(self, hint_info: PropertyHintInfo) -> Self {
-        Self { hint_info, ..self }
-    }
-
-    /// Create a new `PropertyInfo` representing a group in Godot.
-    ///
-    /// See [`EditorInspector`](https://docs.godotengine.org/en/latest/classes/class_editorinspector.html#class-editorinspector) in Godot for
-    /// more information.
-    pub fn new_group(group_name: &str, group_prefix: &str) -> Self {
-        Self {
-            variant_type: VariantType::NIL,
-            class_name: ClassName::none(),
-            property_name: group_name.into(),
-            hint_info: PropertyHintInfo {
-                hint: PropertyHint::NONE,
-                hint_string: group_prefix.into(),
-            },
-            usage: PropertyUsageFlags::GROUP,
-        }
-    }
-
-    /// Create a new `PropertyInfo` representing a subgroup in Godot.
-    ///
-    /// See [`EditorInspector`](https://docs.godotengine.org/en/latest/classes/class_editorinspector.html#class-editorinspector) in Godot for
-    /// more information.
-    pub fn new_subgroup(subgroup_name: &str, subgroup_prefix: &str) -> Self {
-        Self {
-            variant_type: VariantType::NIL,
-            class_name: ClassName::none(),
-            property_name: subgroup_name.into(),
-            hint_info: PropertyHintInfo {
-                hint: PropertyHint::NONE,
-                hint_string: subgroup_prefix.into(),
-            },
-            usage: PropertyUsageFlags::SUBGROUP,
-        }
-    }
-
-    /// Converts to the FFI type. Keep this object allocated while using that!
-    pub fn property_sys(&self) -> sys::GDExtensionPropertyInfo {
-        use crate::obj::EngineBitfield as _;
-        use crate::obj::EngineEnum as _;
-
-        sys::GDExtensionPropertyInfo {
-            type_: self.variant_type.sys(),
-            name: sys::SysPtr::force_mut(self.property_name.string_sys()),
-            class_name: sys::SysPtr::force_mut(self.class_name.string_sys()),
-            hint: u32::try_from(self.hint_info.hint.ord()).expect("hint.ord()"),
-            hint_string: sys::SysPtr::force_mut(self.hint_info.hint_string.string_sys()),
-            usage: u32::try_from(self.usage.ord()).expect("usage.ord()"),
-        }
-    }
-
-    pub fn empty_sys() -> sys::GDExtensionPropertyInfo {
-        use crate::obj::EngineBitfield as _;
-        use crate::obj::EngineEnum as _;
-
-        sys::GDExtensionPropertyInfo {
-            type_: VariantType::NIL.sys(),
-            name: std::ptr::null_mut(),
-            class_name: std::ptr::null_mut(),
-            hint: PropertyHint::NONE.ord() as u32,
-            hint_string: std::ptr::null_mut(),
-            usage: PropertyUsageFlags::NONE.ord() as u32,
-        }
-    }
-
-    /// Consumes self and turns it into a `sys::GDExtensionPropertyInfo`, should be used together with
-    /// [`free_owned_property_sys`](Self::free_owned_property_sys).
-    ///
-    /// This will leak memory unless used together with `free_owned_property_sys`.
-    pub(crate) fn into_owned_property_sys(self) -> sys::GDExtensionPropertyInfo {
-        use crate::obj::EngineBitfield as _;
-        use crate::obj::EngineEnum as _;
-
-        sys::GDExtensionPropertyInfo {
-            type_: self.variant_type.sys(),
-            name: self.property_name.into_owned_string_sys(),
-            class_name: sys::SysPtr::force_mut(self.class_name.string_sys()),
-            hint: u32::try_from(self.hint_info.hint.ord()).expect("hint.ord()"),
-            hint_string: self.hint_info.hint_string.into_owned_string_sys(),
-            usage: u32::try_from(self.usage.ord()).expect("usage.ord()"),
-        }
-    }
-
-    /// Properly frees a `sys::GDExtensionPropertyInfo` created by [`into_owned_property_sys`](Self::into_owned_property_sys).
-    ///
-    /// # Safety
-    ///
-    /// * Must only be used on a struct returned from a call to `into_owned_property_sys`, without modification.
-    /// * Must not be called more than once on a `sys::GDExtensionPropertyInfo` struct.
-    pub(crate) unsafe fn free_owned_property_sys(info: sys::GDExtensionPropertyInfo) {
-        // SAFETY: This function was called on a pointer returned from `into_owned_property_sys`, thus both `info.name` and
-        // `info.hint_string` were created from calls to `into_owned_string_sys` on their respective types.
-        // Additionally, this function isn't called more than once on a struct containing the same `name` or `hint_string` pointers.
-        unsafe {
-            let _name = StringName::from_owned_string_sys(info.name);
-            let _hint_string = GString::from_owned_string_sys(info.hint_string);
-        }
-    }
-}
+pub use method_info::MethodInfo;
+pub use property_info::{PropertyHintInfo, PropertyInfo};
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
-
-/// Describes a method in Godot.
-///
-/// Abstraction of the low-level `sys::GDExtensionMethodInfo`.
-// Currently used for ScriptInstance.
-// TODO check overlap with (private) ClassMethodInfo.
-#[derive(Debug, Clone)]
-pub struct MethodInfo {
-    pub id: i32,
-    pub method_name: StringName,
-    pub class_name: ClassName,
-    pub return_type: PropertyInfo,
-    pub arguments: Vec<PropertyInfo>,
-    pub default_arguments: Vec<Variant>,
-    pub flags: MethodFlags,
-}
-
-impl MethodInfo {
-    /// Consumes self and turns it into a `sys::GDExtensionMethodInfo`, should be used together with
-    /// [`free_owned_method_sys`](Self::free_owned_method_sys).
-    ///
-    /// This will leak memory unless used together with `free_owned_method_sys`.
-    pub fn into_owned_method_sys(self) -> sys::GDExtensionMethodInfo {
-        use crate::obj::EngineBitfield as _;
-
-        // Destructure self to ensure all fields are used.
-        let Self {
-            id,
-            method_name,
-            // TODO: Do we need this?
-            class_name: _class_name,
-            return_type,
-            arguments,
-            default_arguments,
-            flags,
-        } = self;
-
-        let argument_count: u32 = arguments
-            .len()
-            .try_into()
-            .expect("cannot have more than `u32::MAX` arguments");
-        let arguments = arguments
-            .into_iter()
-            .map(|arg| arg.into_owned_property_sys())
-            .collect::<Box<[_]>>();
-        let arguments = Box::leak(arguments).as_mut_ptr();
-
-        let default_argument_count: u32 = default_arguments
-            .len()
-            .try_into()
-            .expect("cannot have more than `u32::MAX` default arguments");
-        let default_argument = default_arguments
-            .into_iter()
-            .map(|arg| arg.into_owned_var_sys())
-            .collect::<Box<[_]>>();
-        let default_arguments = Box::leak(default_argument).as_mut_ptr();
-
-        sys::GDExtensionMethodInfo {
-            id,
-            name: method_name.into_owned_string_sys(),
-            return_value: return_type.into_owned_property_sys(),
-            argument_count,
-            arguments,
-            default_argument_count,
-            default_arguments,
-            flags: flags.ord().try_into().expect("flags should be valid"),
-        }
-    }
-
-    /// Properly frees a `sys::GDExtensionMethodInfo` created by [`into_owned_method_sys`](Self::into_owned_method_sys).
-    ///
-    /// # Safety
-    ///
-    /// * Must only be used on a struct returned from a call to `into_owned_method_sys`, without modification.
-    /// * Must not be called more than once on a `sys::GDExtensionMethodInfo` struct.
-    #[deny(unsafe_op_in_unsafe_fn)]
-    pub unsafe fn free_owned_method_sys(info: sys::GDExtensionMethodInfo) {
-        // Destructure info to ensure all fields are used.
-        let sys::GDExtensionMethodInfo {
-            name,
-            return_value,
-            flags: _flags,
-            id: _id,
-            argument_count,
-            arguments,
-            default_argument_count,
-            default_arguments,
-        } = info;
-
-        // SAFETY: `name` is a pointer that was returned from `StringName::into_owned_string_sys`, and has not been freed before this.
-        let _name = unsafe { StringName::from_owned_string_sys(name) };
-
-        // SAFETY: `return_value` is a pointer that was returned from `PropertyInfo::into_owned_property_sys`, and has not been freed before
-        // this.
-        unsafe { PropertyInfo::free_owned_property_sys(return_value) };
-
-        // SAFETY:
-        // - `from_raw_parts_mut`: `arguments` comes from `as_mut_ptr()` on a mutable slice of length `argument_count`, and no other
-        //    accesses to the pointer happens for the lifetime of the slice.
-        // - `Box::from_raw`: The slice was returned from a call to `Box::leak`, and we have ownership of the value behind this pointer.
-        let arguments = unsafe {
-            let slice = std::slice::from_raw_parts_mut(arguments, u32_to_usize(argument_count));
-
-            Box::from_raw(slice)
-        };
-
-        for info in arguments.iter() {
-            // SAFETY: These infos were originally created from a call to `PropertyInfo::into_owned_property_sys`, and this method
-            // will not be called again on this pointer.
-            unsafe { PropertyInfo::free_owned_property_sys(*info) }
-        }
-
-        // SAFETY:
-        // - `from_raw_parts_mut`: `default_arguments` comes from `as_mut_ptr()` on a mutable slice of length `default_argument_count`, and no
-        //    other accesses to the pointer happens for the lifetime of the slice.
-        // - `Box::from_raw`: The slice was returned from a call to `Box::leak`, and we have ownership of the value behind this pointer.
-        let default_arguments = unsafe {
-            let slice = std::slice::from_raw_parts_mut(
-                default_arguments,
-                u32_to_usize(default_argument_count),
-            );
-
-            Box::from_raw(slice)
-        };
-
-        for variant in default_arguments.iter() {
-            // SAFETY: These pointers were originally created from a call to `Variant::into_owned_var_sys`, and this method will not be
-            // called again on this pointer.
-            let _variant = unsafe { Variant::from_owned_var_sys(*variant) };
-        }
-    }
-}
 
 /// Clean up various resources at end of usage.
 ///

--- a/godot-core/src/meta/property_info.rs
+++ b/godot-core/src/meta/property_info.rs
@@ -1,0 +1,248 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use crate::builtin::{GString, StringName};
+use crate::global::{PropertyHint, PropertyUsageFlags};
+use crate::meta::{ArrayElement, ClassName, GodotType};
+use crate::registry::property::{Export, Var};
+use crate::sys;
+use godot_ffi::VariantType;
+
+/// Describes a property in Godot.
+///
+/// Abstraction of the low-level `sys::GDExtensionPropertyInfo`.
+///
+/// Keeps the actual allocated values (the `sys` equivalent only keeps pointers, which fall out of scope).
+#[derive(Debug, Clone)]
+// Note: is not #[non_exhaustive], so adding fields is a breaking change. Mostly used internally at the moment though.
+pub struct PropertyInfo {
+    /// Which type this property has.
+    ///
+    /// For objects this should be set to [`VariantType::OBJECT`], and the `class_name` field to the actual name of the class.
+    ///
+    /// For [`Variant`][crate::builtin::Variant], this should be set to [`VariantType::NIL`].
+    pub variant_type: VariantType,
+
+    /// Which class this property is.
+    ///
+    /// This should be set to [`ClassName::none()`] unless the variant type is `Object`. You can use
+    /// [`GodotClass::class_name()`](crate::obj::GodotClass::class_name()) to get the right name to use here.
+    pub class_name: ClassName,
+
+    /// The name of this property in Godot.
+    pub property_name: StringName,
+
+    /// Additional type information for this property, e.g. about array types or enum values. Split into `hint` and `hint_string` members.
+    ///
+    /// See also [`PropertyHint`] in the Godot docs.
+    ///
+    /// [`PropertyHint`]: https://docs.godotengine.org/en/latest/classes/class_%40globalscope.html#enum-globalscope-propertyhint
+    pub hint_info: PropertyHintInfo,
+
+    /// How this property should be used. See [`PropertyUsageFlags`] in Godot for the meaning.
+    ///
+    /// [`PropertyUsageFlags`]: https://docs.godotengine.org/en/latest/classes/class_%40globalscope.html#enum-globalscope-propertyusageflags
+    pub usage: PropertyUsageFlags,
+}
+
+impl PropertyInfo {
+    /// Create a new `PropertyInfo` representing a property named `property_name` with type `T`.
+    ///
+    /// This will generate property info equivalent to what a `#[var]` attribute would.
+    pub fn new_var<T: Var>(property_name: &str) -> Self {
+        T::Via::property_info(property_name).with_hint_info(T::var_hint())
+    }
+
+    /// Create a new `PropertyInfo` representing an exported property named `property_name` with type `T`.
+    ///
+    /// This will generate property info equivalent to what an `#[export]` attribute would.
+    pub fn new_export<T: Export>(property_name: &str) -> Self {
+        T::Via::property_info(property_name).with_hint_info(T::export_hint())
+    }
+
+    /// Change the `hint` and `hint_string` to be the given `hint_info`.
+    ///
+    /// See [`export_info_functions`](crate::registry::property::export_info_functions) for functions that return appropriate `PropertyHintInfo`s for
+    /// various Godot annotations.
+    ///
+    /// # Examples
+    ///
+    /// Creating an `@export_range` property.
+    ///
+    // TODO: Make this nicer to use.
+    /// ```no_run
+    /// use godot::register::property::export_info_functions;
+    /// use godot::meta::PropertyInfo;
+    ///
+    /// let property = PropertyInfo::new_export::<f64>("my_range_property")
+    ///     .with_hint_info(export_info_functions::export_range(
+    ///         0.0,
+    ///         10.0,
+    ///         Some(0.1),
+    ///         false,
+    ///         false,
+    ///         false,
+    ///         false,
+    ///         false,
+    ///         false,
+    ///         Some("mm".to_string()),
+    ///     ));
+    /// ```
+    pub fn with_hint_info(self, hint_info: PropertyHintInfo) -> Self {
+        Self { hint_info, ..self }
+    }
+
+    /// Create a new `PropertyInfo` representing a group in Godot.
+    ///
+    /// See [`EditorInspector`](https://docs.godotengine.org/en/latest/classes/class_editorinspector.html#class-editorinspector) in Godot for
+    /// more information.
+    pub fn new_group(group_name: &str, group_prefix: &str) -> Self {
+        Self {
+            variant_type: VariantType::NIL,
+            class_name: ClassName::none(),
+            property_name: group_name.into(),
+            hint_info: PropertyHintInfo {
+                hint: PropertyHint::NONE,
+                hint_string: group_prefix.into(),
+            },
+            usage: PropertyUsageFlags::GROUP,
+        }
+    }
+
+    /// Create a new `PropertyInfo` representing a subgroup in Godot.
+    ///
+    /// See [`EditorInspector`](https://docs.godotengine.org/en/latest/classes/class_editorinspector.html#class-editorinspector) in Godot for
+    /// more information.
+    pub fn new_subgroup(subgroup_name: &str, subgroup_prefix: &str) -> Self {
+        Self {
+            variant_type: VariantType::NIL,
+            class_name: ClassName::none(),
+            property_name: subgroup_name.into(),
+            hint_info: PropertyHintInfo {
+                hint: PropertyHint::NONE,
+                hint_string: subgroup_prefix.into(),
+            },
+            usage: PropertyUsageFlags::SUBGROUP,
+        }
+    }
+
+    /// Converts to the FFI type. Keep this object allocated while using that!
+    pub fn property_sys(&self) -> sys::GDExtensionPropertyInfo {
+        use crate::obj::EngineBitfield as _;
+        use crate::obj::EngineEnum as _;
+
+        sys::GDExtensionPropertyInfo {
+            type_: self.variant_type.sys(),
+            name: sys::SysPtr::force_mut(self.property_name.string_sys()),
+            class_name: sys::SysPtr::force_mut(self.class_name.string_sys()),
+            hint: u32::try_from(self.hint_info.hint.ord()).expect("hint.ord()"),
+            hint_string: sys::SysPtr::force_mut(self.hint_info.hint_string.string_sys()),
+            usage: u32::try_from(self.usage.ord()).expect("usage.ord()"),
+        }
+    }
+
+    pub fn empty_sys() -> sys::GDExtensionPropertyInfo {
+        use crate::obj::EngineBitfield as _;
+        use crate::obj::EngineEnum as _;
+
+        sys::GDExtensionPropertyInfo {
+            type_: VariantType::NIL.sys(),
+            name: std::ptr::null_mut(),
+            class_name: std::ptr::null_mut(),
+            hint: PropertyHint::NONE.ord() as u32,
+            hint_string: std::ptr::null_mut(),
+            usage: PropertyUsageFlags::NONE.ord() as u32,
+        }
+    }
+
+    /// Consumes self and turns it into a `sys::GDExtensionPropertyInfo`, should be used together with
+    /// [`free_owned_property_sys`](Self::free_owned_property_sys).
+    ///
+    /// This will leak memory unless used together with `free_owned_property_sys`.
+    pub(crate) fn into_owned_property_sys(self) -> sys::GDExtensionPropertyInfo {
+        use crate::obj::EngineBitfield as _;
+        use crate::obj::EngineEnum as _;
+
+        sys::GDExtensionPropertyInfo {
+            type_: self.variant_type.sys(),
+            name: self.property_name.into_owned_string_sys(),
+            class_name: sys::SysPtr::force_mut(self.class_name.string_sys()),
+            hint: u32::try_from(self.hint_info.hint.ord()).expect("hint.ord()"),
+            hint_string: self.hint_info.hint_string.into_owned_string_sys(),
+            usage: u32::try_from(self.usage.ord()).expect("usage.ord()"),
+        }
+    }
+
+    /// Properly frees a `sys::GDExtensionPropertyInfo` created by [`into_owned_property_sys`](Self::into_owned_property_sys).
+    ///
+    /// # Safety
+    ///
+    /// * Must only be used on a struct returned from a call to `into_owned_property_sys`, without modification.
+    /// * Must not be called more than once on a `sys::GDExtensionPropertyInfo` struct.
+    pub(crate) unsafe fn free_owned_property_sys(info: sys::GDExtensionPropertyInfo) {
+        // SAFETY: This function was called on a pointer returned from `into_owned_property_sys`, thus both `info.name` and
+        // `info.hint_string` were created from calls to `into_owned_string_sys` on their respective types.
+        // Additionally, this function isn't called more than once on a struct containing the same `name` or `hint_string` pointers.
+        unsafe {
+            let _name = StringName::from_owned_string_sys(info.name);
+            let _hint_string = GString::from_owned_string_sys(info.hint_string);
+        }
+    }
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+
+/// Info needed by Godot, for how to export a type to the editor.
+#[derive(Clone, Eq, PartialEq, Debug)]
+pub struct PropertyHintInfo {
+    pub hint: PropertyHint,
+    pub hint_string: GString,
+}
+
+impl PropertyHintInfo {
+    /// Create a new `PropertyHintInfo` with a property hint of [`PROPERTY_HINT_NONE`](PropertyHint::NONE), and no hint string.
+    pub fn none() -> Self {
+        Self {
+            hint: PropertyHint::NONE,
+            hint_string: GString::new(),
+        }
+    }
+
+    /// Use [`PROPERTY_HINT_NONE`](PropertyHint::NONE) with `T`'s Godot type name.
+    ///
+    /// Starting with Godot version 4.3, the hint string will always be the empty string. Before that, the hint string is set to
+    /// be the Godot type name of `T`.
+    pub fn type_name<T: GodotType>() -> Self {
+        let type_name = T::godot_type_name();
+        let hint_string = if sys::GdextBuild::since_api("4.3") {
+            GString::new()
+        } else {
+            GString::from(type_name)
+        };
+
+        Self {
+            hint: PropertyHint::NONE,
+            hint_string,
+        }
+    }
+
+    /// Use for `#[var]` properties -- [`PROPERTY_HINT_ARRAY_TYPE`](PropertyHint::ARRAY_TYPE) with the type name as hint string.
+    pub fn var_array_element<T: ArrayElement>() -> Self {
+        Self {
+            hint: PropertyHint::ARRAY_TYPE,
+            hint_string: GString::from(T::godot_type_name()),
+        }
+    }
+
+    /// Use for `#[export]` properties -- [`PROPERTY_HINT_TYPE_STRING`](PropertyHint::TYPE_STRING) with the **element** type string as hint string.
+    pub fn export_array_element<T: ArrayElement>() -> Self {
+        Self {
+            hint: PropertyHint::TYPE_STRING,
+            hint_string: GString::from(T::element_type_string()),
+        }
+    }
+}

--- a/godot-core/src/meta/traits.rs
+++ b/godot-core/src/meta/traits.rs
@@ -81,6 +81,9 @@ pub trait GodotType:
 
     #[doc(hidden)]
     fn property_hint_info() -> PropertyHintInfo {
+        // The default implementation is mostly good for builtin types.
+        //PropertyHintInfo::with_type_name::<Self>()
+
         PropertyHintInfo::none()
     }
 

--- a/godot-core/src/meta/traits.rs
+++ b/godot-core/src/meta/traits.rs
@@ -10,11 +10,13 @@ use godot_ffi as sys;
 use crate::builtin::{StringName, Variant};
 use crate::global::PropertyUsageFlags;
 use crate::meta::error::ConvertError;
-use crate::meta::{sealed, ClassName, FromGodot, GodotConvert, PropertyInfo, ToGodot};
+use crate::meta::{
+    sealed, ClassName, FromGodot, GodotConvert, PropertyHintInfo, PropertyInfo, ToGodot,
+};
 use crate::registry::method::MethodParamOrReturnInfo;
 
 // Re-export sys traits in this module, so all are in one place.
-use crate::registry::property::{builtin_type_string, PropertyHintInfo};
+use crate::registry::property::builtin_type_string;
 pub use sys::{GodotFfi, GodotNullableFfi};
 
 /// Conversion of [`GodotFfi`] types to/from [`Variant`].

--- a/godot-core/src/meta/traits.rs
+++ b/godot-core/src/meta/traits.rs
@@ -14,7 +14,7 @@ use crate::meta::{sealed, ClassName, FromGodot, GodotConvert, PropertyInfo, ToGo
 use crate::registry::method::MethodParamOrReturnInfo;
 
 // Re-export sys traits in this module, so all are in one place.
-use crate::registry::property::PropertyHintInfo;
+use crate::registry::property::{builtin_type_string, PropertyHintInfo};
 pub use sys::{GodotFfi, GodotNullableFfi};
 
 /// Conversion of [`GodotFfi`] types to/from [`Variant`].
@@ -126,4 +126,17 @@ pub trait GodotType:
     label = "does not implement `Var`",
     note = "see also: https://godot-rust.github.io/docs/gdext/master/godot/builtin/meta/trait.ArrayElement.html"
 )]
-pub trait ArrayElement: GodotType {}
+pub trait ArrayElement: GodotType + sealed::Sealed {
+    /// Returns the representation of this type as a type string.
+    ///
+    /// Used for elements in arrays and packed arrays (the latter despite `ArrayElement` not having a direct relation).
+    ///
+    /// See [`PropertyHint::TYPE_STRING`] and [upstream docs].
+    ///
+    /// [upstream docs]: https://docs.godotengine.org/en/stable/classes/class_%40globalscope.html#enum-globalscope-propertyhint
+    #[doc(hidden)]
+    fn element_type_string() -> String {
+        // Most array elements and all packed array elements are builtin types, so this is a good default.
+        builtin_type_string::<Self>()
+    }
+}

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -15,13 +15,15 @@ use sys::{static_assert_eq_size_align, VariantType};
 use crate::builtin::{Callable, NodePath, StringName, Variant};
 use crate::global::PropertyHint;
 use crate::meta::error::{ConvertError, FromFfiError};
-use crate::meta::{ArrayElement, CallContext, FromGodot, GodotConvert, GodotType, ToGodot};
+use crate::meta::{
+    ArrayElement, CallContext, FromGodot, GodotConvert, GodotType, PropertyHintInfo, ToGodot,
+};
 use crate::obj::{
     bounds, cap, Bounds, EngineEnum, GdDerefTarget, GdMut, GdRef, GodotClass, Inherits, InstanceId,
     RawGd,
 };
 use crate::private::callbacks;
-use crate::registry::property::{Export, PropertyHintInfo, Var};
+use crate::registry::property::{Export, Var};
 use crate::{classes, out};
 
 /// Smart pointer to objects owned by the Godot engine.

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -736,7 +736,7 @@ impl<T: GodotClass> GodotType for Gd<T> {
 
 impl<T: GodotClass> ArrayElement for Gd<T> {
     fn element_type_string() -> String {
-        match Self::default_export_info().hint {
+        match Self::export_hint().hint {
             hint @ (PropertyHint::RESOURCE_TYPE | PropertyHint::NODE_TYPE) => {
                 format!(
                     "{}/{}:{}",
@@ -792,7 +792,7 @@ impl<T: GodotClass> Var for Gd<T> {
 }
 
 impl<T: GodotClass> Export for Gd<T> {
-    fn default_export_info() -> PropertyHintInfo {
+    fn export_hint() -> PropertyHintInfo {
         let hint = if T::inherits::<classes::Resource>() {
             PropertyHint::RESOURCE_TYPE
         } else if T::inherits::<classes::Node>() {

--- a/godot-macros/src/class/data_models/property.rs
+++ b/godot-macros/src/class/data_models/property.rs
@@ -106,7 +106,7 @@ pub fn make_property_impl(class_name: &Ident, fields: &Fields) -> TokenStream {
                 if let Some(export_hint) = export_hint {
                     quote! {
                         {
-                            let ::godot::register::property::PropertyHintInfo { hint, hint_string } = #export_hint;
+                            let ::godot::meta::PropertyHintInfo { hint, hint_string } = #export_hint;
                             (hint, hint_string)
                         }
                     }
@@ -169,7 +169,7 @@ pub fn make_property_impl(class_name: &Ident, fields: &Fields) -> TokenStream {
                 variant_type: #field_variant_type,
                 class_name: #field_class_name,
                 property_name: #field_name.into(),
-                hint_info: ::godot::register::property::PropertyHintInfo {
+                hint_info: ::godot::meta::PropertyHintInfo {
                     hint,
                     hint_string,
                 },

--- a/godot-macros/src/class/data_models/property.rs
+++ b/godot-macros/src/class/data_models/property.rs
@@ -113,15 +113,15 @@ pub fn make_property_impl(class_name: &Ident, fields: &Fields) -> TokenStream {
                 } else if export.is_some() {
                     quote! {
                         {
-                            let default_export_info = <#field_type as ::godot::register::property::Export>::default_export_info();
-                            (default_export_info.hint, default_export_info.hint_string)
+                            let export_hint = <#field_type as ::godot::register::property::Export>::export_hint();
+                            (export_hint.hint, export_hint.hint_string)
                         }
                     }
                 } else {
                     quote! {
                         {
-                            let default_export_info = <#field_type as ::godot::register::property::Var>::property_hint();
-                            (default_export_info.hint, default_export_info.hint_string)
+                            let export_hint = <#field_type as ::godot::register::property::Var>::var_hint();
+                            (export_hint.hint, export_hint.hint_string)
                         }
                     }
                 }

--- a/godot-macros/src/derive/derive_export.rs
+++ b/godot-macros/src/derive/derive_export.rs
@@ -19,10 +19,6 @@ pub fn derive_export(item: venial::Item) -> ParseResult<TokenStream> {
     let GodotConvert { ty_name: name, .. } = GodotConvert::parse_declaration(item)?;
 
     Ok(quote! {
-        impl ::godot::register::property::Export for #name {
-            fn default_export_info() -> ::godot::register::property::PropertyHintInfo {
-                <#name as ::godot::register::property::Var>::property_hint()
-            }
-        }
+        impl ::godot::register::property::Export for #name {}
     })
 }

--- a/godot-macros/src/derive/derive_var.rs
+++ b/godot-macros/src/derive/derive_var.rs
@@ -34,7 +34,6 @@ pub fn derive_var(item: venial::Item) -> ParseResult<TokenStream> {
             fn property_hint() -> ::godot::register::property::PropertyHintInfo {
                 #property_hint_impl
             }
-
         }
     })
 }

--- a/godot-macros/src/derive/derive_var.rs
+++ b/godot-macros/src/derive/derive_var.rs
@@ -31,7 +31,7 @@ pub fn derive_var(item: venial::Item) -> ParseResult<TokenStream> {
                 *self = ::godot::meta::FromGodot::from_godot(value);
             }
 
-            fn property_hint() -> ::godot::register::property::PropertyHintInfo {
+            fn var_hint() -> ::godot::register::property::PropertyHintInfo {
                 #property_hint_impl
             }
         }
@@ -49,7 +49,7 @@ fn create_property_hint_impl(convert: &GodotConvert) -> TokenStream {
         Data::NewType { field } => {
             let ty = &field.ty;
             quote! {
-                <#ty as ::godot::register::property::Var>::property_hint()
+                <#ty as ::godot::register::property::Var>::var_hint()
             }
         }
         Data::Enum { variants, via } => {

--- a/godot-macros/src/derive/derive_var.rs
+++ b/godot-macros/src/derive/derive_var.rs
@@ -31,7 +31,7 @@ pub fn derive_var(item: venial::Item) -> ParseResult<TokenStream> {
                 *self = ::godot::meta::FromGodot::from_godot(value);
             }
 
-            fn var_hint() -> ::godot::register::property::PropertyHintInfo {
+            fn var_hint() -> ::godot::meta::PropertyHintInfo {
                 #property_hint_impl
             }
         }
@@ -59,7 +59,7 @@ fn create_property_hint_impl(convert: &GodotConvert) -> TokenStream {
             };
 
             quote! {
-                ::godot::register::property::PropertyHintInfo {
+                ::godot::meta::PropertyHintInfo {
                     hint: ::godot::global::PropertyHint::ENUM,
                     hint_string: #hint_string.into(),
                 }

--- a/godot/src/prelude.rs
+++ b/godot/src/prelude.rs
@@ -5,7 +5,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-pub use super::register::property::{Export, TypeStringHint, Var};
+pub use super::register::property::{Export, Var};
 
 // Re-export macros.
 pub use super::register::{godot_api, Export, GodotClass, GodotConvert, Var};

--- a/itest/rust/build.rs
+++ b/itest/rust/build.rs
@@ -414,8 +414,8 @@ fn generate_property_template(inputs: &[Input]) -> PropertyTests {
             continue;
         }
 
-        let property = format_ident!("property_{ident}");
-        let property_array = format_ident!("property_array_{ident}");
+        let var = format_ident!("var_{ident}");
+        let var_array = format_ident!("var_array_{ident}");
         let export = format_ident!("export_{ident}");
         let export_array = format_ident!("export_array_{ident}");
 
@@ -427,14 +427,14 @@ fn generate_property_template(inputs: &[Input]) -> PropertyTests {
             quote! {
                 #[var]
                 #initializer
-                #property: #rust_ty
+                #var: #rust_ty
             },
-            quote! { #[var] #property_array: Array<#rust_ty> },
+            quote! { #[var] #var_array: Array<#rust_ty> },
         ]);
 
         gdscript.extend([
-            format!("var {property}: {gdscript_ty}"),
-            format!("var {property_array}: Array[{gdscript_ty}]"),
+            format!("var {var}: {gdscript_ty}"),
+            format!("var {var_array}: Array[{gdscript_ty}]"),
         ]);
 
         if *is_exportable {

--- a/itest/rust/src/object_tests/property_template_test.rs
+++ b/itest/rust/src/object_tests/property_template_test.rs
@@ -73,7 +73,7 @@ fn property_template_test(ctx: &TestContext) {
 
         if rust_prop != property {
             errors.push(format!(
-                "mismatch in property {name}, GDScript: {property:?}, Rust: {rust_prop:?}"
+                "mismatch in property {name}:\n  GDScript: {property:?}\n  Rust:     {rust_prop:?}"
             ));
         }
     }

--- a/itest/rust/src/object_tests/property_template_test.rs
+++ b/itest/rust/src/object_tests/property_template_test.rs
@@ -39,12 +39,12 @@ fn property_template_test(ctx: &TestContext) {
         // For now, just ignore array properties when we compile for 4.1 but run in 4.2.
         if GdextBuild::since_api("4.2")
             && cfg!(before_api = "4.2")
-            && name.starts_with("property_array_")
+            && name.starts_with("var_array_")
         {
             continue;
         }
 
-        if name.starts_with("property_") || name.starts_with("export_") {
+        if name.starts_with("var_") || name.starts_with("export_") {
             properties.insert(name, property);
         }
     }

--- a/itest/rust/src/object_tests/property_test.rs
+++ b/itest/rust/src/object_tests/property_test.rs
@@ -8,9 +8,9 @@
 use godot::builtin::{dict, Color, Dictionary, GString, Variant, VariantType};
 use godot::classes::{INode, IRefCounted, Node, Object, RefCounted, Resource, Texture};
 use godot::global::{PropertyHint, PropertyUsageFlags};
-use godot::meta::{GodotConvert, ToGodot};
+use godot::meta::{GodotConvert, PropertyHintInfo, ToGodot};
 use godot::obj::{Base, EngineBitfield, EngineEnum, Gd, NewAlloc, NewGd};
-use godot::register::property::{Export, PropertyHintInfo, Var};
+use godot::register::property::{Export, Var};
 use godot::register::{godot_api, Export, GodotClass, GodotConvert, Var};
 use godot::test::itest;
 

--- a/itest/rust/src/object_tests/property_test.rs
+++ b/itest/rust/src/object_tests/property_test.rs
@@ -174,7 +174,7 @@ impl Var for SomeCStyleEnum {
 }
 
 impl Export for SomeCStyleEnum {
-    fn default_export_info() -> PropertyHintInfo {
+    fn export_hint() -> PropertyHintInfo {
         PropertyHintInfo {
             hint: PropertyHint::ENUM,
             hint_string: "A,B,C".into(),


### PR DESCRIPTION
Changes and reuses some code around `PropertyHint`, `PropertyHintInfo`, `Var`, `Export`.

Follow-up to #836.