### PR TITLE
Detect whether virtual functions are required to override

### DIFF
--- a/godot-codegen/src/models/json.rs
+++ b/godot-codegen/src/models/json.rs
@@ -220,6 +220,8 @@ pub struct JsonClassMethod {
     pub is_vararg: bool,
     pub is_static: bool,
     pub is_virtual: bool,
+    #[cfg(since_api = "4.4")]
+    pub is_required: Option<bool>, // Only virtual functions have this field.
     pub hash: Option<i64>,
     pub return_value: Option<JsonMethodReturn>,
     pub arguments: Option<Vec<JsonMethodArg>>,

--- a/godot-codegen/src/special_cases/special_cases.rs
+++ b/godot-codegen/src/special_cases/special_cases.rs
@@ -389,6 +389,7 @@ pub fn get_interface_extra_docs(trait_name: &str) -> Option<&'static str> {
     }
 }
 
+#[cfg(before_api = "4.4")]
 pub fn is_virtual_method_required(class_name: &str, method: &str) -> bool {
     match (class_name, method) {
         ("ScriptLanguageExtension", _) => method != "get_doc_comment_delimiters",


### PR DESCRIPTION
From Godot 4.4 onward, we can use the GDExtension-provided information, which states whether virtual functions have a default implementation or are required to be overridden.

Depends on upstream https://github.com/godotengine/godot/pull/93311.