### PR TITLE
workflows/full-ci: allow manually triggering the workflow (mostly useful for forks)

### DIFF
--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -8,6 +8,9 @@ name: Full CI
 # Runs before merging. Rebases on master to make sure CI passes for latest integration, not only for the PR at the time of creation.
 
 on:
+  # Allow manually triggering the workflow:
+  # https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_dispatch
+  workflow_dispatch:
   merge_group:
 #  push:
 


### PR DESCRIPTION
First I added this temporarily to my WIP branch with the intention to back it out before merge, but maybe it would make sense to also add this to master.

I wanted to be able to run CI in my fork, and this allows triggering the workflow on a branch manually

![image](https://github.com/user-attachments/assets/21caa2e2-3024-4044-a0a1-5bf621f6a269)
