### PR TITLE
Fix user-after-free in `AsObjectArg` pass-by-value (in default-param methods)

### DIFF
--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -402,7 +402,8 @@ jobs:
       - name: "Build and test hot-reload"
         if: ${{ matrix.with-hot-reload }}
         working-directory: examples/hot-reload/godot/test
-        run: ./run-test.sh
+        # Repeat a few times, our hot reload integration test can sometimes be a bit flaky.
+        run: $RETRY ./run-test.sh
         shell: bash
 
 

--- a/godot-codegen/src/generator/functions_common.rs
+++ b/godot-codegen/src/generator/functions_common.rs
@@ -303,6 +303,7 @@ pub fn make_vis(is_private: bool) -> TokenStream {
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Implementation
 
+// Method could possibly be split -- only one invocation uses all 3 return values, the rest uses only index [0] or [2].
 pub(crate) fn make_params_exprs<'a>(
     method_args: impl Iterator<Item = &'a FnParam>,
     is_virtual: bool,

--- a/godot-codegen/src/models/domain.rs
+++ b/godot-codegen/src/models/domain.rs
@@ -627,7 +627,8 @@ pub enum RustTy {
         impl_as_object_arg: TokenStream,
 
         /// only inner `T`
-        #[allow(dead_code)] // only read in minimal config
+        #[allow(dead_code)]
+        // only read in minimal config + RustTy::default_extender_field_decl()
         inner_class: Ident,
     },
 
@@ -645,10 +646,13 @@ impl RustTy {
         }
     }
 
-    /// Returns `( <field tokens>, <needs .as_object_arg()> )`.
-    pub fn private_field_decl(&self) -> (TokenStream, bool) {
+    /// Returns `( <field tokens>, <needs .consume_object()> )`.
+    pub fn default_extender_field_decl(&self) -> (TokenStream, bool) {
         match self {
-            RustTy::EngineClass { object_arg, .. } => (object_arg.clone(), true),
+            RustTy::EngineClass { inner_class, .. } => {
+                let cow_tokens = quote! { ObjectCow<crate::classes::#inner_class> };
+                (cow_tokens, true)
+            }
             other => (other.to_token_stream(), false),
         }
     }

--- a/godot-codegen/src/util.rs
+++ b/godot-codegen/src/util.rs
@@ -28,7 +28,8 @@ pub fn make_imports() -> TokenStream {
         use crate::meta::{ClassName, PtrcallSignatureTuple, VarcallSignatureTuple};
         use crate::classes::native::*;
         use crate::classes::Object;
-        use crate::obj::{Gd, ObjectArg, AsObjectArg};
+        use crate::obj::{Gd, AsObjectArg};
+        use crate::obj::object_arg::{ObjectArg, ObjectCow};
         use crate::sys::GodotFfi as _;
     }
 }

--- a/godot-core/src/meta/sealed.rs
+++ b/godot-core/src/meta/sealed.rs
@@ -63,7 +63,7 @@ impl Sealed for Variant {}
 impl<T: ArrayElement> Sealed for Array<T> {}
 impl<T: GodotClass> Sealed for Gd<T> {}
 impl<T: GodotClass> Sealed for RawGd<T> {}
-impl<T: GodotClass> Sealed for ObjectArg<T> {}
+impl<T: GodotClass> Sealed for object_arg::ObjectArg<T> {}
 impl<T> Sealed for Option<T>
 where
     T: GodotType,

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -646,8 +646,8 @@ where
     ///
     /// let mut shape: Gd<Node> = some_node();
     /// shape.set_owner(Gd::null_arg());
-    pub fn null_arg() -> crate::obj::ObjectNullArg<T> {
-        crate::obj::ObjectNullArg(std::marker::PhantomData)
+    pub fn null_arg() -> crate::obj::object_arg::ObjectNullArg<T> {
+        crate::obj::object_arg::ObjectNullArg(std::marker::PhantomData)
     }
 }
 

--- a/godot-core/src/obj/mod.rs
+++ b/godot-core/src/obj/mod.rs
@@ -15,18 +15,18 @@ mod base;
 mod gd;
 mod guards;
 mod instance_id;
-mod object_arg;
 mod onready;
 mod raw_gd;
 mod traits;
 
+pub(crate) mod object_arg;
 pub(crate) mod rtti;
 
 pub use base::*;
 pub use gd::*;
 pub use guards::{BaseMut, BaseRef, GdMut, GdRef};
 pub use instance_id::*;
-pub use object_arg::*;
+pub use object_arg::AsObjectArg;
 pub use onready::*;
 pub use raw_gd::*;
 pub use traits::*;

--- a/godot-core/src/tools/save_load.rs
+++ b/godot-core/src/tools/save_load.rs
@@ -164,7 +164,7 @@ where
 {
     // TODO unclone GString
     let res = ResourceSaver::singleton()
-        .save_ex(obj.upcast())
+        .save_ex(obj)
         .path(path.clone())
         .done();
 

--- a/itest/rust/src/builtin_tests/containers/array_test.rs
+++ b/itest/rust/src/builtin_tests/containers/array_test.rs
@@ -394,7 +394,7 @@ fn untyped_array_return_from_godot_func() {
     let mut node = Node::new_alloc();
     let mut child = Node::new_alloc();
     child.set_name("child_node".into());
-    node.add_child(child.clone());
+    node.add_child(&child);
     node.queue_free(); // Do not leak even if the test fails.
     let result = node.get_node_and_resource("child_node".into());
 
@@ -431,7 +431,7 @@ fn typed_array_return_from_godot_func() {
     let mut node = Node::new_alloc();
     let mut child = Node::new_alloc();
     child.set_name("child_node".into());
-    node.add_child(child.clone());
+    node.add_child(&child);
     node.queue_free(); // Do not leak even if the test fails.
     let children = node.get_children();
 
@@ -477,10 +477,7 @@ fn array_should_format_with_display() {
 #[cfg(since_api = "4.2")]
 fn array_sort_custom() {
     let mut a = array![1, 2, 3, 4];
-    let func = Callable::from_fn("sort backwards", |args: &[&Variant]| {
-        let res = i32::from_variant(args[0]) > i32::from_variant(args[1]);
-        Ok(Variant::from(res))
-    });
+    let func = backwards_sort_callable();
     a.sort_unstable_custom(func);
     assert_eq!(a, array![4, 3, 2, 1]);
 }
@@ -489,12 +486,17 @@ fn array_sort_custom() {
 #[cfg(since_api = "4.2")]
 fn array_binary_search_custom() {
     let a = array![5, 4, 2, 1];
-    let func = Callable::from_fn("sort backwards", |args: &[&Variant]| {
-        let res = i32::from_variant(args[0]) > i32::from_variant(args[1]);
-        Ok(Variant::from(res))
-    });
+    let func = backwards_sort_callable();
     assert_eq!(a.bsearch_custom(&1, func.clone()), 3);
     assert_eq!(a.bsearch_custom(&3, func), 2);
+}
+
+#[cfg(since_api = "4.2")]
+fn backwards_sort_callable() -> Callable {
+    Callable::from_fn("sort backwards", |args: &[&Variant]| {
+        let res = args[0].to::<i32>() > args[1].to::<i32>();
+        Ok(res.to_variant())
+    })
 }
 
 #[itest]

--- a/itest/rust/src/engine_tests/node_test.rs
+++ b/itest/rust/src/engine_tests/node_test.rs
@@ -67,10 +67,10 @@ fn node_scene_tree() {
 
     let mut parent = Node::new_alloc();
     parent.set_name("parent".into());
-    parent.add_child(child.clone());
+    parent.add_child(&child);
 
     let mut scene = PackedScene::new_gd();
-    let err = scene.pack(parent.clone());
+    let err = scene.pack(&parent);
     assert_eq!(err, global::Error::OK);
 
     let mut tree = SceneTree::new_alloc();


### PR DESCRIPTION
Fixes #835.
No longer causes UB when passing objects by value to engine methods that have default parameters.

Notably, this PR does **not** enforce borrowing/taking by reference (at least for now).