### PR TITLE
Dodge the Creeps Example Needs Signals Connected

### DIFF
--- a/examples/dodge-the-creeps/rust/src/main_scene.rs
+++ b/examples/dodge-the-creeps/rust/src/main_scene.rs
@@ -133,5 +133,9 @@ impl INode for Main {
         self.mob_scene = load("res://Mob.tscn");
         self.music = Some(self.base().get_node_as("Music"));
         self.death_sound = Some(self.base().get_node_as("DeathSound"));
+        let mut hud = self.base().get_node_as::<Hud>("Hud");
+        let mut player = self.base().get_node_as::<player::Player>("Player");
+        hud.connect("start_game".into(), self.base().callable("new_game"));
+        player.connect("hit".into(), self.base().callable("game_over"));
     }
 }


### PR DESCRIPTION
`When` I ran the example for Dodge the Creeps in Godot 4.3, the 'start_game' signal was not connected to the function 'new_game' and the 'hit' signal was not connected to function 'game_over'.

This is a simple fix that corrects the behavior from not running the new_game function and just making the start button disappear upon clicking it:
<img src="https://github.com/user-attachments/assets/1c85e59b-77ef-46ba-87cd-da3596dca9f9" alt="game_start_error" width="250" height="400">,

to having the game run properly (spawning enemies, etc):
<img src="https://github.com/user-attachments/assets/8b8acc21-d696-4393-b468-a580d3ff4033" alt="game_start_proper" width="250" height="400">.

