### PR TITLE
Make arrays exportable only when their inner type is exportable

### DIFF
--- a/godot-core/src/builtin/collections/array.rs
+++ b/godot-core/src/builtin/collections/array.rs
@@ -985,7 +985,10 @@ impl<T: ArrayElement> Var for Array<T> {
     }
 }
 
-impl<T: ArrayElement> Export for Array<T> {
+impl<T> Export for Array<T>
+where
+    T: ArrayElement + Export,
+{
     fn export_hint() -> PropertyHintInfo {
         // If T == Variant, then we return "Array" builtin type hint.
         if Self::has_variant_t() {

--- a/godot-core/src/registry/property.rs
+++ b/godot-core/src/registry/property.rs
@@ -65,6 +65,47 @@ pub trait Export: Var {
     }
 }
 
+/// This function only exists as a place to add doc-tests for the `Export` trait.
+///
+/// Test with export of exportable type should succeed:
+/// ```no_run
+/// use godot::prelude::*;
+///
+/// #[derive(GodotClass)]
+/// #[class(init)]
+/// struct Foo {
+///     #[export]
+///     obj: Option<Gd<Resource>>,
+///     #[export]
+///     array: Array<Gd<Resource>>,
+/// }
+/// ```
+///
+/// Tests with export of non-exportable type should fail:
+/// ```compile_fail
+/// use godot::prelude::*;
+///
+/// #[derive(GodotClass)]
+/// #[class(init)]
+/// struct Foo {
+///     #[export]
+///     obj: Option<Gd<Object>>,
+/// }
+/// ```
+///
+/// ```compile_fail
+/// use godot::prelude::*;
+///
+/// #[derive(GodotClass)]
+/// #[class(init)]
+/// struct Foo {
+///     #[export]
+///     array: Array<Gd<Object>>,
+/// }
+/// ```
+#[allow(dead_code)]
+fn export_doctests() {}
+
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Blanket impls for Option<T>
 


### PR DESCRIPTION
I also added a separate private function under the `Export` trait for some doctests. I wasn't entirely sure it made sense to put them in the `Export` trait's docs since they only really exist to test that compilation fails in certain scenarios and it might be a bit weird to just have a bunch of wrong examples. 

fixes #870