### PR TITLE
`#[class]` attribute: rename `hidden` -> `internal`, deprecate `editor_plugin`

### DIFF
--- a/godot-core/src/deprecated.rs
+++ b/godot-core/src/deprecated.rs
@@ -43,7 +43,11 @@ pub const fn init_default() {}
 
 #[deprecated = "\nThe attribute key #[class(editor_plugin)] is now implied by #[class(base = EditorPlugin)]. It is ignored.\n\
 	More information on https://github.com/godot-rust/gdext/pull/884."]
-pub const fn editor_plugin() {}
+pub const fn class_editor_plugin() {}
+
+#[deprecated = "\nThe attribute key #[class(hidden)] has been renamed to #[class(internal)], following Godot terminology.\n\
+    More information on https://github.com/godot-rust/gdext/pull/884."]
+pub const fn class_hidden() {}
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Godot-side deprecations

--- a/godot-core/src/deprecated.rs
+++ b/godot-core/src/deprecated.rs
@@ -41,6 +41,10 @@ pub use crate::emit_deprecated_warning;
 	More information on https://github.com/godot-rust/gdext/pull/844."]
 pub const fn init_default() {}
 
+#[deprecated = "\nThe attribute key #[class(editor_plugin)] is now implied by #[class(base = EditorPlugin)]. It is ignored.\n\
+	More information on https://github.com/godot-rust/gdext/pull/884."]
+pub const fn editor_plugin() {}
+
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Godot-side deprecations
 

--- a/godot-core/src/registry/class.rs
+++ b/godot-core/src/registry/class.rs
@@ -229,7 +229,7 @@ fn fill_class_info(item: PluginItem, c: &mut ClassRegistrationInfo) {
             default_get_virtual_fn,
             is_tool,
             is_editor_plugin,
-            is_hidden,
+            is_internal,
             is_instantiable,
             #[cfg(all(since_api = "4.3", feature = "docs"))]
                 docs: _,
@@ -257,7 +257,7 @@ fn fill_class_info(item: PluginItem, c: &mut ClassRegistrationInfo) {
             .expect("duplicate: create_instance_func (def)");
 
             #[cfg(before_api = "4.2")]
-            let _ = is_hidden; // mark used
+            let _ = is_internal; // mark used
             #[cfg(since_api = "4.2")]
             {
                 fill_into(
@@ -266,7 +266,7 @@ fn fill_class_info(item: PluginItem, c: &mut ClassRegistrationInfo) {
                 )
                 .expect("duplicate: recreate_instance_func (def)");
 
-                c.godot_params.is_exposed = sys::conv::bool_to_sys(!is_hidden);
+                c.godot_params.is_exposed = sys::conv::bool_to_sys(!is_internal);
             }
 
             #[cfg(before_api = "4.2")]

--- a/godot-core/src/registry/plugin.rs
+++ b/godot-core/src/registry/plugin.rs
@@ -89,11 +89,11 @@ pub enum PluginItem {
         /// Whether `#[class(tool)]` was used.
         is_tool: bool,
 
-        /// Whether `#[class(editor_plugin)]` was used.
+        /// Whether the base class is an `EditorPlugin`.
         is_editor_plugin: bool,
 
-        /// Whether `#[class(hidden)]` was used.
-        is_hidden: bool,
+        /// Whether `#[class(internal)]` was used.
+        is_internal: bool,
 
         /// Whether the class has a default constructor.
         is_instantiable: bool,

--- a/godot-macros/src/lib.rs
+++ b/godot-macros/src/lib.rs
@@ -400,12 +400,12 @@ use crate::util::ident;
 ///
 /// ## Class hiding
 ///
-/// If you want to register a class with Godot, but not have it show up in the editor then you can use `#[class(hidden)]`.
+/// If you want to register a class with Godot, but not have it show up in the editor then you can use `#[class(internal)]`.
 ///
 /// ```
 /// # use godot::prelude::*;
 /// #[derive(GodotClass)]
-/// #[class(base=Node, init, hidden)]
+/// #[class(base=Node, init, internal)]
 /// pub struct Foo {}
 /// ```
 ///

--- a/itest/rust/src/object_tests/virtual_methods_test.rs
+++ b/itest/rust/src/object_tests/virtual_methods_test.rs
@@ -779,7 +779,7 @@ impl GetSetTest {
 // There isn't a good way to test editor plugins, but we can at least declare one to ensure that the macro
 // compiles.
 #[derive(GodotClass)]
-#[class(no_init, base = EditorPlugin, editor_plugin, tool)]
+#[class(no_init, base = EditorPlugin, tool)]
 struct CustomEditorPlugin;
 
 // Just override EditorPlugin::edit() to verify method is declared with Option<T>.


### PR DESCRIPTION
The attribute key `#[class(editor_plugin)]` is now implied by `#[class(base = EditorPlugin)]`.
Specifying it will no longer have an effect and raise a warning.

The attribute key `#[class(hidden)]` is renamed to `#[class(internal)]`, following Godot terminology.
Specifying it will remain possible, with deprecation warning.