### PR TITLE
Disallow `Export` if class doesn't inherit `Node` or `Resource`

### DIFF
--- a/godot-codegen/src/context.rs
+++ b/godot-codegen/src/context.rs
@@ -329,13 +329,32 @@ impl InheritanceTree {
 
     /// Returns all base classes, without the class itself, in order from nearest to furthest (object).
     pub fn collect_all_bases(&self, derived_name: &TyName) -> Vec<TyName> {
-        let mut maybe_base = derived_name;
+        let mut upgoer = derived_name;
         let mut result = vec![];
 
-        while let Some(base) = self.derived_to_base.get(maybe_base) {
+        while let Some(base) = self.derived_to_base.get(upgoer) {
             result.push(base.clone());
-            maybe_base = base;
+            upgoer = base;
         }
         result
+    }
+
+    /// Whether a class is a direct or indirect subclass of another (true for derived == base).
+    pub fn inherits(&self, derived: &TyName, base_name: &str) -> bool {
+        // Reflexive: T inherits T.
+        if derived.godot_ty == base_name {
+            return true;
+        }
+
+        let mut upgoer = derived;
+
+        while let Some(next_base) = self.derived_to_base.get(upgoer) {
+            if next_base.godot_ty == base_name {
+                return true;
+            }
+            upgoer = next_base;
+        }
+
+        false
     }
 }

--- a/godot-core/src/obj/bounds.rs
+++ b/godot-core/src/obj/bounds.rs
@@ -58,7 +58,7 @@ use private::Sealed;
 // Sealed trait
 
 pub(super) mod private {
-    use super::{Declarer, DynMemory, Memory};
+    use super::{Declarer, DynMemory, Exportable, Memory};
 
     // Bounds trait declared here for code locality; re-exported in crate::obj.
 
@@ -97,6 +97,12 @@ pub(super) mod private {
         /// Whether this class is a core Godot class provided by the engine, or declared by the user as a Rust struct.
         // TODO what about GDScript user classes?
         type Declarer: Declarer;
+
+        /// True if *either* `T: Inherits<Node>` *or* `T: Inherits<Resource>` is fulfilled.
+        ///
+        /// Enables `#[export]` for those classes.
+        #[doc(hidden)]
+        type Exportable: Exportable;
     }
 
     /// Implements [`Bounds`] for a user-defined class.
@@ -130,6 +136,7 @@ pub(super) mod private {
                 type Memory = <<$UserClass as $crate::obj::GodotClass>::Base as $crate::obj::Bounds>::Memory;
                 type DynMemory = <<$UserClass as $crate::obj::GodotClass>::Base as $crate::obj::Bounds>::DynMemory;
                 type Declarer = $crate::obj::bounds::DeclUser;
+                type Exportable = <<$UserClass as $crate::obj::GodotClass>::Base as $crate::obj::Bounds>::Exportable;
             }
         };
     }
@@ -417,3 +424,19 @@ impl Declarer for DeclUser {
         }
     }
 }
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// Exportable bounds (still hidden)
+
+#[doc(hidden)]
+pub trait Exportable: Sealed {}
+
+#[doc(hidden)]
+pub enum Yes {}
+impl Sealed for Yes {}
+impl Exportable for Yes {}
+
+#[doc(hidden)]
+pub enum No {}
+impl Sealed for No {}
+impl Exportable for No {}

--- a/godot-core/src/obj/traits.rs
+++ b/godot-core/src/obj/traits.rs
@@ -80,6 +80,7 @@ unsafe impl Bounds for NoBase {
     type Memory = bounds::MemManual;
     type DynMemory = bounds::MemManual;
     type Declarer = bounds::DeclEngine;
+    type Exportable = bounds::No;
 }
 
 /// Non-strict inheritance relationship in the Godot class hierarchy.

--- a/godot-core/src/registry/property.rs
+++ b/godot-core/src/registry/property.rs
@@ -414,6 +414,7 @@ mod export_impls {
 
     // Dictionary: will need to be done manually once they become typed.
     impl_property_by_godot_convert!(Dictionary);
+    impl_property_by_godot_convert!(Variant);
 
     // Packed arrays: we manually implement `Export`.
     impl_property_by_godot_convert!(PackedByteArray, no_export);

--- a/godot-core/src/registry/property.rs
+++ b/godot-core/src/registry/property.rs
@@ -22,8 +22,8 @@ use crate::meta::{FromGodot, GodotConvert, GodotType, PropertyHintInfo, ToGodot}
 /// This does not require [`FromGodot`] or [`ToGodot`], so that something can be used as a property even if it can't be used in function
 /// arguments/return types.
 
-// We also mention #[export] here, because we can't control the order of error messages. Missing Export often also means missing Var trait,
-// and so the Var error message appears first.
+// on_unimplemented: we also mention #[export] here, because we can't control the order of error messages.
+// Missing Export often also means missing Var trait, and so the Var error message appears first.
 #[diagnostic::on_unimplemented(
     message = "`#[var]` properties require `Var` trait; #[export] ones require `Export` trait",
     label = "type cannot be used as a property",
@@ -41,7 +41,10 @@ pub trait Var: GodotConvert {
 }
 
 /// Trait implemented for types that can be used as `#[export]` fields.
-// Mentioning both Var + Export: see above.
+///
+/// `Export` is only implemented for objects `Gd<T>` if either `T: Inherits<Node>` or `T: Inherits<Resource>`, just like GDScript.
+/// This means you cannot use `#[export]` with `Gd<RefCounted>`, for example.
+// on_unimplemented: mentioning both Var + Export; see above.
 #[diagnostic::on_unimplemented(
     message = "`#[var]` properties require `Var` trait; #[export] ones require `Export` trait",
     label = "type cannot be used as a property",

--- a/godot-macros/src/class/derive_godot_class.rs
+++ b/godot-macros/src/class/derive_godot_class.rs
@@ -129,6 +129,7 @@ pub fn derive_godot_class(item: venial::Item) -> ParseResult<TokenStream> {
             type Memory = <<Self as ::godot::obj::GodotClass>::Base as ::godot::obj::Bounds>::Memory;
             type DynMemory = <<Self as ::godot::obj::GodotClass>::Base as ::godot::obj::Bounds>::DynMemory;
             type Declarer = ::godot::obj::bounds::DeclUser;
+            type Exportable = <<Self as ::godot::obj::GodotClass>::Base as ::godot::obj::Bounds>::Exportable;
         }
 
         #godot_init_impl


### PR DESCRIPTION
This adopts the GDScript error message:

> SCRIPT ERROR: Parse Error: Export type can only be built-in, a resource, a node, or an enum.

Also includes a very late addition of `Var` + `Export` for `Variant`, which seemingly no one needed :slightly_smiling_face: 