### PR TITLE
Resolve doc warning with global enums

### DIFF
--- a/godot-core/src/global/mod.rs
+++ b/godot-core/src/global/mod.rs
@@ -16,8 +16,8 @@
 //!
 //! - Color: [`ColorChannelOrder`][crate::builtin::ColorChannelOrder]
 //! - Projection: [`ProjectionEye`][crate::builtin::ProjectionEye], [`ProjectionPlane`][crate::builtin::ProjectionPlane]
-//! - Rectangle: [`Side`][crate::builtin::Side], [`Corner`][crate::builtin::Corner] <sub>(godot-generated)</sub>
-//! - Rotation: [`EulerOrder`][crate::builtin::EulerOrder] <sub>(godot-generated)</sub>
+//! - Rectangle: [`Side`], [`Corner`] <sub>(godot-generated)</sub>
+//! - Rotation: [`EulerOrder`] <sub>(godot-generated)</sub>
 //! - Variant: [`VariantType`][crate::builtin::VariantType], [`VariantOperator`][crate::builtin::VariantOperator]
 //! - Vector: [`Vector2Axis`][crate::builtin::Vector2Axis], [`Vector3Axis`][crate::builtin::Vector3Axis], [`Vector4Axis`][crate::builtin::Vector4Axis]
 //!


### PR DESCRIPTION
If you run `cargo doc`, as apposed to `cargo doc -p godot --no-libs` as in the CI, you get hit with a warning "warning: redundant explicit link target" on the docs in this commit.  I'm not sure why these options together supress the warning (neither individually does).  But this reduces noise in developer consoles.