### PR TITLE
Enable `ResourceLoader::load_threaded_*` with `experimental-threads`

### DIFF
--- a/godot-codegen/Cargo.toml
+++ b/godot-codegen/Cargo.toml
@@ -18,6 +18,7 @@ codegen-rustfmt = []
 double-precision = []
 api-custom = ["godot-bindings/api-custom"]
 experimental-godot-api = []
+experimental-threads = []
 
 [dependencies]
 godot-bindings = { path = "../godot-bindings", version = "=0.1.3" }

--- a/godot-codegen/src/special_cases/special_cases.rs
+++ b/godot-codegen/src/special_cases/special_cases.rs
@@ -51,12 +51,6 @@ pub fn is_class_method_deleted(class_name: &TyName, method: &JsonClassMethod, ct
         | ("GDExtension", "initialize_library")
         | ("GDExtension", "close_library")
 
-        // Thread APIs
-        | ("ResourceLoader", "load_threaded_get")
-        | ("ResourceLoader", "load_threaded_get_status")
-        | ("ResourceLoader", "load_threaded_request")
-        // also: enum ThreadLoadStatus
-
         // TODO: Godot exposed methods that are unavailable, bug reported in https://github.com/godotengine/godot/issues/90303.
         | ("OpenXRHand", "set_hand_skeleton")
         | ("OpenXRHand", "get_hand_skeleton")
@@ -66,8 +60,16 @@ pub fn is_class_method_deleted(class_name: &TyName, method: &JsonClassMethod, ct
         | ("VisualShaderNodeComment", "get_title")
         | ("VisualShaderNodeComment", "set_description")
         | ("VisualShaderNodeComment", "get_description")
+        => true,
 
-        => true, _ => false
+        // Thread APIs
+        #[cfg(not(feature = "experimental-threads"))]
+        | ("ResourceLoader", "load_threaded_get")
+        | ("ResourceLoader", "load_threaded_get_status")
+        | ("ResourceLoader", "load_threaded_request") => true,
+        // also: enum ThreadLoadStatus
+
+        _ => false
     }
 }
 

--- a/godot-core/Cargo.toml
+++ b/godot-core/Cargo.toml
@@ -21,7 +21,7 @@ codegen-lazy-fptrs = [
 ]
 double-precision = ["godot-codegen/double-precision"]
 experimental-godot-api = ["godot-codegen/experimental-godot-api"]
-experimental-threads = ["godot-ffi/experimental-threads"]
+experimental-threads = ["godot-ffi/experimental-threads", "godot-codegen/experimental-threads"]
 experimental-wasm-nothreads = ["godot-ffi/experimental-wasm-nothreads"]
 debug-log = ["godot-ffi/debug-log"]
 trace = []

--- a/godot-ffi/Cargo.toml
+++ b/godot-ffi/Cargo.toml
@@ -14,7 +14,7 @@ homepage = "https://godot-rust.github.io"
 codegen-rustfmt = ["godot-codegen/codegen-rustfmt"]
 codegen-lazy-fptrs = ["godot-codegen/codegen-lazy-fptrs"]
 experimental-godot-api = ["godot-codegen/experimental-godot-api"]
-experimental-threads = []
+experimental-threads = ["godot-codegen/experimental-threads"]
 experimental-wasm-nothreads = ["godot-bindings/experimental-wasm-nothreads"]
 debug-log = []
 


### PR DESCRIPTION
`ResourceLoader::load_threaded_*` methods can be enabled under the `experimental-threads` feature.

Closes #854.