### PR TITLE
Validate that virtual extension classes require `#[class(tool)]`

### DIFF
--- a/godot-core/src/obj/script.rs
+++ b/godot-core/src/obj/script.rs
@@ -53,8 +53,9 @@ use self::bounded_ptr_list::BoundedPtrList;
 /// use godot::extras::{IScriptExtension, ScriptInstance};
 ///
 /// // 1) Define the script.
+/// // This needs #[class(tool)] since the script extension runs in the editor.
 /// #[derive(GodotClass)]
-/// #[class(init, base=ScriptExtension)]
+/// #[class(init, base=ScriptExtension, tool)]
 /// struct MyScript {
 ///    base: Base<ScriptExtension>,
 ///    // ... other fields

--- a/godot-core/src/registry/class.rs
+++ b/godot-core/src/registry/class.rs
@@ -348,6 +348,7 @@ fn fill_into<T>(dst: &mut Option<T>, src: Option<T>) -> Result<(), ()> {
 /// Registers a class with given the dynamic type information `info`.
 fn register_class_raw(mut info: ClassRegistrationInfo) {
     // First register class...
+    validate_class_constraints(&info);
 
     let class_name = info.class_name;
     let parent_class_name = info
@@ -426,6 +427,10 @@ fn register_class_raw(mut info: ClassRegistrationInfo) {
     if info.is_editor_plugin {
         unsafe { interface_fn!(editor_add_plugin)(class_name.string_sys()) };
     }
+}
+
+fn validate_class_constraints(_class: &ClassRegistrationInfo) {
+    // TODO: if we add builder API, the proc-macro checks in parse_struct_attributes() etc. should be duplicated here.
 }
 
 fn unregister_class_raw(class: LoadedClass) {

--- a/itest/rust/src/builtin_tests/script/script_instance_tests.rs
+++ b/itest/rust/src/builtin_tests/script/script_instance_tests.rs
@@ -17,7 +17,7 @@ use godot::register::{godot_api, GodotClass};
 use godot::sys;
 
 #[derive(GodotClass)]
-#[class(base = ScriptExtension, init)]
+#[class(base = ScriptExtension, init, tool)]
 struct TestScript {
     base: Base<ScriptExtension>,
 }


### PR DESCRIPTION
Adds validation for an issue brought up in https://github.com/godot-rust/gdext/issues/826#issuecomment-2282202619.

@TitanNano you might want to have a look?