### PR TITLE
Shorten `#[init(default = ...)]` to `#[init(val = ...)]`

### DIFF
--- a/godot-core/src/deprecated.rs
+++ b/godot-core/src/deprecated.rs
@@ -35,12 +35,19 @@ macro_rules! emit_deprecated_warning {
 pub use crate::emit_deprecated_warning;
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
-// Concrete deprecations
+// Library-side deprecations
+
+#[deprecated = "\nThe attribute key #[init(val = ...)] replaces #[init(default = ...)].\n\
+	More information on https://github.com/godot-rust/gdext/pull/844."]
+pub const fn init_default() {}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// Godot-side deprecations
 
 // This is a Godot-side deprecation. Since it's the only way in Godot 4.1, we keep compatibility for now.
 #[cfg_attr(
     since_api = "4.2",
-    deprecated = "Use #[export(range = (radians_as_degrees))] and not #[export(range = (radians))]. \n\
+    deprecated = "\nUse #[export(range = (radians_as_degrees))] and not #[export(range = (radians))].\n\
 	More information on https://github.com/godotengine/godot/pull/82195."
 )]
 pub const fn export_range_radians() {}

--- a/godot-core/src/obj/onready.rs
+++ b/godot-core/src/obj/onready.rs
@@ -87,7 +87,7 @@ use std::mem;
 ///    base: Base<Node>,
 ///    #[init(node = "ChildPath")]
 ///    auto: OnReady<Gd<Node2D>>,
-///    #[init(default = OnReady::manual())]
+///    #[init(val = OnReady::manual())]
 ///    manual: OnReady<i32>,
 /// }
 ///

--- a/godot-macros/src/class/data_models/field.rs
+++ b/godot-macros/src/class/data_models/field.rs
@@ -11,7 +11,7 @@ use proc_macro2::{Ident, TokenStream};
 pub struct Field {
     pub name: Ident,
     pub ty: venial::TypeExpr,
-    pub default: Option<TokenStream>,
+    pub default_val: Option<TokenStream>,
     pub var: Option<FieldVar>,
     pub export: Option<FieldExport>,
     pub is_onready: bool,
@@ -24,7 +24,7 @@ impl Field {
         Self {
             name: field.name.clone(),
             ty: field.ty.clone(),
-            default: None,
+            default_val: None,
             var: None,
             export: None,
             is_onready: false,
@@ -40,4 +40,7 @@ pub struct Fields {
 
     /// The field with type `Base<T>`, if available.
     pub base_field: Option<Field>,
+
+    /// Deprecation warnings.
+    pub deprecations: Vec<TokenStream>,
 }

--- a/godot-macros/src/class/derive_godot_class.rs
+++ b/godot-macros/src/class/derive_godot_class.rs
@@ -433,7 +433,7 @@ fn parse_fields(
                 field.default_val = Some(default);
             }
 
-            // #[init(default = expr)]
+            // Deprecated #[init(default = expr)]
             if let Some(default) = parser.handle_expr("default")? {
                 if field.default_val.is_some() {
                     return bail!(
@@ -454,7 +454,7 @@ fn parse_fields(
                         parser.span(),
                         "The key `node` in attribute #[init] requires field of type `OnReady<T>`\n\
 				         Help: The syntax #[init(node = \"NodePath\")] is equivalent to \
-				         #[init(default = OnReady::node(\"NodePath\"))], \
+				         #[init(val = OnReady::node(\"NodePath\"))], \
 				         which can only be assigned to fields of type `OnReady<T>`"
                     );
                 }
@@ -464,7 +464,7 @@ fn parse_fields(
 				        parser.span(),
 				        "The key `node` in attribute #[init] is mutually exclusive with the key `default`\n\
 				         Help: The syntax #[init(node = \"NodePath\")] is equivalent to \
-				         #[init(default = OnReady::node(\"NodePath\"))], \
+				         #[init(val = OnReady::node(\"NodePath\"))], \
 				         both aren't allowed since they would override each other"
 			        );
                 }

--- a/godot-macros/src/class/derive_godot_class.rs
+++ b/godot-macros/src/class/derive_godot_class.rs
@@ -75,6 +75,7 @@ pub fn derive_godot_class(item: venial::Item) -> ParseResult<TokenStream> {
     let mut create_fn = quote! { None };
     let mut recreate_fn = quote! { None };
     let mut is_instantiable = true;
+    let deprecations = &fields.deprecations;
 
     match struct_cfg.init_strategy {
         InitStrategy::Generated => {
@@ -137,6 +138,7 @@ pub fn derive_godot_class(item: venial::Item) -> ParseResult<TokenStream> {
         #godot_exports_impl
         #user_class_impl
         #init_expecter
+        #( #deprecations )*
 
         ::godot::sys::plugin_add!(__GODOT_PLUGIN_REGISTRY in #prv; #prv::ClassPlugin {
             class_name: #class_name_obj,
@@ -214,7 +216,7 @@ fn make_godot_init_impl(class_name: &Ident, fields: &Fields) -> TokenStream {
     let rest_init = fields.all_fields.iter().map(|field| {
         let field_name = field.name.clone();
         let value_expr = field
-            .default
+            .default_val
             .clone()
             .unwrap_or_else(|| quote! { ::std::default::Default::default() });
 
@@ -399,6 +401,7 @@ fn parse_fields(
 ) -> ParseResult<Fields> {
     let mut all_fields = vec![];
     let mut base_field = Option::<Field>::None;
+    let mut deprecations = vec![];
 
     // Attributes on struct fields
     for (named_field, _punct) in named_fields {
@@ -425,9 +428,23 @@ fn parse_fields(
                 );
             }
 
+            // #[init(val = expr)]
+            if let Some(default) = parser.handle_expr("val")? {
+                field.default_val = Some(default);
+            }
+
             // #[init(default = expr)]
             if let Some(default) = parser.handle_expr("default")? {
-                field.default = Some(default);
+                if field.default_val.is_some() {
+                    return bail!(
+                        parser.span(),
+                        "Cannot use both `val` and `default` keys in #[init]; prefer using `val`"
+                    );
+                }
+                field.default_val = Some(default);
+                deprecations.push(quote! {
+                    ::godot::__deprecated::emit_deprecated_warning!(init_default);
+                })
             }
 
             // #[init(node = "NodePath")]
@@ -442,7 +459,7 @@ fn parse_fields(
                     );
                 }
 
-                if field.default.is_some() {
+                if field.default_val.is_some() {
                     return bail!(
 				        parser.span(),
 				        "The key `node` in attribute #[init] is mutually exclusive with the key `default`\n\
@@ -452,7 +469,7 @@ fn parse_fields(
 			        );
                 }
 
-                field.default = Some(quote! {
+                field.default_val = Some(quote! {
                     OnReady::node(#node_path)
                 });
             }
@@ -491,7 +508,7 @@ fn parse_fields(
             if field.is_onready
                 || field.var.is_some()
                 || field.export.is_some()
-                || field.default.is_some()
+                || field.default_val.is_some()
             {
                 return bail!(
                     named_field,
@@ -516,6 +533,7 @@ fn parse_fields(
     Ok(Fields {
         all_fields,
         base_field,
+        deprecations,
     })
 }
 

--- a/godot-macros/src/docs.rs
+++ b/godot-macros/src/docs.rs
@@ -167,7 +167,7 @@ pub fn member(member: &Field) -> Option<String> {
     let docs = make_docs_from_attributes(&member.attributes)?;
     let name = &member.name;
     let ty = member.ty.to_token_stream().to_string();
-    let default = member.default.to_token_stream().to_string();
+    let default = member.default_val.to_token_stream().to_string();
     Some(format!(
         r#"<member name="{name}" type="{ty}" default="{default}">{docs}</member>"#
     ))

--- a/godot-macros/src/lib.rs
+++ b/godot-macros/src/lib.rs
@@ -67,14 +67,14 @@ use crate::util::ident;
 /// ```
 ///
 /// The generated `init` function will initialize each struct field (except the field of type `Base<T>`, if any)
-/// using `Default::default()`. To assign some other value, annotate the field with `#[init(default = ...)]`:
+/// using `Default::default()`. To assign some other value, annotate the field with `#[init(val = ...)]`:
 ///
 /// ```
 /// # use godot_macros::GodotClass;
 /// #[derive(GodotClass)]
 /// #[class(init)]
 /// struct MyStruct {
-///     #[init(default = 42)]
+///     #[init(val = 42)]
 ///     my_field: i64
 /// }
 /// ```
@@ -91,7 +91,7 @@ use crate::util::ident;
 /// # #[derive(GodotClass)]
 /// # #[class(init)]
 /// # struct MyStruct {
-/// #[init(default = (HashMap::<i64, i64>::new()))]
+/// #[init(val = (HashMap::<i64, i64>::new()))]
 /// //                             ^ parentheses needed due to this comma
 /// my_field: HashMap<i64, i64>,
 /// # }
@@ -544,7 +544,7 @@ pub fn derive_godot_class(input: TokenStream) -> TokenStream {
 ///
 /// ## Generated `init`
 ///
-/// This initializes the `Base<T>` field, and every other field with either `Default::default()` or the value specified in `#[init(default = ...)]`.
+/// This initializes the `Base<T>` field, and every other field with either `Default::default()` or the value specified in `#[init(val = ...)]`.
 ///
 /// ```no_run
 /// # use godot::prelude::*;
@@ -553,7 +553,7 @@ pub fn derive_godot_class(input: TokenStream) -> TokenStream {
 /// pub struct MyNode {
 ///     base: Base<Node>,
 ///
-///     #[init(default = 42)]
+///     #[init(val = 42)]
 ///     some_integer: i64,
 /// }
 /// ```

--- a/itest/rust/build.rs
+++ b/itest/rust/build.rs
@@ -421,7 +421,7 @@ fn generate_property_template(inputs: &[Input]) -> PropertyTests {
 
         let initializer = initializer
             .as_ref()
-            .map(|init| quote! { #[init(default = #init)] });
+            .map(|init| quote! { #[init(val = #init)] });
 
         rust.extend([
             quote! {

--- a/itest/rust/src/object_tests/onready_test.rs
+++ b/itest/rust/src/object_tests/onready_test.rs
@@ -273,7 +273,7 @@ struct InitWithNodeOrBase {
     base: Base<Node>,
     #[init(node = "child")]
     node: OnReady<Gd<Node>>,
-    #[init(default = OnReady::from_base_fn(|b| b.get_name().to_string()))]
+    #[init(val = OnReady::from_base_fn(|b| b.get_name().to_string()))]
     self_name: OnReady<String>,
 }
 

--- a/itest/rust/src/register_tests/var_test.rs
+++ b/itest/rust/src/register_tests/var_test.rs
@@ -14,10 +14,10 @@ struct WithInitDefaults {
     default_int: i64,
 
     #[var(get)]
-    #[init(default = 42)]
+    #[init(val = 42)]
     literal_int: i64,
 
     #[var(get)]
-    #[init(default = -42)]
+    #[init(val = -42)]
     expr_int: i64,
 }


### PR DESCRIPTION
With the recent addition of `#[init(node = ...)]` syntax for `OnReady` node paths (#807), we now have multiple possible keys for the `#[init]` attribute.

Since "value" is a better differentiator to "node" and possibly other future additions, this is now renamed. `val` also makes the syntax reasonably short, being the most common occurrence. "Default" is a bad name because even `node` represents a default value, it just expands to a more complex expression. The commonality is that everything used as a field initializer inside `init()`, which is expressed by `#[init]` already.

The old syntax has been deprecated and will remain working throughout v0.2. A warning is emitted if it is used.