### PR TITLE
Rewrite `#[var]` + `#[export]` registration to use type-safe API behind scenes

### DIFF
--- a/godot-core/src/registry/godot_register_wrappers.rs
+++ b/godot-core/src/registry/godot_register_wrappers.rs
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+//! Internal registration machinery used by proc-macro APIs.
+
+use crate::builtin::StringName;
+use crate::global::PropertyUsageFlags;
+use crate::meta::{ClassName, GodotConvert, GodotType, PropertyHintInfo, PropertyInfo};
+use crate::obj::GodotClass;
+use crate::registry::property::Var;
+use crate::sys;
+use godot_ffi::GodotFfi;
+
+pub fn register_var_or_export<C: GodotClass, T: Var>(
+    property_name: &str,
+    getter_name: &str,
+    setter_name: &str,
+    hint_info: PropertyHintInfo,
+    usage: PropertyUsageFlags,
+) {
+    let info = PropertyInfo {
+        variant_type: <<T as GodotConvert>::Via as GodotType>::Ffi::variant_type(),
+        class_name: <T as GodotConvert>::Via::class_name(),
+        property_name: StringName::from(property_name),
+        hint_info,
+        usage,
+    };
+
+    let class_name = C::class_name();
+
+    register_var_or_export_inner(info, class_name, getter_name, setter_name);
+}
+
+fn register_var_or_export_inner(
+    info: PropertyInfo,
+    class_name: ClassName,
+    getter_name: &str,
+    setter_name: &str,
+) {
+    let getter_name = StringName::from(getter_name);
+    let setter_name = StringName::from(setter_name);
+
+    let property_info_sys = info.property_sys();
+
+    unsafe {
+        sys::interface_fn!(classdb_register_extension_class_property)(
+            sys::get_library(),
+            class_name.string_sys(),
+            std::ptr::addr_of!(property_info_sys),
+            setter_name.string_sys(),
+            getter_name.string_sys(),
+        );
+    }
+}

--- a/godot-core/src/registry/method.rs
+++ b/godot-core/src/registry/method.rs
@@ -11,6 +11,7 @@ use sys::interface_fn;
 use crate::builtin::{StringName, Variant};
 use crate::global::MethodFlags;
 use crate::meta::{ClassName, PropertyInfo, VarcallSignatureTuple};
+use crate::obj::GodotClass;
 
 /// Info relating to an argument or return type in a method.
 pub struct MethodParamOrReturnInfo {
@@ -52,14 +53,13 @@ impl ClassMethodInfo {
     /// `call_func` and `ptrcall_func`, if provided, must:
     ///
     /// - Follow the behavior expected from the `method_flags`.
-    pub unsafe fn from_signature<S: VarcallSignatureTuple>(
-        class_name: ClassName,
+    pub unsafe fn from_signature<C: GodotClass, S: VarcallSignatureTuple>(
         method_name: StringName,
         call_func: sys::GDExtensionClassMethodCall,
         ptrcall_func: sys::GDExtensionClassMethodPtrCall,
         method_flags: MethodFlags,
         param_names: &[&str],
-        default_arguments: Vec<Variant>,
+        // default_arguments: Vec<Variant>, - not yet implemented
     ) -> Self {
         let return_value = S::return_info();
         let mut arguments = Vec::new();
@@ -79,13 +79,14 @@ impl ClassMethodInfo {
             }))
         }
 
+        let default_arguments = vec![]; // not yet implemented.
         assert!(
             default_arguments.len() <= arguments.len(),
             "cannot have more default arguments than arguments"
         );
 
         Self {
-            class_name,
+            class_name: C::class_name(),
             method_name,
             call_func,
             ptrcall_func,

--- a/godot-core/src/registry/mod.rs
+++ b/godot-core/src/registry/mod.rs
@@ -14,3 +14,6 @@ pub mod constant;
 pub mod method;
 pub mod plugin;
 pub mod property;
+
+#[doc(hidden)]
+pub mod godot_register_wrappers;

--- a/godot-macros/src/class/data_models/func.rs
+++ b/godot-macros/src/class/data_models/func.rs
@@ -118,12 +118,9 @@ pub fn make_method_registration(
             #varcall_fn_decl;
             #ptrcall_fn_decl;
 
-            // SAFETY:
-            // `get_varcall_func` upholds all the requirements for `call_func`.
-            // `get_ptrcall_func` upholds all the requirements for `ptrcall_func`
+            // SAFETY: varcall_fn + ptrcall_fn interpret their in/out parameters correctly.
             let method_info = unsafe {
-                ClassMethodInfo::from_signature::<Sig>(
-                    #class_name::class_name(),
+                ClassMethodInfo::from_signature::<#class_name, Sig>(
                     method_name,
                     Some(varcall_fn),
                     Some(ptrcall_fn),
@@ -131,7 +128,6 @@ pub fn make_method_registration(
                     &[
                         #( #param_ident_strs ),*
                     ],
-                    Vec::new()
                 )
             };
 

--- a/godot-macros/src/util/mod.rs
+++ b/godot-macros/src/util/mod.rs
@@ -32,16 +32,6 @@ pub fn class_name_obj(class: &impl ToTokens) -> TokenStream {
     quote! { <#class as ::godot::obj::GodotClass>::class_name() }
 }
 
-pub fn property_variant_type(property_type: &impl ToTokens) -> TokenStream {
-    let property_type = property_type.to_token_stream();
-    quote! { <<#property_type as ::godot::meta::GodotConvert>::Via as ::godot::meta::GodotType>::Ffi::variant_type() }
-}
-
-pub fn property_variant_class_name(property_type: &impl ToTokens) -> TokenStream {
-    let property_type = property_type.to_token_stream();
-    quote! { <<#property_type as ::godot::meta::GodotConvert>::Via as ::godot::meta::GodotType>::class_name() }
-}
-
 pub fn bail_fn<R, T>(msg: impl AsRef<str>, tokens: T) -> ParseResult<R>
 where
     T: Spanned,

--- a/godot/src/lib.rs
+++ b/godot/src/lib.rs
@@ -178,6 +178,7 @@ pub mod register {
     /// Re-exports used by proc-macro API.
     #[doc(hidden)]
     pub mod private {
+        pub use godot_core::registry::godot_register_wrappers::*;
         pub use godot_core::registry::{constant, method};
     }
 }


### PR DESCRIPTION
Reduces amount of code generated.
Also tiny simplification of `#[func]` codegen.