### PR TITLE
`RawGd::move_return_ptr` with `PtrcallType::Virtual` leaks reference

### DIFF
--- a/godot-core/src/obj/raw_gd.rs
+++ b/godot-core/src/obj/raw_gd.rs
@@ -520,12 +520,14 @@ where
 
     unsafe fn move_return_ptr(self, ptr: sys::GDExtensionTypePtr, call_type: PtrcallType) {
         if T::DynMemory::pass_as_ref(call_type) {
-            interface_fn!(ref_set_object)(ptr as sys::GDExtensionRefPtr, self.obj_sys())
+            // ref_set_object creates a new Ref<T> in the engine and increments the reference count. We have to drop our Gd<T> to decrement
+            // the reference count again.
+            interface_fn!(ref_set_object)(ptr as sys::GDExtensionRefPtr, self.obj_sys());
         } else {
-            ptr::write(ptr as *mut _, self.obj)
+            ptr::write(ptr as *mut _, self.obj);
+            // We've passed ownership to caller.
+            std::mem::forget(self);
         }
-        // We've passed ownership to caller.
-        std::mem::forget(self);
     }
 }
 


### PR DESCRIPTION
I came across this reference leak while working on #771. The engine is creating `AudioEffectInstance`s which are being leaked. This is caused by the `RawGd::move_return_ptr` method.

Calling Godot's `ref_set_object` creates a new ref counted reference in the engine and increments the count by 1. Since we already hold the initial reference, the count is now at 2. Calling `mem::forget(self)` on our reference prevents the count from going down to 1 where it should be after we return from our function.

