### PR TITLE
Get rid of placeholder names like "foo"

### DIFF
--- a/itest/rust/src/builtin_tests/containers/dictionary_test.rs
+++ b/itest/rust/src/builtin_tests/containers/dictionary_test.rs
@@ -77,14 +77,14 @@ fn dictionary_macro() {
     let empty = dict!();
     assert!(empty.is_empty());
 
-    let foo = "foo";
+    let key = "num";
     let dict_complex = dict! {
-        foo: 10,
-        "bar": true,
+        key: 10,
+        "bool": true,
         (1 + 2): Variant::nil(),
     };
-    assert_eq!(dict_complex.get("foo"), Some(10.to_variant()));
-    assert_eq!(dict_complex.get("bar"), Some(true.to_variant()));
+    assert_eq!(dict_complex.get("num"), Some(10.to_variant()));
+    assert_eq!(dict_complex.get("bool"), Some(true.to_variant()));
     assert_eq!(dict_complex.get(3), Some(Variant::nil()));
 }
 

--- a/itest/rust/src/builtin_tests/convert_test.rs
+++ b/itest/rust/src/builtin_tests/convert_test.rs
@@ -90,22 +90,22 @@ fn error_maintains_value() {
 
 // Manual implementation of `GodotConvert` and related traits to ensure conversion works.
 #[derive(PartialEq, Debug)]
-struct Foo {
+struct ConvertedStruct {
     a: i32,
     b: f32,
 }
 
-impl Foo {
+impl ConvertedStruct {
     const MISSING_KEY_A: &'static str = "missing `a` key";
     const MISSING_KEY_B: &'static str = "missing `b` key";
     const TOO_MANY_KEYS: &'static str = "too many keys provided";
 }
 
-impl GodotConvert for Foo {
+impl GodotConvert for ConvertedStruct {
     type Via = Dictionary;
 }
 
-impl ToGodot for Foo {
+impl ToGodot for ConvertedStruct {
     fn to_godot(&self) -> Self::Via {
         dict! {
             "a": self.a,
@@ -114,7 +114,7 @@ impl ToGodot for Foo {
     }
 }
 
-impl FromGodot for Foo {
+impl FromGodot for ConvertedStruct {
     fn try_from_godot(via: Self::Via) -> Result<Self, ConvertError> {
         let a = match via.get("a") {
             Some(a) => a,
@@ -139,20 +139,20 @@ impl FromGodot for Foo {
 
 #[itest]
 fn custom_convert_roundtrip() {
-    let foo = Foo { a: 10, b: 12.34 };
+    let m = ConvertedStruct { a: 10, b: 12.34 };
 
-    let as_dict = foo.to_godot();
-    assert_eq!(as_dict.get("a"), Some(foo.a.to_variant()));
-    assert_eq!(as_dict.get("b"), Some(foo.b.to_variant()));
+    let as_dict = m.to_godot();
+    assert_eq!(as_dict.get("a"), Some(m.a.to_variant()));
+    assert_eq!(as_dict.get("b"), Some(m.b.to_variant()));
 
-    let foo2 = as_dict.to_variant().to::<Foo>();
-    assert_eq!(foo, foo2, "from_variant");
+    let n = as_dict.to_variant().to::<ConvertedStruct>();
+    assert_eq!(m, n, "from_variant");
 
-    let foo3 = Foo::from_godot(as_dict);
-    assert_eq!(foo, foo3, "from_godot");
+    let o = ConvertedStruct::from_godot(as_dict);
+    assert_eq!(m, o, "from_godot");
 }
 
-// Ensure all failure states for the `FromGodot` conversion of `Foo` are propagated through the `try_to`
+// Ensure all failure states for the `FromGodot` conversion of `ManuallyConverted` are propagated through the `try_to`
 // method of `Variant` as they should be.
 #[itest]
 fn custom_convert_error_from_variant() {
@@ -161,20 +161,26 @@ fn custom_convert_error_from_variant() {
     };
     let err = missing_a
         .to_variant()
-        .try_to::<Foo>()
+        .try_to::<ConvertedStruct>()
         .expect_err("should be missing key `a`");
 
-    assert_eq!(err.cause().unwrap().to_string(), Foo::MISSING_KEY_A);
+    assert_eq!(
+        err.cause().unwrap().to_string(),
+        ConvertedStruct::MISSING_KEY_A
+    );
 
     let missing_b = dict! {
         "a": 58,
     };
     let err = missing_b
         .to_variant()
-        .try_to::<Foo>()
+        .try_to::<ConvertedStruct>()
         .expect_err("should be missing key `b`");
 
-    assert_eq!(err.cause().unwrap().to_string(), Foo::MISSING_KEY_B);
+    assert_eq!(
+        err.cause().unwrap().to_string(),
+        ConvertedStruct::MISSING_KEY_B
+    );
 
     let too_many_keys = dict! {
         "a": 12,
@@ -183,10 +189,13 @@ fn custom_convert_error_from_variant() {
     };
     let err = too_many_keys
         .to_variant()
-        .try_to::<Foo>()
+        .try_to::<ConvertedStruct>()
         .expect_err("should have too many keys");
 
-    assert_eq!(err.cause().unwrap().to_string(), Foo::TOO_MANY_KEYS);
+    assert_eq!(
+        err.cause().unwrap().to_string(),
+        ConvertedStruct::TOO_MANY_KEYS
+    );
 
     let wrong_type_a = dict! {
         "a": "hello",
@@ -194,7 +203,7 @@ fn custom_convert_error_from_variant() {
     };
     let err = wrong_type_a
         .to_variant()
-        .try_to::<Foo>()
+        .try_to::<ConvertedStruct>()
         .expect_err("should have wrongly typed key `a`");
 
     assert!(err.cause().is_none());
@@ -209,7 +218,7 @@ fn custom_convert_error_from_variant() {
     };
     let err = wrong_type_b
         .to_variant()
-        .try_to::<Foo>()
+        .try_to::<ConvertedStruct>()
         .expect_err("should have wrongly typed key `b`");
 
     assert!(err.cause().is_none());
@@ -224,7 +233,7 @@ fn custom_convert_error_from_variant() {
     };
     let err = too_big_value
         .to_variant()
-        .try_to::<Foo>()
+        .try_to::<ConvertedStruct>()
         .expect_err("should have too big value for field `a`");
 
     assert!(err.cause().is_none());

--- a/itest/rust/src/object_tests/property_test.rs
+++ b/itest/rust/src/object_tests/property_test.rs
@@ -317,21 +317,23 @@ pub enum TestEnum {
 #[class(no_init)]
 pub struct DeriveProperty {
     #[var]
-    pub foo: TestEnum,
+    pub my_enum: TestEnum,
 }
 
 #[itest]
 fn derive_property() {
-    let mut class = DeriveProperty { foo: TestEnum::B };
-    assert_eq!(class.get_foo(), TestEnum::B as i64);
-    class.set_foo(TestEnum::C as i64);
-    assert_eq!(class.foo, TestEnum::C);
+    let mut class = DeriveProperty {
+        my_enum: TestEnum::B,
+    };
+    assert_eq!(class.get_my_enum(), TestEnum::B as i64);
+    class.set_my_enum(TestEnum::C as i64);
+    assert_eq!(class.my_enum, TestEnum::C);
 }
 
 #[derive(GodotClass)]
 pub struct DeriveExport {
     #[export]
-    pub foo: TestEnum,
+    pub my_enum: TestEnum,
 
     // Tests also qualified base path (type inference of Base<T> without #[hint]).
     pub base: godot::obj::Base<RefCounted>,
@@ -341,7 +343,7 @@ pub struct DeriveExport {
 impl IRefCounted for DeriveExport {
     fn init(base: godot::obj::Base<Self::Base>) -> Self {
         Self {
-            foo: TestEnum::B,
+            my_enum: TestEnum::B,
             base,
         }
     }
@@ -354,7 +356,7 @@ fn derive_export() {
     let property = class
         .get_property_list()
         .iter_shared()
-        .find(|c| c.get_or_nil("name") == "foo".to_variant())
+        .find(|c| c.get_or_nil("name") == "my_enum".to_variant())
         .unwrap();
     // `class_name` should be empty for non-Object variants.
     check_property(&property, "class_name", "");
@@ -377,10 +379,10 @@ pub struct RenamedCustomResource {}
 pub struct ExportResource {
     #[export]
     #[var(usage_flags=[DEFAULT, EDITOR_INSTANTIATE_OBJECT])]
-    pub foo: Option<Gd<CustomResource>>,
+    pub my_resource: Option<Gd<CustomResource>>,
 
     #[export]
-    pub bar: Option<Gd<RenamedCustomResource>>,
+    pub renamed_resource: Option<Gd<RenamedCustomResource>>,
 }
 
 #[itest]
@@ -390,7 +392,7 @@ fn export_resource() {
     let property = class
         .get_property_list()
         .iter_shared()
-        .find(|c| c.get_or_nil("name") == "foo".to_variant())
+        .find(|c| c.get_or_nil("name") == "my_resource".to_variant())
         .unwrap();
     check_property(&property, "class_name", "CustomResource");
     check_property(&property, "type", VariantType::OBJECT.ord());
@@ -405,7 +407,7 @@ fn export_resource() {
     let property = class
         .get_property_list()
         .iter_shared()
-        .find(|c| c.get_or_nil("name") == "bar".to_variant())
+        .find(|c| c.get_or_nil("name") == "renamed_resource".to_variant())
         .unwrap();
     check_property(&property, "class_name", "NewNameCustomResource");
     check_property(&property, "type", VariantType::OBJECT.ord());

--- a/itest/rust/src/object_tests/virtual_methods_test.rs
+++ b/itest/rust/src/object_tests/virtual_methods_test.rs
@@ -188,7 +188,7 @@ struct FormatLoaderTest {
 
 impl FormatLoaderTest {
     fn resource_type() -> GString {
-        GString::from("foo")
+        GString::from("some_resource_type")
     }
 }
 
@@ -599,7 +599,7 @@ fn test_notifications() {
 fn test_get_called() {
     let obj = GetTest::new_gd();
     assert!(!obj.bind().get_called.get());
-    assert!(obj.get("foo".into()).is_nil());
+    assert!(obj.get("inexistent".into()).is_nil());
     assert!(obj.bind().get_called.get());
 
     let obj = GetTest::new_gd();
@@ -626,7 +626,7 @@ fn test_get_returns_correct() {
 fn test_set_called() {
     let mut obj = SetTest::new_gd();
     assert!(!obj.bind().set_called);
-    obj.set("foo".into(), Variant::nil());
+    obj.set("inexistent_property".into(), Variant::nil());
     assert!(obj.bind().set_called);
 
     let mut obj = SetTest::new_gd();


### PR DESCRIPTION
With Rust 1.81, [this lint](https://rust-lang.github.io/rust-clippy/master/index.html#/disallowed_names) is now active by default. Since those placeholders can have better names in every single instance, I agree with Clippy here.