### PR TITLE
[WIP] Multiple #[godot_api] impl blocks

### DIFF
--- a/godot-core/Cargo.toml
+++ b/godot-core/Cargo.toml
@@ -47,6 +47,7 @@ godot-ffi = { path = "../godot-ffi", version = "=0.1.3" }
 glam = { version = "0.28", features = ["debug-glam-assert"] }
 serde = { version = "1", features = ["derive"], optional = true }
 godot-cell = { path = "../godot-cell", version = "=0.1.3" }
+group-by = "1.0.0"
 
 [build-dependencies]
 godot-bindings = { path = "../godot-bindings", version = "=0.1.3" }

--- a/godot-core/src/private.rs
+++ b/godot-core/src/private.rs
@@ -23,6 +23,9 @@ use crate::meta::CallContext;
 use crate::sys;
 use std::sync::{atomic, Arc, Mutex};
 use sys::Global;
+
+use std::mem;
+use group_by::group_by;
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Global variables
 
@@ -125,12 +128,48 @@ pub fn next_class_id() -> u16 {
     NEXT_CLASS_ID.fetch_add(1, atomic::Ordering::Relaxed)
 }
 
-pub(crate) fn iterate_plugins(mut visitor: impl FnMut(&ClassPlugin)) {
+// HACK: call this once before iterate_plugins
+pub(crate) fn merge_plugins() {
+    let mut plugins = __godot_rust_plugin___GODOT_PLUGIN_REGISTRY.lock().unwrap();
+
+    let my_plugins : Vec<ClassPlugin> = mem::replace::<Vec<ClassPlugin>>(&mut *plugins, vec!{});
+
+    //let grouped = group_by(my_plugins.into_iter(), |x| { (mem::discriminant(&x.item), x.class_name) });
+
+
+    //let mut result : Vec<ClassPlugin> = vec!{};
+
+    // for (key, mut group) in grouped {
+    //     let (discriminant, class_name) = key;
+
+    //     match &group[0].item {
+    //         PluginItem::InherentImpl(i) => {
+    //             // merge
+    //             let mut first = i;
+    //             for i in 1 .. group.len() - 1 {
+
+    //             }
+    //         },
+    //         _ => {
+    //             // all others, copy as-is
+    //             result.push(group.remove(0));
+    //         }
+    //     }
+    // }
+
+    let _ : Vec<ClassPlugin> = mem::replace(&mut *plugins, my_plugins);
+}
+
+pub(crate) fn iterate_plugins(mut visitor: impl FnMut(&ClassPlugin)) {    
+    crate::private::merge_plugins();
     sys::plugin_foreach!(__GODOT_PLUGIN_REGISTRY; visitor);
 }
 
 #[cfg(feature = "codegen-full")] // Remove if used in other scenarios.
 pub(crate) fn find_inherent_impl(class_name: crate::meta::ClassName) -> Option<InherentImpl> {
+    
+    crate::private::merge_plugins();
+    
     // We do this manually instead of using `iterate_plugins()` because we want to break as soon as we find a match.
     let plugins = __godot_rust_plugin___GODOT_PLUGIN_REGISTRY.lock().unwrap();
 

--- a/godot-ffi/src/plugins.rs
+++ b/godot-ffi/src/plugins.rs
@@ -49,6 +49,45 @@ macro_rules! plugin_add_inner_wasm {
     };
 }
 
+
+#[doc(hidden)]
+#[macro_export]
+#[allow(clippy::deprecated_cfg_attr)]
+#[cfg_attr(rustfmt, rustfmt::skip)]
+// ^ skip: paste's [< >] syntax chokes fmt
+//   cfg_attr: workaround for https://github.com/rust-lang/rust/pull/52234#issuecomment-976702997
+macro_rules! execute_pre_main {
+    ($body:expr; ) => {
+        const _: () = {
+            #[allow(non_upper_case_globals)]
+            #[used]
+            // Windows:
+            #[cfg_attr(target_os = "windows", link_section = ".CRT$XCU")]
+            // MacOS + iOS:
+            #[cfg_attr(target_os = "ios", link_section = "__DATA,__mod_init_func")]
+            #[cfg_attr(target_os = "macos", link_section = "__DATA,__mod_init_func")]
+            // Linux, Android, BSD:
+            #[cfg_attr(target_os = "android", link_section = ".init_array")]
+            #[cfg_attr(target_os = "dragonfly", link_section = ".init_array")]
+            #[cfg_attr(target_os = "freebsd", link_section = ".init_array")]
+            #[cfg_attr(target_os = "linux", link_section = ".init_array")]
+            #[cfg_attr(target_os = "netbsd", link_section = ".init_array")]
+            #[cfg_attr(target_os = "openbsd", link_section = ".init_array")]
+            static __init: extern "C" fn() = {
+                #[cfg_attr(target_os = "android", link_section = ".text.startup")]
+                #[cfg_attr(target_os = "linux", link_section = ".text.startup")]
+                extern "C" fn __inner_init() {
+                    $body
+                }
+                __inner_init
+            };
+
+            #[cfg(target_family = "wasm")]
+            todo!("wasm not yet implemented")
+        };
+    };
+}
+
 #[doc(hidden)]
 #[macro_export]
 #[allow(clippy::deprecated_cfg_attr)]

--- a/godot-ffi/src/plugins.rs
+++ b/godot-ffi/src/plugins.rs
@@ -57,7 +57,7 @@ macro_rules! plugin_add_inner_wasm {
 // ^ skip: paste's [< >] syntax chokes fmt
 //   cfg_attr: workaround for https://github.com/rust-lang/rust/pull/52234#issuecomment-976702997
 macro_rules! execute_pre_main {
-    ($body:expr; ) => {
+    ($body:expr) => {
         const _: () = {
             #[allow(non_upper_case_globals)]
             #[used]

--- a/godot-macros/Cargo.toml
+++ b/godot-macros/Cargo.toml
@@ -26,6 +26,7 @@ quote = "1.0.29"
 # Enabled by `docs`
 markdown = { version = "=1.0.0-alpha.21", optional = true }
 venial = "0.6"
+rand = "0.8.5"
 
 [build-dependencies]
 godot-bindings = { path = "../godot-bindings", version = "=0.1.3" } # emit_godot_version_cfg

--- a/godot-macros/src/class/data_models/inherent_impl.rs
+++ b/godot-macros/src/class/data_models/inherent_impl.rs
@@ -94,7 +94,7 @@ pub fn transform_inherent_impl(mut impl_block: venial::Impl) -> ParseResult<Toke
     let constant_registration = make_constant_registration(consts, &class_name, &class_name_obj)?;
 
     let suffix = &rand::random::<u32>().to_string();
-    let trait_name = format!("ImplementsGodotApi_{suffix}");
+    let trait_name = format_ident!("ImplementsGodotApi_{suffix}");
 
     let trait_definition = quote! {
         /// Auto-implemented for `#[godot_api] impl MyClass` blocks
@@ -109,8 +109,8 @@ pub fn transform_inherent_impl(mut impl_block: venial::Impl) -> ParseResult<Toke
         }
     };
 
-    let register_user_methods_constants_fn_name = format!("register_user_methods_constants_{suffix}");
-    let register_user_rpcs_fn_name = format!("register_user_rpcs{suffix}");
+    let register_user_methods_constants_fn_name = format_ident!("register_user_methods_constants_{suffix}");
+    let register_user_rpcs_fn_name = format_ident!("register_user_rpcs{suffix}");
 
     let helper_definitions = quote! {
         pub fn #register_user_methods_constants_fn_name<T: #trait_name>(_class_builder: &mut dyn Any) {

--- a/godot-macros/src/class/data_models/inherent_impl.rs
+++ b/godot-macros/src/class/data_models/inherent_impl.rs
@@ -100,13 +100,13 @@ pub fn transform_inherent_impl(meta: TokenStream, mut impl_block: venial::Impl) 
 
     let fill_storage = quote! {
         ::godot::sys::execute_pre_main!({
-            #method_storage_name.push(||{
+            #method_storage_name.lock().unwrap().push(||{
 
                 #( #method_registrations )*
                 #( #signal_registrations )*
 
             });
-            #constants_storage_name.push(||{
+            #constants_storage_name.lock().unwrap().push(||{
 
                 #constant_registration
 
@@ -134,13 +134,15 @@ pub fn transform_inherent_impl(meta: TokenStream, mut impl_block: venial::Impl) 
         let trait_impl = quote! {
             impl ::godot::obj::cap::ImplementsGodotApi for #class_name {
                 fn __register_methods() {
-                    for f in #method_storage_name {
+                    let guard = #method_storage_name.lock().unwrap();
+                    for f in guard {
                         f();
                     }
                 }
     
                 fn __register_constants() {
-                    for f in #constants_storage_name {
+                    let guard = #constants_storage_name.lock().unwrap();
+                    for f in guard {
                         f();
                     }
                 }
@@ -185,7 +187,7 @@ pub fn transform_inherent_impl(meta: TokenStream, mut impl_block: venial::Impl) 
     } else {
 
         let result = quote! {
-            
+
             #impl_block
 
             #fill_storage

--- a/godot-macros/src/class/data_models/inherent_impl.rs
+++ b/godot-macros/src/class/data_models/inherent_impl.rs
@@ -135,14 +135,14 @@ pub fn transform_inherent_impl(meta: TokenStream, mut impl_block: venial::Impl) 
             impl ::godot::obj::cap::ImplementsGodotApi for #class_name {
                 fn __register_methods() {
                     let guard = #method_storage_name.lock().unwrap();
-                    for f in guard {
+                    for f in guard.iter() {
                         f();
                     }
                 }
     
                 fn __register_constants() {
                     let guard = #constants_storage_name.lock().unwrap();
-                    for f in guard {
+                    for f in guard.iter() {
                         f();
                     }
                 }

--- a/godot-macros/src/class/data_models/inherent_impl.rs
+++ b/godot-macros/src/class/data_models/inherent_impl.rs
@@ -123,7 +123,7 @@ pub fn transform_inherent_impl(mut impl_block: venial::Impl) -> ParseResult<Toke
             T::__register_constants();
         }
         
-        pub fn #register_user_rpcs_fn_name<T: #trait_name>>(object: &mut dyn Any) {
+        pub fn #register_user_rpcs_fn_name<T: #trait_name>(object: &mut dyn Any) {
             T::__register_rpcs(object);
         }
         
@@ -136,7 +136,7 @@ pub fn transform_inherent_impl(mut impl_block: venial::Impl) -> ParseResult<Toke
 
         #helper_definitions
 
-        impl trait_name for #class_name {
+        impl #trait_name for #class_name {
             fn __register_methods() {
                 #( #method_registrations )*
                 #( #signal_registrations )*

--- a/godot-macros/src/class/data_models/inherent_impl.rs
+++ b/godot-macros/src/class/data_models/inherent_impl.rs
@@ -99,13 +99,13 @@ pub fn transform_inherent_impl(mut impl_block: venial::Impl) -> ParseResult<Toke
     let trait_definition = quote! {
         /// Auto-implemented for `#[godot_api] impl MyClass` blocks
         #[doc(hidden)]
-        pub trait #trait_name: GodotClass {
+        pub trait #trait_name: ::godot::obj::GodotClass {
             #[doc(hidden)]
             fn __register_methods();
             #[doc(hidden)]
             fn __register_constants();
             #[doc(hidden)]
-            fn __register_rpcs(_: &mut dyn Any) {}
+            fn __register_rpcs(_: &mut dyn std::any::Any) {}
         }
     };
 
@@ -113,7 +113,7 @@ pub fn transform_inherent_impl(mut impl_block: venial::Impl) -> ParseResult<Toke
     let register_user_rpcs_fn_name = format_ident!("register_user_rpcs{suffix}");
 
     let helper_definitions = quote! {
-        pub fn #register_user_methods_constants_fn_name<T: #trait_name>(_class_builder: &mut dyn Any) {
+        pub fn #register_user_methods_constants_fn_name<T: #trait_name>(_class_builder: &mut dyn std::any::Any) {
             // let class_builder = class_builder
             //     .downcast_mut::<ClassBuilder<T>>()
             //     .expect("bad type erasure");
@@ -123,7 +123,7 @@ pub fn transform_inherent_impl(mut impl_block: venial::Impl) -> ParseResult<Toke
             T::__register_constants();
         }
         
-        pub fn #register_user_rpcs_fn_name<T: #trait_name>(object: &mut dyn Any) {
+        pub fn #register_user_rpcs_fn_name<T: #trait_name>(object: &mut dyn std::any::Any) {
             T::__register_rpcs(object);
         }
         

--- a/godot-macros/src/class/data_models/inherent_impl.rs
+++ b/godot-macros/src/class/data_models/inherent_impl.rs
@@ -111,7 +111,7 @@ pub fn transform_inherent_impl(meta: TokenStream, mut impl_block: venial::Impl) 
                 #constant_registration
 
             });
-        })
+        });
     };
 
     if !is_secondary {

--- a/godot-macros/src/class/data_models/inherent_impl.rs
+++ b/godot-macros/src/class/data_models/inherent_impl.rs
@@ -65,7 +65,9 @@ struct FuncAttr {
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 
 /// Codegen for `#[godot_api] impl MyType`
-pub fn transform_inherent_impl(mut impl_block: venial::Impl) -> ParseResult<TokenStream> {
+pub fn transform_inherent_impl(meta: TokenStream, mut impl_block: venial::Impl) -> ParseResult<TokenStream> {
+    let is_secondary = meta.to_string().contains("secondary");
+
     let class_name = util::validate_impl(&impl_block, None, "godot_api")?;
     let class_name_obj = util::class_name_obj(&class_name);
     let prv = quote! { ::godot::private };
@@ -93,78 +95,106 @@ pub fn transform_inherent_impl(mut impl_block: venial::Impl) -> ParseResult<Toke
 
     let constant_registration = make_constant_registration(consts, &class_name, &class_name_obj)?;
 
-    let suffix = &rand::random::<u32>().to_string();
-    let trait_name = format_ident!("ImplementsGodotApi_{suffix}");
+    let method_storage_name =  format_ident!("__registration_methods_{class_name}");
+    let constants_storage_name =  format_ident!("__registration_constants_{class_name}");
 
-    let trait_definition = quote! {
-        /// Auto-implemented for `#[godot_api] impl MyClass` blocks
-        #[doc(hidden)]
-        pub trait #trait_name: ::godot::obj::GodotClass {
-            #[doc(hidden)]
-            fn __register_methods();
-            #[doc(hidden)]
-            fn __register_constants();
-            #[doc(hidden)]
-            fn __register_rpcs(_: &mut dyn std::any::Any) {}
-        }
-    };
+    let fill_storage = quote! {
+        ::godot::sys::execute_pre_main!({
+            #method_storage_name.push(||{
 
-    let register_user_methods_constants_fn_name = format_ident!("register_user_methods_constants_{suffix}");
-    let register_user_rpcs_fn_name = format_ident!("register_user_rpcs{suffix}");
-
-    let helper_definitions = quote! {
-        pub fn #register_user_methods_constants_fn_name<T: #trait_name>(_class_builder: &mut dyn std::any::Any) {
-            // let class_builder = class_builder
-            //     .downcast_mut::<ClassBuilder<T>>()
-            //     .expect("bad type erasure");
-        
-            //T::register_methods(class_builder);
-            T::__register_methods();
-            T::__register_constants();
-        }
-        
-        pub fn #register_user_rpcs_fn_name<T: #trait_name>(object: &mut dyn std::any::Any) {
-            T::__register_rpcs(object);
-        }
-        
-    };
-
-    let result = quote! {
-        #impl_block
-
-        #trait_definition
-
-        #helper_definitions
-
-        impl #trait_name for #class_name {
-            fn __register_methods() {
                 #( #method_registrations )*
                 #( #signal_registrations )*
-            }
 
-            fn __register_constants() {
+            });
+            #constants_storage_name.push(||{
+
                 #constant_registration
-            }
 
-            #rpc_registrations
-        }
-
-        ::godot::sys::plugin_add!(__GODOT_PLUGIN_REGISTRY in #prv; #prv::ClassPlugin {
-            class_name: #class_name_obj,
-            item: #prv::PluginItem::InherentImpl(#prv::InherentImpl {
-                register_methods_constants_fn: #prv::ErasedRegisterFn {
-                    raw: #register_user_rpcs_fn_name::<#class_name>,
-                },
-                register_rpcs_fn: Some(#prv::ErasedRegisterRpcsFn {
-                    raw: #register_user_rpcs_fn_name::<#class_name>,
-                }),
-                #docs
-            }),
-            init_level: <#class_name as ::godot::obj::GodotClass>::INIT_LEVEL,
-        });
+            });
+        })
     };
 
-    Ok(result)
+    if !is_secondary {
+
+        // we are the primary
+
+        let storage =  quote! {
+
+            #[used]
+            #[allow(non_upper_case_globals)]
+            #[doc(hidden)]
+            static #method_storage_name: std::sync::Mutex<Vec<fn()>> = std::sync::Mutex::new(Vec::new());
+            
+            #[used]
+            #[allow(non_upper_case_globals)]
+            #[doc(hidden)]
+            static #constants_storage_name: std::sync::Mutex<Vec<fn()>> = std::sync::Mutex::new(Vec::new());
+        };
+
+        let trait_impl = quote! {
+            impl ::godot::obj::cap::ImplementsGodotApi for #class_name {
+                fn __register_methods() {
+                    for f in #method_storage_name {
+                        f();
+                    }
+                }
+    
+                fn __register_constants() {
+                    for f in #constants_storage_name {
+                        f();
+                    }
+                }
+    
+                #rpc_registrations
+            }
+        };
+
+        let class_registration = quote! {
+   
+            ::godot::sys::plugin_add!(__GODOT_PLUGIN_REGISTRY in #prv; #prv::ClassPlugin {
+                class_name: #class_name_obj,
+                item: #prv::PluginItem::InherentImpl(#prv::InherentImpl {
+                    register_methods_constants_fn: #prv::ErasedRegisterFn {
+                        raw: #prv::callbacks::register_user_methods_constants::<#class_name>,
+                    },
+                    register_rpcs_fn: Some(#prv::ErasedRegisterRpcsFn {
+                        raw: #prv::callbacks::register_user_rpcs::<#class_name>,
+                    }),
+                    #docs
+                }),
+                init_level: <#class_name as ::godot::obj::GodotClass>::INIT_LEVEL,
+            });
+
+        };
+
+        let result = quote! {
+
+            #impl_block
+
+            #storage
+
+            #trait_impl
+
+            #fill_storage
+
+            #class_registration
+
+        };
+
+        return Ok(result);
+    } else {
+
+        let result = quote! {
+            
+            #impl_block
+
+            #fill_storage
+    
+        };
+    
+        Ok(result)
+    }
+
 }
 
 fn process_godot_fns(

--- a/godot-macros/src/class/data_models/inherent_impl.rs
+++ b/godot-macros/src/class/data_models/inherent_impl.rs
@@ -93,10 +93,50 @@ pub fn transform_inherent_impl(mut impl_block: venial::Impl) -> ParseResult<Toke
 
     let constant_registration = make_constant_registration(consts, &class_name, &class_name_obj)?;
 
+    let suffix = &rand::random::<u32>().to_string();
+    let trait_name = format!("ImplementsGodotApi_{suffix}");
+
+    let trait_definition = quote! {
+        /// Auto-implemented for `#[godot_api] impl MyClass` blocks
+        #[doc(hidden)]
+        pub trait #trait_name: GodotClass {
+            #[doc(hidden)]
+            fn __register_methods();
+            #[doc(hidden)]
+            fn __register_constants();
+            #[doc(hidden)]
+            fn __register_rpcs(_: &mut dyn Any) {}
+        }
+    };
+
+    let register_user_methods_constants_fn_name = format!("register_user_methods_constants_{suffix}");
+    let register_user_rpcs_fn_name = format!("register_user_rpcs{suffix}");
+
+    let helper_definitions = quote! {
+        pub fn #register_user_methods_constants_fn_name<T: #trait_name>(_class_builder: &mut dyn Any) {
+            // let class_builder = class_builder
+            //     .downcast_mut::<ClassBuilder<T>>()
+            //     .expect("bad type erasure");
+        
+            //T::register_methods(class_builder);
+            T::__register_methods();
+            T::__register_constants();
+        }
+        
+        pub fn #register_user_rpcs_fn_name<T: #trait_name>>(object: &mut dyn Any) {
+            T::__register_rpcs(object);
+        }
+        
+    };
+
     let result = quote! {
         #impl_block
 
-        impl ::godot::obj::cap::ImplementsGodotApi for #class_name {
+        #trait_definition
+
+        #helper_definitions
+
+        impl trait_name for #class_name {
             fn __register_methods() {
                 #( #method_registrations )*
                 #( #signal_registrations )*
@@ -113,10 +153,10 @@ pub fn transform_inherent_impl(mut impl_block: venial::Impl) -> ParseResult<Toke
             class_name: #class_name_obj,
             item: #prv::PluginItem::InherentImpl(#prv::InherentImpl {
                 register_methods_constants_fn: #prv::ErasedRegisterFn {
-                    raw: #prv::callbacks::register_user_methods_constants::<#class_name>,
+                    raw: #register_user_rpcs_fn_name::<#class_name>,
                 },
                 register_rpcs_fn: Some(#prv::ErasedRegisterRpcsFn {
-                    raw: #prv::callbacks::register_user_rpcs::<#class_name>,
+                    raw: #register_user_rpcs_fn_name::<#class_name>,
                 }),
                 #docs
             }),

--- a/godot-macros/src/class/godot_api.rs
+++ b/godot-macros/src/class/godot_api.rs
@@ -11,7 +11,7 @@ use crate::class::{transform_inherent_impl, transform_trait_impl};
 use crate::util::bail;
 use crate::ParseResult;
 
-pub fn attribute_godot_api(input_decl: venial::Item) -> ParseResult<TokenStream> {
+pub fn attribute_godot_api(meta: TokenStream, input_decl: venial::Item) -> ParseResult<TokenStream> {
     let decl = match input_decl {
         venial::Item::Impl(decl) => decl,
         _ => bail!(
@@ -34,6 +34,6 @@ pub fn attribute_godot_api(input_decl: venial::Item) -> ParseResult<TokenStream>
     if decl.trait_ty.is_some() {
         transform_trait_impl(decl)
     } else {
-        transform_inherent_impl(decl)
+        transform_inherent_impl(meta, decl)
     }
 }

--- a/godot-macros/src/lib.rs
+++ b/godot-macros/src/lib.rs
@@ -680,8 +680,8 @@ pub fn derive_godot_class(input: TokenStream) -> TokenStream {
 ///
 /// Please refer to [the book](https://godot-rust.github.io/book/register/constants.html).
 #[proc_macro_attribute]
-pub fn godot_api(_meta: TokenStream, input: TokenStream) -> TokenStream {
-    translate(input, class::attribute_godot_api)
+pub fn godot_api(meta: TokenStream, input: TokenStream) -> TokenStream {
+    translate(input, |body| class::attribute_godot_api(TokenStream2::from(meta), body))
 }
 
 /// Derive macro for [`GodotConvert`](../builtin/meta/trait.GodotConvert.html) on structs.


### PR DESCRIPTION
fixes https://github.com/godot-rust/gdext/issues/925

right after creating that issue I figured it couldn't be that hard and bashed my head against rust macros for a while.

This is in a very rough state, but it works!

```rust
use godot::prelude::*;

use godot::classes::Node;
use godot::classes::INode;

#[derive(GodotClass)]
#[class(base=Node, init)]
pub struct TestNode {
    base: Base<Node>
}

#[godot_api]
impl TestNode {
    #[func]
    fn foo() {
        godot_print!("[TestNode] called 'foo'");
    }
}



#[godot_api(secondary)]
impl TestNode {
    #[func]
    fn bar() {
        godot_print!("[TestNode] called 'bar'");
    }
}


```

![image](https://github.com/user-attachments/assets/faf2fb80-450e-4676-b3d6-2f56567bbe68)

I'll clean it up over the next few days
