### PR TITLE
Don't abort on panic inside Callable

### DIFF
--- a/godot-core/src/meta/signature.rs
+++ b/godot-core/src/meta/signature.rs
@@ -627,6 +627,14 @@ impl<'a> CallContext<'a> {
         }
     }
 
+    /// Call from Godot into a custom Callable.
+    pub fn custom_callable(function_name: &'a str) -> Self {
+        Self {
+            class_name: Cow::Borrowed("<Callable>"),
+            function_name,
+        }
+    }
+
     /// Outbound call from Rust into the engine, class/builtin APIs.
     pub const fn outbound(class_name: &'a str, function_name: &'a str) -> Self {
         Self {


### PR DESCRIPTION
This makes the behavior of `Callable` / signals consistent with normal method calls. Without this PR, a panic inside a `Callable::from_fn()` closure/function simply prints a backtrace and aborts the process.