### PR TITLE
Implement dynTrait for Gd<T: TraitA>

### DIFF
--- a/godot-core/src/obj/traits.rs
+++ b/godot-core/src/obj/traits.rs
@@ -553,6 +553,12 @@ pub mod cap {
         fn __godot_property_get_revert(&self, property: StringName) -> Option<Variant>;
     }
 
+    #[doc(hidden)]
+    pub trait DynTrait: GodotClass {
+        #[doc(hidden)]
+        fn __register_dyn_traits();
+    }
+
     /// Auto-implemented for `#[godot_api] impl MyClass` blocks
     pub trait ImplementsGodotApi: GodotClass {
         #[doc(hidden)]

--- a/godot-core/src/private.rs
+++ b/godot-core/src/private.rs
@@ -9,7 +9,8 @@ pub use crate::gen::classes::class_macros;
 pub use crate::obj::rtti::ObjectRtti;
 pub use crate::registry::callbacks;
 pub use crate::registry::plugin::{
-    ClassPlugin, ErasedRegisterFn, ErasedRegisterRpcsFn, InherentImpl, PluginItem,
+    ClassPlugin, ErasedRegisterDynTraitFn, ErasedRegisterFn, ErasedRegisterRpcsFn, InherentImpl,
+    PluginItem,
 };
 pub use crate::storage::{as_storage, Storage};
 pub use sys::out;

--- a/godot-core/src/registry/callbacks.rs
+++ b/godot-core/src/registry/callbacks.rs
@@ -345,6 +345,10 @@ pub fn register_user_properties<T: cap::ImplementsGodotExports>(_class_builder: 
     T::__register_exports();
 }
 
+pub fn register_user_dyn_traits<T: cap::DynTrait>(_class_builder: &mut dyn Any) {
+    T::__register_dyn_traits();
+}
+
 pub fn register_user_methods_constants<T: cap::ImplementsGodotApi>(_class_builder: &mut dyn Any) {
     // let class_builder = class_builder
     //     .downcast_mut::<ClassBuilder<T>>()

--- a/godot-core/src/registry/class.rs
+++ b/godot-core/src/registry/class.rs
@@ -245,6 +245,7 @@ fn fill_class_info(item: PluginItem, c: &mut ClassRegistrationInfo) {
             is_instantiable,
             #[cfg(all(since_api = "4.3", feature = "register-docs"))]
                 docs: _,
+            register_dyn_trait_fn: _,
         } => {
             c.parent_class_name = Some(base_class_name);
             c.default_virtual_fn = default_get_virtual_fn;

--- a/godot-core/src/registry/plugin.rs
+++ b/godot-core/src/registry/plugin.rs
@@ -45,6 +45,17 @@ impl fmt::Debug for ErasedRegisterFn {
 }
 
 #[derive(Copy, Clone)]
+pub struct ErasedRegisterDynTraitFn {
+    pub raw: fn(&mut dyn Any),
+}
+
+impl fmt::Debug for ErasedRegisterDynTraitFn {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "0x{:0>16x}", self.raw as usize)
+    }
+}
+
+#[derive(Copy, Clone)]
 pub struct ErasedRegisterRpcsFn {
     pub raw: fn(&mut dyn Any),
 }
@@ -95,6 +106,8 @@ pub enum PluginItem {
 
         /// Callback to library-generated function which registers properties in the `struct` definition.
         register_properties_fn: ErasedRegisterFn,
+
+        register_dyn_trait_fn: ErasedRegisterDynTraitFn,
 
         free_fn: unsafe extern "C" fn(
             _class_user_data: *mut std::ffi::c_void,

--- a/godot-macros/src/class/derive_godot_class.rs
+++ b/godot-macros/src/class/derive_godot_class.rs
@@ -213,6 +213,7 @@ struct ClassAttributes {
     is_internal: bool,
     rename: Option<Ident>,
     deprecations: Vec<TokenStream>,
+    dyn_traits: Vec<Ident>,
 }
 
 impl ClassAttributes {
@@ -335,6 +336,7 @@ fn parse_struct_attributes(class: &venial::Struct) -> ParseResult<ClassAttribute
     let mut is_internal = false;
     let mut rename: Option<Ident> = None;
     let mut deprecations = vec![];
+    let mut dyn_traits = vec![];
 
     // #[class] attribute on struct
     if let Some(mut parser) = KvParser::parse(&class.attributes, "class")? {
@@ -382,6 +384,17 @@ fn parse_struct_attributes(class: &venial::Struct) -> ParseResult<ClassAttribute
             });
         }
 
+        if let Some(mut dyn_traits_list) = parser.handle_list("dyn_trait")? {
+            loop {
+                if let Ok(Some(token)) = dyn_traits_list.try_next_ident() {
+                    dyn_traits.push(token);
+                } else {
+                    break
+                }
+            }
+
+        }
+
         parser.finish()?;
     }
 
@@ -394,6 +407,7 @@ fn parse_struct_attributes(class: &venial::Struct) -> ParseResult<ClassAttribute
         is_internal,
         rename,
         deprecations,
+        dyn_traits
     })
 }
 

--- a/godot-macros/src/class/derive_godot_class.rs
+++ b/godot-macros/src/class/derive_godot_class.rs
@@ -389,10 +389,9 @@ fn parse_struct_attributes(class: &venial::Struct) -> ParseResult<ClassAttribute
                 if let Ok(Some(token)) = dyn_traits_list.try_next_ident() {
                     dyn_traits.push(token);
                 } else {
-                    break
+                    break;
                 }
             }
-
         }
 
         parser.finish()?;
@@ -407,7 +406,7 @@ fn parse_struct_attributes(class: &venial::Struct) -> ParseResult<ClassAttribute
         is_internal,
         rename,
         deprecations,
-        dyn_traits
+        dyn_traits,
     })
 }
 

--- a/godot-macros/src/class/dyn_trait.rs
+++ b/godot-macros/src/class/dyn_trait.rs
@@ -5,107 +5,223 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+// note - it is WiP, so forgive any weird docs, comments and whatnot
+
 use crate::class::{ReceiverType, SignatureInfo};
 use crate::util::{bail, ident, KvParser};
 use crate::{util, ParseResult};
 use proc_macro2::TokenStream;
-use proc_macro2::{Group, Ident, TokenTree};
+use proc_macro2::{Ident, TokenTree};
 use quote::{quote, ToTokens};
-use venial::TraitMember;
 
-struct DynTraitDispatch {
-    base_ty: Ident,
-    trait_name: Ident,
-    dispatch_name: Ident,
-    wrapper_name: Ident,
-    methods_signatures: Vec<SignatureInfo>,
+enum DynTraitMethod {
+    /// Methods that are explicitly marked as non-dispatchable by user.
+    NonDispatchable(SignatureInfo),
+    /// Allegedly [object-safe](https://doc.rust-lang.org/reference/items/traits.html#object-safety) methods. Making sure that they are for sure object safe is user responsibility.
+    Dispatchable(SignatureInfo),
 }
 
-fn parse_trait_member(params: &mut TraitMember, method_signatures: &mut Vec<SignatureInfo>) {
-    match params {
-        TraitMember::AssocFunction(f) => {
-            let mut receiver_type: Option<ReceiverType> = None;
-            let signature = util::reduce_to_signature(f);
-            let num_params = signature.params.len();
-            let mut param_idents = Vec::with_capacity(num_params);
-            let mut param_types = Vec::with_capacity(num_params);
-            let ret_type = match signature.return_ty {
-                None => quote! { () },
-                Some(ty) => ty
-                    .tokens
-                    .into_iter()
-                    .map(|tt| match tt {
-                        TokenTree::Group(group) => {
-                            TokenTree::Group(Group::new(group.delimiter(), group.stream()))
-                        }
-                        tt => tt,
-                    })
-                    .collect(),
-            };
+struct DynTraitDispatch {
+    /// Base godot type used by our wrapper.
+    base_ty: Ident,
+    trait_name: Ident,
+    /// Name of our internal dispatch method
+    dispatch_name: Ident,
+    /// dynTrait object name.
+    wrapper_name: Ident,
+    /// Signatures for our normal methods
+    methods_signatures: Vec<DynTraitMethod>,
+}
 
-            for (arg, _) in signature.params.inner {
-                match arg {
-                    venial::FnParam::Receiver(recv) => {
-                        receiver_type = if recv.tk_mut.is_some() {
-                            Some(ReceiverType::Mut)
-                        } else if recv.tk_ref.is_some() {
-                            Some(ReceiverType::Ref)
-                        } else {
-                            panic!("Receiver not supported");
-                        };
-                    }
-                    venial::FnParam::Typed(arg) => {
-                        let ty = venial::TypeExpr {
-                            tokens: arg
-                                .ty
-                                .tokens
-                                .into_iter()
-                                .map(|tt| match tt {
-                                    TokenTree::Group(group) => TokenTree::Group(Group::new(
-                                        group.delimiter(),
-                                        group.stream(),
-                                    )),
-                                    tt => tt,
-                                })
-                                .collect(),
-                        };
-                        param_types.push(ty);
-                        param_idents.push(arg.name);
-                    }
-                }
-            }
-
-            method_signatures.push(SignatureInfo {
-                method_name: signature.name,
-                receiver_type: receiver_type.unwrap_or(ReceiverType::Static),
-                param_idents,
-                param_types,
-                ret_type,
-            });
+/// Creates non-dispatchable method for our wrapper.
+/// Generated method on wrapper panics on use and informs user why they can't dynamically dispatch a method explicitly marked as non-dispatchable
+fn create_non_dispatchable_method(signature: SignatureInfo) -> TokenStream {
+    let method_name = signature.method_name;
+    let ret = signature.ret_type;
+    let function_params: Vec<TokenStream> = signature
+        .param_types
+        .iter()
+        .zip(signature.param_idents.iter())
+        .map(|(ident, param)| quote! {#param: #ident})
+        .collect();
+    let receiver = match signature.receiver_type {
+        ReceiverType::Ref => quote! {&self},
+        ReceiverType::Mut => quote! {&mut self},
+        ReceiverType::Static => TokenStream::default(),
+        _ => unreachable!(),
+    };
+    let panic_message = format!(
+        "error: the {} method cannot be invoked on a trait object",
+        method_name
+    );
+    quote! {
+        fn #method_name(#receiver #(#function_params),*) -> #ret {
+            panic!(#panic_message)
         }
-        TraitMember::AssocConstant(c) => {
-            unimplemented!()
-        }
-        TraitMember::AssocType(t) => {
-            unimplemented!()
-        }
-        TraitMember::Macro(_) => unimplemented!(),
-        _ => {}
     }
 }
 
+/// Codegen for methods on our wrapper and dispatched closures
+fn create_dispatch_method(
+    signature: SignatureInfo,
+    base_ty: &Ident,
+    trait_name: &Ident,
+) -> ParseResult<(TokenStream, TokenStream, TokenStream)> {
+    let dispatch_func_name = ident(&format!("dispatch_{}", signature.method_name));
+    let ret = signature.ret_type;
+    let param_types = signature.param_types;
+    let param_idents = signature.param_idents;
+    let method_name = signature.method_name;
+    let function_params: Vec<TokenStream> = param_types
+        .iter()
+        .zip(param_idents.iter())
+        .map(|(ident, param)| quote! {#param: #ident})
+        .collect();
+    let (mutability, receiver, bind) = match signature.receiver_type {
+        ReceiverType::Ref => (
+            quote! { & },
+            quote! {&self, },
+            quote! {
+                let instance = base.cast::<T>();
+                let guard: GdRef<T> = instance.bind();
+            },
+        ),
+        ReceiverType::Mut => (
+            quote! { &mut },
+            quote! {&mut self, },
+            quote! {
+                let mut instance = base.cast::<T>();
+                let mut guard: GdMut<T> = instance.bind_mut();
+            },
+        ),
+        _ => {
+            // return proper error to user.
+            return bail!(
+                &method_name,
+        "error[E0038]: the trait cannot be made into an object.\n \
+        note: for a trait to be \"object safe\" it needs to allow \
+        building a vtable to allow the call to be resolvable dynamically; \
+        for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>"
+            );
+        }
+    };
+    let fields = quote! {#dispatch_func_name: fn(Gd<#base_ty>, #(#param_types,)* fn(#mutability dyn #trait_name, #(#param_types),*) -> #ret) -> #ret};
+    let declarations = quote! {
+        #dispatch_func_name: |base, #(#param_idents),*, closure| {
+                #bind
+                closure(#mutability *guard, #(#param_idents),*)
+            }
+    };
+    let methods = quote! {
+        fn #method_name(#receiver #(#function_params),*) -> #ret {
+            unsafe {((*self.dispatch).#dispatch_func_name)(self.base.clone(), #(#param_idents,)* |dispatch: #mutability dyn #trait_name, #(#param_idents,)*| {dispatch.#method_name(#(#param_idents),*)})}
+        }
+    };
+
+    Ok((fields, declarations, methods))
+}
+
+/// Naive check for where Self: Sized
+fn is_function_sized(f: &mut venial::Function) -> bool {
+    if let Some(where_clause) = f.where_clause.as_ref() {
+        return where_clause.items.items().any(|i| {
+            let Some(TokenTree::Ident(bound)) = &i
+                .bound
+                .tokens
+                .iter()
+                .find(|x| matches!(x, TokenTree::Ident(_)))
+            else {
+                return false;
+            };
+            if *bound != "Sized" {
+                return false;
+            }
+            let left_side = i
+                .left_side
+                .iter()
+                .fold(String::new(), |acc, arg| format!("{acc}{arg}"));
+            left_side == "Self"
+        });
+    };
+    false
+}
+
+/// Checks if given associated function is explicitly non-dispatchable
+/// Explicitly non-dispatchable functions have a `where Self: Sized` bound.
+fn check_if_dispatchable(
+    f: &mut venial::Function,
+    signature_info: SignatureInfo,
+) -> DynTraitMethod {
+    if is_function_sized(f) {
+        // This trait is object-safe, but this method can't be dispatched on a trait object.
+        return DynTraitMethod::NonDispatchable(signature_info);
+    }
+    DynTraitMethod::Dispatchable(signature_info)
+}
+
+/// Creates signature for given function and check if it is marked as non-dispatchable.
+fn parse_associated_function(f: &mut venial::Function) -> DynTraitMethod {
+    let mut receiver_type: ReceiverType = ReceiverType::Static;
+    let signature = util::reduce_to_signature(f);
+    let num_params = signature.params.len();
+    let mut param_idents = Vec::with_capacity(num_params);
+    let mut param_types = Vec::with_capacity(num_params);
+
+    let ret_type = match signature.return_ty {
+        None => quote! { () },
+        Some(ty) => ty.to_token_stream(),
+    };
+
+    for (arg, _) in signature.params.inner {
+        match arg {
+            venial::FnParam::Receiver(recv) => {
+                receiver_type = if recv.tk_mut.is_some() {
+                    ReceiverType::Mut
+                } else if recv.tk_ref.is_some() {
+                    ReceiverType::Ref
+                } else {
+                    // Receiver is not present at all.
+                    unreachable!()
+                };
+            }
+            venial::FnParam::Typed(arg) => {
+                let ty = venial::TypeExpr {
+                    tokens: arg.ty.tokens,
+                };
+
+                param_types.push(ty);
+                param_idents.push(arg.name);
+            }
+        }
+    }
+
+    // we need to provide correct signature for given trait method
+    // even if it is not dispatchable.
+    let signature = SignatureInfo {
+        method_name: signature.name,
+        receiver_type,
+        param_idents,
+        param_types,
+        ret_type,
+    };
+    check_if_dispatchable(f, signature)
+}
+
 pub fn attribute_dyn_trait(input_decl: venial::Item) -> ParseResult<TokenStream> {
-    let venial::Item::Trait(mut decl) = input_decl else {
+    let venial::Item::Trait(mut decl) = input_decl.clone() else {
         bail!(
             input_decl,
             "#[dyn_trait] can only be applied on trait blocks",
         )?
     };
+
     let trait_name = decl.name.clone();
     let dispatch_name = ident(&format! {"{}GdDispatch", decl.name});
     let mut wrapper_name = ident(&format!("{}GdDyn", decl.name));
     let mut base_ty = ident("Object");
     let attr = std::mem::take(&mut decl.attributes);
+
+    // #[dyn_trait]
     if let Some(mut parser) = KvParser::parse(&attr, "dyn_trait")? {
         if let Ok(Some(name)) = parser.handle_ident("name") {
             wrapper_name = name;
@@ -115,23 +231,35 @@ pub fn attribute_dyn_trait(input_decl: venial::Item) -> ParseResult<TokenStream>
         };
     }
 
-    let mut methods_signatures = Vec::new();
-    for trait_member in decl.body_items.iter_mut() {
-        parse_trait_member(trait_member, &mut methods_signatures);
-    }
-    let trait_dispatch = DynTraitDispatch {
+    let mut trait_dispatch = DynTraitDispatch {
         base_ty,
         trait_name,
         dispatch_name,
         wrapper_name,
-        methods_signatures,
+        methods_signatures: vec![],
     };
-    let ret = create_dyn_trait_dispatch(trait_dispatch, decl.to_token_stream());
-    eprintln!("{ret}");
-    ParseResult::Ok(ret)
+
+    for trait_member in decl.body_items.iter_mut() {
+        let venial::TraitMember::AssocFunction(f) = trait_member else {
+            bail!(
+                trait_member,
+                "error[E0038]: the trait cannot be made into an object\n\
+                note: for a trait to be \"object safe\" it needs to allow building a vtable to allow the call to be resolvable dynamically; \
+                for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>"
+            )?
+        };
+        trait_dispatch
+            .methods_signatures
+            .push(parse_associated_function(f));
+    }
+    create_dyn_trait_dispatch(trait_dispatch, decl.to_token_stream())
 }
 
-pub fn create_dyn_trait_dispatch(s: DynTraitDispatch, initial: TokenStream) -> TokenStream {
+/// Codegen for `#[dyn_trait] for trait MyTrait`
+fn create_dyn_trait_dispatch(
+    s: DynTraitDispatch,
+    initial: TokenStream,
+) -> ParseResult<TokenStream> {
     let DynTraitDispatch {
         base_ty,
         trait_name,
@@ -150,54 +278,32 @@ pub fn create_dyn_trait_dispatch(s: DynTraitDispatch, initial: TokenStream) -> T
     let mut dispatch_fields: Vec<TokenStream> = vec![];
     let mut dispatch_declarations: Vec<TokenStream> = vec![];
     let mut wrapper_methods: Vec<TokenStream> = vec![];
+
     for signature in methods_signatures.into_iter() {
-        let dispatch_func_name = ident(&format!("dispatch_{}", signature.method_name));
-        let (mutability, receiver) = match signature.receiver_type {
-            ReceiverType::Ref => (quote! { & }, quote! {&self}),
-            ReceiverType::Mut => (quote! { &mut }, quote! {&mut self}),
-            ReceiverType::GdSelf => !unreachable!(),
-            ReceiverType::Static => (quote! { () }, quote! {}),
-        };
-        let ret = signature.ret_type;
-        let param_types = signature.param_types;
-        let param_idents = signature.param_idents;
-        let method_name = signature.method_name;
-        let function_params: Vec<TokenStream> = param_types
-            .iter()
-            .zip(param_idents.iter())
-            .map(|(ident, param)| quote! {#param: #ident})
-            .collect();
-        dispatch_fields.push(
-            quote! {
-                #dispatch_func_name: fn(Gd<#base_ty>, #(#param_types,)* fn(#mutability dyn #trait_name, #(#param_types),*) -> #ret) -> #ret
+        match signature {
+            DynTraitMethod::NonDispatchable(sig) => {
+                wrapper_methods.push(create_non_dispatchable_method(sig));
             }
-        );
-        dispatch_declarations.push(quote! {
-            #dispatch_func_name: |base, #(#param_idents),*, closure| {
-                let mut instance = base.cast::<T>();
-                let mut guard: GdMut<T> = instance.bind_mut();
-                closure(&mut *guard, #(#param_idents),*)
+            DynTraitMethod::Dispatchable(sig) => {
+                let (fields, declarations, methods) =
+                    create_dispatch_method(sig, &base_ty, &trait_name)?;
+                dispatch_fields.push(fields);
+                dispatch_declarations.push(declarations);
+                wrapper_methods.push(methods);
             }
-        });
-        wrapper_methods.push(
-            quote! {
-                fn #method_name(#receiver, #(#function_params),*) -> #ret {
-                    unsafe {((*self.dispatch).#dispatch_func_name)(self.base.clone(), #(#param_idents,)* |dispatch: #mutability dyn #trait_name, #(#param_idents,)*| {dispatch.#method_name(#(#param_idents),*)})}
-                }
-            }
-        );
+        }
     }
 
-    quote! {
+    let ret = quote! {
         #initial
 
         static #registry_name: godot::sys::Global<std::collections::HashMap<String, #dispatch_name>> = godot::sys::Global::default();
 
-
-        pub fn #register_dispatch_name<T>(name: String)
+        pub fn #register_dispatch_name<T>()
             where
                 T: Inherits<#base_ty> + GodotClass + godot::obj::Bounds<Declarer = godot::obj::bounds::DeclUser> + #trait_name
         {
+            let name = T::class_name().to_string();
             let mut registry = #registry_name.lock();
             registry.entry(name).or_insert_with(
             || #dispatch_name::new::<T>()
@@ -226,18 +332,43 @@ pub fn create_dyn_trait_dispatch(s: DynTraitDispatch, initial: TokenStream) -> T
         }
 
         impl #wrapper_name {
-            pub fn new(base: Gd<#base_ty>) -> Self {
+            pub fn new(base: Gd<#base_ty>) -> Result<Self, &'static str> {
                 let registry = #registry_name.lock();
-                let dispatch = &registry[&base.get_class().to_string()] as *const #dispatch_name;
-                Self {
+                let Some(dispatch) = registry.get(&base.get_class().to_string()) else {
+                    return Err("Given class is not registered as dynTrait object!")
+                };
+                Ok(Self {
                     base,
-                    dispatch
-                }
+                    dispatch: dispatch as *const #dispatch_name
+                })
             }
         }
 
         impl #trait_name for #wrapper_name {
             #(#wrapper_methods)*
         }
-    }
+
+        impl GodotConvert for #wrapper_name {
+            type Via = Gd<#base_ty>;
+        }
+
+        impl ToGodot for #wrapper_name {
+            type ToVia<'v> = Gd<#base_ty>
+                where Self: 'v;
+            fn to_godot(&self) -> Self::ToVia<'_> {
+                self.base.clone()
+            }
+        }
+
+        impl FromGodot for #wrapper_name {
+            fn try_from_godot(via: Self::Via) -> Result<Self, ConvertError> {
+                match #wrapper_name::new(via) {
+                    Ok(s) => Ok(s),
+                    Err(message) => Err(ConvertError::new(message))
+                }
+            }
+        }
+
+    };
+    Ok(ret)
 }

--- a/godot-macros/src/class/dyn_trait.rs
+++ b/godot-macros/src/class/dyn_trait.rs
@@ -1,0 +1,228 @@
+use std::fmt::format;
+use proc_macro2::{Group, Ident, TokenTree};
+use quote::{quote, ToTokens};
+use proc_macro2::TokenStream;
+use venial::{FnParam, Item, Punctuated, TraitMember};
+use crate::{ParseResult, util};
+use crate::class::{FuncDefinition, maybe_rename_parameter, ReceiverType, SignatureInfo};
+use crate::util::{bail, ident, KvParser};
+
+struct DynTraitDispatch {
+    base_ty: Ident,
+    trait_name: Ident,
+    dispatch_name: Ident,
+    wrapper_name: Ident,
+    methods_signatures: Vec<SignatureInfo>
+}
+
+
+fn parse_trait_member(params: &mut TraitMember, method_signatures: &mut Vec<SignatureInfo>) {
+    match params {
+        TraitMember::AssocFunction(f) => {
+            let mut receiver_type: Option<ReceiverType> = None;
+            let mut signature = util::reduce_to_signature(f);
+            let num_params = signature.params.len();
+            let mut param_idents = Vec::with_capacity(num_params);
+            let mut param_types = Vec::with_capacity(num_params);
+            let ret_type = match signature.return_ty {
+                None => quote! { () },
+                Some(ty) => ty.tokens.into_iter().map(|tt| match tt {
+                    TokenTree::Group(group) => TokenTree::Group(Group::new(
+                        group.delimiter(),
+                        group.stream()
+                    )),
+                    tt => tt
+                }).collect()
+            };
+
+            for (arg, _) in signature.params.inner {
+                match arg {
+                    venial::FnParam::Receiver(recv) => {
+                        receiver_type = if recv.tk_mut.is_some() {
+                            Some(ReceiverType::Mut)
+                        } else if recv.tk_ref.is_some() {
+                            Some(ReceiverType::Ref)
+                        } else {
+                            panic!("Receiver not supported");
+                        };
+                    }
+                    venial::FnParam::Typed(arg) => {
+                        let ty = venial::TypeExpr {
+                            tokens: arg.ty.tokens.into_iter().map(|tt| match tt {
+                                TokenTree::Group(group) => {
+                                    TokenTree::Group(Group::new(
+                                        group.delimiter(),
+                                        group.stream(),
+                                    ))
+                                }
+                                tt => tt,
+                            }).collect(),
+                        };
+                        param_types.push(ty);
+                        param_idents.push(arg.name);
+                    }
+                }
+            }
+
+            method_signatures.push(SignatureInfo {
+                method_name: signature.name,
+                receiver_type: receiver_type.unwrap_or(ReceiverType::Static),
+                param_idents,
+                param_types,
+                ret_type,
+            });
+        }
+        TraitMember::AssocConstant(c) => {
+            unimplemented!()
+        }
+        TraitMember::AssocType(t) => {
+            unimplemented!()
+        }
+        TraitMember::Macro(_) => unimplemented!(),
+        _ => {}
+    }
+}
+
+
+pub fn attribute_dyn_trait(input_decl: venial::Item) -> ParseResult<TokenStream> {
+    let venial::Item::Trait(mut decl) = input_decl else {
+        bail!(
+            input_decl,
+            "#[dyn_trait] can only be applied on trait blocks",
+        )?
+    };
+    let trait_name = decl.name.clone();
+    let dispatch_name = ident(&format! {"{}GdDispatch", decl.name});
+    let mut wrapper_name =  ident(&format!("{}GdDyn", decl.name));
+    let mut base_ty = ident("Object");
+    let attr = std::mem::take(&mut decl.attributes);
+    if let Some(mut parser) = KvParser::parse(&attr, "dyn_trait")? {
+        if let Ok(Some(name)) = parser.handle_ident("name") {
+            wrapper_name = name;
+        };
+        if let Ok(Some(base)) = parser.handle_ident("base") {
+            base_ty = base;
+        };
+    }
+
+    let mut methods_signatures = Vec::new();
+    for trait_member in decl.body_items.iter_mut() {
+        parse_trait_member(trait_member, &mut methods_signatures);
+    }
+    let trait_dispatch = DynTraitDispatch {
+        base_ty,
+        trait_name,
+        dispatch_name,
+        wrapper_name,
+        methods_signatures,
+    };
+    let ret = create_dyn_trait_dispatch(trait_dispatch, decl.to_token_stream());
+    eprintln!("{ret}");
+    ParseResult::Ok(ret)
+}
+
+pub fn create_dyn_trait_dispatch(s: DynTraitDispatch, initial: TokenStream) -> TokenStream {
+    let DynTraitDispatch {
+        base_ty,
+        trait_name,
+        dispatch_name,
+        wrapper_name,
+        methods_signatures
+    } = s;
+    let registry_name = ident(&format!("{}_DISPATCH_REGISTRY", trait_name.to_string().to_uppercase()));
+    let register_dispatch_name = ident(&format!("register_{}_dispatch", trait_name.to_string().to_lowercase()));
+    let mut dispatch_fields: Vec<TokenStream> = vec![];
+    let mut dispatch_declarations: Vec<TokenStream> = vec![];
+    let mut wrapper_methods: Vec<TokenStream> = vec![];
+    for signature in methods_signatures.into_iter() {
+        let dispatch_func_name = ident(&format!("dispatch_{}", signature.method_name));
+        let (mutability, receiver) = match signature.receiver_type {
+            ReceiverType::Ref => (quote! { & }, quote! {&self}),
+            ReceiverType::Mut => (quote! { &mut }, quote! {&mut self}),
+            ReceiverType::GdSelf => !unreachable!(),
+            ReceiverType::Static => (quote!{ () }, quote! {})
+        };
+        let ret = signature.ret_type;
+        let param_types = signature.param_types;
+        let param_idents = signature.param_idents;
+        let method_name = signature.method_name;
+        let function_params: Vec<TokenStream> = param_types.iter().zip(param_idents.iter()).map(
+            |(ident, param)| quote! {#param: #ident}
+        ).collect();
+        dispatch_fields.push(
+            quote! {
+                #dispatch_func_name: fn(Gd<#base_ty>, #(#param_types,)* fn(#mutability dyn #trait_name, #(#param_types),*) -> #ret) -> #ret
+            }
+        );
+        dispatch_declarations.push(
+            quote! {
+                #dispatch_func_name: |base, #(#param_idents),*, closure| {
+                    let mut instance = base.cast::<T>();
+                    let mut guard: GdMut<T> = instance.bind_mut();
+                    closure(&mut *guard, #(#param_idents),*)
+                }
+            }
+        );
+        wrapper_methods.push(
+            quote! {
+                fn #method_name(#receiver, #(#function_params),*) -> #ret {
+                    unsafe {((*self.dispatch).#dispatch_func_name)(self.base.clone(), #(#param_idents,)* |dispatch: #mutability dyn #trait_name, #(#param_idents,)*| {dispatch.#method_name(#(#param_idents),*)})}
+                }
+            }
+        );
+    }
+
+
+    quote! {
+        #initial
+
+        static #registry_name: godot::sys::Global<std::collections::HashMap<String, #dispatch_name>> = godot::sys::Global::default();
+
+
+        pub fn #register_dispatch_name<T>(name: String)
+            where
+                T: Inherits<#base_ty> + GodotClass + godot::obj::Bounds<Declarer = godot::obj::bounds::DeclUser> + #trait_name
+        {
+            let mut registry = #registry_name.lock();
+            registry.entry(name).or_insert_with(
+            || #dispatch_name::new::<T>()
+        );
+        }
+
+        struct #dispatch_name {
+            #(#dispatch_fields),*
+        }
+
+
+        impl #dispatch_name {
+            fn new<T>() -> Self
+                where
+                    T: Inherits<#base_ty> + GodotClass + godot::obj::Bounds<Declarer = godot::obj::bounds::DeclUser> + #trait_name
+            {
+                Self {
+                #(#dispatch_declarations),*
+                }
+            }
+        }
+
+        pub struct #wrapper_name {
+            pub base: Gd<#base_ty>,
+            dispatch: *const #dispatch_name
+        }
+
+        impl #wrapper_name {
+            pub fn new(base: Gd<#base_ty>) -> Self {
+                let registry = #registry_name.lock();
+                let dispatch = &registry[&base.get_class().to_string()] as *const #dispatch_name;
+                Self {
+                    base,
+                    dispatch
+                }
+            }
+        }
+
+        impl #trait_name for #wrapper_name {
+            #(#wrapper_methods)*
+        }
+    }
+}

--- a/godot-macros/src/class/dyn_trait.rs
+++ b/godot-macros/src/class/dyn_trait.rs
@@ -107,7 +107,7 @@ fn create_dispatch_method(
     };
     let fields = quote! {#dispatch_func_name: fn(Gd<#base_ty>, #(#param_types,)* fn(#mutability dyn #trait_name, #(#param_types),*) -> #ret) -> #ret};
     let declarations = quote! {
-        #dispatch_func_name: |base, #(#param_idents),*, closure| {
+        #dispatch_func_name: |base, #(#param_idents,)* closure| {
                 #bind
                 closure(#mutability *guard, #(#param_idents),*)
             }
@@ -303,6 +303,7 @@ fn create_dyn_trait_dispatch(
             where
                 T: Inherits<#base_ty> + GodotClass + godot::obj::Bounds<Declarer = godot::obj::bounds::DeclUser> + #trait_name
         {
+            godot_print!("called!");
             let name = T::class_name().to_string();
             let mut registry = #registry_name.lock();
             registry.entry(name).or_insert_with(
@@ -326,6 +327,7 @@ fn create_dyn_trait_dispatch(
             }
         }
 
+        #[derive(Debug)]
         pub struct #wrapper_name {
             pub base: Gd<#base_ty>,
             dispatch: *const #dispatch_name

--- a/godot-macros/src/class/dyn_trait.rs
+++ b/godot-macros/src/class/dyn_trait.rs
@@ -80,7 +80,7 @@ fn create_dispatch_method(
     let (mutability, receiver, bind) = match signature.receiver_type {
         ReceiverType::Ref => (
             quote! { & },
-            quote! {&self, },
+            quote! { &self, },
             quote! {
                 let instance = base.cast::<T>();
                 let guard: GdRef<T> = instance.bind();
@@ -88,14 +88,14 @@ fn create_dispatch_method(
         ),
         ReceiverType::Mut => (
             quote! { &mut },
-            quote! {&mut self, },
+            quote! { &mut self, },
             quote! {
                 let mut instance = base.cast::<T>();
                 let mut guard: GdMut<T> = instance.bind_mut();
             },
         ),
         _ => {
-            // return proper error to user.
+            // return proper error to an user.
             return bail!(
                 &method_name,
         "error[E0038]: the trait cannot be made into an object.\n \
@@ -303,7 +303,6 @@ fn create_dyn_trait_dispatch(
             where
                 T: Inherits<#base_ty> + GodotClass + godot::obj::Bounds<Declarer = godot::obj::bounds::DeclUser> + #trait_name
         {
-            godot_print!("called!");
             let name = T::class_name().to_string();
             let mut registry = #registry_name.lock();
             registry.entry(name).or_insert_with(

--- a/godot-macros/src/class/dyn_trait.rs
+++ b/godot-macros/src/class/dyn_trait.rs
@@ -205,47 +205,6 @@ fn parse_associated_function(f: &mut venial::Function) -> DynTraitMethod {
     check_if_dispatchable(f, signature)
 }
 
-/// Proc-macro attribute to be used with `trait` blocks that allows to use user-defined `GodotClass` as Trait Objects.
-///
-/// ```no_run
-/// # use godot::prelude::*;
-///
-/// #[dyn_trait(name=MyTraitObjectName, base=RefCounted)]
-/// trait GdDynTrait {
-///     fn method(&self) -> GString;
-///     fn non_dispatchable_method() where Self: Sized;
-/// }
-///
-/// #[derive(GodotClass)]
-/// #[class(init, dyn_trait = (GdDynTrait))]
-/// struct MyDynStruct {
-///     field: i64,
-///     base: Base<RefCounted>,
-/// }
-///
-/// impl GdDynTrait for MyDynStruct {
-///     fn method(&self) -> GString {
-///         return GString::from("I am dynamic!");
-///     }
-///     fn non_dispatchable_method() {
-///         godot_print!("I can't be dispatched!");
-///     }
-/// }
-///
-///#[derive(GodotClass)]
-/// #[class(init)]
-/// struct OtherStruct {
-///     base: Base<RefCounted>,
-/// }
-/// #[godot_api]
-/// impl OtherStruct {
-///     #[func]
-///     fn some_method(&self, other: MyTraitObjectName) {
-///         godot_print!("hello {}", other.method());
-///     }
-/// }
-///
-/// ```
 pub fn attribute_dyn_trait(input_decl: venial::Item) -> ParseResult<TokenStream> {
     let venial::Item::Trait(mut decl) = input_decl.clone() else {
         bail!(

--- a/godot-macros/src/class/dyn_trait.rs
+++ b/godot-macros/src/class/dyn_trait.rs
@@ -1,38 +1,46 @@
-use std::fmt::format;
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use crate::class::{ReceiverType, SignatureInfo};
+use crate::util::{bail, ident, KvParser};
+use crate::{util, ParseResult};
+use proc_macro2::TokenStream;
 use proc_macro2::{Group, Ident, TokenTree};
 use quote::{quote, ToTokens};
-use proc_macro2::TokenStream;
-use venial::{FnParam, Item, Punctuated, TraitMember};
-use crate::{ParseResult, util};
-use crate::class::{FuncDefinition, maybe_rename_parameter, ReceiverType, SignatureInfo};
-use crate::util::{bail, ident, KvParser};
+use venial::TraitMember;
 
 struct DynTraitDispatch {
     base_ty: Ident,
     trait_name: Ident,
     dispatch_name: Ident,
     wrapper_name: Ident,
-    methods_signatures: Vec<SignatureInfo>
+    methods_signatures: Vec<SignatureInfo>,
 }
-
 
 fn parse_trait_member(params: &mut TraitMember, method_signatures: &mut Vec<SignatureInfo>) {
     match params {
         TraitMember::AssocFunction(f) => {
             let mut receiver_type: Option<ReceiverType> = None;
-            let mut signature = util::reduce_to_signature(f);
+            let signature = util::reduce_to_signature(f);
             let num_params = signature.params.len();
             let mut param_idents = Vec::with_capacity(num_params);
             let mut param_types = Vec::with_capacity(num_params);
             let ret_type = match signature.return_ty {
                 None => quote! { () },
-                Some(ty) => ty.tokens.into_iter().map(|tt| match tt {
-                    TokenTree::Group(group) => TokenTree::Group(Group::new(
-                        group.delimiter(),
-                        group.stream()
-                    )),
-                    tt => tt
-                }).collect()
+                Some(ty) => ty
+                    .tokens
+                    .into_iter()
+                    .map(|tt| match tt {
+                        TokenTree::Group(group) => {
+                            TokenTree::Group(Group::new(group.delimiter(), group.stream()))
+                        }
+                        tt => tt,
+                    })
+                    .collect(),
             };
 
             for (arg, _) in signature.params.inner {
@@ -48,15 +56,18 @@ fn parse_trait_member(params: &mut TraitMember, method_signatures: &mut Vec<Sign
                     }
                     venial::FnParam::Typed(arg) => {
                         let ty = venial::TypeExpr {
-                            tokens: arg.ty.tokens.into_iter().map(|tt| match tt {
-                                TokenTree::Group(group) => {
-                                    TokenTree::Group(Group::new(
+                            tokens: arg
+                                .ty
+                                .tokens
+                                .into_iter()
+                                .map(|tt| match tt {
+                                    TokenTree::Group(group) => TokenTree::Group(Group::new(
                                         group.delimiter(),
                                         group.stream(),
-                                    ))
-                                }
-                                tt => tt,
-                            }).collect(),
+                                    )),
+                                    tt => tt,
+                                })
+                                .collect(),
                         };
                         param_types.push(ty);
                         param_idents.push(arg.name);
@@ -83,7 +94,6 @@ fn parse_trait_member(params: &mut TraitMember, method_signatures: &mut Vec<Sign
     }
 }
 
-
 pub fn attribute_dyn_trait(input_decl: venial::Item) -> ParseResult<TokenStream> {
     let venial::Item::Trait(mut decl) = input_decl else {
         bail!(
@@ -93,7 +103,7 @@ pub fn attribute_dyn_trait(input_decl: venial::Item) -> ParseResult<TokenStream>
     };
     let trait_name = decl.name.clone();
     let dispatch_name = ident(&format! {"{}GdDispatch", decl.name});
-    let mut wrapper_name =  ident(&format!("{}GdDyn", decl.name));
+    let mut wrapper_name = ident(&format!("{}GdDyn", decl.name));
     let mut base_ty = ident("Object");
     let attr = std::mem::take(&mut decl.attributes);
     if let Some(mut parser) = KvParser::parse(&attr, "dyn_trait")? {
@@ -127,10 +137,16 @@ pub fn create_dyn_trait_dispatch(s: DynTraitDispatch, initial: TokenStream) -> T
         trait_name,
         dispatch_name,
         wrapper_name,
-        methods_signatures
+        methods_signatures,
     } = s;
-    let registry_name = ident(&format!("{}_DISPATCH_REGISTRY", trait_name.to_string().to_uppercase()));
-    let register_dispatch_name = ident(&format!("register_{}_dispatch", trait_name.to_string().to_lowercase()));
+    let registry_name = ident(&format!(
+        "{}_DISPATCH_REGISTRY",
+        trait_name.to_string().to_uppercase()
+    ));
+    let register_dispatch_name = ident(&format!(
+        "register_{}_dispatch",
+        trait_name.to_string().to_lowercase()
+    ));
     let mut dispatch_fields: Vec<TokenStream> = vec![];
     let mut dispatch_declarations: Vec<TokenStream> = vec![];
     let mut wrapper_methods: Vec<TokenStream> = vec![];
@@ -140,29 +156,29 @@ pub fn create_dyn_trait_dispatch(s: DynTraitDispatch, initial: TokenStream) -> T
             ReceiverType::Ref => (quote! { & }, quote! {&self}),
             ReceiverType::Mut => (quote! { &mut }, quote! {&mut self}),
             ReceiverType::GdSelf => !unreachable!(),
-            ReceiverType::Static => (quote!{ () }, quote! {})
+            ReceiverType::Static => (quote! { () }, quote! {}),
         };
         let ret = signature.ret_type;
         let param_types = signature.param_types;
         let param_idents = signature.param_idents;
         let method_name = signature.method_name;
-        let function_params: Vec<TokenStream> = param_types.iter().zip(param_idents.iter()).map(
-            |(ident, param)| quote! {#param: #ident}
-        ).collect();
+        let function_params: Vec<TokenStream> = param_types
+            .iter()
+            .zip(param_idents.iter())
+            .map(|(ident, param)| quote! {#param: #ident})
+            .collect();
         dispatch_fields.push(
             quote! {
                 #dispatch_func_name: fn(Gd<#base_ty>, #(#param_types,)* fn(#mutability dyn #trait_name, #(#param_types),*) -> #ret) -> #ret
             }
         );
-        dispatch_declarations.push(
-            quote! {
-                #dispatch_func_name: |base, #(#param_idents),*, closure| {
-                    let mut instance = base.cast::<T>();
-                    let mut guard: GdMut<T> = instance.bind_mut();
-                    closure(&mut *guard, #(#param_idents),*)
-                }
+        dispatch_declarations.push(quote! {
+            #dispatch_func_name: |base, #(#param_idents),*, closure| {
+                let mut instance = base.cast::<T>();
+                let mut guard: GdMut<T> = instance.bind_mut();
+                closure(&mut *guard, #(#param_idents),*)
             }
-        );
+        });
         wrapper_methods.push(
             quote! {
                 fn #method_name(#receiver, #(#function_params),*) -> #ret {
@@ -171,7 +187,6 @@ pub fn create_dyn_trait_dispatch(s: DynTraitDispatch, initial: TokenStream) -> T
             }
         );
     }
-
 
     quote! {
         #initial

--- a/godot-macros/src/class/mod.rs
+++ b/godot-macros/src/class/mod.rs
@@ -6,8 +6,8 @@
  */
 
 mod derive_godot_class;
-mod godot_api;
 mod dyn_trait;
+mod godot_api;
 
 mod data_models {
     pub mod constant;
@@ -34,5 +34,5 @@ pub(crate) use data_models::property::*;
 pub(crate) use data_models::rpc::*;
 pub(crate) use data_models::signal::*;
 pub(crate) use derive_godot_class::*;
-pub(crate) use godot_api::*;
 pub(crate) use dyn_trait::*;
+pub(crate) use godot_api::*;

--- a/godot-macros/src/class/mod.rs
+++ b/godot-macros/src/class/mod.rs
@@ -7,6 +7,8 @@
 
 mod derive_godot_class;
 mod godot_api;
+mod dyn_trait;
+
 mod data_models {
     pub mod constant;
     pub mod field;
@@ -33,3 +35,4 @@ pub(crate) use data_models::rpc::*;
 pub(crate) use data_models::signal::*;
 pub(crate) use derive_godot_class::*;
 pub(crate) use godot_api::*;
+pub(crate) use dyn_trait::*;

--- a/godot-macros/src/lib.rs
+++ b/godot-macros/src/lib.rs
@@ -754,6 +754,15 @@ pub fn godot_api(_meta: TokenStream, input: TokenStream) -> TokenStream {
     translate(input, class::attribute_godot_api)
 }
 
+#[proc_macro_attribute]
+pub fn dyn_trait(meta: TokenStream, input: TokenStream) -> TokenStream {
+    translate_meta(
+        "dyn_trait",
+        meta,
+        input,
+        class::attribute_dyn_trait)
+}
+
 /// Derive macro for [`GodotConvert`](../builtin/meta/trait.GodotConvert.html) on structs.
 ///
 /// This derive macro also derives [`ToGodot`](../builtin/meta/trait.ToGodot.html) and [`FromGodot`](../builtin/meta/trait.FromGodot.html).

--- a/godot-macros/src/lib.rs
+++ b/godot-macros/src/lib.rs
@@ -756,11 +756,7 @@ pub fn godot_api(_meta: TokenStream, input: TokenStream) -> TokenStream {
 
 #[proc_macro_attribute]
 pub fn dyn_trait(meta: TokenStream, input: TokenStream) -> TokenStream {
-    translate_meta(
-        "dyn_trait",
-        meta,
-        input,
-        class::attribute_dyn_trait)
+    translate_meta("dyn_trait", meta, input, class::attribute_dyn_trait)
 }
 
 /// Derive macro for [`GodotConvert`](../builtin/meta/trait.GodotConvert.html) on structs.

--- a/godot-macros/src/lib.rs
+++ b/godot-macros/src/lib.rs
@@ -754,6 +754,47 @@ pub fn godot_api(_meta: TokenStream, input: TokenStream) -> TokenStream {
     translate(input, class::attribute_godot_api)
 }
 
+/// Proc-macro attribute to be used with `trait` blocks that allows to use user-defined `GodotClass` as Trait Objects.
+///
+/// ```no_run
+/// # use godot::prelude::*;
+///
+/// #[dyn_trait(name=MyTraitObjectName, base=RefCounted)]
+/// trait GdDynTrait {
+///     fn method(&self) -> GString;
+///     fn non_dispatchable_method() where Self: Sized;
+/// }
+///
+/// #[derive(GodotClass)]
+/// #[class(init, dyn_trait = (GdDynTrait))]
+/// struct MyDynStruct {
+///     field: i64,
+///     base: Base<RefCounted>,
+/// }
+///
+/// impl GdDynTrait for MyDynStruct {
+///     fn method(&self) -> GString {
+///         return GString::from("I am dynamic!");
+///     }
+///     fn non_dispatchable_method() {
+///         godot_print!("I can't be dispatched!");
+///     }
+/// }
+///
+///#[derive(GodotClass)]
+/// #[class(init)]
+/// struct OtherStruct {
+///     base: Base<RefCounted>,
+/// }
+/// #[godot_api]
+/// impl OtherStruct {
+///     #[func]
+///     fn some_method(&self, other: MyTraitObjectName) {
+///         godot_print!("hello {}", other.method());
+///     }
+/// }
+///
+/// ```
 #[proc_macro_attribute]
 pub fn dyn_trait(meta: TokenStream, input: TokenStream) -> TokenStream {
     translate_meta("dyn_trait", meta, input, class::attribute_dyn_trait)

--- a/godot-macros/src/util/kv_parser.rs
+++ b/godot-macros/src/util/kv_parser.rs
@@ -16,7 +16,7 @@ pub(crate) type KvMap = HashMap<Ident, Option<KvValue>>;
 
 /// Struct to parse attributes like `#[attr(key, key2="value", key3=123)]` in a very user-friendly way.
 pub(crate) struct KvParser {
-    map: KvMap,
+    pub(crate) map: KvMap,
     span: Span,
 }
 

--- a/godot-macros/src/util/kv_parser.rs
+++ b/godot-macros/src/util/kv_parser.rs
@@ -16,7 +16,7 @@ pub(crate) type KvMap = HashMap<Ident, Option<KvValue>>;
 
 /// Struct to parse attributes like `#[attr(key, key2="value", key3=123)]` in a very user-friendly way.
 pub(crate) struct KvParser {
-    pub(crate) map: KvMap,
+    map: KvMap,
     span: Span,
 }
 

--- a/godot/src/lib.rs
+++ b/godot/src/lib.rs
@@ -175,7 +175,7 @@ pub mod init {
 /// Register/export Rust symbols to Godot: classes, methods, enums...
 pub mod register {
     pub use godot_core::registry::property;
-    pub use godot_macros::{godot_api, Export, GodotClass, GodotConvert, Var};
+    pub use godot_macros::{godot_api, dyn_trait, Export, GodotClass, GodotConvert, Var};
 
     #[cfg(feature = "__codegen-full")]
     pub use godot_core::registry::RpcConfig;

--- a/godot/src/lib.rs
+++ b/godot/src/lib.rs
@@ -175,7 +175,7 @@ pub mod init {
 /// Register/export Rust symbols to Godot: classes, methods, enums...
 pub mod register {
     pub use godot_core::registry::property;
-    pub use godot_macros::{godot_api, dyn_trait, Export, GodotClass, GodotConvert, Var};
+    pub use godot_macros::{dyn_trait, godot_api, Export, GodotClass, GodotConvert, Var};
 
     #[cfg(feature = "__codegen-full")]
     pub use godot_core::registry::RpcConfig;

--- a/godot/src/prelude.rs
+++ b/godot/src/prelude.rs
@@ -8,7 +8,7 @@
 pub use super::register::property::{Export, Var};
 
 // Re-export macros.
-pub use super::register::{godot_api, dyn_trait, Export, GodotClass, GodotConvert, Var};
+pub use super::register::{dyn_trait, godot_api, Export, GodotClass, GodotConvert, Var};
 
 pub use super::builtin::__prelude_reexport::*;
 pub use super::builtin::math::FloatExt as _;

--- a/godot/src/prelude.rs
+++ b/godot/src/prelude.rs
@@ -8,7 +8,7 @@
 pub use super::register::property::{Export, Var};
 
 // Re-export macros.
-pub use super::register::{godot_api, Export, GodotClass, GodotConvert, Var};
+pub use super::register::{godot_api, dyn_trait, Export, GodotClass, GodotConvert, Var};
 
 pub use super::builtin::__prelude_reexport::*;
 pub use super::builtin::math::FloatExt as _;


### PR DESCRIPTION
closes: #631
Adds an ability to cast `Gd<T: Trait>` to dyn Traitobject. 

It is based on dynamic dispatch. Long story short, we create set of closures for every dynTrait Class which allow us to cast `Gd<TraitBase>` to `Gd<dynTraitClass>`, bind it and finally use given binded smart pointer gd as a dyn TraitObject. 

I'm not sure if it is the best possible approach, albeit it is much better than anything else I've tried so far (this being – inheritance with custom-godot-api, hacky "codegen" (same as previous but with more errors), some unsafe magic with enum dispatch and just-let-godot-runtime-handle-it-all). Creating proper dynTraits might be a bit wonky due to [Rust Object Safety](https://doc.rust-lang.org/reference/items/traits.html#object-safety). 

Ergonomics wise it is… pretty good. I've been using it for some time (two months) and it handles all of my usecases (throwing gdext-rust-declared commands Objects from gdscript to rust dispatcher) without much issue. 

I still have to do docs (ETA: 4 days) and tests (ETA: after initial review); Outside of that I would change declaration from
```rust
#[derive(GodotClass)]
#[class(init, base=…, dyn_trait = (TraitA, TraitB))]
```
to
```rust
#[derive(GodotClass)]
#[class(init, base=…)]
#[dyn_trait(traits=(TraitA, TraitB))]
```
let me know if it is alright.

Parts of the macro that check if given trait can be used to create trait objects are a bit wonky – I would gladly apply any suggestions. Same goes for checking if given method is marked as non-dispatchable.

Generated signatures in internal godot docs properly point to dynTraits Base object – it would be cool if we would be able to somehow specify _groups_ or traits for exports and docs in the future.
![image](https://github.com/user-attachments/assets/21493647-ace9-4bef-b2f6-4823e2270704)

I have no idea how to export dynTraitObjects with Arrays<…> and whatnot. It would be good idea to explore this topic in the future.

Demo: 
```rust
use godot::prelude::*;

struct MyExtension;

#[gdextension]
unsafe impl ExtensionLibrary for MyExtension {}

#[derive(GodotClass)]
#[class(init, base=Node)]
struct BiggestBrother {
    #[init(val = 1)]
    brother_count: u32
}

#[godot_api]
impl BiggestBrother {
    #[func]
    fn check_brother(&mut self, mut brother: BrotherDispatch) {
        brother.greet();
        godot_print!("nice to see you, {}", brother.get_name());
        brother.return_greeting();
        godot_print!("here is your new greeting!");
        let new_greeting = GString::from(format!("Hello, I am {} no. {}", brother.get_name(), self.brother_count));
        self.brother_count += 1;
        brother.take_greeting(new_greeting);
        brother.greet();
    }
}

#[derive(GodotClass)]
#[class(init, base=Node, dyn_trait = (TraitA))]
struct BigBrother {
    greeting: GString,
    base: Base<Node>
}

impl TraitA for BigBrother {
    fn get_name(&self) -> GString {
        GString::from("Big Brother")
    }

    fn greet(&self) {
        godot_print!("{}", self.greeting)
    }

    fn return_greeting(&self) -> GString {
        GString::from("Hello to you as well")
    }

    fn take_greeting(&mut self, new_greeting: GString) {
        self.greeting = new_greeting;
    }

    fn non_dispatchable() -> Self where Self: Sized {
        unimplemented!()
    }
}

#[derive(GodotClass)]
#[class(init, base=Node, dyn_trait = (TraitA))]
struct SmallBrother {
    greeting: GString,
    base: Base<Node>
}

impl TraitA for SmallBrother {
    fn get_name(&self) -> GString {
        GString::from("small brother")
    }

    fn greet(&self) {
        godot_print!("{}", self.greeting)
    }

    fn return_greeting(&self) -> GString {
        GString::from("hello to you as well")
    }

    fn take_greeting(&mut self, new_greeting: GString) {
        self.greeting = GString::from(&new_greeting.to_string().to_lowercase());
    }

    fn non_dispatchable() -> Self where Self: Sized {
        unimplemented!()
    }
}


#[dyn_trait(name=BrotherDispatch, base=Node)]
#[allow(unused_variables)]
pub trait TraitA {
    fn get_name(&self) -> GString;
    fn greet(&self);
    fn return_greeting(&self) -> GString;
    fn take_greeting(&mut self, new_greeting: GString);
    fn non_dispatchable() -> Self where Self: Sized;
}
```
```gdscript
extends BiggestBrother

var current_brother = 0


func _on_timer_timeout() -> void:
	var brother: Node = get_child(current_brother)
	self.check_brother(brother)
	current_brother = (current_brother + 1) % (get_child_count() - 1)
```

Output (after calling it in a scene with `n` brothers):
```bash
nice to see you, small brother
here is your new greeting!
hello, i am small brother no. 1

nice to see you, Big Brother
here is your new greeting!
Hello, I am Big Brother no. 2

nice to see you, small brother
here is your new greeting!
hello, i am small brother no. 3
hello, i am small brother no. 1
nice to see you, small brother
here is your new greeting!
hello, i am small brother no. 4
(…)
```