### PR TITLE
Support Unicode class names (Godot 4.4+)

### DIFF
--- a/godot-codegen/src/generator/classes.rs
+++ b/godot-codegen/src/generator/classes.rs
@@ -218,7 +218,7 @@ fn make_class(class: &Class, ctx: &mut Context, view: &ApiView) -> GeneratedClas
                     // Optimization note: instead of lazy init, could use separate static which is manually initialized during registration.
                     static CLASS_NAME: std::sync::OnceLock<ClassName> = std::sync::OnceLock::new();
 
-                    let name: &'static ClassName = CLASS_NAME.get_or_init(|| ClassName::alloc_next(#class_name_cstr));
+                    let name: &'static ClassName = CLASS_NAME.get_or_init(|| ClassName::alloc_next_ascii(#class_name_cstr));
                     *name
                 }
 

--- a/godot-core/src/registry/class.rs
+++ b/godot-core/src/registry/class.rs
@@ -399,7 +399,7 @@ fn register_class_raw(mut info: ClassRegistrationInfo) {
     // This can happen during hot reload if a class changes base type in an incompatible way (e.g. RefCounted -> Node).
     if registration_failed {
         godot_error!(
-            "Failed to register class `{class_name}`; check preceding Godot stderr messages"
+            "Failed to register class `{class_name}`; check preceding Godot stderr messages."
         );
     }
 

--- a/itest/rust/src/register_tests/mod.rs
+++ b/itest/rust/src/register_tests/mod.rs
@@ -10,7 +10,7 @@ mod conversion_test;
 mod derive_godotconvert_test;
 mod func_test;
 mod gdscript_ffi_test;
-mod keyword_parameters_test;
+mod naming_tests;
 mod option_ffi_test;
 mod var_test;
 

--- a/itest/rust/src/register_tests/naming_tests.rs
+++ b/itest/rust/src/register_tests/naming_tests.rs
@@ -26,3 +26,8 @@ impl IEditorExportPlugin for KeywordParameterEditorExportPlugin {
     fn get_customization_configuration_hash(&self) -> u64 { unreachable!() }
     fn get_name(&self) -> GString { unreachable!() }
 }
+
+#[cfg(since_api = "4.4")]
+#[derive(GodotClass)]
+#[class(no_init)]
+struct 统一码 {}


### PR DESCRIPTION
Follows upstream https://github.com/godotengine/godot/pull/96501.