### PR TITLE
OpenXR is not available on Web

### DIFF
--- a/godot-codegen/src/special_cases/special_cases.rs
+++ b/godot-codegen/src/special_cases/special_cases.rs
@@ -88,12 +88,12 @@ pub fn is_godot_type_deleted(godot_ty: &str) -> bool {
 
     // OpenXR has not been available for macOS before 4.2.
     // See e.g. https://github.com/GodotVR/godot-xr-tools/issues/479.
-    // OpenXR is also not available on iOS: https://github.com/godotengine/godot/blob/13ba673c42951fd7cfa6fd8a7f25ede7e9ad92bb/modules/openxr/config.py#L2
+    // OpenXR is also not available on iOS and Web: https://github.com/godotengine/godot/blob/13ba673c42951fd7cfa6fd8a7f25ede7e9ad92bb/modules/openxr/config.py#L2
     // Do not hardcode a list of OpenXR classes, as more may be added in future Godot versions; instead use prefix.
     if godot_ty.starts_with("OpenXR") {
         let target_os = std::env::var("CARGO_CFG_TARGET_OS");
         match target_os.as_deref() {
-            Ok("ios") => return true,
+            Ok("ios") | Ok("emscripten") => return true,
             Ok("macos") => {
                 #[cfg(before_api = "4.2")]
                 return true;


### PR DESCRIPTION
This solves if only the `experimental-wasm` feature is enabled:
```
tmp_js_export.js:477 USER ERROR: Parameter "mb" is null.
[...]
   at: gdextension_classdb_get_method_bind (core/extension/gdextension_interface.cpp:1514)
onPrintError	@	tmp_js_export.js:477
put_char	@	tmp_js_export.js:9
write	@	tmp_js_export.js:9
write	@	tmp_js_export.js:9
doWritev	@	tmp_js_export.js:9
_fd_write	@	tmp_js_export.js:9
$func1089	@	006438ee:0xae4a5
$__vfprintf_internal	@	006438ee:0xe663b
$vfprintf	@	006438ee:0xc1226
$func51049	@	0aaeb74a:0x244476c
$func11246	@	0aaeb74a:0xd142a9
$func51045	@	0aaeb74a:0x244443c
$func51051	@	0aaeb74a:0x24448ee
$func588	@	0aaeb74a:0x263a11
$func58168	@	0aaeb74a:0x25a2fa4
$godot_ffi::toolbox::load_class_method::h7004fd928532e203	@	113b4072:0x1a4166
$godot_ffi::gen::table_servers_classes::load_OpenXRExtensionWrapperExtension_methods::h3453d437e1bc866c	@	113b4072:0x37d16f
$godot_ffi::gen::table_servers_classes::ClassServersMethodTable::load::hf6fa54a7205b2921	@	113b4072:0x3791ad
$godot_ffi::load_class_method_table::he441fc4d5db02c13	@	113b4072:0xb6df6
$godot_core::init::gdext_on_level_init::ha90d9e801e54a5e1	@	113b4072:0x148318
$godot_core::init::ffi_initialize_layer::try_load::h20de838fd98a9287	@	113b4072:0x73db9
$godot_core::init::ffi_initialize_layer::_$u7b$$u7b$closure$u7d$$u7d$::h2d368561f88007fc	@	113b4072:0x73c18
$std::panicking::try::do_call::h4f2efaeef897fea1	@	113b4072:0x6412e
$__rust_try	@	113b4072:0x63b03
$std::panicking::try::h566dad4660340261	@	113b4072:0x63fc8
$std::panic::catch_unwind::hf7ca23cdac81bbe3	@	113b4072:0x2a63b
$godot_core::private::handle_panic_with_print::hffdb3b408832ba25	@	113b4072:0x48dda
$godot_core::private::handle_panic::h319d5cecceae38c0	@	113b4072:0x4866b
$godot_core::init::ffi_initialize_layer::he11365a7b833f9b1	@	113b4072:0x73afe
$func58013	@	0aaeb74a:0x2599d56
$func1213	@	0aaeb74a:0x431d7a
$func1264	@	0aaeb74a:0x448231
$_Z14godot_web_mainiPPc	@	0aaeb74a:0x2e41ef
__Z14godot_web_mainiPPc	@	tmp_js_export.js:9
$__main_argc_argv	@	006438ee:0xa5975
callMain	@	tmp_js_export.js:9
(anonymous)	@	tmp_js_export.js:804
(anonymous)	@	tmp_js_export.js:799
Promise.then		
start	@	tmp_js_export.js:778
(anonymous)	@	tmp_js_export.js:837
Promise.then		
startGame	@	tmp_js_export.js:836
(anonymous)	@	tmp_js_export.html:181
(anonymous)	@	tmp_js_export.html:195
```