### PR TITLE
`AsObjectArg<T>` is now implemented for `&mut Gd<T>`

### DIFF
--- a/godot-core/src/obj/object_arg.rs
+++ b/godot-core/src/obj/object_arg.rs
@@ -67,6 +67,22 @@ where
     }
 }
 
+impl<T, U> AsObjectArg<T> for &mut Gd<U>
+where
+    T: GodotClass + Bounds<Declarer = bounds::DeclEngine>,
+    U: Inherits<T>,
+{
+    // Delegate to &Gd impl.
+
+    fn as_object_arg(&self) -> ObjectArg<T> {
+        <&Gd<U>>::as_object_arg(&&**self)
+    }
+
+    fn consume_object(self) -> ObjectCow<T> {
+        <&Gd<U>>::consume_object(&*self)
+    }
+}
+
 impl<T, U> AsObjectArg<T> for Option<U>
 where
     T: GodotClass + Bounds<Declarer = bounds::DeclEngine>,

--- a/itest/rust/src/object_tests/object_arg_test.rs
+++ b/itest/rust/src/object_tests/object_arg_test.rs
@@ -34,6 +34,16 @@ fn object_arg_borrowed() {
 }
 
 #[itest]
+fn object_arg_borrowed_mut() {
+    with_objects(|mut manual, mut refc| {
+        let db = ClassDb::singleton();
+        let a = db.class_set_property(&mut manual, "name".into(), Variant::from("hello"));
+        let b = db.class_set_property(&mut refc, "value".into(), Variant::from(-123));
+        (a, b)
+    });
+}
+
+#[itest]
 fn object_arg_option_owned() {
     with_objects(|manual, refc| {
         let db = ClassDb::singleton();
@@ -49,6 +59,16 @@ fn object_arg_option_borrowed() {
         let db = ClassDb::singleton();
         let a = db.class_set_property(Some(&manual), "name".into(), Variant::from("hello"));
         let b = db.class_set_property(Some(&refc), "value".into(), Variant::from(-123));
+        (a, b)
+    });
+}
+
+#[itest]
+fn object_arg_option_borrowed_mut() {
+    with_objects(|mut manual, mut refc| {
+        let db = ClassDb::singleton();
+        let a = db.class_set_property(Some(&mut manual), "name".into(), Variant::from("hello"));
+        let b = db.class_set_property(Some(&mut refc), "value".into(), Variant::from(-123));
         (a, b)
     });
 }


### PR DESCRIPTION
Based on #846.

If you have a `&mut Gd`, you can now pass it to engine APIs, just like `&Gd`.