### PR TITLE
Fix `enum_test.rs` accidentally excluded from itest

### DIFF
--- a/itest/rust/src/object_tests/enum_test.rs
+++ b/itest/rust/src/object_tests/enum_test.rs
@@ -10,29 +10,30 @@ use godot::builtin::varray;
 use godot::classes::input::CursorShape;
 use godot::classes::mesh::PrimitiveType;
 use godot::classes::{time, ArrayMesh};
-use godot::global::{Orientation, Key};
+use godot::global::{Key, Orientation};
+use godot::obj::NewGd;
 use std::collections::HashSet;
 
 #[itest]
 fn enum_ords() {
     use godot::obj::EngineEnum;
-    assert_eq!(CursorShape::CURSOR_ARROW.ord(), 0);
-    assert_eq!(CursorShape::CURSOR_IBEAM.ord(), 1);
-    assert_eq!(CursorShape::CURSOR_POINTING_HAND.ord(), 2);
-    assert_eq!(CursorShape::CURSOR_CROSS.ord(), 3);
-    assert_eq!(CursorShape::CURSOR_WAIT.ord(), 4);
-    assert_eq!(CursorShape::CURSOR_BUSY.ord(), 5);
-    assert_eq!(CursorShape::CURSOR_DRAG.ord(), 6);
-    assert_eq!(CursorShape::CURSOR_CAN_DROP.ord(), 7);
-    assert_eq!(CursorShape::CURSOR_FORBIDDEN.ord(), 8);
-    assert_eq!(CursorShape::CURSOR_VSIZE.ord(), 9);
-    assert_eq!(CursorShape::CURSOR_HSIZE.ord(), 10);
-    assert_eq!(CursorShape::CURSOR_BDIAGSIZE.ord(), 11);
-    assert_eq!(CursorShape::CURSOR_FDIAGSIZE.ord(), 12);
-    assert_eq!(CursorShape::CURSOR_MOVE.ord(), 13);
-    assert_eq!(CursorShape::CURSOR_VSPLIT.ord(), 14);
-    assert_eq!(CursorShape::CURSOR_HSPLIT.ord(), 15);
-    assert_eq!(CursorShape::CURSOR_HELP.ord(), 16);
+    assert_eq!(CursorShape::ARROW.ord(), 0);
+    assert_eq!(CursorShape::IBEAM.ord(), 1);
+    assert_eq!(CursorShape::POINTING_HAND.ord(), 2);
+    assert_eq!(CursorShape::CROSS.ord(), 3);
+    assert_eq!(CursorShape::WAIT.ord(), 4);
+    assert_eq!(CursorShape::BUSY.ord(), 5);
+    assert_eq!(CursorShape::DRAG.ord(), 6);
+    assert_eq!(CursorShape::CAN_DROP.ord(), 7);
+    assert_eq!(CursorShape::FORBIDDEN.ord(), 8);
+    assert_eq!(CursorShape::VSIZE.ord(), 9);
+    assert_eq!(CursorShape::HSIZE.ord(), 10);
+    assert_eq!(CursorShape::BDIAGSIZE.ord(), 11);
+    assert_eq!(CursorShape::FDIAGSIZE.ord(), 12);
+    assert_eq!(CursorShape::MOVE.ord(), 13);
+    assert_eq!(CursorShape::VSPLIT.ord(), 14);
+    assert_eq!(CursorShape::HSPLIT.ord(), 15);
+    assert_eq!(CursorShape::HELP.ord(), 16);
 }
 
 #[itest]
@@ -48,18 +49,18 @@ fn enum_equality() {
 #[itest]
 fn enum_hash() {
     let mut months = HashSet::new();
-    months.insert(time::Month::MONTH_JANUARY);
-    months.insert(time::Month::MONTH_FEBRUARY);
-    months.insert(time::Month::MONTH_MARCH);
-    months.insert(time::Month::MONTH_APRIL);
-    months.insert(time::Month::MONTH_MAY);
-    months.insert(time::Month::MONTH_JUNE);
-    months.insert(time::Month::MONTH_JULY);
-    months.insert(time::Month::MONTH_AUGUST);
-    months.insert(time::Month::MONTH_SEPTEMBER);
-    months.insert(time::Month::MONTH_OCTOBER);
-    months.insert(time::Month::MONTH_NOVEMBER);
-    months.insert(time::Month::MONTH_DECEMBER);
+    months.insert(time::Month::JANUARY);
+    months.insert(time::Month::FEBRUARY);
+    months.insert(time::Month::MARCH);
+    months.insert(time::Month::APRIL);
+    months.insert(time::Month::MAY);
+    months.insert(time::Month::JUNE);
+    months.insert(time::Month::JULY);
+    months.insert(time::Month::AUGUST);
+    months.insert(time::Month::SEPTEMBER);
+    months.insert(time::Month::OCTOBER);
+    months.insert(time::Month::NOVEMBER);
+    months.insert(time::Month::DECEMBER);
 
     assert_eq!(months.len(), 12);
 }
@@ -68,15 +69,15 @@ fn enum_hash() {
 // This fails upon calling the function, we don't actually need to make a good call.
 #[itest]
 fn add_surface_from_arrays() {
-    let mut mesh = ArrayMesh::new();
-    mesh.add_surface_from_arrays(PrimitiveType::PRIMITIVE_TRIANGLES, varray![]);
+    let mut mesh = ArrayMesh::new_gd();
+    mesh.add_surface_from_arrays(PrimitiveType::TRIANGLES, &varray![]);
 }
 
 #[itest]
 fn enum_as_str() {
     use godot::obj::EngineEnum;
-    assert_eq!(Orientation::Vertical.as_str(), "VERTICAL");
-    assert_eq!(Orientation::Horizontal.as_str(), "HORIZONTAL");
+    assert_eq!(Orientation::VERTICAL.as_str(), "VERTICAL");
+    assert_eq!(Orientation::HORIZONTAL.as_str(), "HORIZONTAL");
 
     assert_eq!(Key::NONE.as_str(), "NONE");
     assert_eq!(Key::SPECIAL.as_str(), "SPECIAL");
@@ -88,8 +89,14 @@ fn enum_as_str() {
 #[itest]
 fn enum_godot_name() {
     use godot::obj::EngineEnum;
-    assert_eq!(Orientation::Vertical.godot_name(), Orientation::Vertical.as_str());
-    assert_eq!(Orientation::Horizontal.godot_name(), Orientation::Vertical.as_str());
+    assert_eq!(
+        Orientation::VERTICAL.godot_name(),
+        Orientation::VERTICAL.as_str()
+    );
+    assert_eq!(
+        Orientation::HORIZONTAL.godot_name(),
+        Orientation::HORIZONTAL.as_str()
+    );
 
     assert_eq!(Key::NONE.godot_name(), "KEY_NONE");
     assert_eq!(Key::SPECIAL.godot_name(), "KEY_SPECIAL");

--- a/itest/rust/src/object_tests/mod.rs
+++ b/itest/rust/src/object_tests/mod.rs
@@ -9,6 +9,7 @@ mod base_test;
 mod class_name_test;
 mod class_rename_test;
 mod dynamic_call_test;
+mod enum_test;
 // `get_property_list` is only supported in Godot 4.3+
 #[cfg(since_api = "4.3")]
 mod get_property_list_test;


### PR DESCRIPTION
I randomly notice that the file enum_tests.rs was not included in the project, and therefore not compiled and tested.

<img width="822" alt="image" src="https://github.com/user-attachments/assets/d3622aeb-30f2-438f-99ee-c66c4e0214cd">

If not including it was on purpose pls just close the PR
