### PR TITLE
Pass-by-ref for non-`Copy` builtins (backend)

### DIFF
--- a/godot-core/src/global/mod.rs
+++ b/godot-core/src/global/mod.rs
@@ -42,19 +42,19 @@ use crate::obj::Gd;
 // Reminder: remove #![allow(deprecated)] in utilities.test along with the below functions.
 
 #[deprecated = "Instance utilities in `godot::global` will be removed. Use methods on `Gd` and `InstanceId` instead.\n\
-    For detailed reasons, see https://github.com/godot-rust/gdext/pull/892."]
+    For detailed reasons, see https://github.com/godot-rust/gdext/pull/901."]
 pub fn instance_from_id(instance_id: i64) -> Option<Gd<crate::classes::Object>> {
     crate::gen::utilities::instance_from_id(instance_id)
 }
 
 #[deprecated = "Instance utilities in `godot::global` will be removed. Use methods on `Gd` and `InstanceId` instead.\n\
-    For detailed reasons, see https://github.com/godot-rust/gdext/pull/892."]
+    For detailed reasons, see https://github.com/godot-rust/gdext/pull/901."]
 pub fn is_instance_valid(instance: Variant) -> bool {
     crate::gen::utilities::is_instance_valid(&instance)
 }
 
 #[deprecated = "Instance utilities in `godot::global` will be removed. Use methods on `Gd` and `InstanceId` instead.\n\
-    For detailed reasons, see https://github.com/godot-rust/gdext/pull/892."]
+    For detailed reasons, see https://github.com/godot-rust/gdext/pull/901."]
 pub fn is_instance_id_valid(instance_id: i64) -> bool {
     crate::gen::utilities::is_instance_id_valid(instance_id)
 }

--- a/godot-core/src/meta/ref_arg.rs
+++ b/godot-core/src/meta/ref_arg.rs
@@ -4,18 +4,33 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
+use crate::builtin::Variant;
 use crate::meta::error::ConvertError;
-use crate::meta::{FromGodot, GodotConvert, ToGodot};
+use crate::meta::{FromGodot, GodotConvert, GodotFfiVariant, ToGodot};
+use crate::sys;
+use godot_ffi::{GodotFfi, GodotNullableFfi, PtrcallType};
 use std::fmt;
 
 pub struct RefArg<'r, T> {
-    pub(crate) shared_ref: &'r T,
+    /// Only `None` if `T: GodotNullableFfi` and `T::is_null()` is true.
+    shared_ref: Option<&'r T>,
 }
 
 impl<'r, T> RefArg<'r, T> {
     pub fn new(shared_ref: &'r T) -> Self {
-        RefArg { shared_ref }
+        RefArg {
+            shared_ref: Some(shared_ref),
+        }
     }
+}
+
+macro_rules! wrong_direction {
+    ($fn:ident) => {
+        unreachable!(concat!(
+            stringify!($fn),
+            ": RefArg should only be passed *to* Godot, not *from*."
+        ))
+    };
 }
 
 impl<'r, T> GodotConvert for RefArg<'r, T>
@@ -33,7 +48,11 @@ where
     where Self: 'v;
 
     fn to_godot(&self) -> Self::ToVia<'_> {
-        self.shared_ref.to_godot()
+        let shared_ref = self
+            .shared_ref
+            .expect("Objects are currently mapped through ObjectArg; RefArg shouldn't be null");
+
+        shared_ref.to_godot()
     }
 }
 
@@ -43,7 +62,7 @@ where
     T: FromGodot,
 {
     fn try_from_godot(_via: Self::Via) -> Result<Self, ConvertError> {
-        unreachable!("RefArg should only be passed *to* Godot, not *from*.")
+        wrong_direction!(try_from_godot)
     }
 }
 
@@ -53,5 +72,85 @@ where
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "&{:?}", self.shared_ref)
+    }
+}
+
+// SAFETY: delegated to T.
+unsafe impl<'r, T> GodotFfi for RefArg<'r, T>
+where
+    T: GodotFfi,
+{
+    fn variant_type() -> sys::VariantType {
+        T::variant_type()
+    }
+
+    unsafe fn new_from_sys(_ptr: sys::GDExtensionConstTypePtr) -> Self {
+        wrong_direction!(new_from_sys)
+    }
+
+    unsafe fn new_with_uninit(_init_fn: impl FnOnce(sys::GDExtensionUninitializedTypePtr)) -> Self {
+        wrong_direction!(new_with_uninit)
+    }
+
+    unsafe fn new_with_init(_init_fn: impl FnOnce(sys::GDExtensionTypePtr)) -> Self {
+        wrong_direction!(new_with_init)
+    }
+
+    fn sys(&self) -> sys::GDExtensionConstTypePtr {
+        match self.shared_ref {
+            Some(r) => r.sys(),
+            None => std::ptr::null(),
+        }
+    }
+
+    fn sys_mut(&mut self) -> sys::GDExtensionTypePtr {
+        unreachable!("RefArg::sys_mut() currently not used by FFI marshalling layer, but only by specific functions");
+    }
+
+    // This function must be overridden; the default delegating to sys() is wrong for e.g. RawGd<T>.
+    // See also other manual overrides of as_arg_ptr().
+    fn as_arg_ptr(&self) -> sys::GDExtensionConstTypePtr {
+        match self.shared_ref {
+            Some(r) => r.as_arg_ptr(),
+            None => std::ptr::null(),
+        }
+    }
+
+    unsafe fn from_arg_ptr(_ptr: sys::GDExtensionTypePtr, _call_type: PtrcallType) -> Self {
+        wrong_direction!(from_arg_ptr)
+    }
+
+    unsafe fn move_return_ptr(self, _dst: sys::GDExtensionTypePtr, _call_type: PtrcallType) {
+        // This one is implemented, because it's used for return types implementing ToGodot.
+        unreachable!("Calling RefArg::move_return_ptr is a mistake, as RefArg is intended only for arguments. Use the underlying value type.");
+    }
+}
+
+impl<'r, T> GodotFfiVariant for RefArg<'r, T>
+where
+    T: GodotFfiVariant,
+{
+    fn ffi_to_variant(&self) -> Variant {
+        match self.shared_ref {
+            Some(r) => r.ffi_to_variant(),
+            None => Variant::nil(),
+        }
+    }
+
+    fn ffi_from_variant(_variant: &Variant) -> Result<Self, ConvertError> {
+        wrong_direction!(ffi_from_variant)
+    }
+}
+
+impl<'r, T> GodotNullableFfi for RefArg<'r, T>
+where
+    T: GodotNullableFfi,
+{
+    fn null() -> Self {
+        RefArg { shared_ref: None }
+    }
+
+    fn is_null(&self) -> bool {
+        self.shared_ref.map(|r| r.is_null()).unwrap_or(true)
     }
 }

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -17,7 +17,7 @@ use crate::global::PropertyHint;
 use crate::meta::error::{ConvertError, FromFfiError};
 use crate::meta::{
     ArrayElement, CallContext, ClassName, FromGodot, GodotConvert, GodotType, PropertyHintInfo,
-    ToGodot,
+    RefArg, ToGodot,
 };
 use crate::obj::{
     bounds, cap, Bounds, EngineEnum, GdDerefTarget, GdMut, GdRef, GodotClass, Inherits, InstanceId,
@@ -696,8 +696,11 @@ impl<T: GodotClass> FromGodot for Gd<T> {
 impl<T: GodotClass> GodotType for Gd<T> {
     type Ffi = RawGd<T>;
 
-    fn to_ffi(&self) -> Self::Ffi {
-        self.raw.clone()
+    type ToFfi<'f> = RefArg<'f, RawGd<T>>
+    where Self: 'f;
+
+    fn to_ffi(&self) -> Self::ToFfi<'_> {
+        RefArg::new(&self.raw)
     }
 
     fn into_ffi(self) -> Self::Ffi {

--- a/godot-core/src/obj/object_arg.rs
+++ b/godot-core/src/obj/object_arg.rs
@@ -270,8 +270,9 @@ impl<T: GodotClass> FromGodot for ObjectArg<T> {
 
 impl<T: GodotClass> GodotType for ObjectArg<T> {
     type Ffi = Self;
+    type ToFfi<'f> = Self; // TODO: maybe ObjectArg becomes redundant with RefArg?
 
-    fn to_ffi(&self) -> Self::Ffi {
+    fn to_ffi(&self) -> Self::ToFfi<'_> {
         (*self).clone()
     }
 
@@ -305,8 +306,8 @@ impl<T: GodotClass> GodotFfiVariant for ObjectArg<T> {
 }
 
 impl<T: GodotClass> GodotNullableFfi for ObjectArg<T> {
-    fn flatten_option(opt: Option<Self>) -> Self {
-        opt.unwrap_or_else(Self::null)
+    fn null() -> Self {
+        Self::null()
     }
 
     fn is_null(&self) -> bool {

--- a/godot-ffi/src/godot_ffi.rs
+++ b/godot-ffi/src/godot_ffi.rs
@@ -109,8 +109,13 @@ pub unsafe trait GodotFfi {
 /// This is currently only implemented for `RawGd`.
 // TODO: Consider implementing for `Variant`.
 pub trait GodotNullableFfi: Sized + GodotFfi {
-    fn flatten_option(opt: Option<Self>) -> Self;
+    fn null() -> Self;
+
     fn is_null(&self) -> bool;
+
+    fn flatten_option(opt: Option<Self>) -> Self {
+        opt.unwrap_or_else(Self::null)
+    }
 }
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------

--- a/godot-macros/Cargo.toml
+++ b/godot-macros/Cargo.toml
@@ -24,7 +24,7 @@ proc-macro2 = "1.0.80" # Literal::c_string() added in 1.0.80.
 quote = "1.0.29"
 
 # Enabled by `docs`
-markdown = { version = "1.0.0-alpha.19", optional = true }
+markdown = { version = "=1.0.0-alpha.21", optional = true }
 venial = "0.6"
 
 [build-dependencies]

--- a/godot-macros/src/docs/markdown_converter.rs
+++ b/godot-macros/src/docs/markdown_converter.rs
@@ -7,19 +7,20 @@
 
 //! Converts [Markdown](https://en.wikipedia.org/wiki/Markdown) to [BBCode](https://en.wikipedia.org/wiki/BBCode).
 
-use markdown::mdast::Node;
+use markdown::mdast as md;
 use markdown::{to_mdast, ParseOptions};
 use std::collections::HashMap;
 
 pub fn to_bbcode(md: &str) -> String {
-    // to_mdast() never errors with normal arkdown, so unwrap is safe.
+    // to_mdast() never errors with normal Markdown, so unwrap is safe.
     let n = to_mdast(md, &ParseOptions::gfm()).unwrap();
+
     let definitions = n
         .children()
         .unwrap() // root node always has children
         .iter()
         .filter_map(|n| match n {
-            Node::Definition(definition) => Some((&*definition.identifier, &*definition.url)),
+            md::Node::Definition(def) => Some((&*def.identifier, &*def.url)),
             _ => None,
         })
         .collect::<HashMap<_, _>>();
@@ -27,24 +28,32 @@ pub fn to_bbcode(md: &str) -> String {
     walk_node(&n, &definitions).unwrap_or_default()
 }
 
-fn walk_node(node: &Node, definitions: &HashMap<&str, &str>) -> Option<String> {
-    use Node::*;
+fn walk_node(node: &md::Node, definitions: &HashMap<&str, &str>) -> Option<String> {
+    use md::Node::*;
+
     let bbcode = match node {
         Root(root) => walk_nodes(&root.children, definitions, "[br][br]"),
-        InlineCode(markdown::mdast::InlineCode { value, .. }) => format!("[code]{value}[/code]"),
+
+        InlineCode(md::InlineCode { value, .. }) => format!("[code]{value}[/code]"),
+
         Delete(delete) => format!("[s]{}[/s]", walk_nodes(&delete.children, definitions, "")),
+
         Emphasis(emphasis) => format!("[i]{}[/i]", walk_nodes(&emphasis.children, definitions, "")),
-        Image(markdown::mdast::Image { url, .. }) => format!("[img]{url}[/img]",),
+
+        Image(md::Image { url, .. }) => format!("[img]{url}[/img]",),
+
         ImageReference(image) => {
             format!(
                 "[img]{}[/img]",
                 definitions.get(&&*image.identifier).unwrap()
             )
         }
-        Link(markdown::mdast::Link { url, children, .. }) => {
+
+        Link(md::Link { url, children, .. }) => {
             format!("[url={url}]{}[/url]", walk_nodes(children, definitions, ""))
         }
-        LinkReference(markdown::mdast::LinkReference {
+
+        LinkReference(md::LinkReference {
             identifier,
             children,
             ..
@@ -53,23 +62,31 @@ fn walk_node(node: &Node, definitions: &HashMap<&str, &str>) -> Option<String> {
             definitions.get(&&**identifier).unwrap(),
             walk_nodes(children, definitions, "")
         ),
+
         Strong(strong) => format!("[b]{}[/b]", walk_nodes(&strong.children, definitions, "")),
+
         Text(text) => text.value.clone(),
+
         // TODO: more langs?
-        Code(markdown::mdast::Code { value, .. }) => format!("[codeblock]{value}[/codeblock]"),
+        Code(md::Code { value, .. }) => format!("[codeblock]{value}[/codeblock]"),
+
         Paragraph(paragraph) => walk_nodes(&paragraph.children, definitions, ""),
-        // bbcode supports lists but docs dont
-        List(_) | BlockQuote(_) | FootnoteReference(_) | FootnoteDefinition(_) | Table(_) => {
-            "".into()
+
+        // BBCode supports lists, but docs don't.
+        List(_) | Blockquote(_) | FootnoteReference(_) | FootnoteDefinition(_) | Table(_) => {
+            String::new()
         }
+
         Html(html) => html.value.clone(),
+
         _ => walk_nodes(&node.children()?, definitions, ""),
     };
+
     Some(bbcode)
 }
 
-/// Calls [`walk_node`] over every node its given, joining them with the supplied separator.
-fn walk_nodes(nodes: &[Node], definitions: &HashMap<&str, &str>, separator: &str) -> String {
+/// Calls [`walk_node`] over every node it receives, joining them with the supplied separator.
+fn walk_nodes(nodes: &[md::Node], definitions: &HashMap<&str, &str>, separator: &str) -> String {
     nodes
         .iter()
         .filter_map(|n| walk_node(n, definitions))

--- a/itest/rust/src/object_tests/object_test.rs
+++ b/itest/rust/src/object_tests/object_test.rs
@@ -68,7 +68,9 @@ fn object_user_roundtrip_write() {
 
     let obj: Gd<RefcPayload> = Gd::from_object(user);
     assert_eq!(obj.bind().value, value);
-    let raw = obj.to_ffi();
+
+    // Use into_ffi() instead of to_ffi(), as the latter returns a reference and isn't used for returns anymore.
+    let raw = obj.into_ffi();
 
     let raw2 = unsafe {
         RawGd::<RefcPayload>::new_with_uninit(|ptr| {
@@ -94,6 +96,20 @@ fn object_engine_roundtrip() {
     let obj2 = Gd::from_ffi(raw2);
     assert_eq!(obj2.get_position(), pos);
     obj.free();
+}
+
+#[itest]
+fn object_null_argument() {
+    // Objects currently use ObjectArg instead of RefArg, so this scenario shouldn't occur. Test can be updated if code is refactored.
+
+    let null_obj = Option::<Gd<Node>>::None;
+
+    let via = null_obj.to_godot();
+    let ffi = via.to_ffi();
+
+    expect_panic("not yet implemented: pass objects through RefArg", || {
+        ffi.to_godot();
+    });
 }
 
 #[itest]


### PR DESCRIPTION
Follow-up to #900. Adds `GodotType::ToFfi<'f>` to keep by-ref semantics also in the FFI layer.

Refactors some related parts:
* `GodotNullableFfi` now has a `null()` associated function.
* Correct usage of `as_arg() `and `move_return_ptr()`.
* `into_ffi()` helper needs marshal_args! macro, since it has transient borrowed state.

Closes #790.