### PR TITLE
in debug, include location information in error message on panic

### DIFF
--- a/godot-core/src/private.rs
+++ b/godot-core/src/private.rs
@@ -387,27 +387,39 @@ where
             // Handle panic info only in Debug mode.
             #[cfg(debug_assertions)]
             {
-                let guard = info.lock().unwrap();
-                let info = guard.as_ref().expect("no panic info available");
+                let msg = extract_panic_message(err);
+                let mut msg = format_panic_message(msg);
+
+                // try to add location information
+                if let Ok(guard) = info.lock() {
+                    if let Some(info) = guard.as_ref() {
+                        msg = format!("{}\n  at {}:{}", msg, info.file, info.line);
+                    }
+                }
+
                 if print {
                     godot_error!(
-                        "Rust function panicked at {}:{}.\n  Context: {}",
-                        info.file,
-                        info.line,
+                        "Rust function panicked: {}\n  Context: {}",
+                        msg,
                         error_context()
                     );
                     //eprintln!("Backtrace:\n{}", info.backtrace);
                 }
+
+                Err(msg)
             }
 
-            let msg = extract_panic_message(err);
-            let msg = format_panic_message(msg);
+            #[cfg(not(debug_assertions))]
+            {
+                let msg = extract_panic_message(err);
+                let msg = format_panic_message(msg);
 
-            if print {
-                godot_error!("{msg}");
+                if print {
+                    godot_error!("{msg}");
+                }
+
+                Err(msg)
             }
-
-            Err(msg)
         }
     }
 }

--- a/godot-core/src/private.rs
+++ b/godot-core/src/private.rs
@@ -390,7 +390,7 @@ where
                 let msg = extract_panic_message(err);
                 let mut msg = format_panic_message(msg);
 
-                // try to add location information
+                // Try to add location information.
                 if let Ok(guard) = info.lock() {
                     if let Some(info) = guard.as_ref() {
                         msg = format!("{}\n  at {}:{}", msg, info.file, info.line);

--- a/itest/rust/src/object_tests/dynamic_call_test.rs
+++ b/itest/rust/src/object_tests/dynamic_call_test.rs
@@ -149,19 +149,25 @@ fn dynamic_call_with_panic() {
     assert_eq!(call_error.class_name(), Some("Object"));
     assert_eq!(call_error.method_name(), "call");
 
-    #[cfg(target_os = "windows")]
-    let path = "itest\\rust\\src\\object_tests\\object_test.rs";
-    #[cfg(not(target_os = "windows"))]
-    let path = "itest/rust/src/object_tests/object_test.rs";
+    let appendix = if cfg!(debug_assertions) {
+        let mut path = "itest/rust/src/object_tests/object_test.rs".to_string();
 
-    // Obtain line number dynamically, avoids tedious maintenance on code reorganization.
-    let line = ObjPayload::get_panic_line();
+        if cfg!(target_os = "windows") {
+            path = path.replace('/', "\\")
+        }
+
+        // Obtain line number dynamically, avoids tedious maintenance on code reorganization.
+        let line = ObjPayload::get_panic_line();
+
+        format!("\n  at {path}:{line}")
+    } else {
+        String::new()
+    };
 
     let expected_error_message = format!(
         "godot-rust function call failed: Object::call(&\"do_panic\")\
         \n  Source: ObjPayload::do_panic()\
-        \n    Reason: [panic]  do_panic exploded\
-        \n  at {path}:{line}"
+        \n    Reason: [panic]  do_panic exploded{appendix}"
     );
 
     assert_eq!(call_error.to_string(), expected_error_message);

--- a/itest/rust/src/object_tests/dynamic_call_test.rs
+++ b/itest/rust/src/object_tests/dynamic_call_test.rs
@@ -154,11 +154,14 @@ fn dynamic_call_with_panic() {
     #[cfg(not(target_os = "windows"))]
     let path = "itest/rust/src/object_tests/object_test.rs";
 
+    // Obtain line number dynamically, avoids tedious maintenance on code reorganization.
+    let line = ObjPayload::get_panic_line();
+
     let expected_error_message = format!(
         "godot-rust function call failed: Object::call(&\"do_panic\")\
         \n  Source: ObjPayload::do_panic()\
         \n    Reason: [panic]  do_panic exploded\
-        \n  at {path}:893"
+        \n  at {path}:{line}"
     );
 
     assert_eq!(call_error.to_string(), expected_error_message);

--- a/itest/rust/src/object_tests/dynamic_call_test.rs
+++ b/itest/rust/src/object_tests/dynamic_call_test.rs
@@ -148,12 +148,20 @@ fn dynamic_call_with_panic() {
 
     assert_eq!(call_error.class_name(), Some("Object"));
     assert_eq!(call_error.method_name(), "call");
-    assert_eq!(
-        call_error.to_string(),
+
+    #[cfg(target_os = "windows")]
+    let path = "itest\\rust\\src\\object_tests\\object_test.rs";
+    #[cfg(not(target_os = "windows"))]
+    let path = "itest/rust/src/object_tests/object_test.rs";
+
+    let expected_error_message = format!(
         "godot-rust function call failed: Object::call(&\"do_panic\")\
         \n  Source: ObjPayload::do_panic()\
-        \n    Reason: [panic]  do_panic exploded"
+        \n    Reason: [panic]  do_panic exploded\
+        \n  at {path}:893"
     );
+
+    assert_eq!(call_error.to_string(), expected_error_message);
 
     obj.free();
 }

--- a/itest/rust/src/object_tests/object_test.rs
+++ b/itest/rust/src/object_tests/object_test.rs
@@ -887,6 +887,11 @@ impl ObjPayload {
     fn do_panic(&self) {
         panic!("do_panic exploded");
     }
+
+    // Obtain the line number of the panic!() call above; keep equidistant to do_panic() method.
+    pub fn get_panic_line() -> u32 {
+        line!() - 5
+    }
 }
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
fixes https://github.com/godot-rust/gdext/issues/923

![image](https://github.com/user-attachments/assets/bbf298e4-8a80-4422-80a5-5a1f18ece0e6)
