### PR TITLE
Dev-dependencies are enabling full codegen

### DIFF
--- a/godot-core/Cargo.toml
+++ b/godot-core/Cargo.toml
@@ -53,7 +53,7 @@ godot-codegen = { path = "../godot-codegen", version = "=0.1.3" }
 
 # Reverse dev dependencies so doctests can use `godot::` prefix.
 [dev-dependencies]
-godot = { path = "../godot" }
+godot = { path = "../godot", default-features = false }
 serde_json = { version = "1.0" }
 
 # https://docs.rs/about/metadata

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -641,12 +641,11 @@ where
     ///
     /// # Example
     /// ```no_run
-    /// # fn some_shape() -> Gd<GltfPhysicsShape> { unimplemented!() }
+    /// # fn some_node() -> Gd<Node> { unimplemented!() }
     /// use godot::prelude::*;
-    /// use godot::classes::GltfPhysicsShape;
     ///
-    /// let mut shape: Gd<GltfPhysicsShape> = some_shape();
-    /// shape.set_importer_mesh(Gd::null_arg());
+    /// let mut shape: Gd<Node> = some_node();
+    /// shape.set_owner(Gd::null_arg());
     pub fn null_arg() -> crate::obj::ObjectNullArg<T> {
         crate::obj::ObjectNullArg(std::marker::PhantomData)
     }

--- a/godot-macros/Cargo.toml
+++ b/godot-macros/Cargo.toml
@@ -31,7 +31,7 @@ godot-bindings = { path = "../godot-bindings", version = "=0.1.3" } # emit_godot
 
 # Reverse dev dependencies so doctests can use `godot::` prefix.
 [dev-dependencies]
-godot = { path = "../godot" }
+godot = { path = "../godot", default-features = false }
 
 # https://docs.rs/about/metadata
 [package.metadata.docs.rs]


### PR DESCRIPTION
The `godot` crate is used as a dev-dependency in `godot-core` and `godot-macros`, but the default features are not disabled. This enables full code gen when the tests of these crates are being compiled, even when passing `--no-default-features`.

(I pulled this out of #771 as it isn't really connected with required virtual methods.)