### PR TITLE
Best-effort checks for `Array<Integer>` conversions; fix `Debug` for variants containing typed arrays

### DIFF
--- a/godot-codegen/src/conv/type_conversions.rs
+++ b/godot-codegen/src/conv/type_conversions.rs
@@ -218,7 +218,7 @@ fn to_rust_type_uncached(full_ty: &GodotTy, ctx: &mut Context) -> RustTy {
         let rust_elem_ty = to_rust_type(elem_ty, None, ctx);
         return if ctx.is_builtin(elem_ty) {
             RustTy::BuiltinArray {
-                elem_type: quote! { Array<#rust_elem_ty> }
+                elem_type: quote! { Array<#rust_elem_ty> },
             }
         } else {
             RustTy::EngineArray {

--- a/godot-codegen/src/conv/type_conversions.rs
+++ b/godot-codegen/src/conv/type_conversions.rs
@@ -217,7 +217,9 @@ fn to_rust_type_uncached(full_ty: &GodotTy, ctx: &mut Context) -> RustTy {
     } else if let Some(elem_ty) = ty.strip_prefix("typedarray::") {
         let rust_elem_ty = to_rust_type(elem_ty, None, ctx);
         return if ctx.is_builtin(elem_ty) {
-            RustTy::BuiltinArray(quote! { Array<#rust_elem_ty> })
+            RustTy::BuiltinArray {
+                elem_type: quote! { Array<#rust_elem_ty> }
+            }
         } else {
             RustTy::EngineArray {
                 tokens: quote! { Array<#rust_elem_ty> },

--- a/godot-codegen/src/models/domain.rs
+++ b/godot-codegen/src/models/domain.rs
@@ -588,11 +588,13 @@ pub struct GodotTy {
 
 #[derive(Clone, Debug)]
 pub enum RustTy {
-    /// `bool`, `Vector3i`
+    /// `bool`, `Vector3i`, `Array`
     BuiltinIdent(Ident),
 
     /// `Array<i32>`
-    BuiltinArray(TokenStream),
+    ///
+    /// Note that untyped arrays are mapped as `BuiltinIdent("Array")`.
+    BuiltinArray { elem_type: TokenStream },
 
     /// C-style raw pointer to a `RustTy`.
     RawPointer { inner: Box<RustTy>, is_const: bool },
@@ -674,7 +676,7 @@ impl ToTokens for RustTy {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         match self {
             RustTy::BuiltinIdent(ident) => ident.to_tokens(tokens),
-            RustTy::BuiltinArray(path) => path.to_tokens(tokens),
+            RustTy::BuiltinArray { elem_type } => elem_type.to_tokens(tokens),
             RustTy::RawPointer {
                 inner,
                 is_const: true,

--- a/godot-codegen/src/special_cases/codegen_special_cases.rs
+++ b/godot-codegen/src/special_cases/codegen_special_cases.rs
@@ -37,7 +37,7 @@ fn is_type_excluded(ty: &str, ctx: &mut Context) -> bool {
     fn is_rust_type_excluded(ty: &RustTy) -> bool {
         match ty {
             RustTy::BuiltinIdent(_) => false,
-            RustTy::BuiltinArray(_) => false,
+            RustTy::BuiltinArray { .. } => false,
             RustTy::RawPointer { inner, .. } => is_rust_type_excluded(inner),
             RustTy::EngineArray { elem_class, .. } => is_class_excluded(elem_class.as_str()),
             RustTy::EngineEnum {

--- a/godot-core/src/builtin/collections/array.rs
+++ b/godot-core/src/builtin/collections/array.rs
@@ -731,7 +731,12 @@ impl<T: ArrayElement> Array<T> {
         let variant_type = VariantType::from_sys(
             self.as_inner().get_typed_builtin() as sys::GDExtensionVariantType
         );
-        let class_name = self.as_inner().get_typed_class_name();
+
+        let class_name = if variant_type == VariantType::OBJECT {
+            Some(self.as_inner().get_typed_class_name())
+        } else {
+            None
+        };
 
         ArrayTypeInfo {
             variant_type,
@@ -768,12 +773,22 @@ impl<T: ArrayElement> Array<T> {
         if type_info.is_typed() {
             let script = Variant::nil();
 
+            // A bit contrived because empty StringName is lazy-initialized but must also remain valid.
+            #[allow(unused_assignments)]
+            let mut empty_string_name = None;
+            let class_name = if let Some(class_name) = &type_info.class_name {
+                class_name.string_sys()
+            } else {
+                empty_string_name = Some(StringName::default());
+                empty_string_name.unwrap().string_sys()
+            };
+
             // SAFETY: The array is a newly created empty untyped array.
             unsafe {
                 interface_fn!(array_set_typed)(
                     self.sys_mut(),
                     type_info.variant_type.sys(),
-                    type_info.class_name.string_sys(),
+                    class_name, // must be empty if variant_type != OBJECT.
                     script.var_sys(),
                 );
             }

--- a/godot-core/src/builtin/collections/array.rs
+++ b/godot-core/src/builtin/collections/array.rs
@@ -813,7 +813,8 @@ impl<T: ArrayElement> Array<T> {
                 class_name.string_sys()
             } else {
                 empty_string_name = Some(StringName::default());
-                empty_string_name.unwrap().string_sys()
+                // as_ref() crucial here -- otherwise the StringName is dropped.
+                empty_string_name.as_ref().unwrap().string_sys()
             };
 
             // SAFETY: The array is a newly created empty untyped array.

--- a/godot-core/src/builtin/collections/array.rs
+++ b/godot-core/src/builtin/collections/array.rs
@@ -34,6 +34,9 @@ use sys::{ffi_methods, interface_fn, GodotFfi};
 /// `Array<T>`, where the type `T` must implement `ArrayElement`. Some types like `Array<T>` cannot
 /// be stored inside arrays, as Godot prevents nesting.
 ///
+/// If you plan to use any integer or float types apart from `i64` and `f64`, read
+/// [this documentation](../meta/trait.ArrayElement.html#integer-and-float-types).
+///
 /// # Reference semantics
 ///
 /// Like in GDScript, `Array` acts as a reference type: multiple `Array` instances may

--- a/godot-core/src/builtin/collections/dictionary.rs
+++ b/godot-core/src/builtin/collections/dictionary.rs
@@ -606,7 +606,7 @@ impl<'a> Keys<'a> {
         TypedKeys::from_untyped(self)
     }
 
-    /// Returns an array of the keys
+    /// Returns an array of the keys.
     pub fn array(self) -> VariantArray {
         // Can only be called
         assert!(self.iter.is_first);

--- a/godot-core/src/builtin/collections/packed_array.rs
+++ b/godot-core/src/builtin/collections/packed_array.rs
@@ -548,7 +548,7 @@ macro_rules! impl_packed_array {
             fn export_hint() -> $crate::meta::PropertyHintInfo {
                 // In 4.3 Godot can (and does) use type hint strings for packed arrays, see https://github.com/godotengine/godot/pull/82952.
                 if sys::GdextBuild::since_api("4.3") {
-                    $crate::meta::PropertyHintInfo::export_array_element::<$Element>()
+                    $crate::meta::PropertyHintInfo::export_packed_array_element::<$Element>()
                 } else {
                     $crate::meta::PropertyHintInfo::type_name::<$PackedArray>()
                 }

--- a/godot-core/src/meta/error/convert_error.rs
+++ b/godot-core/src/meta/error/convert_error.rs
@@ -169,12 +169,19 @@ impl fmt::Display for ErrorKind {
 /// Conversion failed during a [`FromGodot`](crate::meta::FromGodot) call.
 #[derive(Eq, PartialEq, Debug)]
 pub(crate) enum FromGodotError {
+    /// Destination `Array<T>` has different type than source's runtime type.
     BadArrayType {
         expected: ArrayTypeInfo,
         actual: ArrayTypeInfo,
     },
+
+    /// Special case of `BadArrayType` where a custom int type such as `i8` cannot hold a dynamic `i64` value.
+    BadArrayTypeInt { expected: ArrayTypeInfo, value: i64 },
+
     /// InvalidEnum is also used by bitfields.
     InvalidEnum,
+
+    /// `InstanceId` cannot be 0.
     ZeroInstanceId,
 }
 
@@ -218,6 +225,12 @@ impl fmt::Display for FromGodotError {
                 write!(
                     f,
                     "expected array of class {exp_class}, got array of class {act_class}"
+                )
+            }
+            Self::BadArrayTypeInt { expected, value } => {
+                write!(
+                    f,
+                    "integer value {value} does not fit into Array of type {expected:?}"
                 )
             }
             Self::InvalidEnum => write!(f, "invalid engine enum value"),

--- a/godot-core/src/meta/error/convert_error.rs
+++ b/godot-core/src/meta/error/convert_error.rs
@@ -208,17 +208,16 @@ impl fmt::Display for FromGodotError {
                     };
                 }
 
+                let exp_class = expected.class_name().expect("lhs class name present");
+                let act_class = actual.class_name().expect("rhs class name present");
                 assert_ne!(
-                    expected.class_name(),
-                    actual.class_name(),
+                    exp_class, act_class,
                     "BadArrayType with expected == got, this is a gdext bug"
                 );
 
                 write!(
                     f,
-                    "expected array of class {}, got array of class {}",
-                    expected.class_name(),
-                    actual.class_name()
+                    "expected array of class {exp_class}, got array of class {act_class}"
                 )
             }
             Self::InvalidEnum => write!(f, "invalid engine enum value"),

--- a/godot-core/src/meta/godot_convert/impls.rs
+++ b/godot-core/src/meta/godot_convert/impls.rs
@@ -5,7 +5,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use crate::builtin::Variant;
+use crate::builtin::{Array, Variant};
 use crate::meta::error::{ConvertError, FromFfiError, FromVariantError};
 use crate::meta::{
     ArrayElement, ClassName, FromGodot, GodotConvert, GodotNullableFfi, GodotType,
@@ -174,6 +174,13 @@ macro_rules! impl_godot_scalar {
             impl_godot_scalar!(@shared_fns; $Via, $param_metadata);
         }
 
+        // For integer types, we can validate the conversion.
+        impl ArrayElement for $T {
+            fn debug_validate_elements(array: &Array<Self>) -> Result<(), ConvertError> {
+                array.debug_validate_elements()
+            }
+        }
+
         impl_godot_scalar!(@shared_traits; $T);
     };
 
@@ -196,6 +203,9 @@ macro_rules! impl_godot_scalar {
             impl_godot_scalar!(@shared_fns; $Via, $param_metadata);
         }
 
+        // For f32, conversion from f64 is lossy but will always succeed. Thus no debug validation needed.
+        impl ArrayElement for $T {}
+
         impl_godot_scalar!(@shared_traits; $T);
     };
 
@@ -210,8 +220,6 @@ macro_rules! impl_godot_scalar {
     };
 
     (@shared_traits; $T:ty) => {
-        impl ArrayElement for $T {}
-
         impl GodotConvert for $T {
             type Via = $T;
         }

--- a/godot-core/src/meta/godot_convert/mod.rs
+++ b/godot-core/src/meta/godot_convert/mod.rs
@@ -91,8 +91,10 @@ pub trait FromGodot: Sized + GodotConvert {
     /// # Panics
     /// If the conversion fails.
     fn from_variant(variant: &Variant) -> Self {
-        Self::try_from_variant(variant)
-            .unwrap_or_else(|err| panic!("FromGodot::from_variant() failed: {err}"))
+        Self::try_from_variant(variant).unwrap_or_else(|err| {
+            eprintln!("FromGodot::from_variant() failed: {err}");
+            panic!()
+        })
     }
 }
 

--- a/godot-core/src/meta/mod.rs
+++ b/godot-core/src/meta/mod.rs
@@ -46,7 +46,7 @@ mod traits;
 pub mod error;
 pub use class_name::ClassName;
 pub use godot_convert::{FromGodot, GodotConvert, ToGodot};
-pub use traits::{ArrayElement, GodotType};
+pub use traits::{ArrayElement, GodotType, PackedArrayElement};
 
 pub(crate) use crate::impl_godot_as_self;
 pub(crate) use array_type_info::ArrayTypeInfo;

--- a/godot-core/src/meta/property_info.rs
+++ b/godot-core/src/meta/property_info.rs
@@ -7,7 +7,7 @@
 
 use crate::builtin::{GString, StringName};
 use crate::global::{PropertyHint, PropertyUsageFlags};
-use crate::meta::{ArrayElement, ClassName, GodotType};
+use crate::meta::{ArrayElement, ClassName, GodotType, PackedArrayElement};
 use crate::registry::property::{Export, Var};
 use crate::sys;
 use godot_ffi::VariantType;
@@ -240,6 +240,14 @@ impl PropertyHintInfo {
 
     /// Use for `#[export]` properties -- [`PROPERTY_HINT_TYPE_STRING`](PropertyHint::TYPE_STRING) with the **element** type string as hint string.
     pub fn export_array_element<T: ArrayElement>() -> Self {
+        Self {
+            hint: PropertyHint::TYPE_STRING,
+            hint_string: GString::from(T::element_type_string()),
+        }
+    }
+
+    /// Use for `#[export]` properties -- [`PROPERTY_HINT_TYPE_STRING`](PropertyHint::TYPE_STRING) with the **element** type string as hint string.
+    pub fn export_packed_array_element<T: PackedArrayElement>() -> Self {
         Self {
             hint: PropertyHint::TYPE_STRING,
             hint_string: GString::from(T::element_type_string()),

--- a/godot-core/src/meta/traits.rs
+++ b/godot-core/src/meta/traits.rs
@@ -189,4 +189,3 @@ impl PackedArrayElement for crate::builtin::Vector3 {}
 impl PackedArrayElement for crate::builtin::Vector4 {}
 impl PackedArrayElement for crate::builtin::Color {}
 impl PackedArrayElement for crate::builtin::GString {}
-

--- a/godot-core/src/meta/traits.rs
+++ b/godot-core/src/meta/traits.rs
@@ -7,7 +7,7 @@
 
 use godot_ffi as sys;
 
-use crate::builtin::{StringName, Variant};
+use crate::builtin::{Array, StringName, Variant};
 use crate::global::PropertyUsageFlags;
 use crate::meta::error::ConvertError;
 use crate::meta::{
@@ -157,6 +157,11 @@ pub trait ArrayElement: GodotType + sealed::Sealed {
         // Most array elements and all packed array elements are builtin types, so this is a good default.
         builtin_type_string::<Self>()
     }
+
+    fn debug_validate_elements(_array: &Array<Self>) -> Result<(), ConvertError> {
+        // No-op for most element types.
+        Ok(())
+    }
 }
 
 /// Marker trait to identify types that can be stored in `Packed*Array` types.
@@ -184,3 +189,4 @@ impl PackedArrayElement for crate::builtin::Vector3 {}
 impl PackedArrayElement for crate::builtin::Vector4 {}
 impl PackedArrayElement for crate::builtin::Color {}
 impl PackedArrayElement for crate::builtin::GString {}
+

--- a/godot-core/src/meta/traits.rs
+++ b/godot-core/src/meta/traits.rs
@@ -128,20 +128,44 @@ pub trait GodotType:
 /// - `Option` is only supported for `Option<Gd<T>>`, but not e.g. `Option<i32>`.
 #[diagnostic::on_unimplemented(
     message = "`Array<T>` can only store element types supported in Godot arrays (no nesting).",
-    label = "does not implement `Var`",
-    note = "see also: https://godot-rust.github.io/docs/gdext/master/godot/builtin/meta/trait.ArrayElement.html"
+    label = "has invalid element type",
 )]
 pub trait ArrayElement: GodotType + sealed::Sealed {
     /// Returns the representation of this type as a type string.
     ///
-    /// Used for elements in arrays and packed arrays (the latter despite `ArrayElement` not having a direct relation).
+    /// Used for elements in arrays (the latter despite `ArrayElement` not having a direct relation).
     ///
-    /// See [`PropertyHint::TYPE_STRING`] and [upstream docs].
-    ///
-    /// [upstream docs]: https://docs.godotengine.org/en/stable/classes/class_%40globalscope.html#enum-globalscope-propertyhint
+    /// See [`PropertyHint::TYPE_STRING`] and
+    /// [upstream docs](https://docs.godotengine.org/en/stable/classes/class_%40globalscope.html#enum-globalscope-propertyhint).
     #[doc(hidden)]
     fn element_type_string() -> String {
         // Most array elements and all packed array elements are builtin types, so this is a good default.
         builtin_type_string::<Self>()
     }
 }
+
+/// Marker trait to identify types that can be stored in `Packed*Array` types.
+#[diagnostic::on_unimplemented(
+    message = "`Packed*Array` can only store element types supported in Godot packed arrays.",
+    label = "has invalid element type"
+)]
+pub trait PackedArrayElement: GodotType + sealed::Sealed {
+    /// See [`ArrayElement::element_type_string()`].
+    #[doc(hidden)]
+    fn element_type_string() -> String {
+        builtin_type_string::<Self>()
+    }
+}
+
+// Implement all packed array element types.
+impl PackedArrayElement for u8 {}
+impl PackedArrayElement for i32 {}
+impl PackedArrayElement for i64 {}
+impl PackedArrayElement for f32 {}
+impl PackedArrayElement for f64 {}
+impl PackedArrayElement for crate::builtin::Vector2 {}
+impl PackedArrayElement for crate::builtin::Vector3 {}
+#[cfg(since_api = "4.3")]
+impl PackedArrayElement for crate::builtin::Vector4 {}
+impl PackedArrayElement for crate::builtin::Color {}
+impl PackedArrayElement for crate::builtin::GString {}

--- a/godot-core/src/meta/traits.rs
+++ b/godot-core/src/meta/traits.rs
@@ -120,15 +120,30 @@ pub trait GodotType:
 
 /// Marker trait to identify types that can be stored in [`Array<T>`][crate::builtin::Array].
 ///
-/// The types for which this trait is implemented, overlap mostly with [`GodotType`].
-/// This is done consistently what GDScript allows inside `Array[T]`.
+/// The types, for which this trait is implemented, overlap mostly with [`GodotType`].
 ///
 /// Notable differences are:
 /// - Only `VariantArray`, not `Array<T>` is allowed (typed arrays cannot be nested).
 /// - `Option` is only supported for `Option<Gd<T>>`, but not e.g. `Option<i32>`.
+///
+/// # Integer and float types
+/// `u8`, `i8`, `u16`, `i16`, `u32`, `i32` and `f32` are supported by this trait, however they don't have their own array type in Godot.
+/// The engine only knows about `i64` ("int") and `f64` ("float") types. This means that when using any integer or float type, Godot
+/// will treat it as the equivalent of GDScript's `Array[int]` or `Array[float]`, respectively.
+///
+/// As a result, when converting from a Godot typed array to a Rust `Array<T>`, the values stored may not actually fit into a `T`.
+/// For example, you have a GDScript `Array[int]` which stores value 160, and you convert it to a Rust `Array<i8>`. This means that you may
+/// end up with panics on element access (since the `Variant` storing 160 will fail to convert to `i8`). In Debug mode, we add additional
+/// best-effort checks to detect such errors, however they are expensive and not bullet-proof. If you need very rigid type safety, stick to
+/// `i64` and `f64`. The other types however can be extremely convenient and work well, as long as you are aware of the limitations.
+///
+/// `u64` is entirely unsupported since it cannot be safely stored inside a `Variant`.
+///
+/// Also, keep in mind that Godot uses `Variant` for each element. If performance matters and you have small element types such as `u8`,
+/// consider using packed arrays (e.g. `PackedByteArray`) instead.
 #[diagnostic::on_unimplemented(
     message = "`Array<T>` can only store element types supported in Godot arrays (no nesting).",
-    label = "has invalid element type",
+    label = "has invalid element type"
 )]
 pub trait ArrayElement: GodotType + sealed::Sealed {
     /// Returns the representation of this type as a type string.

--- a/itest/rust/src/builtin_tests/containers/variant_test.rs
+++ b/itest/rust/src/builtin_tests/containers/variant_test.rs
@@ -130,7 +130,7 @@ fn variant_bad_conversions() {
         .expect_err("`nil` should not convert to `Dictionary`");
 }
 
-#[itest(focus)]
+#[itest]
 fn variant_array_bad_conversions() {
     let i32_array: Array<i32> = array![1, 2, 160, -40];
     let i32_variant = i32_array.to_variant();
@@ -140,15 +140,19 @@ fn variant_array_bad_conversions() {
     #[cfg(debug_assertions)]
     {
         let err = i8_back.expect_err("Array<i32> -> Array<i8> conversion should fail");
-        assert_eq!(err.to_string(), "`i8` cannot store the given value: 160")
+        assert_eq!(
+            err.to_string(),
+            "integer value 160 does not fit into Array of type INT: [1, 2, 160, -40]"
+        )
     }
 
     // In Release mode, we expect the conversion to succeed, but a panic to occur on element access.
     #[cfg(not(debug_assertions))]
     {
         let i8_array = i8_back.expect("Array<i32> -> Array<i8> conversion should succeed");
-        expect_panic("i8_array[2] should panic", || {
-            i8_array[2];
+        expect_panic("accessing element 160 as i8 should panic", || {
+            // Note: get() returns Err on out-of-bounds, but currently panics on bad element type, since that's always a bug.
+            i8_array.get(2);
         });
     }
 }

--- a/itest/rust/src/builtin_tests/containers/variant_test.rs
+++ b/itest/rust/src/builtin_tests/containers/variant_test.rs
@@ -9,7 +9,7 @@ use std::cmp::Ordering;
 use std::fmt::Display;
 
 use godot::builtin::{
-    dict, varray, GString, NodePath, Signal, StringName, Variant, Vector2, Vector3,
+    array, dict, varray, Array, GString, NodePath, Signal, StringName, Variant, Vector2, Vector3,
 };
 use godot::builtin::{Basis, Dictionary, VariantArray, VariantOperator, VariantType};
 use godot::classes::{Node, Node2D};
@@ -128,6 +128,29 @@ fn variant_bad_conversions() {
         .to_variant()
         .try_to::<Dictionary>()
         .expect_err("`nil` should not convert to `Dictionary`");
+}
+
+#[itest(focus)]
+fn variant_array_bad_conversions() {
+    let i32_array: Array<i32> = array![1, 2, 160, -40];
+    let i32_variant = i32_array.to_variant();
+    let i8_back = i32_variant.try_to::<Array<i8>>();
+
+    // In Debug mode, we expect an error upon conversion.
+    #[cfg(debug_assertions)]
+    {
+        let err = i8_back.expect_err("Array<i32> -> Array<i8> conversion should fail");
+        assert_eq!(err.to_string(), "`i8` cannot store the given value: 160")
+    }
+
+    // In Release mode, we expect the conversion to succeed, but a panic to occur on element access.
+    #[cfg(not(debug_assertions))]
+    {
+        let i8_array = i8_back.expect("Array<i32> -> Array<i8> conversion should succeed");
+        expect_panic("i8_array[2] should panic", || {
+            i8_array[2];
+        });
+    }
 }
 
 #[itest]


### PR DESCRIPTION
Addresses part of #727: the `Variant` `Debug` impl no longer panics.
However, conversions from `Array<T>` to `VariantArray` are still not possible, and need more design (`OutArray` PR #806).

Closes #805.

I decided to **not** forbid `Array` with element types `u8`, `i8`, `u16`, `i16`, `u32`, `i32` and `f32`, for the following reasons:
- `Array` is a general-purpose sequential data structure with focus on versatility/convenience. It's not particularly fast for small elements due to its `Variant` storage and conversions, but it supports the widest range of element types. The integer types fit somewhat naturally.
- The number of conversions introduced by enforcing `i64` (a not very natural type in everyday gamedev) would make a lot of code more tedious. It's already something [I really dislike about `f64`](https://github.com/godot-rust/gdext/issues/510), and I don't want to proliferate this practice.
- A typical use case of `Array<i16>` etc. is exposing data from Rust to GDScript, e.g. returning from `#[func]` or as a `#[var]` property. If such an integer type is chosen in place of `i64`, that's usually because the developer knows the domain of the possible values, and the risk of inputing too big numbers is limited.
- We do not lose memory safety if an unrepresentable number is stored in the array. It "only" causes a logic error -- which would happen anyway -- but at a later point (on access instead of array construction). There is of course a small risk that this is missed.
- Because of that risk, Debug mode by default runs a O(n) validity check on the elements for non-`i64` integer conversions. I consider justifiable because a) arrays are often small and/or sequential iteration is fast, b) performance is _already_ bad for `Array` and people who care use packed arrays, c) it's turned off in Release mode. It's also a no-op for all other array element types. This check is best-effort, so it won't catch all scenarios (like appending from GDScript).
- People who want maximum type safety can simply stick to `i64` and `f64`. This also means no runtime checks.

Furthermore, [godot-cpp also allows `Array` with these element types](https://github.com/godotengine/godot-cpp/blob/9b98377a62ae456b0ee082062dbe98d1a13e7bda/include/godot_cpp/core/type_info.hpp#L366-L373). They go even further and enable `uint64_t`, something we don't do.