### PR TITLE
codegen-rustfmt: use 2021 edition

### DIFF
--- a/godot-codegen/src/lib.rs
+++ b/godot-codegen/src/lib.rs
@@ -73,6 +73,9 @@ mod rustfmt {
 
         for files in out_files.chunks(20) {
             let mut command = Command::new("rustfmt");
+            command.arg("--edition");
+            command.arg("2021");
+
             for file in files {
                 command.arg(file);
             }


### PR DESCRIPTION
The default edition (2015) will fail on some newer syntax constructs, such as `c"string"`.