### PR TITLE
Unicode `ClassName::new_cached()`; adjust test 

### DIFF
--- a/itest/rust/src/builtin_tests/containers/callable_test.rs
+++ b/itest/rust/src/builtin_tests/containers/callable_test.rs
@@ -165,6 +165,7 @@ pub mod custom_callable {
     use super::*;
     use crate::framework::assert_eq_self;
     use godot::builtin::{Dictionary, RustCallable};
+    use godot::sys::GdextBuild;
     use std::fmt;
     use std::hash::Hash;
     use std::sync::{Arc, Mutex};
@@ -285,8 +286,12 @@ pub mod custom_callable {
         dict.set(b, "hi");
         assert_eq!(hash_count(&at), 1, "hash for a untouched if b is inserted");
         assert_eq!(hash_count(&bt), 1, "hash needed for b dict key");
-        assert_eq!(eq_count(&at), 1, "hash collision, eq for a needed");
-        assert_eq!(eq_count(&bt), 1, "hash collision, eq for b needed");
+
+        // Introduced in https://github.com/godotengine/godot/pull/96797.
+        let eq = if GdextBuild::since_api("4.4") { 2 } else { 1 };
+
+        assert_eq!(eq_count(&at), eq, "hash collision, eq for a needed");
+        assert_eq!(eq_count(&bt), eq, "hash collision, eq for b needed");
     }
 
     #[itest]

--- a/itest/rust/src/object_tests/class_name_test.rs
+++ b/itest/rust/src/object_tests/class_name_test.rs
@@ -13,14 +13,24 @@ use godot::sys;
 use std::borrow::Cow;
 
 struct A;
+struct U;
 
 implement_godot_bounds!(A);
+implement_godot_bounds!(U);
 
 impl GodotClass for A {
     type Base = godot::classes::Object;
 
     fn class_name() -> ClassName {
         ClassName::new_cached::<A>(|| "A".to_string())
+    }
+}
+
+impl GodotClass for U {
+    type Base = godot::classes::Object;
+
+    fn class_name() -> ClassName {
+        ClassName::new_cached::<U>(|| "统一码".to_string())
     }
 }
 
@@ -37,3 +47,27 @@ fn class_name_dynamic() {
     assert_eq!(a.to_string_name(), StringName::from("A"));
     assert_eq!(a.to_cow_str(), Cow::<'static, str>::Owned("A".to_string()));
 }
+
+#[cfg(since_api = "4.4")]
+#[itest]
+fn class_name_dynamic_unicode() {
+    let a = U::class_name();
+    let b = U::class_name();
+
+    assert_eq!(a, b);
+    assert_eq!(sys::hash_value(&a), sys::hash_value(&b));
+
+    assert_eq!(a.to_string(), "统一码");
+    assert_eq!(a.to_gstring(), GString::from("统一码"));
+    assert_eq!(a.to_string_name(), StringName::from("统一码"));
+    assert_eq!(
+        a.to_cow_str(),
+        Cow::<'static, str>::Owned("统一码".to_string())
+    );
+}
+
+// Test Unicode proc-macro support for ClassName.
+#[cfg(since_api = "4.4")]
+#[derive(godot::register::GodotClass)]
+#[class(no_init)]
+struct 统一码 {}

--- a/itest/rust/src/register_tests/naming_tests.rs
+++ b/itest/rust/src/register_tests/naming_tests.rs
@@ -26,8 +26,3 @@ impl IEditorExportPlugin for KeywordParameterEditorExportPlugin {
     fn get_customization_configuration_hash(&self) -> u64 { unreachable!() }
     fn get_name(&self) -> GString { unreachable!() }
 }
-
-#[cfg(since_api = "4.4")]
-#[derive(GodotClass)]
-#[class(no_init)]
-struct 统一码 {}


### PR DESCRIPTION
Follow-up to #891: `ClassName::new_cached()` now also supports Unicode.

Also un-breaks CI by modifying a test that relied on the number of equality comparisons inside `Dictionary`. This behavior was changed in https://github.com/godotengine/godot/pull/96797.