### PR TITLE
String argument conversion + `AsArg` trait

### DIFF
--- a/examples/dodge-the-creeps/rust/src/hud.rs
+++ b/examples/dodge-the-creeps/rust/src/hud.rs
@@ -15,7 +15,7 @@ impl Hud {
     #[func]
     pub fn show_message(&self, text: GString) {
         let mut message_label = self.base().get_node_as::<Label>("MessageLabel");
-        message_label.set_text(text);
+        message_label.set_text(&text);
         message_label.show();
 
         let mut timer = self.base().get_node_as::<Timer>("MessageTimer");
@@ -26,13 +26,13 @@ impl Hud {
         self.show_message("Game Over".into());
 
         let mut timer = self.base().get_tree().unwrap().create_timer(2.0).unwrap();
-        timer.connect("timeout".into(), self.base().callable("show_start_button"));
+        timer.connect("timeout", self.base().callable("show_start_button"));
     }
 
     #[func]
     fn show_start_button(&mut self) {
         let mut message_label = self.base().get_node_as::<Label>("MessageLabel");
-        message_label.set_text("Dodge the\nCreeps!".into());
+        message_label.set_text("Dodge the\nCreeps!");
         message_label.show();
 
         let mut button = self.base().get_node_as::<Button>("StartButton");
@@ -43,7 +43,7 @@ impl Hud {
     pub fn update_score(&self, score: i64) {
         let mut label = self.base().get_node_as::<Label>("ScoreLabel");
 
-        label.set_text(score.to_string().into());
+        label.set_text(&score.to_string());
     }
 
     #[func]
@@ -55,7 +55,7 @@ impl Hud {
         // This method keeps a &mut Hud, and start_game calls Main::new_game(), which itself accesses this Hud
         // instance through Gd<Hud>::bind_mut(). It will try creating a 2nd &mut reference, and thus panic.
         // Deferring the signal is one option to work around it.
-        self.base_mut().emit_signal("start_game".into(), &[]);
+        self.base_mut().emit_signal("start_game", &[]);
     }
 
     #[func]

--- a/examples/dodge-the-creeps/rust/src/main_scene.rs
+++ b/examples/dodge-the-creeps/rust/src/main_scene.rs
@@ -102,7 +102,7 @@ impl Main {
         mob.set_linear_velocity(Vector2::new(range, 0.0).rotated(real::from_f32(direction)));
 
         let mut hud = self.base().get_node_as::<Hud>("Hud");
-        hud.connect("start_game".into(), mob.callable("on_start_game"));
+        hud.connect("start_game", mob.callable("on_start_game"));
     }
 
     fn music(&mut self) -> &mut AudioStreamPlayer {

--- a/examples/dodge-the-creeps/rust/src/mob.rs
+++ b/examples/dodge-the-creeps/rust/src/mob.rs
@@ -47,6 +47,6 @@ impl IRigidBody2D for Mob {
         let mut rng = rand::thread_rng();
         let animation_name = anim_names.choose(&mut rng).unwrap();
 
-        sprite.set_animation(animation_name.into());
+        sprite.set_animation(animation_name.arg());
     }
 }

--- a/examples/dodge-the-creeps/rust/src/player.rs
+++ b/examples/dodge-the-creeps/rust/src/player.rs
@@ -18,13 +18,13 @@ impl Player {
     #[func]
     fn on_player_body_entered(&mut self, _body: Gd<PhysicsBody2D>) {
         self.base_mut().hide();
-        self.base_mut().emit_signal("hit".into(), &[]);
+        self.base_mut().emit_signal("hit", &[]);
 
         let mut collision_shape = self
             .base()
             .get_node_as::<CollisionShape2D>("CollisionShape2D");
 
-        collision_shape.set_deferred("disabled".into(), &true.to_variant());
+        collision_shape.set_deferred("disabled", &true.to_variant());
     }
 
     #[func]
@@ -65,16 +65,16 @@ impl IArea2D for Player {
 
         // Note: exact=false by default, in Rust we have to provide it explicitly
         let input = Input::singleton();
-        if input.is_action_pressed("move_right".into()) {
+        if input.is_action_pressed("move_right") {
             velocity += Vector2::RIGHT;
         }
-        if input.is_action_pressed("move_left".into()) {
+        if input.is_action_pressed("move_left") {
             velocity += Vector2::LEFT;
         }
-        if input.is_action_pressed("move_down".into()) {
+        if input.is_action_pressed("move_down") {
             velocity += Vector2::DOWN;
         }
-        if input.is_action_pressed("move_up".into()) {
+        if input.is_action_pressed("move_up") {
             velocity += Vector2::UP;
         }
 
@@ -94,7 +94,7 @@ impl IArea2D for Player {
                 animated_sprite.set_flip_v(velocity.y > 0.0)
             }
 
-            animated_sprite.play_ex().name(animation.into()).done();
+            animated_sprite.play_ex().name(animation).done();
         } else {
             animated_sprite.stop();
         }

--- a/godot-bindings/src/lib.rs
+++ b/godot-bindings/src/lib.rs
@@ -115,7 +115,7 @@ mod depend_on_prebuilt {
                 .get(2)
                 .and_then(|patch| patch.parse().ok())
                 .unwrap_or(0),
-            status: "stable".into(),
+            status: "stable".to_string(),
             custom_rev: None,
         }
     }

--- a/godot-codegen/src/context.rs
+++ b/godot-codegen/src/context.rs
@@ -7,7 +7,7 @@
 
 use crate::generator::method_tables::MethodTableKey;
 use crate::generator::notifications;
-use crate::models::domain::{GodotTy, RustTy, TyName};
+use crate::models::domain::{ArgPassing, GodotTy, RustTy, TyName};
 use crate::models::json::{
     JsonBuiltinClass, JsonBuiltinMethod, JsonClass, JsonClassConstant, JsonClassMethod,
 };
@@ -243,10 +243,16 @@ impl<'a> Context<'a> {
         self.builtin_types.contains(ty_name)
     }
 
-    pub fn is_builtin_copy(&self, ty_name: &str) -> bool {
-        debug_assert!(!ty_name.starts_with("Packed")); // Already handled separately.
+    pub fn get_builtin_arg_passing(&self, ty_name: &str) -> ArgPassing {
+        // Already handled separately.
+        debug_assert!(!ty_name.starts_with("Packed"));
 
-        !matches!(ty_name, "Variant" | "VariantArray" | "Dictionary")
+        // Arrays are also handled separately, and use ByRef.
+        match ty_name {
+            "Variant" | "VariantArray" | "Dictionary" => ArgPassing::ByRef,
+            "GString" | "NodePath" | "StringName" => ArgPassing::ImplAsArg,
+            _ => ArgPassing::ByValue,
+        }
     }
 
     pub fn is_native_structure(&self, ty_name: &str) -> bool {

--- a/godot-codegen/src/models/domain.rs
+++ b/godot-codegen/src/models/domain.rs
@@ -599,8 +599,8 @@ pub struct GodotTy {
 
 #[derive(Clone, Debug)]
 pub enum RustTy {
-    /// `bool`, `Vector3i`, `Array`
-    BuiltinIdent { ty: Ident, is_copy: bool },
+    /// `bool`, `Vector3i`, `Array`, `GString`
+    BuiltinIdent { ty: Ident, arg_passing: ArgPassing },
 
     /// `Array<i32>`
     ///
@@ -667,8 +667,10 @@ impl RustTy {
     pub fn is_pass_by_ref(&self) -> bool {
         matches!(
             self,
-            RustTy::BuiltinIdent { is_copy: false, .. }
-                | RustTy::BuiltinArray { .. }
+            RustTy::BuiltinIdent {
+                arg_passing: ArgPassing::ByRef,
+                ..
+            } | RustTy::BuiltinArray { .. }
                 | RustTy::EngineArray { .. }
         )
     }
@@ -699,6 +701,15 @@ impl fmt::Display for RustTy {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.to_token_stream().to_string().replace(" ", ""))
     }
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum ArgPassing {
+    ByValue,
+    ByRef,
+    ImplAsArg,
 }
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------

--- a/godot-codegen/src/models/domain.rs
+++ b/godot-codegen/src/models/domain.rs
@@ -674,6 +674,17 @@ impl RustTy {
                 | RustTy::EngineArray { .. }
         )
     }
+
+    pub fn needs_lifetime(&self) -> bool {
+        matches!(
+            self,
+            RustTy::BuiltinIdent {
+                arg_passing: ArgPassing::ByRef | ArgPassing::ImplAsArg,
+                ..
+            } | RustTy::BuiltinArray { .. }
+                | RustTy::EngineArray { .. }
+        )
+    }
 }
 
 impl ToTokens for RustTy {

--- a/godot-codegen/src/util.rs
+++ b/godot-codegen/src/util.rs
@@ -25,7 +25,7 @@ pub fn make_imports() -> TokenStream {
     quote! {
         use godot_ffi as sys;
         use crate::builtin::*;
-        use crate::meta::{ClassName, PtrcallSignatureTuple, RefArg, VarcallSignatureTuple};
+        use crate::meta::{AsArg, ClassName, CowArg, PtrcallSignatureTuple, RefArg, VarcallSignatureTuple};
         use crate::classes::native::*;
         use crate::classes::Object;
         use crate::obj::{Gd, AsObjectArg};

--- a/godot-core/src/builtin/callable.rs
+++ b/godot-core/src/builtin/callable.rs
@@ -185,7 +185,7 @@ impl Callable {
     }
 
     /// Returns the name of the method represented by this callable. If the callable is a lambda function,
-    /// returns the function's name.
+    /// returns the surrounding function's name.
     ///
     /// ## Known Bugs
     ///

--- a/godot-core/src/builtin/collections/array.rs
+++ b/godot-core/src/builtin/collections/array.rs
@@ -945,13 +945,13 @@ impl<'r, T: ArrayElement> AsArg<Array<T>> for &'r Array<T> {
 }
 
 impl<T: ArrayElement> ArgTarget for Array<T> {
-    type Type<'v> = CowArg<'v, Self>;
+    type Arg<'v> = CowArg<'v, Self>;
 
-    fn value_to_arg<'v>(self) -> Self::Type<'v> {
+    fn value_to_arg<'v>(self) -> Self::Arg<'v> {
         CowArg::Owned(self)
     }
 
-    fn arg_to_ref<'r>(arg: &'r Self::Type<'_>) -> &'r Self {
+    fn arg_to_ref<'r>(arg: &'r Self::Arg<'_>) -> &'r Self {
         arg.cow_as_ref()
     }
 }

--- a/godot-core/src/builtin/collections/array.rs
+++ b/godot-core/src/builtin/collections/array.rs
@@ -12,8 +12,8 @@ use crate::builtin::*;
 use crate::meta;
 use crate::meta::error::{ConvertError, FromGodotError, FromVariantError};
 use crate::meta::{
-    ArgTarget, ArrayElement, ArrayTypeInfo, AsArg, CowArg, FromGodot, GodotConvert,
-    GodotFfiVariant, GodotType, PropertyHintInfo, RefArg, ToGodot,
+    ApiParam, ArrayElement, ArrayTypeInfo, AsArg, CowArg, FromGodot, GodotConvert, GodotFfiVariant,
+    GodotType, PropertyHintInfo, RefArg, ToGodot,
 };
 use crate::registry::property::{Export, Var};
 use godot_ffi as sys;
@@ -944,7 +944,7 @@ impl<'r, T: ArrayElement> AsArg<Array<T>> for &'r Array<T> {
     }
 }
 
-impl<T: ArrayElement> ArgTarget for Array<T> {
+impl<T: ArrayElement> ApiParam for Array<T> {
     type Arg<'v> = CowArg<'v, Self>;
 
     fn value_to_arg<'v>(self) -> Self::Arg<'v> {
@@ -1221,7 +1221,7 @@ impl<T: ArrayElement + ToGodot> Extend<T> for Array<T> {
         // A faster implementation using `resize()` and direct pointer writes might still be possible.
         // Note that this could technically also use iter(), since no moves need to happen (however Extend requires IntoIterator).
         for item in iter.into_iter() {
-            self.push(ArgTarget::value_to_arg(item));
+            self.push(ApiParam::value_to_arg(item));
         }
     }
 }

--- a/godot-core/src/builtin/collections/array.rs
+++ b/godot-core/src/builtin/collections/array.rs
@@ -4,15 +4,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
-use std::borrow::Borrow;
+
 use std::fmt;
 use std::marker::PhantomData;
 
 use crate::builtin::*;
+use crate::meta;
 use crate::meta::error::{ConvertError, FromGodotError, FromVariantError};
 use crate::meta::{
-    ArrayElement, ArrayTypeInfo, FromGodot, GodotConvert, GodotFfiVariant, GodotType,
-    PropertyHintInfo, RefArg, ToGodot,
+    ArgTarget, ArrayElement, ArrayTypeInfo, AsArg, CowArg, FromGodot, GodotConvert,
+    GodotFfiVariant, GodotType, PropertyHintInfo, RefArg, ToGodot,
 };
 use crate::registry::property::{Export, Var};
 use godot_ffi as sys;
@@ -85,8 +86,8 @@ use sys::{ffi_methods, interface_fn, GodotFfi};
 /// # use godot::prelude::*;
 /// // VariantArray allows dynamic element types.
 /// let mut array = VariantArray::new();
-/// array.push(10.to_variant());
-/// array.push("Hello".to_variant());
+/// array.push(&10.to_variant());
+/// array.push(&"Hello".to_variant());
 ///
 /// // Or equivalent, use the `varray!` macro which converts each element.
 /// let array = varray![10, "Hello"];
@@ -195,12 +196,14 @@ impl<T: ArrayElement> Array<T> {
     }
 
     /// Returns `true` if the array contains the given value. Equivalent of `has` in GDScript.
-    pub fn contains(&self, value: &T) -> bool {
+    pub fn contains(&self, value: impl AsArg<T>) -> bool {
+        meta::arg_into_ref!(value: T);
         self.as_inner().has(&value.to_variant())
     }
 
     /// Returns the number of times a value is in the array.
-    pub fn count(&self, value: &T) -> usize {
+    pub fn count(&self, value: impl AsArg<T>) -> usize {
+        meta::arg_into_ref!(value: T);
         to_usize(self.as_inner().count(&value.to_variant()))
     }
 
@@ -258,15 +261,14 @@ impl<T: ArrayElement> Array<T> {
 
     /// Sets the value at the specified index.
     ///
-    /// `value` uses `Borrow<T>` to accept either by value or by reference.
-    ///
     /// # Panics
     ///
     /// If `index` is out of bounds.
-    pub fn set(&mut self, index: usize, value: impl Borrow<T>) {
+    pub fn set(&mut self, index: usize, value: impl AsArg<T>) {
         let ptr_mut = self.ptr_mut(index);
 
-        let variant = value.borrow().to_variant();
+        meta::arg_into_ref!(value: T);
+        let variant = value.to_variant();
 
         // SAFETY: `ptr_mut` just checked that the index is not out of bounds.
         unsafe { variant.move_into_var_ptr(ptr_mut) };
@@ -274,24 +276,27 @@ impl<T: ArrayElement> Array<T> {
 
     /// Appends an element to the end of the array.
     ///
-    /// `value` uses `Borrow<T>` to accept either by value or by reference.
-    ///
     /// _Godot equivalents: `append` and `push_back`_
     #[doc(alias = "append")]
     #[doc(alias = "push_back")]
-    pub fn push(&mut self, value: impl Borrow<T>) {
+    pub fn push(&mut self, value: impl AsArg<T>) {
+        meta::arg_into_ref!(value: T);
+
         // SAFETY: The array has type `T` and we're writing a value of type `T` to it.
         let mut inner = unsafe { self.as_inner_mut() };
-        inner.push_back(&value.borrow().to_variant());
+        inner.push_back(&value.to_variant());
     }
 
     /// Adds an element at the beginning of the array, in O(n).
     ///
     /// On large arrays, this method is much slower than [`push()`][Self::push], as it will move all the array's elements.
     /// The larger the array, the slower `push_front()` will be.
-    pub fn push_front(&mut self, value: T) {
+    pub fn push_front(&mut self, value: impl AsArg<T>) {
+        meta::arg_into_ref!(value: T);
+
         // SAFETY: The array has type `T` and we're writing a value of type `T` to it.
-        unsafe { self.as_inner_mut() }.push_front(&value.to_variant());
+        let mut inner_array = unsafe { self.as_inner_mut() };
+        inner_array.push_front(&value.to_variant());
     }
 
     /// Removes and returns the last element of the array. Returns `None` if the array is empty.
@@ -325,12 +330,14 @@ impl<T: ArrayElement> Array<T> {
     ///
     /// # Panics
     /// If `index > len()`.
-    pub fn insert(&mut self, index: usize, value: T) {
+    pub fn insert(&mut self, index: usize, value: impl AsArg<T>) {
         let len = self.len();
         assert!(
             index <= len,
             "Array insertion index {index} is out of bounds: length is {len}",
         );
+
+        meta::arg_into_ref!(value: T);
 
         // SAFETY: The array has type `T` and we're writing a value of type `T` to it.
         unsafe { self.as_inner_mut() }.insert(to_i64(index), &value.to_variant());
@@ -359,14 +366,18 @@ impl<T: ArrayElement> Array<T> {
     ///
     /// On large arrays, this method is much slower than [`pop()`][Self::pop], as it will move all the array's
     /// elements after the removed element.
-    pub fn erase(&mut self, value: &T) {
+    pub fn erase(&mut self, value: impl AsArg<T>) {
+        meta::arg_into_ref!(value: T);
+
         // SAFETY: We don't write anything to the array.
         unsafe { self.as_inner_mut() }.erase(&value.to_variant());
     }
 
     /// Assigns the given value to all elements in the array. This can be used together with
     /// `resize` to create an array with a given size and initialized elements.
-    pub fn fill(&mut self, value: &T) {
+    pub fn fill(&mut self, value: impl AsArg<T>) {
+        meta::arg_into_ref!(value: T);
+
         // SAFETY: The array has type `T` and we're writing values of type `T` to it.
         unsafe { self.as_inner_mut() }.fill(&value.to_variant());
     }
@@ -377,16 +388,27 @@ impl<T: ArrayElement> Array<T> {
     /// then the new elements are set to `value`.
     ///
     /// If you know that the new size is smaller, then consider using [`shrink`](Array::shrink) instead.
-    pub fn resize(&mut self, new_size: usize, value: &T) {
+    pub fn resize(&mut self, new_size: usize, value: impl AsArg<T>) {
         let original_size = self.len();
 
         // SAFETY: While we do insert `Variant::nil()` if the new size is larger, we then fill it with `value` ensuring that all values in the
         // array are of type `T` still.
         unsafe { self.as_inner_mut() }.resize(to_i64(new_size));
 
+        meta::arg_into_ref!(value: T);
+
         // If new_size < original_size then this is an empty iterator and does nothing.
         for i in original_size..new_size {
-            self.set(i, value);
+            // Exception safety: if to_variant() panics, the array will become inconsistent (filled with non-T nils).
+            // At the moment (Nov 2024), this can only happen for u64, which isn't a valid Array element type.
+            // This could be changed to use clone() (if that doesn't panic) or store a variant without moving.
+            let variant = value.to_variant();
+
+            let ptr_mut = self.ptr_mut(i);
+
+            // SAFETY: we iterate pointer within bounds; ptr_mut() additionally checks them.
+            // ptr_mut() lookup could be optimized if we know the internal layout.
+            unsafe { variant.move_into_var_ptr(ptr_mut) };
         }
     }
 
@@ -534,8 +556,12 @@ impl<T: ArrayElement> Array<T> {
     }
 
     /// Searches the array for the first occurrence of a value and returns its index, or `None` if
-    /// not found. Starts searching at index `from`; pass `None` to search the entire array.
-    pub fn find(&self, value: &T, from: Option<usize>) -> Option<usize> {
+    /// not found.
+    ///
+    /// Starts searching at index `from`; pass `None` to search the entire array.
+    pub fn find(&self, value: impl AsArg<T>, from: Option<usize>) -> Option<usize> {
+        meta::arg_into_ref!(value: T);
+
         let from = to_i64(from.unwrap_or(0));
         let index = self.as_inner().find(&value.to_variant(), from);
         if index >= 0 {
@@ -546,11 +572,15 @@ impl<T: ArrayElement> Array<T> {
     }
 
     /// Searches the array backwards for the last occurrence of a value and returns its index, or
-    /// `None` if not found. Starts searching at index `from`; pass `None` to search the entire
-    /// array.
-    pub fn rfind(&self, value: &T, from: Option<usize>) -> Option<usize> {
+    /// `None` if not found.
+    ///
+    /// Starts searching at index `from`; pass `None` to search the entire array.
+    pub fn rfind(&self, value: impl AsArg<T>, from: Option<usize>) -> Option<usize> {
+        meta::arg_into_ref!(value: T);
+
         let from = from.map(to_i64).unwrap_or(-1);
         let index = self.as_inner().rfind(&value.to_variant(), from);
+
         // It's not documented, but `rfind` returns -1 if not found.
         if index >= 0 {
             Some(to_usize(index))
@@ -566,7 +596,9 @@ impl<T: ArrayElement> Array<T> {
     /// would maintain sorting order.
     ///
     /// Calling `bsearch` on an unsorted array results in unspecified behavior.
-    pub fn bsearch(&self, value: &T) -> usize {
+    pub fn bsearch(&self, value: impl AsArg<T>) -> usize {
+        meta::arg_into_ref!(value: T);
+
         to_usize(self.as_inner().bsearch(&value.to_variant(), true))
     }
 
@@ -582,7 +614,9 @@ impl<T: ArrayElement> Array<T> {
     ///
     /// Consider using `sort_custom()` to ensure the sorting order is compatible with
     /// your callable's ordering
-    pub fn bsearch_custom(&self, value: &T, func: Callable) -> usize {
+    pub fn bsearch_custom(&self, value: impl AsArg<T>, func: Callable) -> usize {
+        meta::arg_into_ref!(value: T);
+
         to_usize(
             self.as_inner()
                 .bsearch_custom(&value.to_variant(), func, true),
@@ -901,6 +935,27 @@ unsafe impl<T: ArrayElement> GodotFfi for Array<T> {
 // Only implement for untyped arrays; typed arrays cannot be nested in Godot.
 impl ArrayElement for VariantArray {}
 
+impl<'r, T: ArrayElement> AsArg<Array<T>> for &'r Array<T> {
+    fn into_arg<'cow>(self) -> CowArg<'cow, Array<T>>
+    where
+        'r: 'cow, // Original reference must be valid for at least as long as the returned cow.
+    {
+        CowArg::Borrowed(self)
+    }
+}
+
+impl<T: ArrayElement> ArgTarget for Array<T> {
+    type Type<'v> = CowArg<'v, Self>;
+
+    fn value_to_arg<'v>(self) -> Self::Type<'v> {
+        CowArg::Owned(self)
+    }
+
+    fn arg_to_ref<'r>(arg: &'r Self::Type<'_>) -> &'r Self {
+        arg.cow_as_ref()
+    }
+}
+
 impl<T: ArrayElement> GodotConvert for Array<T> {
     type Via = Self;
 }
@@ -1166,7 +1221,7 @@ impl<T: ArrayElement + ToGodot> Extend<T> for Array<T> {
         // A faster implementation using `resize()` and direct pointer writes might still be possible.
         // Note that this could technically also use iter(), since no moves need to happen (however Extend requires IntoIterator).
         for item in iter.into_iter() {
-            self.push(&item);
+            self.push(ArgTarget::value_to_arg(item));
         }
     }
 }
@@ -1309,7 +1364,7 @@ macro_rules! varray {
             use $crate::meta::ToGodot as _;
             let mut array = $crate::builtin::VariantArray::default();
             $(
-                array.push($elements.to_variant());
+                array.push(&$elements.to_variant());
             )*
             array
         }

--- a/godot-core/src/builtin/collections/packed_array.rs
+++ b/godot-core/src/builtin/collections/packed_array.rs
@@ -8,7 +8,7 @@
 use godot_ffi as sys;
 
 use crate::builtin::*;
-use crate::meta::{Arg, AsArg, ToGodot};
+use crate::meta::{AsArg, ToGodot};
 use std::{fmt, ops, ptr};
 use sys::types::*;
 use sys::{ffi_methods, interface_fn, GodotFfi};
@@ -107,7 +107,7 @@ macro_rules! impl_packed_array {
             }
 
             /// Returns the number of times a value is in the array.
-            pub fn count(&self, value: Arg<$Element>) -> usize {
+            pub fn count(&self, value: impl AsArg<$Element>) -> usize {
                 to_usize(self.as_inner().count(value.into_arg().into_packed_arg()))
             }
 
@@ -140,7 +140,7 @@ macro_rules! impl_packed_array {
             /// Note: On large arrays, this method is much slower than `push` as it will move all
             /// the array's elements after the inserted element. The larger the array, the slower
             /// `insert` will be.
-            pub fn insert(&mut self, index: usize, value: Arg<$Element>) {
+            pub fn insert(&mut self, index: usize, value: impl AsArg<$Element>) {
                 // Intentional > and not >=.
                 if index > self.len() {
                     self.panic_out_of_bounds(index);
@@ -170,7 +170,7 @@ macro_rules! impl_packed_array {
 
             /// Assigns the given value to all elements in the array. This can be used together
             /// with `resize` to create an array with a given size and initialized elements.
-            pub fn fill(&mut self, value: Arg<$Element>) {
+            pub fn fill(&mut self, value: impl AsArg<$Element>) {
                 self.as_inner().fill(value.into_arg().into_packed_arg());
             }
 
@@ -262,7 +262,7 @@ macro_rules! impl_packed_array {
             /// Searches the array for the first occurrence of a value and returns its index, or
             /// `None` if not found. Starts searching at index `from`; pass `None` to search the
             /// entire array.
-            pub fn find(&self, value: Arg<$Element>, from: Option<usize>) -> Option<usize> {
+            pub fn find(&self, value: impl AsArg<$Element>, from: Option<usize>) -> Option<usize> {
                 let from = to_i64(from.unwrap_or(0));
                 let index = self.as_inner().find(value.into_arg().into_packed_arg(), from);
                 if index >= 0 {
@@ -275,7 +275,7 @@ macro_rules! impl_packed_array {
             /// Searches the array backwards for the last occurrence of a value and returns its
             /// index, or `None` if not found. Starts searching at index `from`; pass `None` to
             /// search the entire array.
-            pub fn rfind(&self, value: Arg<$Element>, from: Option<usize>) -> Option<usize> {
+            pub fn rfind(&self, value: impl AsArg<$Element>, from: Option<usize>) -> Option<usize> {
                 let from = from.map(to_i64).unwrap_or(-1);
                 let index = self.as_inner().rfind(value.into_arg().into_packed_arg(), from);
                 // It's not documented, but `rfind` returns -1 if not found.
@@ -291,7 +291,7 @@ macro_rules! impl_packed_array {
             /// If the value is not present in the array, returns the insertion index that would maintain sorting order.
             ///
             /// Calling `bsearch()` on an unsorted array results in unspecified (but safe) behavior.
-            pub fn bsearch(&self, value: Arg<$Element>) -> usize {
+            pub fn bsearch(&self, value: impl AsArg<$Element>) -> usize {
                 to_usize(self.as_inner().bsearch(value.into_arg().into_packed_arg(), true))
             }
 

--- a/godot-core/src/builtin/collections/packed_array.rs
+++ b/godot-core/src/builtin/collections/packed_array.rs
@@ -491,7 +491,7 @@ macro_rules! impl_packed_array {
                 // A faster implementation using `resize()` and direct pointer writes might still be
                 // possible.
                 for item in iter.into_iter() {
-                    self.push(meta::ArgTarget::value_to_arg(item));
+                    self.push(meta::ApiParam::value_to_arg(item));
                 }
             }
         }

--- a/godot-core/src/builtin/color.rs
+++ b/godot-core/src/builtin/color.rs
@@ -10,6 +10,7 @@ use crate::builtin::inner::InnerColor;
 use crate::builtin::math::ApproxEq;
 use crate::builtin::{ColorHsv, GString};
 
+use crate::meta::{arg_into_ref, AsArg};
 use godot_ffi as sys;
 use std::ops;
 use sys::{ffi_methods, GodotFfi};
@@ -93,9 +94,9 @@ impl Color {
     /// - `#RGB` and `RGB`. Equivalent to `#RRGGBBff`.
     ///
     /// Returns `None` if the format is invalid.
-    pub fn from_html<S: Into<GString>>(html: S) -> Option<Self> {
-        let html = html.into();
-        InnerColor::html_is_valid(html.clone()).then(|| InnerColor::html(html))
+    pub fn from_html<S: AsArg<GString>>(html: S) -> Option<Self> {
+        arg_into_ref!(html);
+        InnerColor::html_is_valid(html).then(|| InnerColor::html(html))
     }
 
     /// Constructs a `Color` from a string, which can be either:
@@ -112,13 +113,15 @@ impl Color {
     ///
     /// [color_constants]: https://docs.godotengine.org/en/latest/classes/class_color.html#constants
     /// [cheat_sheet]: https://raw.githubusercontent.com/godotengine/godot-docs/master/img/color_constants.png
-    pub fn from_string<S: Into<GString>>(string: S) -> Option<Self> {
+    pub fn from_string(string: impl AsArg<GString>) -> Option<Self> {
+        arg_into_ref!(string);
+
         let color = InnerColor::from_string(
-            string.into(),
+            string,
             Self::from_rgba(f32::NAN, f32::NAN, f32::NAN, f32::NAN),
         );
-        // Assumption: the implementation of `from_string` in the engine will never return any NaN
-        // upon success.
+
+        // Assumption: the implementation of `from_string` in the engine will never return any NaN upon success.
         if color.r.is_nan() {
             None
         } else {

--- a/godot-core/src/builtin/signal.rs
+++ b/godot-core/src/builtin/signal.rs
@@ -95,7 +95,7 @@ impl Signal {
             return;
         };
 
-        object.emit_signal(self.name(), varargs);
+        object.emit_signal(&self.name(), varargs);
     }
 
     /// Returns an [`Array`] of connections for this signal.

--- a/godot-core/src/builtin/string/node_path.rs
+++ b/godot-core/src/builtin/string/node_path.rs
@@ -49,6 +49,22 @@ impl NodePath {
             .expect("Godot hashes are uint32_t")
     }
 
+    crate::meta::declare_arg_method! {
+        /// Use as argument for an [`impl AsArg<GString|StringName>`][crate::meta::AsArg] parameter.
+        ///
+        /// This is a convenient way to convert arguments of similar string types.
+        ///
+        /// # Example
+        /// [`PackedStringArray`][crate::builtin::PackedStringArray] can insert elements using `AsArg<GString>`, so let's pass a `NodePath`:
+        /// ```no_run
+        /// # use godot::prelude::*;
+        /// let node_path = NodePath::from("Node2D/Label");
+        ///
+        /// let mut array = PackedStringArray::new();
+        /// array.push(node_path.arg());
+        /// ```
+    }
+
     #[doc(hidden)]
     pub fn as_inner(&self) -> inner::InnerNodePath {
         inner::InnerNodePath::from_outer(self)

--- a/godot-core/src/builtin/string/string_name.rs
+++ b/godot-core/src/builtin/string/string_name.rs
@@ -78,6 +78,22 @@ impl StringName {
             .expect("Godot hashes are uint32_t")
     }
 
+    /// Convert to `GString`.
+    ///
+    /// Equivalent to [`GString::from(self)`](struct.GString.html#impl-From%3C%26StringName%3E-for-GString) or `self.into()`,
+    /// but the latter cannot be type-inferred.
+    pub fn to_gstring(&self) -> GString {
+        GString::from(self)
+    }
+
+    /// Convert to `NodePath`.
+    ///
+    /// Equivalent to [`NodePath::from(self)`](struct.NodePath.html#impl-From%3C%26String%3E-for-NodePath) or `self.into()`,
+    /// but the latter cannot be type-inferred.
+    pub fn to_node_path(&self) -> NodePath {
+        NodePath::from(self)
+    }
+
     /// O(1), non-lexicographic, non-stable ordering relation.
     ///
     /// The result of the comparison is **not** lexicographic and **not** stable across multiple runs of your application.
@@ -248,6 +264,7 @@ impl From<&String> for StringName {
 }
 
 impl From<&GString> for StringName {
+    /// See also [`GString::to_string_name()`].
     fn from(string: &GString) -> Self {
         unsafe {
             Self::new_with_uninit(|self_ptr| {

--- a/godot-core/src/builtin/string/string_name.rs
+++ b/godot-core/src/builtin/string/string_name.rs
@@ -78,20 +78,20 @@ impl StringName {
             .expect("Godot hashes are uint32_t")
     }
 
-    /// Convert to `GString`.
-    ///
-    /// Equivalent to [`GString::from(self)`](struct.GString.html#impl-From%3C%26StringName%3E-for-GString) or `self.into()`,
-    /// but the latter cannot be type-inferred.
-    pub fn to_gstring(&self) -> GString {
-        GString::from(self)
-    }
-
-    /// Convert to `NodePath`.
-    ///
-    /// Equivalent to [`NodePath::from(self)`](struct.NodePath.html#impl-From%3C%26String%3E-for-NodePath) or `self.into()`,
-    /// but the latter cannot be type-inferred.
-    pub fn to_node_path(&self) -> NodePath {
-        NodePath::from(self)
+    crate::meta::declare_arg_method! {
+        /// Use as argument for an [`impl AsArg<GString|NodePath>`][crate::meta::AsArg] parameter.
+        ///
+        /// This is a convenient way to convert arguments of similar string types.
+        ///
+        /// # Example
+        /// [`Node::set_name()`][crate::classes::Node::set_name] takes `GString`, let's pass a `StringName`:
+        /// ```no_run
+        /// # use godot::prelude::*;
+        /// let name = StringName::from("my cool node");
+        ///
+        /// let mut node = Node::new_alloc();
+        /// node.set_name(name.arg());
+        /// ```
     }
 
     /// O(1), non-lexicographic, non-stable ordering relation.

--- a/godot-core/src/builtin/variant/impls.rs
+++ b/godot-core/src/builtin/variant/impls.rs
@@ -82,6 +82,8 @@ macro_rules! impl_ffi_variant {
         }
 
         impl ArrayElement for $T {}
+
+        impl_ffi_variant!(@as_arg $by_ref_or_val $T);
     };
 
     (@godot_type_name $T:ty) => {
@@ -111,6 +113,14 @@ macro_rules! impl_ffi_variant {
             self.clone()
         }
     };
+
+    (@as_arg by_ref $T:ty) => {
+        $crate::meta::impl_asarg_by_ref!($T);
+    };
+
+    (@as_arg by_val $T:ty) => {
+        $crate::meta::impl_asarg_by_value!($T);
+    };
 }
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
@@ -125,9 +135,6 @@ mod impls {
     impl_ffi_variant!(bool, bool_to_variant, bool_from_variant);
     impl_ffi_variant!(i64, int_to_variant, int_from_variant; int);
     impl_ffi_variant!(f64, float_to_variant, float_from_variant; float);
-    impl_ffi_variant!(Aabb, aabb_to_variant, aabb_from_variant; AABB);
-    impl_ffi_variant!(Basis, basis_to_variant, basis_from_variant);
-    impl_ffi_variant!(Callable, callable_to_variant, callable_from_variant);
     impl_ffi_variant!(Vector2, vector2_to_variant, vector2_from_variant);
     impl_ffi_variant!(Vector3, vector3_to_variant, vector3_from_variant);
     impl_ffi_variant!(Vector4, vector4_to_variant, vector4_from_variant);
@@ -135,10 +142,20 @@ mod impls {
     impl_ffi_variant!(Vector3i, vector3i_to_variant, vector3i_from_variant);
     impl_ffi_variant!(Vector4i, vector4i_to_variant, vector4i_from_variant);
     impl_ffi_variant!(Quaternion, quaternion_to_variant, quaternion_from_variant);
+    impl_ffi_variant!(Transform2D, transform_2d_to_variant, transform_2d_from_variant);
+    impl_ffi_variant!(Transform3D, transform_3d_to_variant, transform_3d_from_variant);
+    impl_ffi_variant!(Basis, basis_to_variant, basis_from_variant);
+    impl_ffi_variant!(Projection, projection_to_variant, projection_from_variant);
+    impl_ffi_variant!(Plane, plane_to_variant, plane_from_variant);
+    impl_ffi_variant!(Rect2, rect2_to_variant, rect2_from_variant);
+    impl_ffi_variant!(Rect2i, rect2i_to_variant, rect2i_from_variant);
+    impl_ffi_variant!(Aabb, aabb_to_variant, aabb_from_variant; AABB);
     impl_ffi_variant!(Color, color_to_variant, color_from_variant);
-    impl_ffi_variant!(GString, string_to_variant, string_from_variant; String);
-    impl_ffi_variant!(StringName, string_name_to_variant, string_name_from_variant);
-    impl_ffi_variant!(NodePath, node_path_to_variant, node_path_from_variant);
+    impl_ffi_variant!(Rid, rid_to_variant, rid_from_variant; RID);
+    impl_ffi_variant!(ref GString, string_to_variant, string_from_variant; String);
+    impl_ffi_variant!(ref StringName, string_name_to_variant, string_name_from_variant);
+    impl_ffi_variant!(ref NodePath, node_path_to_variant, node_path_from_variant);
+    impl_ffi_variant!(ref Dictionary, dictionary_to_variant, dictionary_from_variant);
     impl_ffi_variant!(ref PackedByteArray, packed_byte_array_to_variant, packed_byte_array_from_variant);
     impl_ffi_variant!(ref PackedInt32Array, packed_int32_array_to_variant, packed_int32_array_from_variant);
     impl_ffi_variant!(ref PackedInt64Array, packed_int64_array_to_variant, packed_int64_array_from_variant);
@@ -150,16 +167,8 @@ mod impls {
     #[cfg(since_api = "4.3")]
     impl_ffi_variant!(ref PackedVector4Array, packed_vector4_array_to_variant, packed_vector4_array_from_variant);
     impl_ffi_variant!(ref PackedColorArray, packed_color_array_to_variant, packed_color_array_from_variant);
-    impl_ffi_variant!(Plane, plane_to_variant, plane_from_variant);
-    impl_ffi_variant!(Projection, projection_to_variant, projection_from_variant);
-    impl_ffi_variant!(Rid, rid_to_variant, rid_from_variant; RID);
-    impl_ffi_variant!(Rect2, rect2_to_variant, rect2_from_variant);
-    impl_ffi_variant!(Rect2i, rect2i_to_variant, rect2i_from_variant);
-    impl_ffi_variant!(Signal, signal_to_variant, signal_from_variant);
-    impl_ffi_variant!(Transform2D, transform_2d_to_variant, transform_2d_from_variant);
-    impl_ffi_variant!(Transform3D, transform_3d_to_variant, transform_3d_from_variant);
-    impl_ffi_variant!(ref Dictionary, dictionary_to_variant, dictionary_from_variant);
-
+    impl_ffi_variant!(ref Signal, signal_to_variant, signal_from_variant);
+    impl_ffi_variant!(ref Callable, callable_to_variant, callable_from_variant);
 }
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
@@ -197,7 +206,7 @@ impl GodotType for () {
     }
 
     fn godot_type_name() -> String {
-        "Variant".into()
+        "Variant".to_string()
     }
 }
 
@@ -242,6 +251,6 @@ impl GodotType for Variant {
     }
 
     fn godot_type_name() -> String {
-        "Variant".into()
+        "Variant".to_string()
     }
 }

--- a/godot-core/src/classes/class_runtime.rs
+++ b/godot-core/src/classes/class_runtime.rs
@@ -107,7 +107,7 @@ fn is_derived_base_cached(derived: ClassName, base: ClassName) -> bool {
 
     // Query Godot API (takes linear time in depth of inheritance tree).
     let is_parent_class =
-        ClassDb::singleton().is_parent_class(derived.to_string_name(), base.to_string_name());
+        ClassDb::singleton().is_parent_class(&derived.to_string_name(), &base.to_string_name());
 
     // Insert only successful queries. Those that fail are on the error path already and don't need to be fast.
     if is_parent_class {

--- a/godot-core/src/classes/manual_extensions.rs
+++ b/godot-core/src/classes/manual_extensions.rs
@@ -4,9 +4,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
-
 use crate::builtin::NodePath;
 use crate::classes::{Node, PackedScene};
+use crate::meta::{arg_into_ref, AsArg};
 use crate::obj::{Gd, Inherits};
 
 /// Manual extensions for the `Node` class.
@@ -15,16 +15,15 @@ impl Node {
     ///
     /// # Panics
     /// If the node is not found, or if it does not have type `T` or inherited.
-    pub fn get_node_as<T>(&self, path: impl Into<NodePath>) -> Gd<T>
+    pub fn get_node_as<T>(&self, path: impl AsArg<NodePath>) -> Gd<T>
     where
         T: Inherits<Node>,
     {
-        let path = path.into();
-        let copy = path.clone(); // TODO avoid copy
+        arg_into_ref!(path);
 
         self.try_get_node_as(path).unwrap_or_else(|| {
             panic!(
-                "There is no node of type {ty} at path `{copy}`",
+                "There is no node of type {ty} at path `{path}`",
                 ty = T::class_name()
             )
         })
@@ -34,11 +33,11 @@ impl Node {
     ///
     /// If the node is not found, or if it does not have type `T` or inherited,
     /// `None` will be returned.
-    pub fn try_get_node_as<T>(&self, path: impl Into<NodePath>) -> Option<Gd<T>>
+    pub fn try_get_node_as<T>(&self, path: impl AsArg<NodePath>) -> Option<Gd<T>>
     where
         T: Inherits<Node>,
     {
-        let path = path.into();
+        arg_into_ref!(path);
 
         // TODO differentiate errors (not found, bad type) with Result
         self.get_node_or_null(path)

--- a/godot-core/src/meta/as_arg.rs
+++ b/godot-core/src/meta/as_arg.rs
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use crate::builtin::{GString, NodePath, StringName};
+use crate::meta::ToGodot;
+use std::ffi::CStr;
+
+#[diagnostic::on_unimplemented(
+    message = "The provided argument of type `{Self}` cannot be implicitly converted to a `{T}` parameter",
+    note = "GString/StringName aren't implicitly convertible for performance reasons; use their dedicated `to_*` conversion methods."
+)]
+pub trait AsArg<T: ToGodot> {
+    fn as_arg(&self) -> T::ToVia<'_>;
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// Blanket impls
+
+impl<'a, T: ToGodot> AsArg<T> for &'a T {
+    fn as_arg(&self) -> T::ToVia<'_> {
+        self.to_godot()
+    }
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// GString
+
+impl AsArg<GString> for &str {
+    fn as_arg(&self) -> GString {
+        GString::from(*self)
+    }
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// StringName
+
+impl AsArg<StringName> for &str {
+    fn as_arg(&self) -> StringName {
+        StringName::from(*self)
+    }
+}
+
+impl AsArg<StringName> for &'static CStr {
+    fn as_arg(&self) -> StringName {
+        StringName::from(*self)
+    }
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// NodePath
+
+impl AsArg<NodePath> for &str {
+    fn as_arg(&self) -> NodePath {
+        NodePath::from(*self)
+    }
+}

--- a/godot-core/src/meta/as_arg.rs
+++ b/godot-core/src/meta/as_arg.rs
@@ -6,7 +6,7 @@
  */
 
 use crate::builtin::{GString, NodePath, StringName};
-use crate::meta::CowArg;
+use crate::meta::{CowArg, GodotType};
 use std::ffi::CStr;
 
 /// Implicit conversions for arguments passed to Godot APIs.
@@ -23,7 +23,7 @@ use std::ffi::CStr;
 /// Implicitly converting from `T` for by-ref builtins is explicitly not supported. This emphasizes that there is no need to consume the object,
 /// thus discourages unnecessary cloning.
 ///
-/// If you need to pass owned values in generic code, you can use [`ArgTarget::value_to_arg()`].
+/// If you need to pass owned values in generic code, you can use [`ApiParam::value_to_arg()`].
 ///
 /// # Performance for strings
 /// Godot has three string types: [`GString`], [`StringName`] and [`NodePath`]. Conversions between those three, as well as between `String` and
@@ -37,18 +37,25 @@ use std::ffi::CStr;
 ///
 /// If you want to convert between Godot's string types for the sake of argument passing, each type provides an `arg()` method, such as
 /// [`GString::arg()`]. You cannot use this method in other contexts.
+///
+/// # Using the trait
+/// `AsArg` is meant to be used from the function call site, not the declaration site. If you declare a parameter as `impl AsArg<...>` yourself,
+/// you can only forward it as-is to a Godot API -- there are no stable APIs to access the inner object yet.
+///
+/// Furthermore, there is currently no benefit in implementing `AsArg` for your own types, as it's only used by Godot APIs which don't accept
+/// custom types. Classes are already supported through upcasting and [`AsObjectArg`][crate::obj::AsObjectArg].
 #[diagnostic::on_unimplemented(
     message = "Argument of type `{Self}` cannot be passed to an `impl AsArg<{T}>` parameter",
     note = "If you pass by value, consider borrowing instead.",
     note = "GString/StringName/NodePath aren't implicitly convertible for performance reasons; use their `arg()` method.",
     note = "See also `AsArg` docs: https://godot-rust.github.io/docs/gdext/master/godot/meta/trait.AsArg.html"
 )]
-pub trait AsArg<T: ArgTarget>
+pub trait AsArg<T: ApiParam>
 where
     Self: Sized,
 {
     #[doc(hidden)]
-    fn into_arg<'r>(self) -> <T as ArgTarget>::Arg<'r>
+    fn into_arg<'r>(self) -> <T as ApiParam>::Arg<'r>
     where
         Self: 'r;
 }
@@ -70,7 +77,7 @@ macro_rules! arg_into_ref {
     };
     ($arg_variable:ident: $T:ty) => {
         let $arg_variable = $arg_variable.into_arg();
-        let $arg_variable: &$T = $crate::meta::ArgTarget::arg_to_ref(&$arg_variable);
+        let $arg_variable: &$T = $crate::meta::ApiParam::arg_to_ref(&$arg_variable);
     };
 }
 
@@ -82,7 +89,7 @@ macro_rules! arg_into_owned {
     ($arg_variable:ident) => {
         let $arg_variable = $arg_variable.into_arg();
         let $arg_variable = $arg_variable.cow_into_owned();
-        // cow_into_owned() is not yet used generically; could be abstracted in ArgTarget::arg_to_owned() as well.
+        // cow_into_owned() is not yet used generically; could be abstracted in ApiParam::arg_to_owned() as well.
     };
 }
 
@@ -90,13 +97,13 @@ macro_rules! arg_into_owned {
 macro_rules! impl_asarg_by_value {
     ($T:ty) => {
         impl $crate::meta::AsArg<$T> for $T {
-            fn into_arg<'r>(self) -> <$T as $crate::meta::ArgTarget>::Arg<'r> {
+            fn into_arg<'r>(self) -> <$T as $crate::meta::ApiParam>::Arg<'r> {
                 // Moves value (but typically a Copy type).
                 self
             }
         }
 
-        impl $crate::meta::ArgTarget for $T {
+        impl $crate::meta::ApiParam for $T {
             type Arg<'v> = $T;
 
             fn value_to_arg<'v>(self) -> Self::Arg<'v> {
@@ -121,7 +128,7 @@ macro_rules! impl_asarg_by_ref {
             // Thus, keep `where` on same line.
             // type ArgType<'v> = &'v $T where Self: 'v;
 
-            fn into_arg<'cow>(self) -> <$T as $crate::meta::ArgTarget>::Arg<'cow>
+            fn into_arg<'cow>(self) -> <$T as $crate::meta::ApiParam>::Arg<'cow>
             where
                 'r: 'cow, // Original reference must be valid for at least as long as the returned cow.
             {
@@ -129,7 +136,7 @@ macro_rules! impl_asarg_by_ref {
             }
         }
 
-        impl $crate::meta::ArgTarget for $T {
+        impl $crate::meta::ApiParam for $T {
             type Arg<'v> = $crate::meta::CowArg<'v, $T>;
 
             fn value_to_arg<'v>(self) -> Self::Arg<'v> {
@@ -150,11 +157,11 @@ macro_rules! declare_arg_method {
         ///
         /// # Generic bounds
         /// The bounds are implementation-defined and may change at any time. Do not use this function in a generic context requiring `T`
-        /// -- use the `From` trait or [`ArgTarget`][crate::meta::ArgTarget] in that case.
+        /// -- use the `From` trait or [`ApiParam`][crate::meta::ApiParam] in that case.
         pub fn arg<T>(&self) -> impl $crate::meta::AsArg<T>
         where
             for<'a> T: From<&'a Self>
-                + $crate::meta::ArgTarget<Arg<'a> = $crate::meta::CowArg<'a, T>>
+                + $crate::meta::ApiParam<Arg<'a> = $crate::meta::CowArg<'a, T>>
                 + 'a,
         {
             $crate::meta::CowArg::Owned(T::from(self))
@@ -171,7 +178,7 @@ macro_rules! declare_arg_method {
 /// This is necessary for packed array dispatching to different "inner" backend signatures.
 impl<'a, T> AsArg<T> for CowArg<'a, T>
 where
-    for<'r> T: ArgTarget<Arg<'r> = CowArg<'r, T>> + 'r,
+    for<'r> T: ApiParam<Arg<'r> = CowArg<'r, T>> + 'r,
 {
     fn into_arg<'r>(self) -> CowArg<'r, T>
     where
@@ -181,7 +188,7 @@ where
     }
 }
 
-// impl<'a, T> ArgTarget for CowArg<'a, T> {
+// impl<'a, T> ApiParam for CowArg<'a, T> {
 //     type Type<'v> = CowArg<'v, T>
 //         where Self: 'v;
 // }
@@ -243,7 +250,8 @@ impl AsArg<NodePath> for &String {
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 
 /// Implemented for all parameter types `T` that are allowed to receive [impl `AsArg<T>`][AsArg].
-pub trait ArgTarget
+pub trait ApiParam: GodotType
+// GodotType bound not required right now, but conceptually should always be the case.
 where
     Self: Sized,
 {

--- a/godot-core/src/meta/as_arg.rs
+++ b/godot-core/src/meta/as_arg.rs
@@ -9,9 +9,24 @@ use crate::builtin::{GString, NodePath, StringName};
 use crate::meta::ToGodot;
 use std::ffi::CStr;
 
+/// Implicit conversions for arguments passed to Godot APIs.
+///
+/// An `impl AsArg<T>` parameter allows values to be passed which can be represented in the target type `T`. Note that unlike `From<T>`,
+/// this trait is implemented more conservatively.
+///
+/// # Performance for strings
+/// Godot has three string types: [`GString`], [`StringName`] and [`NodePath`]. Conversions between those three, as well as between `String` and
+/// them, is generally expensive because of allocations, re-encoding, validations, hashing, etc. While this doesn't matter for a few strings
+/// passed to engine APIs, it can become a problematic when passing long strings in a hot loop.
+///
+/// As a result, `AsArg<T>` is currently only implemented for certain conversions:
+/// - `&T` and `&mut T`, since those require no conversion or copy.
+/// - String literals like `"string"` and `c"string"`. While these _do_ need conversions, those are quite explicit, and
+///   `&'static CStr -> StringName` in particular is cheap.
 #[diagnostic::on_unimplemented(
     message = "The provided argument of type `{Self}` cannot be implicitly converted to a `{T}` parameter",
-    note = "GString/StringName aren't implicitly convertible for performance reasons; use their dedicated `to_*` conversion methods."
+    note = "GString/StringName aren't implicitly convertible for performance reasons; use their dedicated `to_*` conversion methods.",
+    note = "See also `AsArg` docs: https://godot-rust.github.io/docs/gdext/master/godot/meta/trait.AsArg.html"
 )]
 pub trait AsArg<T: ToGodot> {
     fn as_arg(&self) -> T::ToVia<'_>;

--- a/godot-core/src/meta/cow_arg.rs
+++ b/godot-core/src/meta/cow_arg.rs
@@ -47,7 +47,7 @@ impl<'r, T> CowArg<'r, T> {
     }
 }
 
-/// Exists for polymorphism in [`crate::meta::ArgTarget`].
+/// Exists for polymorphism in [`crate::meta::ApiParam`].
 ///
 /// Necessary for generics in e.g. `Array<T>`, when accepting `impl AsArg<T>` parameters.
 ///

--- a/godot-core/src/meta/cow_arg.rs
+++ b/godot-core/src/meta/cow_arg.rs
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use crate::builtin::Variant;
+use crate::meta::error::ConvertError;
+use crate::meta::{FromGodot, GodotConvert, GodotFfiVariant, RefArg, ToGodot};
+use crate::sys;
+use godot_ffi::{GodotFfi, GodotNullableFfi, PtrcallType};
+use std::fmt;
+
+/// Owned or borrowed value, used when passing arguments through `impl AsArg` to Godot APIs.
+#[doc(hidden)]
+pub enum CowArg<'r, T> {
+    Owned(T),
+    Borrowed(RefArg<'r, T>),
+}
+
+impl<'r, T> CowArg<'r, T> {
+    pub fn as_ref(&self) -> &T {
+        match self {
+            CowArg::Owned(v) => v,
+            CowArg::Borrowed(r) => r.as_ref(),
+        }
+    }
+}
+
+macro_rules! wrong_direction {
+    ($fn:ident) => {
+        unreachable!(concat!(
+            stringify!($fn),
+            ": CowArg should only be passed *to* Godot, not *from*."
+        ))
+    };
+}
+
+impl<'r, T> GodotConvert for CowArg<'r, T>
+where
+    T: GodotConvert,
+{
+    type Via = T::Via;
+}
+
+impl<'r, T> ToGodot for CowArg<'r, T>
+where
+    T: ToGodot,
+{
+    type ToVia<'v> = T::ToVia<'v>
+    where Self: 'v;
+
+    fn to_godot(&self) -> Self::ToVia<'_> {
+        self.as_ref().to_godot()
+    }
+}
+
+// TODO refactor signature tuples into separate in+out traits, so FromGodot is no longer needed.
+impl<'r, T> FromGodot for CowArg<'r, T>
+where
+    T: FromGodot,
+{
+    fn try_from_godot(_via: Self::Via) -> Result<Self, ConvertError> {
+        wrong_direction!(try_from_godot)
+    }
+}
+
+impl<'r, T> fmt::Debug for CowArg<'r, T>
+where
+    T: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            CowArg::Owned(v) => write!(f, "CowArg::Owned({v:?})"),
+            CowArg::Borrowed(r) => write!(f, "CowArg::Borrowed({r:?})"),
+        }
+    }
+}
+
+// SAFETY: delegated to T.
+unsafe impl<'r, T> GodotFfi for CowArg<'r, T>
+where
+    T: GodotFfi,
+{
+    fn variant_type() -> sys::VariantType {
+        T::variant_type()
+    }
+
+    unsafe fn new_from_sys(_ptr: sys::GDExtensionConstTypePtr) -> Self {
+        wrong_direction!(new_from_sys)
+    }
+
+    unsafe fn new_with_uninit(_init_fn: impl FnOnce(sys::GDExtensionUninitializedTypePtr)) -> Self {
+        wrong_direction!(new_with_uninit)
+    }
+
+    unsafe fn new_with_init(_init_fn: impl FnOnce(sys::GDExtensionTypePtr)) -> Self {
+        wrong_direction!(new_with_init)
+    }
+
+    fn sys(&self) -> sys::GDExtensionConstTypePtr {
+        self.as_ref().sys()
+    }
+
+    fn sys_mut(&mut self) -> sys::GDExtensionTypePtr {
+        unreachable!("CowArg::sys_mut() currently not used by FFI marshalling layer, but only by specific functions");
+    }
+
+    // This function must be overridden; the default delegating to sys() is wrong for e.g. RawGd<T>.
+    // See also other manual overrides of as_arg_ptr().
+    fn as_arg_ptr(&self) -> sys::GDExtensionConstTypePtr {
+        self.as_ref().as_arg_ptr()
+    }
+
+    unsafe fn from_arg_ptr(_ptr: sys::GDExtensionTypePtr, _call_type: PtrcallType) -> Self {
+        wrong_direction!(from_arg_ptr)
+    }
+
+    unsafe fn move_return_ptr(self, _dst: sys::GDExtensionTypePtr, _call_type: PtrcallType) {
+        // This one is implemented, because it's used for return types implementing ToGodot.
+        unreachable!("Calling CowArg::move_return_ptr is a mistake, as CowArg is intended only for arguments. Use the underlying value type.");
+    }
+}
+
+impl<'r, T> GodotFfiVariant for CowArg<'r, T>
+where
+    T: GodotFfiVariant,
+{
+    fn ffi_to_variant(&self) -> Variant {
+        self.as_ref().ffi_to_variant()
+    }
+
+    fn ffi_from_variant(_variant: &Variant) -> Result<Self, ConvertError> {
+        wrong_direction!(ffi_from_variant)
+    }
+}
+
+impl<'r, T> GodotNullableFfi for CowArg<'r, T>
+where
+    T: GodotNullableFfi,
+{
+    fn null() -> Self {
+        CowArg::Owned(T::null())
+    }
+
+    fn is_null(&self) -> bool {
+        self.as_ref().is_null()
+    }
+}

--- a/godot-core/src/meta/error/call_error.rs
+++ b/godot-core/src/meta/error/call_error.rs
@@ -55,7 +55,7 @@ use std::fmt;
 ///     let mut obj: Gd<MyClass> = MyClass::new_gd();
 ///
 ///     // Dynamic call. Note: forgot to pass the argument.
-///     let result: Result<Variant, CallError> = obj.try_call("my_method".into(), &[]);
+///     let result: Result<Variant, CallError> = obj.try_call("my_method", &[]);
 ///
 ///     // Get immediate and original errors.
 ///     // Note that source() can be None or of type ConvertError.

--- a/godot-core/src/meta/godot_convert/impls.rs
+++ b/godot-core/src/meta/godot_convert/impls.rs
@@ -247,6 +247,8 @@ macro_rules! impl_godot_scalar {
                 Ok(via)
             }
         }
+
+        $crate::impl_asarg_by_value!($T);
     };
 }
 

--- a/godot-core/src/meta/mod.rs
+++ b/godot-core/src/meta/mod.rs
@@ -58,11 +58,15 @@ pub use godot_convert::{FromGodot, GodotConvert, ToGodot};
 pub use rpc_config::RpcConfig;
 pub use traits::{ArrayElement, GodotType, PackedArrayElement};
 
-pub(crate) use crate::impl_godot_as_self;
 pub(crate) use array_type_info::ArrayTypeInfo;
 pub(crate) use traits::{GodotFfiVariant, GodotNullableFfi};
 
 use crate::registry::method::MethodParamOrReturnInfo;
+
+pub(crate) use crate::{
+    arg_into_owned, arg_into_ref, declare_arg_method, impl_asarg_by_ref, impl_asarg_by_value,
+    impl_godot_as_self,
+};
 
 #[doc(hidden)]
 pub use cow_arg::*;

--- a/godot-core/src/meta/mod.rs
+++ b/godot-core/src/meta/mod.rs
@@ -42,6 +42,7 @@ mod method_info;
 mod property_info;
 mod ref_arg;
 // RpcConfig uses MultiplayerPeer::TransferMode and MultiplayerApi::RpcMode, which are only enabled in `codegen-full` feature.
+mod cow_arg;
 #[cfg(feature = "codegen-full")]
 mod rpc_config;
 mod sealed;
@@ -63,6 +64,8 @@ pub(crate) use traits::{GodotFfiVariant, GodotNullableFfi};
 
 use crate::registry::method::MethodParamOrReturnInfo;
 
+#[doc(hidden)]
+pub use cow_arg::*;
 #[doc(hidden)]
 pub use ref_arg::*;
 #[doc(hidden)]

--- a/godot-core/src/meta/mod.rs
+++ b/godot-core/src/meta/mod.rs
@@ -35,6 +35,7 @@
 //! [`try_cast()`][crate::obj::Gd::try_cast] and [`upcast()`][crate::obj::Gd::upcast]. Upcasts are infallible.
 
 mod array_type_info;
+mod as_arg;
 mod class_name;
 mod godot_convert;
 mod method_info;
@@ -48,6 +49,8 @@ mod signature;
 mod traits;
 
 pub mod error;
+
+pub use as_arg::*;
 pub use class_name::ClassName;
 pub use godot_convert::{FromGodot, GodotConvert, ToGodot};
 #[cfg(feature = "codegen-full")]

--- a/godot-core/src/meta/ref_arg.rs
+++ b/godot-core/src/meta/ref_arg.rs
@@ -4,6 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
+
 use crate::builtin::Variant;
 use crate::meta::error::ConvertError;
 use crate::meta::{FromGodot, GodotConvert, GodotFfiVariant, ToGodot};

--- a/godot-core/src/meta/ref_arg.rs
+++ b/godot-core/src/meta/ref_arg.rs
@@ -38,18 +38,18 @@ impl<'r, T> RefArg<'r, T> {
     ///
     /// # Panics
     /// If `T` is `Option<Gd<...>>::None`.
-    pub fn as_ref(&self) -> &T {
+    pub fn get_ref(&self) -> &T {
         self.shared_ref.expect("RefArg is null")
     }
 
     /// Returns the stored reference.
     ///
     /// Returns `None` if `T` is `Option<Gd<...>>::None`.
-    pub fn as_ref_or_none(&self) -> Option<&T>
+    pub fn get_ref_or_none(&self) -> Option<&T>
     where
         T: GodotNullableFfi,
     {
-        self.shared_ref.clone()
+        self.shared_ref
     }
 
     /// Returns the stored reference.
@@ -60,7 +60,7 @@ impl<'r, T> RefArg<'r, T> {
     where
         T: Clone,
     {
-        self.as_ref().clone()
+        self.get_ref().clone()
     }
 }
 

--- a/godot-core/src/meta/rpc_config.rs
+++ b/godot-core/src/meta/rpc_config.rs
@@ -9,8 +9,8 @@ use crate::builtin::{Dictionary, StringName};
 use crate::classes::multiplayer_api::RpcMode;
 use crate::classes::multiplayer_peer::TransferMode;
 use crate::classes::Node;
-use crate::dict;
-use crate::meta::ToGodot;
+use crate::meta::{AsArg, ToGodot};
+use crate::{arg_into_ref, dict};
 
 /// Configuration for a remote procedure call, typically used with `#[rpc(config = ...)]`.
 ///
@@ -36,8 +36,9 @@ impl Default for RpcConfig {
 
 impl RpcConfig {
     /// Register `method` as a remote procedure call on `node`.
-    pub fn configure_node(self, node: &mut Node, method_name: impl Into<StringName>) {
-        node.rpc_config(method_name.into(), &self.to_dictionary().to_variant());
+    pub fn configure_node(self, node: &mut Node, method_name: impl AsArg<StringName>) {
+        arg_into_ref!(method_name);
+        node.rpc_config(method_name, &self.to_dictionary().to_variant());
     }
 
     /// Returns a [`Dictionary`] populated with the values required for a call to [`Node::rpc_config()`].

--- a/godot-core/src/meta/traits.rs
+++ b/godot-core/src/meta/traits.rs
@@ -162,7 +162,7 @@ pub trait GodotType: GodotConvert<Via = Self> + sealed::Sealed + Sized + 'static
     message = "`Array<T>` can only store element types supported in Godot arrays (no nesting).",
     label = "has invalid element type"
 )]
-pub trait ArrayElement: GodotType + ToGodot + FromGodot + sealed::Sealed + meta::ArgTarget {
+pub trait ArrayElement: GodotType + ToGodot + FromGodot + sealed::Sealed + meta::ApiParam {
     /// Returns the representation of this type as a type string.
     ///
     /// Used for elements in arrays (the latter despite `ArrayElement` not having a direct relation).

--- a/godot-core/src/meta/traits.rs
+++ b/godot-core/src/meta/traits.rs
@@ -7,7 +7,7 @@
 
 use godot_ffi as sys;
 
-use crate::builtin::{Array, StringName, Variant};
+use crate::builtin::Variant;
 use crate::global::PropertyUsageFlags;
 use crate::meta::error::ConvertError;
 use crate::meta::{
@@ -17,6 +17,7 @@ use crate::registry::method::MethodParamOrReturnInfo;
 
 // Re-export sys traits in this module, so all are in one place.
 use crate::registry::property::builtin_type_string;
+use crate::{builtin, meta};
 pub use sys::{GodotFfi, GodotNullableFfi};
 
 /// Conversion of [`GodotFfi`] types to/from [`Variant`].
@@ -91,7 +92,7 @@ pub trait GodotType: GodotConvert<Via = Self> + sealed::Sealed + Sized + 'static
         PropertyInfo {
             variant_type: Self::Ffi::variant_type(),
             class_name: Self::class_name(),
-            property_name: StringName::from(property_name),
+            property_name: builtin::StringName::from(property_name),
             hint_info: Self::property_hint_info(),
             usage: PropertyUsageFlags::DEFAULT,
         }
@@ -161,7 +162,7 @@ pub trait GodotType: GodotConvert<Via = Self> + sealed::Sealed + Sized + 'static
     message = "`Array<T>` can only store element types supported in Godot arrays (no nesting).",
     label = "has invalid element type"
 )]
-pub trait ArrayElement: GodotType + ToGodot + FromGodot + sealed::Sealed {
+pub trait ArrayElement: GodotType + ToGodot + FromGodot + sealed::Sealed + meta::ArgTarget {
     /// Returns the representation of this type as a type string.
     ///
     /// Used for elements in arrays (the latter despite `ArrayElement` not having a direct relation).
@@ -174,7 +175,7 @@ pub trait ArrayElement: GodotType + ToGodot + FromGodot + sealed::Sealed {
         builtin_type_string::<Self>()
     }
 
-    fn debug_validate_elements(_array: &Array<Self>) -> Result<(), ConvertError> {
+    fn debug_validate_elements(_array: &builtin::Array<Self>) -> Result<(), ConvertError> {
         // No-op for most element types.
         Ok(())
     }
@@ -199,9 +200,9 @@ impl PackedArrayElement for i32 {}
 impl PackedArrayElement for i64 {}
 impl PackedArrayElement for f32 {}
 impl PackedArrayElement for f64 {}
-impl PackedArrayElement for crate::builtin::Vector2 {}
-impl PackedArrayElement for crate::builtin::Vector3 {}
+impl PackedArrayElement for builtin::Vector2 {}
+impl PackedArrayElement for builtin::Vector3 {}
 #[cfg(since_api = "4.3")]
-impl PackedArrayElement for crate::builtin::Vector4 {}
-impl PackedArrayElement for crate::builtin::Color {}
-impl PackedArrayElement for crate::builtin::GString {}
+impl PackedArrayElement for builtin::Vector4 {}
+impl PackedArrayElement for builtin::Color {}
+impl PackedArrayElement for builtin::GString {}

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -782,13 +782,13 @@ impl<'r, T: GodotClass> AsArg<Gd<T>> for &'r Gd<T> {
 }
 
 impl<T: GodotClass> ArgTarget for Gd<T> {
-    type Type<'v> = CowArg<'v, Gd<T>>;
+    type Arg<'v> = CowArg<'v, Gd<T>>;
 
-    fn value_to_arg<'v>(self) -> Self::Type<'v> {
+    fn value_to_arg<'v>(self) -> Self::Arg<'v> {
         CowArg::Owned(self)
     }
 
-    fn arg_to_ref<'r>(arg: &'r Self::Type<'_>) -> &'r Self {
+    fn arg_to_ref<'r>(arg: &'r Self::Arg<'_>) -> &'r Self {
         arg.cow_as_ref()
     }
 }
@@ -804,13 +804,13 @@ impl<'r, T: GodotClass> AsArg<Option<Gd<T>>> for Option<&'r Gd<T>> {
 }
 
 impl<T: GodotClass> ArgTarget for Option<Gd<T>> {
-    type Type<'v> = CowArg<'v, Option<Gd<T>>>;
+    type Arg<'v> = CowArg<'v, Option<Gd<T>>>;
 
-    fn value_to_arg<'v>(self) -> Self::Type<'v> {
+    fn value_to_arg<'v>(self) -> Self::Arg<'v> {
         CowArg::Owned(self)
     }
 
-    fn arg_to_ref<'r>(arg: &'r Self::Type<'_>) -> &'r Self {
+    fn arg_to_ref<'r>(arg: &'r Self::Arg<'_>) -> &'r Self {
         arg.cow_as_ref()
     }
 }

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -16,7 +16,7 @@ use crate::builtin::{Callable, NodePath, StringName, Variant};
 use crate::global::PropertyHint;
 use crate::meta::error::{ConvertError, FromFfiError};
 use crate::meta::{
-    ArgTarget, ArrayElement, AsArg, CallContext, ClassName, CowArg, FromGodot, GodotConvert,
+    ApiParam, ArrayElement, AsArg, CallContext, ClassName, CowArg, FromGodot, GodotConvert,
     GodotType, PropertyHintInfo, RefArg, ToGodot,
 };
 use crate::obj::{
@@ -781,7 +781,7 @@ impl<'r, T: GodotClass> AsArg<Gd<T>> for &'r Gd<T> {
     }
 }
 
-impl<T: GodotClass> ArgTarget for Gd<T> {
+impl<T: GodotClass> ApiParam for Gd<T> {
     type Arg<'v> = CowArg<'v, Gd<T>>;
 
     fn value_to_arg<'v>(self) -> Self::Arg<'v> {
@@ -803,7 +803,7 @@ impl<'r, T: GodotClass> AsArg<Option<Gd<T>>> for Option<&'r Gd<T>> {
     }
 }
 
-impl<T: GodotClass> ArgTarget for Option<Gd<T>> {
+impl<T: GodotClass> ApiParam for Option<Gd<T>> {
     type Arg<'v> = CowArg<'v, Option<Gd<T>>>;
 
     fn value_to_arg<'v>(self) -> Self::Arg<'v> {

--- a/godot-core/src/obj/object_arg.rs
+++ b/godot-core/src/obj/object_arg.rs
@@ -25,6 +25,10 @@ use std::ptr;
 /// The GDExtension API does not inform about nullability of its function parameters. It is up to you to verify that the arguments you pass
 /// are only null when this is allowed. Doing this wrong should be safe, but can lead to the function call failing.
 /// </div>
+
+#[diagnostic::on_unimplemented(
+    message = "The provided argument of type `{Self}` cannot be converted to a `Gd<{T}>` parameter"
+)]
 pub trait AsObjectArg<T>
 where
     T: GodotClass + Bounds<Declarer = bounds::DeclEngine>,

--- a/godot-core/src/obj/object_arg.rs
+++ b/godot-core/src/obj/object_arg.rs
@@ -38,7 +38,7 @@ where
 
     /// Returns
     #[doc(hidden)]
-    fn consume_object(self) -> ObjectCow<T>;
+    fn consume_arg(self) -> ObjectCow<T>;
 }
 
 impl<T, U> AsObjectArg<T> for Gd<U>
@@ -50,7 +50,7 @@ where
         <&Gd<U>>::as_object_arg(&self)
     }
 
-    fn consume_object(self) -> ObjectCow<T> {
+    fn consume_arg(self) -> ObjectCow<T> {
         ObjectCow::Owned(self.upcast())
     }
 }
@@ -66,7 +66,7 @@ where
         unsafe { ObjectArg::from_raw_gd(&self.raw) }
     }
 
-    fn consume_object(self) -> ObjectCow<T> {
+    fn consume_arg(self) -> ObjectCow<T> {
         ObjectCow::Borrowed(self.as_object_arg())
     }
 }
@@ -82,8 +82,8 @@ where
         <&Gd<U>>::as_object_arg(&&**self)
     }
 
-    fn consume_object(self) -> ObjectCow<T> {
-        <&Gd<U>>::consume_object(&*self)
+    fn consume_arg(self) -> ObjectCow<T> {
+        <&Gd<U>>::consume_arg(&*self)
     }
 }
 
@@ -97,10 +97,10 @@ where
             .map_or_else(ObjectArg::null, AsObjectArg::as_object_arg)
     }
 
-    fn consume_object(self) -> ObjectCow<T> {
+    fn consume_arg(self) -> ObjectCow<T> {
         match self {
-            Some(obj) => obj.consume_object(),
-            None => Gd::null_arg().consume_object(),
+            Some(obj) => obj.consume_arg(),
+            None => Gd::null_arg().consume_arg(),
         }
     }
 }
@@ -113,7 +113,7 @@ where
         ObjectArg::null()
     }
 
-    fn consume_object(self) -> ObjectCow<T> {
+    fn consume_arg(self) -> ObjectCow<T> {
         // Null pointer is safe to borrow.
         ObjectCow::Borrowed(ObjectArg::null())
     }
@@ -139,8 +139,8 @@ where
 {
     /// Returns the actual `ObjectArg` to be passed to function calls.
     ///
-    /// [`ObjectCow`] does not implement [`AsObjectArg<T>`] because a differently-named method is more explicit (less errors in codegen),
-    /// and because [`AsObjectArg::consume_object()`] is not meaningful.
+    /// [`ObjectCow`] does not implement [`AsObjectArg<T>`] because a differently-named method is more explicit (fewer errors in codegen),
+    /// and because [`AsObjectArg::consume_arg()`] is not meaningful.
     pub fn cow_as_object_arg(&self) -> ObjectArg<T> {
         match self {
             ObjectCow::Owned(gd) => gd.as_object_arg(),

--- a/godot-core/src/obj/onready.rs
+++ b/godot-core/src/obj/onready.rs
@@ -7,7 +7,7 @@
 
 use crate::builtin::NodePath;
 use crate::classes::Node;
-use crate::meta::GodotConvert;
+use crate::meta::{arg_into_owned, AsArg, GodotConvert};
 use crate::obj::{Gd, GodotClass, Inherits};
 use crate::registry::property::Var;
 use std::fmt::{self, Debug, Formatter};
@@ -119,9 +119,10 @@ impl<T: GodotClass + Inherits<Node>> OnReady<Gd<T>> {
     ///
     /// Note that the panic will only happen if and when the node enters the SceneTree for the first time
     ///  (i.e.: it receives the `READY` notification).
-    pub fn node(path: impl Into<NodePath>) -> Self {
-        let path = path.into();
-        Self::from_base_fn(|base| base.get_node_as(path))
+    pub fn node(path: impl AsArg<NodePath>) -> Self {
+        arg_into_owned!(path);
+
+        Self::from_base_fn(move |base| base.get_node_as(&path))
     }
 }
 

--- a/godot-core/src/obj/raw_gd.rs
+++ b/godot-core/src/obj/raw_gd.rs
@@ -123,7 +123,7 @@ impl<T: GodotClass> RawGd<T> {
 
         // SAFETY: Object is always a base class.
         let cast_is_valid = unsafe { as_obj.as_upcast_ref::<classes::Object>() }
-            .is_class(U::class_name().to_gstring());
+            .is_class(&U::class_name().to_gstring());
 
         std::mem::forget(as_obj);
         cast_is_valid

--- a/godot-core/src/obj/script.rs
+++ b/godot-core/src/obj/script.rs
@@ -444,7 +444,7 @@ impl<'a, T: ScriptInstance> SiMut<'a, T> {
     ///         let node = Node::new_alloc();
     ///
     ///         // We can call back into `self` through Godot:
-    ///         this.base_mut().call("script_method".into(), &[]);
+    ///         this.base_mut().call("script_method", &[]);
     ///
     ///         Ok(Variant::nil())
     ///     }

--- a/godot-core/src/obj/traits.rs
+++ b/godot-core/src/obj/traits.rs
@@ -368,7 +368,7 @@ pub trait WithBaseField: GodotClass + Bounds<Declarer = bounds::DeclUser> {
     /// #[godot_api]
     /// impl INode for MyClass {
     ///     fn process(&mut self, _delta: f64) {
-    ///         self.base_mut().call("other_method".into(), &[]);
+    ///         self.base_mut().call("other_method", &[]);
     ///     }
     /// }
     ///

--- a/godot-core/src/registry/constant.rs
+++ b/godot-core/src/registry/constant.rs
@@ -19,12 +19,12 @@ pub struct IntegerConstant {
 }
 
 impl IntegerConstant {
-    pub fn new<T>(name: StringName, value: T) -> Self
+    pub fn new<T>(name: &str, value: T) -> Self
     where
         T: TryInto<i64> + Copy + std::fmt::Debug,
     {
         Self {
-            name,
+            name: StringName::from(name),
             value: value.try_into().ok().unwrap_or_else(|| {
                 panic!("exported constant `{value:?}` must be representable as `i64`")
             }),

--- a/godot-core/src/storage/instance_storage.rs
+++ b/godot-core/src/storage/instance_storage.rs
@@ -226,7 +226,8 @@ pub unsafe fn destroy_storage<T: GodotClass>(instance_ptr: sys::GDExtensionClass
         // In Debug mode, crash which may trigger breakpoint.
         // In Release mode, leak player object (Godot philosophy: don't crash if somehow avoidable). Likely leads to follow-up issues.
         if cfg!(debug_assertions) {
-            crate::classes::Os::singleton().crash(error.into());
+            let error = crate::builtin::GString::from(error);
+            crate::classes::Os::singleton().crash(&error);
         } else {
             leak_rust_object = true;
             godot_error!("{}", error);

--- a/godot-core/src/tools/save_load.rs
+++ b/godot-core/src/tools/save_load.rs
@@ -9,6 +9,7 @@ use crate::builtin::GString;
 use crate::classes::{Resource, ResourceLoader, ResourceSaver};
 use crate::global::Error as GodotError;
 use crate::meta::error::IoError;
+use crate::meta::{arg_into_ref, AsArg};
 use crate::obj::{Gd, Inherits};
 
 /// ⚠️ Loads a resource from the filesystem located at `path`, panicking on error.
@@ -26,12 +27,12 @@ use crate::obj::{Gd, Inherits};
 /// # Panics
 /// If the resource cannot be loaded, or is not of type `T` or inherited.
 #[inline]
-pub fn load<T>(path: impl Into<GString>) -> Gd<T>
+pub fn load<T>(path: impl AsArg<GString>) -> Gd<T>
 where
     T: Inherits<Resource>,
 {
-    let path = path.into();
-    load_impl(&path).unwrap_or_else(|err| panic!("failed: {err}"))
+    arg_into_ref!(path);
+    load_impl(path).unwrap_or_else(|err| panic!("failed to load resource at '{path}': {err}"))
 }
 
 /// Loads a resource from the filesystem located at `path`.
@@ -64,11 +65,12 @@ where
 /// }
 /// ```
 #[inline]
-pub fn try_load<T>(path: impl Into<GString>) -> Result<Gd<T>, IoError>
+pub fn try_load<T>(path: impl AsArg<GString>) -> Result<Gd<T>, IoError>
 where
     T: Inherits<Resource>,
 {
-    load_impl(&path.into())
+    arg_into_ref!(path);
+    load_impl(path)
 }
 
 /// ⚠️ Saves a [`Resource`]-inheriting object into the file located at `path`.
@@ -86,12 +88,13 @@ where
 /// ```
 /// use godot::
 #[inline]
-pub fn save<T>(obj: Gd<T>, path: impl Into<GString>)
+pub fn save<T>(obj: Gd<T>, path: impl AsArg<GString>)
 where
     T: Inherits<Resource>,
 {
-    let path = path.into();
-    save_impl(obj, &path)
+    arg_into_ref!(path);
+
+    save_impl(obj, path)
         .unwrap_or_else(|err| panic!("failed to save resource at path '{}': {}", &path, err));
 }
 
@@ -122,11 +125,13 @@ where
 /// assert!(res.is_ok());
 /// ```
 #[inline]
-pub fn try_save<T>(obj: Gd<T>, path: impl Into<GString>) -> Result<(), IoError>
+pub fn try_save<T>(obj: Gd<T>, path: impl AsArg<GString>) -> Result<(), IoError>
 where
     T: Inherits<Resource>,
 {
-    save_impl(obj, &path.into())
+    arg_into_ref!(path);
+
+    save_impl(obj, path)
 }
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
@@ -138,12 +143,12 @@ fn load_impl<T>(path: &GString) -> Result<Gd<T>, IoError>
 where
     T: Inherits<Resource>,
 {
-    // TODO unclone GString
-    match ResourceLoader::singleton()
-        .load_ex(path.clone())
-        .type_hint(T::class_name().to_gstring())
-        .done()
-    {
+    let loaded = ResourceLoader::singleton()
+        .load_ex(path)
+        .type_hint(&T::class_name().to_gstring())
+        .done();
+
+    match loaded {
         Some(res) => match res.try_cast::<T>() {
             Ok(obj) => Ok(obj),
             Err(_) => Err(IoError::loading_cast(
@@ -162,18 +167,15 @@ fn save_impl<T>(obj: Gd<T>, path: &GString) -> Result<(), IoError>
 where
     T: Inherits<Resource>,
 {
-    // TODO unclone GString
-    let res = ResourceSaver::singleton()
-        .save_ex(obj)
-        .path(path.clone())
-        .done();
+    let res = ResourceSaver::singleton().save_ex(obj).path(path).done();
 
     if res == GodotError::OK {
-        return Ok(());
+        Ok(())
+    } else {
+        Err(IoError::saving(
+            res,
+            T::class_name().to_string(),
+            path.to_string(),
+        ))
     }
-    Err(IoError::saving(
-        res,
-        T::class_name().to_string(),
-        path.to_string(),
-    ))
 }

--- a/godot-core/src/tools/translate.rs
+++ b/godot-core/src/tools/translate.rs
@@ -38,17 +38,21 @@ pub use crate::{tr, tr_n};
 /// in Godot.
 #[macro_export]
 macro_rules! tr {
-    ($fmt:literal $(, $($args:tt)*)?) => {
-        $crate::classes::Engine::singleton()
-            .tr(format!($fmt $(, $($args)*)?).into())
-    };
+    ($fmt:literal $(, $($args:tt)*)?) => {{
+        let msg = format!($fmt $(, $($args)*)?);
 
-    ($context:expr; $fmt:literal $(, $($args:tt)*)?) => {
+        $crate::classes::Engine::singleton().tr(&msg)
+    }};
+
+    ($context:expr; $fmt:literal $(, $($args:tt)*)?) => {{
+        let msg = format!($fmt $(, $($args)*)?);
+        let context = format!("{}", $context);
+
         $crate::classes::Engine::singleton()
-            .tr_ex(format!($fmt $(, $($args)*)?).into())
-            .context(format!("{}", $context).into())
+            .tr_ex(&msg)
+            .context(&context)
             .done()
-    };
+    }};
 }
 
 /// A convenience macro for using the [`Object::tr_n()`](crate::classes::Object::tr_n()) and
@@ -85,8 +89,8 @@ macro_rules! tr_n {
     ($n:expr; $singular:literal, $plural:literal $(, $($args:tt)*)?) => {
         $crate::classes::Engine::singleton()
             .tr_n(
-                format!($singular$(, $($args)*)?).into(),
-                format!($plural$(, $($args)*)?).into(),
+                &format!($singular$(, $($args)*)?),
+                &format!($plural$(, $($args)*)?),
                 $n,
             )
     };
@@ -94,11 +98,11 @@ macro_rules! tr_n {
     ($n:expr, $context:expr; $singular:literal, $plural:literal $(, $($args:tt)*)?) => {
         $crate::classes::Engine::singleton()
             .tr_n_ex(
-                format!($singular$(, $($args)*)?).into(),
-                format!($plural$(, $($args)*)?).into(),
+                &format!($singular$(, $($args)*)?),
+                &format!($plural$(, $($args)*)?),
                 $n,
             )
-            .context(format!("{}", $context).into())
+            .context(&format!("{}", $context))
             .done()
     };
 }

--- a/godot-macros/src/class/data_models/constant.rs
+++ b/godot-macros/src/class/data_models/constant.rs
@@ -56,7 +56,7 @@ pub fn make_constant_registration(
                     #class_name_obj,
                     ConstantKind::Integer(
                         IntegerConstant::new(
-                            StringName::from(#integer_constant_names),
+                            #integer_constant_names,
                             #integer_constant_values
                         )
                     )

--- a/godot-macros/src/docs.rs
+++ b/godot-macros/src/docs.rs
@@ -4,6 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
+
 mod markdown_converter;
 
 use crate::class::{ConstDefinition, Field, FuncDefinition, SignalDefinition};
@@ -182,7 +183,8 @@ fn make_constant_docs(constant: &Constant) -> Option<String> {
         .initializer
         .as_ref()
         .map(|x| x.to_token_stream().to_string())
-        .unwrap_or("null".into());
+        .unwrap_or_else(|| "null".to_string());
+
     Some(format!(
         r#"<constant name="{name}" value="{value}">{docs}</constant>"#,
         name = xml_escape(name),
@@ -223,7 +225,8 @@ pub fn make_virtual_method_docs(method: Function) -> Option<String> {
     let ret = method
         .return_ty
         .map(|x| x.to_token_stream().to_string())
-        .unwrap_or("void".into());
+        .unwrap_or_else(|| "void".to_string());
+
     let params = params(method.params.iter().filter_map(|(x, _)| match x {
         FnParam::Receiver(_) => None,
         FnParam::Typed(y) => Some((&y.name, &y.ty)),

--- a/godot-macros/src/lib.rs
+++ b/godot-macros/src/lib.rs
@@ -658,7 +658,7 @@ pub fn derive_godot_class(input: TokenStream) -> TokenStream {
 /// impl MyStruct {
 ///     #[func(virtual)]
 ///     fn language(&self) -> GString {
-///         "Rust".into()
+///         GString::from("Rust")
 ///     }
 /// }
 /// # }

--- a/itest/rust/src/builtin_tests/containers/dictionary_test.rs
+++ b/itest/rust/src/builtin_tests/containers/dictionary_test.rs
@@ -389,10 +389,10 @@ fn dictionary_iter() {
     };
 
     let map = HashMap::<String, Variant>::from([
-        ("foo".into(), 0.to_variant()),
-        ("bar".into(), true.to_variant()),
-        ("baz".into(), "foobar".to_variant()),
-        ("nil".into(), Variant::nil()),
+        ("foo".to_string(), 0.to_variant()),
+        ("bar".to_string(), true.to_variant()),
+        ("baz".to_string(), "foobar".to_variant()),
+        ("nil".to_string(), Variant::nil()),
     ]);
 
     let map2: HashMap<String, Variant> = dictionary.iter_shared().typed().collect();

--- a/itest/rust/src/builtin_tests/containers/packed_array_test.rs
+++ b/itest/rust/src/builtin_tests/containers/packed_array_test.rs
@@ -7,7 +7,7 @@
 
 use crate::framework::{expect_panic, itest};
 use godot::builtin::{
-    Color, PackedByteArray, PackedColorArray, PackedFloat32Array, PackedInt32Array,
+    Color, GString, PackedByteArray, PackedColorArray, PackedFloat32Array, PackedInt32Array,
     PackedStringArray,
 };
 
@@ -35,8 +35,8 @@ fn packed_array_from_vec_str() {
     let string_array = PackedStringArray::from(vec!["hello".into(), "world".into()]);
 
     assert_eq!(string_array.len(), 2);
-    assert_eq!(string_array[0], "hello".into());
-    assert_eq!(string_array[1], "world".into());
+    assert_eq!(string_array[0], GString::from("hello"));
+    assert_eq!(string_array[1], GString::from("world"));
 }
 
 #[itest]
@@ -68,8 +68,8 @@ fn packed_array_from_array_str() {
     let string_array = PackedStringArray::from(["hello".into(), "world".into()]);
 
     assert_eq!(string_array.len(), 2);
-    assert_eq!(string_array[0], "hello".into());
-    assert_eq!(string_array[1], "world".into());
+    assert_eq!(string_array[0], GString::from("hello"));
+    assert_eq!(string_array[1], GString::from("world"));
 }
 
 #[itest]
@@ -205,13 +205,14 @@ fn packed_array_index() {
         let _ = array[0];
     });
 
-    array.push("first".into());
-    array.push("second".into());
+    // Note: push works on &str as well as GString, or references of it.
+    array.push("first");
+    array.push(&GString::from("second"));
 
     assert_eq!(array[0], "first".into());
     assert_eq!(array[1], "second".into());
 
-    array[0] = "begin".into();
+    array[0] = GString::from("begin");
     assert_eq!(array[0], "begin".into());
 }
 
@@ -228,29 +229,29 @@ fn packed_array_get() {
 fn packed_array_binary_search() {
     let array = PackedByteArray::from(&[1, 3]);
 
-    assert_eq!(array.bsearch(&0), 0);
-    assert_eq!(array.bsearch(&1), 0);
-    assert_eq!(array.bsearch(&2), 1);
-    assert_eq!(array.bsearch(&3), 1);
-    assert_eq!(array.bsearch(&4), 2);
+    assert_eq!(array.bsearch(0), 0);
+    assert_eq!(array.bsearch(1), 0);
+    assert_eq!(array.bsearch(2), 1);
+    assert_eq!(array.bsearch(3), 1);
+    assert_eq!(array.bsearch(4), 2);
 }
 
 #[itest]
 fn packed_array_find() {
     let array = PackedByteArray::from(&[1, 2, 1]);
 
-    assert_eq!(array.find(&0, None), None);
-    assert_eq!(array.find(&1, None), Some(0));
-    assert_eq!(array.find(&1, Some(1)), Some(2));
+    assert_eq!(array.find(0, None), None);
+    assert_eq!(array.find(1, None), Some(0));
+    assert_eq!(array.find(1, Some(1)), Some(2));
 }
 
 #[itest]
 fn packed_array_rfind() {
     let array = PackedByteArray::from(&[1, 2, 1]);
 
-    assert_eq!(array.rfind(&0, None), None);
-    assert_eq!(array.rfind(&1, None), Some(2));
-    assert_eq!(array.rfind(&1, Some(1)), Some(0));
+    assert_eq!(array.rfind(0, None), None);
+    assert_eq!(array.rfind(1, None), Some(2));
+    assert_eq!(array.rfind(1, Some(1)), Some(0));
 }
 
 #[itest]

--- a/itest/rust/src/builtin_tests/containers/signal_test.rs
+++ b/itest/rust/src/builtin_tests/containers/signal_test.rs
@@ -82,8 +82,8 @@ fn signals() {
         let signal_name = format!("signal_{i}_arg");
         let receiver_name = format!("receive_{i}_arg");
 
-        emitter.connect(signal_name.clone().into(), receiver.callable(receiver_name));
-        emitter.emit_signal(signal_name.into(), arg);
+        emitter.connect(&signal_name, receiver.callable(receiver_name));
+        emitter.emit_signal(&signal_name, arg);
 
         assert!(receiver.bind().used[i].get());
     }
@@ -96,7 +96,7 @@ fn signals() {
 fn instantiate_signal() {
     let mut object = RefCounted::new_gd();
 
-    object.add_user_signal("test_signal".into());
+    object.add_user_signal("test_signal");
 
     let signal = Signal::from_object_signal(&object, "test_signal");
 
@@ -110,20 +110,18 @@ fn instantiate_signal() {
 fn emit_signal() {
     let mut object = RefCounted::new_gd();
 
-    object.add_user_signal("test_signal".into());
+    object.add_user_signal("test_signal");
 
     let signal = Signal::from_object_signal(&object, "test_signal");
     let receiver = Receiver::new_alloc();
 
     object.connect(
-        StringName::from("test_signal"),
+        &StringName::from("test_signal"), // explicit StringName
         Callable::from_object_method(&receiver, "receive_1_arg"),
     );
-
     assert_eq!(signal.connections().len(), 1);
 
     signal.emit(&[987i64.to_variant()]);
-
     assert!(receiver.bind().used[1].get());
 
     receiver.free();
@@ -133,17 +131,15 @@ fn emit_signal() {
 fn connect_signal() {
     let mut object = RefCounted::new_gd();
 
-    object.add_user_signal("test_signal".into());
+    object.add_user_signal("test_signal");
 
     let signal = Signal::from_object_signal(&object, "test_signal");
     let receiver = Receiver::new_alloc();
 
     signal.connect(Callable::from_object_method(&receiver, "receive_1_arg"), 0);
-
     assert_eq!(signal.connections().len(), 1);
 
-    object.emit_signal(StringName::from("test_signal"), &[987i64.to_variant()]);
-
+    object.emit_signal("test_signal", &[987i64.to_variant()]);
     assert!(receiver.bind().used[1].get());
 
     receiver.free();
@@ -151,7 +147,7 @@ fn connect_signal() {
 
 #[cfg(since_api = "4.2")]
 mod custom_callable {
-    use godot::builtin::{Callable, Signal, StringName};
+    use godot::builtin::{Callable, Signal};
     use godot::meta::ToGodot;
     use std::sync::atomic::{AtomicU32, Ordering};
     use std::sync::Arc;
@@ -168,10 +164,10 @@ mod custom_callable {
             "test_signal",
             connect_signal_panic_from_fn,
             |node| {
-                node.add_user_signal("test_signal".into());
+                node.add_user_signal("test_signal");
             },
             |node| {
-                node.emit_signal(StringName::from("test_signal"), &[987i64.to_variant()]);
+                node.emit_signal("test_signal", &[987i64.to_variant()]);
             },
         );
     }
@@ -182,10 +178,10 @@ mod custom_callable {
             "test_signal",
             connect_signal_panic_from_custom,
             |node| {
-                node.add_user_signal("test_signal".into());
+                node.add_user_signal("test_signal");
             },
             |node| {
-                node.emit_signal(StringName::from("test_signal"), &[987i64.to_variant()]);
+                node.emit_signal("test_signal", &[987i64.to_variant()]);
             },
         );
     }

--- a/itest/rust/src/builtin_tests/containers/variant_test.rs
+++ b/itest/rust/src/builtin_tests/containers/variant_test.rs
@@ -382,7 +382,7 @@ fn variant_null_object_is_nil() {
 
     // Simulates an object that is returned but null
     // Use reflection to get a variant as return type
-    let variant = node.call("get_node_or_null".into(), &[node_path.to_variant()]);
+    let variant = node.call("get_node_or_null", &[node_path.to_variant()]);
     let raw_type: sys::GDExtensionVariantType =
         unsafe { sys::interface_fn!(variant_get_type)(variant.var_sys()) };
 

--- a/itest/rust/src/builtin_tests/convert_test.rs
+++ b/itest/rust/src/builtin_tests/convert_test.rs
@@ -338,7 +338,7 @@ fn as_npath_arg<T: AsArg<NodePath>>(t: T) -> NodePath {
     t.as_arg()
 }
 
-#[itest(focus)]
+#[itest]
 fn strings_as_arg() {
     let str = "GodotRocks";
     let cstr = c"GodotRocks";

--- a/itest/rust/src/builtin_tests/convert_test.rs
+++ b/itest/rust/src/builtin_tests/convert_test.rs
@@ -6,11 +6,12 @@
  */
 
 use godot::builtin::{
-    array, dict, Array, Dictionary, GString, Variant, VariantArray, Vector2, Vector2Axis,
+    array, dict, Array, Dictionary, GString, NodePath, StringName, Variant, VariantArray, Vector2,
+    Vector2Axis,
 };
 use godot::classes::{Node, Resource};
 use godot::meta::error::ConvertError;
-use godot::meta::{FromGodot, GodotConvert, ToGodot};
+use godot::meta::{AsArg, FromGodot, GodotConvert, ToGodot};
 use godot::obj::{Gd, NewAlloc};
 
 use crate::framework::itest;
@@ -323,4 +324,34 @@ fn slice_to_array() {
     let from = &[1, 2, 3];
     let to = from.to_variant().try_to::<Array<f32>>();
     assert!(to.is_err());
+}
+
+fn as_gstring_arg<T: AsArg<GString>>(t: T) -> GString {
+    t.as_arg()
+}
+
+fn as_sname_arg<T: AsArg<StringName>>(t: T) -> StringName {
+    t.as_arg()
+}
+
+fn as_npath_arg<T: AsArg<NodePath>>(t: T) -> NodePath {
+    t.as_arg()
+}
+
+#[itest(focus)]
+fn strings_as_arg() {
+    let str = "GodotRocks";
+    let cstr = c"GodotRocks";
+    let gstring = GString::from("GodotRocks");
+    let sname = StringName::from("GodotRocks");
+    let npath = NodePath::from("GodotRocks");
+
+    assert_eq!(as_gstring_arg(str), gstring);
+    assert_eq!(as_gstring_arg(&gstring), gstring);
+
+    assert_eq!(as_sname_arg(str), sname);
+    assert_eq!(as_sname_arg(cstr), sname);
+
+    assert_eq!(as_npath_arg(str), npath);
+    assert_eq!(as_npath_arg(&npath), npath);
 }

--- a/itest/rust/src/builtin_tests/convert_test.rs
+++ b/itest/rust/src/builtin_tests/convert_test.rs
@@ -11,7 +11,7 @@ use godot::builtin::{
 };
 use godot::classes::{Node, Resource};
 use godot::meta::error::ConvertError;
-use godot::meta::{AsArg, FromGodot, GodotConvert, ToGodot};
+use godot::meta::{AsArg, CowArg, FromGodot, GodotConvert, ToGodot};
 use godot::obj::{Gd, NewAlloc};
 
 use crate::framework::itest;
@@ -254,7 +254,7 @@ fn vec_to_array() {
 
     let from = vec![GString::from("Hello"), GString::from("World")];
     let to = from.to_variant().to::<Array<GString>>();
-    assert_eq!(to, array![GString::from("Hello"), GString::from("World")]);
+    assert_eq!(to, array!["Hello", "World"]);
 
     // Invalid conversion.
     let from = vec![1, 2, 3];
@@ -268,7 +268,7 @@ fn array_to_vec() {
     let to = from.to_variant().to::<Vec<i32>>();
     assert_eq!(to, vec![1, 2, 3]);
 
-    let from = array![GString::from("Hello"), GString::from("World")];
+    let from: Array<GString> = array!["Hello", "World"];
     let to = from.to_variant().to::<Vec<GString>>();
     assert_eq!(to, vec![GString::from("Hello"), GString::from("World")]);
 
@@ -286,7 +286,7 @@ fn rust_array_to_array() {
 
     let from = [GString::from("Hello"), GString::from("World")];
     let to = from.to_variant().to::<Array<GString>>();
-    assert_eq!(to, array![GString::from("Hello"), GString::from("World")]);
+    assert_eq!(to, array!["Hello", "World"]);
 
     // Invalid conversion.
     let from = [1, 2, 3];
@@ -300,7 +300,7 @@ fn array_to_rust_array() {
     let to = from.to_variant().to::<[i32; 3]>();
     assert_eq!(to, [1, 2, 3]);
 
-    let from = array![GString::from("Hello"), GString::from("World")];
+    let from: Array<GString> = array!["Hello", "World"];
     let to = from.to_variant().to::<[GString; 2]>();
     assert_eq!(to, [GString::from("Hello"), GString::from("World")]);
 
@@ -318,7 +318,7 @@ fn slice_to_array() {
 
     let from = &[GString::from("Hello"), GString::from("World")];
     let to = from.to_variant().to::<Array<GString>>();
-    assert_eq!(to, array![GString::from("Hello"), GString::from("World")]);
+    assert_eq!(to, array!["Hello", "World"]);
 
     // Invalid conversion.
     let from = &[1, 2, 3];
@@ -326,32 +326,42 @@ fn slice_to_array() {
     assert!(to.is_err());
 }
 
-fn as_gstring_arg<T: AsArg<GString>>(t: T) -> GString {
-    t.as_arg()
+fn as_gstr_arg<'a, T: 'a + AsArg<GString>>(t: T) -> CowArg<'a, GString> {
+    t.into_arg()
 }
 
-fn as_sname_arg<T: AsArg<StringName>>(t: T) -> StringName {
-    t.as_arg()
+fn as_sname_arg<'a, T: 'a + AsArg<StringName>>(t: T) -> CowArg<'a, StringName> {
+    t.into_arg()
 }
 
-fn as_npath_arg<T: AsArg<NodePath>>(t: T) -> NodePath {
-    t.as_arg()
+fn as_npath_arg<'a, T: 'a + AsArg<NodePath>>(t: T) -> CowArg<'a, NodePath> {
+    t.into_arg()
 }
 
 #[itest]
 fn strings_as_arg() {
+    // Note: CowArg is an internal type.
+
     let str = "GodotRocks";
     let cstr = c"GodotRocks";
     let gstring = GString::from("GodotRocks");
     let sname = StringName::from("GodotRocks");
     let npath = NodePath::from("GodotRocks");
 
-    assert_eq!(as_gstring_arg(str), gstring);
-    assert_eq!(as_gstring_arg(&gstring), gstring);
+    assert_eq!(as_gstr_arg(str), CowArg::Owned(gstring.clone()));
+    assert_eq!(as_gstr_arg(&gstring), CowArg::Borrowed(&gstring));
+    assert_eq!(as_gstr_arg(sname.arg()), CowArg::Owned(gstring.clone()));
+    assert_eq!(as_gstr_arg(npath.arg()), CowArg::Owned(gstring.clone()));
 
-    assert_eq!(as_sname_arg(str), sname);
-    assert_eq!(as_sname_arg(cstr), sname);
+    assert_eq!(as_sname_arg(str), CowArg::Owned(sname.clone()));
+    #[cfg(since_api = "4.2")]
+    assert_eq!(as_sname_arg(cstr), CowArg::Owned(sname.clone()));
+    assert_eq!(as_sname_arg(&sname), CowArg::Borrowed(&sname));
+    assert_eq!(as_sname_arg(gstring.arg()), CowArg::Owned(sname.clone()));
+    assert_eq!(as_sname_arg(npath.arg()), CowArg::Owned(sname.clone()));
 
-    assert_eq!(as_npath_arg(str), npath);
-    assert_eq!(as_npath_arg(&npath), npath);
+    assert_eq!(as_npath_arg(str), CowArg::Owned(npath.clone()));
+    assert_eq!(as_npath_arg(&npath), CowArg::Borrowed(&npath));
+    assert_eq!(as_npath_arg(gstring.arg()), CowArg::Owned(npath.clone()));
+    assert_eq!(as_npath_arg(sname.arg()), CowArg::Owned(npath.clone()));
 }

--- a/itest/rust/src/builtin_tests/script/script_instance_tests.rs
+++ b/itest/rust/src/builtin_tests/script/script_instance_tests.rs
@@ -160,7 +160,7 @@ impl ScriptInstance for TestScriptInstance {
 
             "script_method_re_entering" => {
                 let mut base = this.base_mut();
-                let result = base.call("script_method_toggle_property_b".into(), &[]);
+                let result = base.call("script_method_toggle_property_b", &[]);
 
                 Ok(result)
             }

--- a/itest/rust/src/builtin_tests/serde_test.rs
+++ b/itest/rust/src/builtin_tests/serde_test.rs
@@ -59,7 +59,7 @@ fn serde_array_rust_native_type() {
 
 #[itest]
 fn serde_array_godot_builtin_type() {
-    let value: Array<GString> = array!["Godot".into(), "Rust".into(), "Rocks".into()];
+    let value: Array<GString> = array!["Godot", "Rust", "Rocks"];
 
     let expected_json = r#"["Godot","Rust","Rocks"]"#;
 

--- a/itest/rust/src/engine_tests/codegen_test.rs
+++ b/itest/rust/src/engine_tests/codegen_test.rs
@@ -36,16 +36,16 @@ fn codegen_static_builtin_method() {
     let pi = InnerString::num(std::f64::consts::PI, 3);
     assert_eq!(pi, GString::from("3.142"));
 
-    let col = InnerColor::html("#663399cc".into());
+    let col = InnerColor::html("#663399cc");
     assert_eq!(col, Color::from_rgba(0.4, 0.2, 0.6, 0.8));
 }
 
 #[itest]
 fn codegen_static_class_method() {
-    let exists = FileAccess::file_exists("inexistent".into());
+    let exists = FileAccess::file_exists("inexistent");
     assert!(!exists);
 
-    let exists = FileAccess::file_exists("res://itest.gdextension".into());
+    let exists = FileAccess::file_exists("res://itest.gdextension");
     assert!(exists);
 
     // see also object_test for reference count verification

--- a/itest/rust/src/engine_tests/gfile_test.rs
+++ b/itest/rust/src/engine_tests/gfile_test.rs
@@ -28,7 +28,7 @@ fn remove_test_file() {
 fn basic_read_write_works() {
     let mut file = GFile::open(TEST_FULL_PATH, ModeFlags::WRITE).unwrap();
     let line_to_store = GString::from("TESTING1");
-    file.write_gstring_line(line_to_store.clone()).unwrap();
+    file.write_gstring_line(&line_to_store).unwrap();
     drop(file);
 
     let mut file = GFile::open(TEST_FULL_PATH, ModeFlags::READ).unwrap();

--- a/itest/rust/src/engine_tests/native_structures_test.rs
+++ b/itest/rust/src/engine_tests/native_structures_test.rs
@@ -111,9 +111,7 @@ fn native_structure_parameter() {
 
     let ptr = ptr::addr_of!(caret);
     let mut object = NativeStructTests::new_gd();
-    let result: Dictionary = object
-        .call("pass_native_struct".into(), &[ptr.to_variant()])
-        .to();
+    let result: Dictionary = object.call("pass_native_struct", &[ptr.to_variant()]).to();
 
     assert_eq!(
         result.at("leading_caret").to::<Rect2>(),
@@ -137,7 +135,7 @@ fn native_structure_parameter() {
 fn native_structure_pointer_to_array_parameter() {
     // Instantiate a custom class.
     let mut object = NativeStructTests::new_gd();
-    let result_ptr: *const Glyph = object.call("native_struct_array_ret".into(), &[]).to();
+    let result_ptr: *const Glyph = object.call("native_struct_array_ret", &[]).to();
     let result = unsafe { std::slice::from_raw_parts(result_ptr, 2) };
 
     // Check the result array.
@@ -240,7 +238,7 @@ fn native_structure_refcounted_pointers() {
     assert_eq!(retrieved.instance_id(), id);
 
     // Manually decrement refcount (method unexposed).
-    //Gd::<RefCounted>::from_instance_id(id).call("unreference".into(), &[]);
+    //Gd::<RefCounted>::from_instance_id(id).call("unreference", &[]);
 
     // RefCounted, do NOT increment ref-count.
     let object = RefCounted::new_gd();

--- a/itest/rust/src/engine_tests/node_test.rs
+++ b/itest/rust/src/engine_tests/node_test.rs
@@ -17,23 +17,23 @@ use crate::framework::{itest, TestContext};
 #[itest]
 fn node_get_node() {
     let mut child = Node3D::new_alloc();
-    child.set_name("child".into());
+    child.set_name("child");
     let child_id = child.instance_id();
 
     let mut parent = Node3D::new_alloc();
-    parent.set_name("parent".into());
+    parent.set_name("parent");
     parent.add_child(child);
 
     let mut grandparent = Node::new_alloc();
-    grandparent.set_name("grandparent".into());
+    grandparent.set_name("grandparent");
     grandparent.add_child(parent);
 
     // Directly on Gd<T>
-    let found = grandparent.get_node_as::<Node3D>(NodePath::from("parent/child"));
+    let found = grandparent.get_node_as::<Node3D>("parent/child");
     assert_eq!(found.instance_id(), child_id);
 
     // Deref via &T
-    let found = grandparent.try_get_node_as::<Node3D>(NodePath::from("parent/child"));
+    let found = grandparent.try_get_node_as::<Node3D>(&NodePath::from("parent/child"));
     let found = found.expect("try_get_node_as() returned Some(..)");
     assert_eq!(found.instance_id(), child_id);
 
@@ -43,9 +43,9 @@ fn node_get_node() {
 #[itest]
 fn node_get_node_fail() {
     let mut child = Node3D::new_alloc();
-    child.set_name("child".into());
+    child.set_name("child");
 
-    let found = child.try_get_node_as::<Node3D>(NodePath::from("non-existent"));
+    let found = child.try_get_node_as::<Node3D>("non-existent");
     assert!(found.is_none());
 
     child.free();
@@ -63,10 +63,10 @@ fn node_path_from_str(ctx: &TestContext) {
 #[itest(skip)]
 fn node_scene_tree() {
     let mut child = Node::new_alloc();
-    child.set_name("kid".into());
+    child.set_name("kid");
 
     let mut parent = Node::new_alloc();
-    parent.set_name("parent".into());
+    parent.set_name("parent");
     parent.add_child(&child);
 
     let mut scene = PackedScene::new_gd();
@@ -89,6 +89,6 @@ fn node_call_group(ctx: &TestContext) {
     let mut node = ctx.scene_tree.clone();
     let mut tree = node.get_tree().unwrap();
 
-    node.add_to_group("group".into());
-    tree.call_group("group".into(), "set_name".into(), &[Variant::from("name")]);
+    node.add_to_group("group");
+    tree.call_group("group", "set_name", &[Variant::from("name")]);
 }

--- a/itest/rust/src/engine_tests/utilities_test.rs
+++ b/itest/rust/src/engine_tests/utilities_test.rs
@@ -42,6 +42,7 @@ fn utilities_str() {
 
     let empty = str(&[]);
 
+    // TODO: implement GString==&str operator. Then look for "...".into() patterns and replace them.
     assert_eq!(concat, "12 is a true number".into());
     assert_eq!(empty, GString::new());
 }

--- a/itest/rust/src/object_tests/dynamic_call_test.rs
+++ b/itest/rust/src/object_tests/dynamic_call_test.rs
@@ -5,7 +5,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use godot::builtin::{StringName, Variant, Vector3};
+use godot::builtin::{Variant, Vector3};
 use godot::classes::{Node, Node3D, Object};
 use godot::meta::error::CallError;
 use godot::meta::{FromGodot, ToGodot};
@@ -20,7 +20,7 @@ fn dynamic_call_no_args() {
     let mut node = Node3D::new_alloc().upcast::<Object>();
 
     let static_id = node.instance_id();
-    let reflect_id_variant = node.call(StringName::from("get_instance_id"), &[]);
+    let reflect_id_variant = node.call("get_instance_id", &[]);
 
     let reflect_id = InstanceId::from_variant(&reflect_id_variant);
 
@@ -34,11 +34,8 @@ fn dynamic_call_with_args() {
 
     let expected_pos = Vector3::new(2.5, 6.42, -1.11);
 
-    let none = node.call(
-        StringName::from("set_position"),
-        &[expected_pos.to_variant()],
-    );
-    let actual_pos = node.call(StringName::from("get_position"), &[]);
+    let none = node.call("set_position", &[expected_pos.to_variant()]);
+    let actual_pos = node.call("get_position", &[]);
 
     assert_eq!(none, Variant::nil());
     assert_eq!(actual_pos, expected_pos.to_variant());
@@ -54,12 +51,12 @@ fn dynamic_call_with_too_few_args() {
 
     // Use panicking version.
     expect_panic("call with too few arguments", || {
-        obj.call("take_1_int".into(), &[]);
+        obj.call("take_1_int", &[]);
     });
 
     // Use Result-based version.
     let call_error = obj
-        .try_call("take_1_int".into(), &[])
+        .try_call("take_1_int", &[])
         .expect_err("expected failed call");
 
     // User-facing method to which error was propagated.
@@ -95,12 +92,12 @@ fn dynamic_call_with_too_many_args() {
 
     // Use panicking version.
     expect_panic("call with too many arguments", || {
-        obj.call("take_1_int".into(), &[42.to_variant(), 43.to_variant()]);
+        obj.call("take_1_int", &[42.to_variant(), 43.to_variant()]);
     });
 
     // Use Result-based version.
     let call_error = obj
-        .try_call("take_1_int".into(), &[42.to_variant(), 43.to_variant()])
+        .try_call("take_1_int", &[42.to_variant(), 43.to_variant()])
         .expect_err("expected failed call");
 
     assert_eq!(call_error.class_name(), Some("Object"));
@@ -121,12 +118,12 @@ fn dynamic_call_parameter_mismatch() {
 
     // Use panicking version.
     expect_panic("call with wrong argument type", || {
-        obj.call("take_1_int".into(), &["string".to_variant()]);
+        obj.call("take_1_int", &["string".to_variant()]);
     });
 
     // Use Result-based version.
     let call_error = obj
-        .try_call("take_1_int".into(), &["string".to_variant()])
+        .try_call("take_1_int", &["string".to_variant()])
         .expect_err("expected failed call");
 
     assert_eq!(call_error.class_name(), Some("Object"));
@@ -146,7 +143,7 @@ fn dynamic_call_parameter_mismatch() {
 fn dynamic_call_with_panic() {
     let mut obj = ObjPayload::new_alloc();
 
-    let result = obj.try_call("do_panic".into(), &[]);
+    let result = obj.try_call("do_panic", &[]);
     let call_error = result.expect_err("panic should cause a call error");
 
     assert_eq!(call_error.class_name(), Some("Object"));
@@ -176,12 +173,12 @@ fn dynamic_call_with_too_few_args_engine() {
 
     // Use panicking version.
     expect_panic("call with too few arguments", || {
-        node.call("rpc_config".into(), &["some_method".to_variant()]);
+        node.call("rpc_config", &["some_method".to_variant()]);
     });
 
     // Use Result-based version.
     let call_error = node
-        .try_call("rpc_config".into(), &["some_method".to_variant()])
+        .try_call("rpc_config", &["some_method".to_variant()])
         .expect_err("expected failed call");
 
     assert_eq!(call_error.class_name(), Some("Object"));
@@ -208,7 +205,7 @@ fn dynamic_call_with_too_many_args_engine() {
     // Use panicking version.
     expect_panic("call with too many arguments", || {
         node.call(
-            "rpc_config".into(),
+            "rpc_config",
             &["some_method".to_variant(), Variant::nil(), 123.to_variant()],
         );
     });
@@ -216,7 +213,7 @@ fn dynamic_call_with_too_many_args_engine() {
     // Use Result-based version.
     let call_error = node
         .try_call(
-            "rpc_config".into(),
+            "rpc_config",
             &["some_method".to_variant(), Variant::nil(), 123.to_variant()],
         )
         .expect_err("expected failed call");
@@ -243,12 +240,12 @@ fn dynamic_call_parameter_mismatch_engine() {
 
     // Use panicking version.
     expect_panic("call with wrong argument type", || {
-        node.call("set_name".into(), &[123.to_variant()]);
+        node.call("set_name", &[123.to_variant()]);
     });
 
     // Use Result-based version.
     let call_error = node
-        .try_call("set_name".into(), &[123.to_variant()])
+        .try_call("set_name", &[123.to_variant()])
         .expect_err("expected failed call");
 
     // Note: currently no mention of Node::set_name(). Not sure if easily possible to add.

--- a/itest/rust/src/object_tests/init_level_test.rs
+++ b/itest/rust/src/object_tests/init_level_test.rs
@@ -32,7 +32,7 @@ pub fn initialize_init_level_test(level: InitLevel) {
 
         let mut some_object = SomeObject::new_alloc();
         // Need to go through Godot here as otherwise we bypass the failure.
-        some_object.call("set_has_run_true".into(), &[]);
+        some_object.call("set_has_run_true", &[]);
         some_object.free();
     }
 }

--- a/itest/rust/src/object_tests/object_arg_test.rs
+++ b/itest/rust/src/object_tests/object_arg_test.rs
@@ -17,8 +17,8 @@ use crate::object_tests::object_test::{user_refc_instance, RefcPayload};
 fn object_arg_owned() {
     with_objects(|manual, refc| {
         let db = ClassDb::singleton();
-        let a = db.class_set_property(manual, "name".into(), &Variant::from("hello"));
-        let b = db.class_set_property(refc, "value".into(), &Variant::from(-123));
+        let a = db.class_set_property(manual, "name", &Variant::from("hello"));
+        let b = db.class_set_property(refc, "value", &Variant::from(-123));
         (a, b)
     });
 }
@@ -27,8 +27,8 @@ fn object_arg_owned() {
 fn object_arg_borrowed() {
     with_objects(|manual, refc| {
         let db = ClassDb::singleton();
-        let a = db.class_set_property(&manual, "name".into(), &Variant::from("hello"));
-        let b = db.class_set_property(&refc, "value".into(), &Variant::from(-123));
+        let a = db.class_set_property(&manual, "name", &Variant::from("hello"));
+        let b = db.class_set_property(&refc, "value", &Variant::from(-123));
         (a, b)
     });
 }
@@ -37,8 +37,8 @@ fn object_arg_borrowed() {
 fn object_arg_borrowed_mut() {
     with_objects(|mut manual, mut refc| {
         let db = ClassDb::singleton();
-        let a = db.class_set_property(&mut manual, "name".into(), &Variant::from("hello"));
-        let b = db.class_set_property(&mut refc, "value".into(), &Variant::from(-123));
+        let a = db.class_set_property(&mut manual, "name", &Variant::from("hello"));
+        let b = db.class_set_property(&mut refc, "value", &Variant::from(-123));
         (a, b)
     });
 }
@@ -47,8 +47,8 @@ fn object_arg_borrowed_mut() {
 fn object_arg_option_owned() {
     with_objects(|manual, refc| {
         let db = ClassDb::singleton();
-        let a = db.class_set_property(Some(manual), "name".into(), &Variant::from("hello"));
-        let b = db.class_set_property(Some(refc), "value".into(), &Variant::from(-123));
+        let a = db.class_set_property(Some(manual), "name", &Variant::from("hello"));
+        let b = db.class_set_property(Some(refc), "value", &Variant::from(-123));
         (a, b)
     });
 }
@@ -57,8 +57,8 @@ fn object_arg_option_owned() {
 fn object_arg_option_borrowed() {
     with_objects(|manual, refc| {
         let db = ClassDb::singleton();
-        let a = db.class_set_property(Some(&manual), "name".into(), &Variant::from("hello"));
-        let b = db.class_set_property(Some(&refc), "value".into(), &Variant::from(-123));
+        let a = db.class_set_property(Some(&manual), "name", &Variant::from("hello"));
+        let b = db.class_set_property(Some(&refc), "value", &Variant::from(-123));
         (a, b)
     });
 }
@@ -67,8 +67,8 @@ fn object_arg_option_borrowed() {
 fn object_arg_option_borrowed_mut() {
     with_objects(|mut manual, mut refc| {
         let db = ClassDb::singleton();
-        let a = db.class_set_property(Some(&mut manual), "name".into(), &Variant::from("hello"));
-        let b = db.class_set_property(Some(&mut refc), "value".into(), &Variant::from(-123));
+        let a = db.class_set_property(Some(&mut manual), "name", &Variant::from("hello"));
+        let b = db.class_set_property(Some(&mut refc), "value", &Variant::from(-123));
         (a, b)
     });
 }
@@ -80,10 +80,10 @@ fn object_arg_option_none() {
 
     // Will emit errors but should not crash.
     let db = ClassDb::singleton();
-    let error = db.class_set_property(manual, "name".into(), &Variant::from("hello"));
+    let error = db.class_set_property(manual, "name", &Variant::from("hello"));
     assert_eq!(error, global::Error::ERR_UNAVAILABLE);
 
-    let error = db.class_set_property(refc, "value".into(), &Variant::from(-123));
+    let error = db.class_set_property(refc, "value", &Variant::from(-123));
     assert_eq!(error, global::Error::ERR_UNAVAILABLE);
 }
 
@@ -91,10 +91,10 @@ fn object_arg_option_none() {
 fn object_arg_null_arg() {
     // Will emit errors but should not crash.
     let db = ClassDb::singleton();
-    let error = db.class_set_property(Gd::null_arg(), "name".into(), &Variant::from("hello"));
+    let error = db.class_set_property(Gd::null_arg(), "name", &Variant::from("hello"));
     assert_eq!(error, global::Error::ERR_UNAVAILABLE);
 
-    let error = db.class_set_property(Gd::null_arg(), "value".into(), &Variant::from(-123));
+    let error = db.class_set_property(Gd::null_arg(), "value", &Variant::from(-123));
     assert_eq!(error, global::Error::ERR_UNAVAILABLE);
 }
 

--- a/itest/rust/src/object_tests/object_swap_test.rs
+++ b/itest/rust/src/object_tests/object_swap_test.rs
@@ -204,7 +204,7 @@ fn object_subtype_swap_func_return() {
         "returning badly typed Gd<T> from #[func] causes panic",
         || {
             // Call through Godot.
-            holder.call("return_swapped_node".into(), &[]);
+            holder.call("return_swapped_node", &[]);
         },
     );
 }
@@ -214,7 +214,7 @@ fn object_freed_func_return() {
     let mut holder = SwapHolder::new_gd();
     expect_panic("returning dead Gd<T> from #[func] causes panic", || {
         // Call through Godot.
-        let _dead = holder.call("add_dead_object_and_return".into(), &[]);
+        let _dead = holder.call("add_dead_object_and_return", &[]);
     }); // Destructor will not panic again (which would cause abort).
 }
 
@@ -255,7 +255,7 @@ impl SwapHolder {
         let mut node: Gd<Object> = Object::new_alloc();
         // Don't register with self.gc; already freed.
 
-        node.call("free".into(), &[]);
+        node.call("free", &[]);
         node
     }
 
@@ -264,7 +264,7 @@ impl SwapHolder {
         self.gc.push(node.clone());
 
         // Free already but still register with self.gc, to trigger 2nd error in destructor.
-        node.call("free".into(), &[]);
+        node.call("free", &[]);
         panic!("artificially trigger panic");
     }
 }

--- a/itest/rust/src/object_tests/onready_test.rs
+++ b/itest/rust/src/object_tests/onready_test.rs
@@ -133,8 +133,8 @@ fn onready_property_access() {
     let mut obj = OnReadyWithImpl::create(true);
     obj.notify(NodeNotification::READY);
 
-    obj.set("auto".into(), &33.to_variant());
-    obj.set("manual".into(), &44.to_variant());
+    obj.set("auto", &33.to_variant());
+    obj.set("manual", &44.to_variant());
 
     {
         let obj = obj.bind();
@@ -142,8 +142,8 @@ fn onready_property_access() {
         assert_eq!(*obj.manual, 44);
     }
 
-    let auto = obj.get("auto".into()).to::<i32>();
-    let manual = obj.get("manual".into()).to::<i64>();
+    let auto = obj.get("auto").to::<i32>();
+    let manual = obj.get("manual").to::<i64>();
     assert_eq!(auto, 33);
     assert_eq!(manual, 44);
 
@@ -153,10 +153,10 @@ fn onready_property_access() {
 #[itest]
 fn init_attribute_node_key_lifecycle() {
     let mut obj = InitWithNodeOrBase::new_alloc();
-    obj.set_name("CustomNodeName".into());
+    obj.set_name("CustomNodeName");
 
     let mut child = Node::new_alloc();
-    child.set_name("child".into());
+    child.set_name("child");
     obj.add_child(child);
 
     obj.notify(NodeNotification::READY);

--- a/itest/rust/src/object_tests/property_test.rs
+++ b/itest/rust/src/object_tests/property_test.rs
@@ -177,7 +177,7 @@ impl Export for SomeCStyleEnum {
     fn export_hint() -> PropertyHintInfo {
         PropertyHintInfo {
             hint: PropertyHint::ENUM,
-            hint_string: "A,B,C".into(),
+            hint_string: GString::from("A,B,C"),
         }
     }
 }
@@ -225,9 +225,9 @@ impl HasCustomProperty {
         use SomeCStyleEnum::*;
 
         match self.some_c_style_enum {
-            A => "A".into(),
-            B => "B".into(),
-            C => "C".into(),
+            A => GString::from("A"),
+            B => GString::from("B"),
+            C => GString::from("C"),
         }
     }
 }

--- a/itest/rust/src/object_tests/reentrant_test.rs
+++ b/itest/rust/src/object_tests/reentrant_test.rs
@@ -26,14 +26,14 @@ impl ReentrantClass {
     #[func]
     fn first_calls(&mut self) {
         self.first_called_pre = true;
-        self.base_mut().call("second".into(), &[]);
+        self.base_mut().call("second", &[]);
         self.first_called_post = true;
     }
 
     #[func]
     fn first_signal(&mut self) {
         self.first_called_pre = true;
-        self.base_mut().emit_signal("some_signal".into(), &[]);
+        self.base_mut().emit_signal("some_signal", &[]);
         self.first_called_post = true;
     }
 
@@ -51,7 +51,7 @@ fn reentrant_call_succeeds() {
     assert!(!class.bind().first_called_post);
     assert!(!class.bind().second_called);
 
-    class.call("first_calls".into(), &[]);
+    class.call("first_calls", &[]);
 
     assert!(class.bind().first_called_pre);
     assert!(class.bind().first_called_post);
@@ -65,13 +65,13 @@ fn reentrant_emit_succeeds() {
     let mut class = ReentrantClass::new_alloc();
 
     let callable = class.callable("second");
-    class.connect("some_signal".into(), callable);
+    class.connect("some_signal", callable);
 
     assert!(!class.bind().first_called_pre);
     assert!(!class.bind().first_called_post);
     assert!(!class.bind().second_called);
 
-    class.call("first_signal".into(), &[]);
+    class.call("first_signal", &[]);
 
     assert!(class.bind().first_called_pre);
     assert!(class.bind().first_called_post);

--- a/itest/rust/src/object_tests/singleton_test.rs
+++ b/itest/rust/src/object_tests/singleton_test.rs
@@ -38,8 +38,8 @@ fn singleton_is_operational() {
     let value = GString::from("SOME_VALUE");
 
     // set_environment is const, for some reason
-    os.set_environment(key.clone(), value.clone());
+    os.set_environment(&key, &value);
 
-    let read_value = os.get_environment(key);
+    let read_value = os.get_environment(&key);
     assert_eq!(read_value, value);
 }

--- a/itest/rust/src/register_tests/constant_test.rs
+++ b/itest/rust/src/register_tests/constant_test.rs
@@ -67,7 +67,7 @@ impl HasConstants {
 
 /// Checks at runtime if a class has a given integer constant through [ClassDb].
 fn class_has_integer_constant<T: GodotClass>(name: &str) -> bool {
-    ClassDb::singleton().class_has_integer_constant(T::class_name().to_string_name(), name.into())
+    ClassDb::singleton().class_has_integer_constant(&T::class_name().to_string_name(), name)
 }
 
 #[itest]
@@ -83,18 +83,16 @@ fn constants_correct_value() {
         ),
     ];
 
+    let class_name = HasConstants::class_name().to_string_name();
     let constants = ClassDb::singleton()
-        .class_get_integer_constant_list_ex(HasConstants::class_name().to_string_name())
+        .class_get_integer_constant_list_ex(&class_name)
         .no_inheritance(true)
         .done();
 
     for (constant_name, constant_value) in CONSTANTS {
-        assert!(constants.contains(&constant_name.into()));
+        assert!(constants.contains(constant_name));
         assert_eq!(
-            ClassDb::singleton().class_get_integer_constant(
-                HasConstants::class_name().to_string_name(),
-                constant_name.into()
-            ),
+            ClassDb::singleton().class_get_integer_constant(&class_name, constant_name),
             constant_value
         );
     }
@@ -142,9 +140,9 @@ impl godot::obj::cap::ImplementsGodotApi for HasOtherConstants {
             ConstantKind::Enum {
                 name: Self::ENUM_NAME.into(),
                 enumerators: vec![
-                    IntegerConstant::new("ENUM_A".into(), Self::ENUM_A),
-                    IntegerConstant::new("ENUM_B".into(), Self::ENUM_B),
-                    IntegerConstant::new("ENUM_C".into(), Self::ENUM_C),
+                    IntegerConstant::new("ENUM_A", Self::ENUM_A),
+                    IntegerConstant::new("ENUM_B", Self::ENUM_B),
+                    IntegerConstant::new("ENUM_C", Self::ENUM_C),
                 ],
             },
         )
@@ -156,9 +154,9 @@ impl godot::obj::cap::ImplementsGodotApi for HasOtherConstants {
             ConstantKind::Bitfield {
                 name: Self::BITFIELD_NAME.into(),
                 flags: vec![
-                    IntegerConstant::new("BITFIELD_A".into(), Self::BITFIELD_A),
-                    IntegerConstant::new("BITFIELD_B".into(), Self::BITFIELD_B),
-                    IntegerConstant::new("BITFIELD_C".into(), Self::BITFIELD_C),
+                    IntegerConstant::new("BITFIELD_A", Self::BITFIELD_A),
+                    IntegerConstant::new("BITFIELD_B", Self::BITFIELD_B),
+                    IntegerConstant::new("BITFIELD_C", Self::BITFIELD_C),
                 ],
             },
         )
@@ -192,30 +190,24 @@ macro_rules! test_enum_export {
     ) => {
         #$attr
         fn $test_name() {
-            let class_name = <$class>::class_name();
+            let class_name = <$class>::class_name().to_string_name();
             let enum_name = StringName::from(<$class>::$enum_name);
             let variants = [
                 $((stringify!($enumerators), <$class>::$enumerators)),*
             ];
 
             assert!(ClassDb::singleton()
-                .class_has_enum_ex(
-                    class_name.to_string_name(),
-                    enum_name.clone(),
-                )
+                .class_has_enum_ex(&class_name, &enum_name)
                 .no_inheritance(true)
                 .done());
 
             let godot_variants = ClassDb::singleton()
-                .class_get_enum_constants_ex(
-                    class_name.to_string_name(),
-                    enum_name.into(),
-                )
+                .class_get_enum_constants_ex(&class_name, &enum_name)
                 .no_inheritance(true)
                 .done();
 
             let constants = ClassDb::singleton()
-                .class_get_integer_constant_list_ex(class_name.to_string_name())
+                .class_get_integer_constant_list_ex(&class_name)
                 .no_inheritance(true)
                 .done();
 
@@ -224,7 +216,7 @@ macro_rules! test_enum_export {
                 assert!(godot_variants.contains(&variant_name));
                 assert!(constants.contains(&variant_name));
                 assert_eq!(
-                    ClassDb::singleton().class_get_integer_constant(class_name.to_string_name(), variant_name.into()),
+                    ClassDb::singleton().class_get_integer_constant(&class_name, variant_name.arg()),
                     variant_value
                 );
             }

--- a/itest/rust/src/register_tests/derive_godotconvert_test.rs
+++ b/itest/rust/src/register_tests/derive_godotconvert_test.rs
@@ -58,7 +58,7 @@ enum EnumIntyWithExprs {
 
 #[itest]
 fn newtype_tuple_struct() {
-    roundtrip(TupleNewtype("hello!".into()));
+    roundtrip(TupleNewtype(GString::from("hello!")));
 }
 
 #[itest]

--- a/itest/rust/src/register_tests/func_test.rs
+++ b/itest/rust/src/register_tests/func_test.rs
@@ -181,10 +181,8 @@ impl GdSelfObj {
         // Since a self reference is held while the signal is emitted, when
         // GDScript tries to call update_internal(), there will be a failure due
         // to the double borrow and self.internal_value won't be changed.
-        self.base_mut().emit_signal(
-            "update_internal_signal".into(),
-            &[new_internal.to_variant()],
-        );
+        self.base_mut()
+            .emit_signal("update_internal_signal", &[new_internal.to_variant()]);
         self.internal_value
     }
 
@@ -192,10 +190,7 @@ impl GdSelfObj {
     fn succeed_at_updating_internal_value(mut this: Gd<Self>, new_internal: i32) -> i32 {
         // Since this isn't bound while the signal is emitted, GDScript will succeed at calling
         // update_internal() and self.internal_value will be changed.
-        this.emit_signal(
-            "update_internal_signal".into(),
-            &[new_internal.to_variant()],
-        );
+        this.emit_signal("update_internal_signal", &[new_internal.to_variant()]);
 
         this.bind().internal_value
     }
@@ -303,12 +298,12 @@ fn cfg_removes_or_keeps_signals() {
 /// Checks at runtime if a class has a given method through [ClassDb].
 fn class_has_method<T: GodotClass>(name: &str) -> bool {
     ClassDb::singleton()
-        .class_has_method_ex(T::class_name().to_string_name(), name.into())
+        .class_has_method_ex(&T::class_name().to_string_name(), name)
         .no_inheritance(true)
         .done()
 }
 
 /// Checks at runtime if a class has a given signal through [ClassDb].
 fn class_has_signal<T: GodotClass>(name: &str) -> bool {
-    ClassDb::singleton().class_has_signal(T::class_name().to_string_name(), name.into())
+    ClassDb::singleton().class_has_signal(&T::class_name().to_string_name(), name)
 }

--- a/itest/rust/src/register_tests/func_virtual_test.rs
+++ b/itest/rust/src/register_tests/func_virtual_test.rs
@@ -60,7 +60,7 @@ fn func_virtual() {
     assert_eq!(object.bind().greet_lang(72), GString::from("GDScript#72"));
 
     // Dynamic call: "GDScript".
-    let result = object.call("_greet_lang".into(), &[72.to_variant()]);
+    let result = object.call("_greet_lang", &[72.to_variant()]);
     assert_eq!(result, "GDScript#72".to_variant());
 }
 
@@ -81,7 +81,7 @@ fn func_virtual_renamed() {
     );
 
     // Dynamic call: "GDScript".
-    let result = object.call("greet_lang2".into(), &["Hello".to_variant()]);
+    let result = object.call("greet_lang2", &["Hello".to_variant()]);
     assert_eq!(result, "Hello GDScript".to_variant());
 }
 
@@ -102,7 +102,7 @@ fn func_virtual_gd_self() {
     );
 
     // Dynamic call: "GDScript".
-    let result = object.call("_greet_lang3".into(), &["Hoi".to_variant()]);
+    let result = object.call("_greet_lang3", &["Hoi".to_variant()]);
     assert_eq!(result, "Hoi GDScript".to_variant());
 }
 
@@ -141,7 +141,7 @@ func _get_thing():
 "#;
 
     let mut script = GDScript::new_gd();
-    script.set_source_code(code.into());
+    script.set_source_code(code);
     script.reload(); // Necessary so compile is triggered.
 
     let methods = script


### PR DESCRIPTION
This is a colossal PR, simply because the changes go very deep into code generation and touch all the foundations:
- Add `AsArg<T>` trait for generic passing of string arguments.
- Change codegen to use `impl AsArg<T>` for strings.
- Refactor the very messy parameter/lifetime/extender signature generation.
- Generalize `AsArg<T>` for generic argument passing inside `Array<T>` and `Packed*Array`.
- Update hundreds of occurrences in `itest`, `examples` as well as higher-level internal code.

**TLDR:** instead of 
```rs
godot_method("thing".into());
godot_method(gstring.clone());
```
you now write:
```rs
godot_method("thing");
godot_method(&gstring);
```

There are still some rough edges, but it's a mergeable start, and I'd like to iteratively improve it based on user feedback. Since the whole argument passing has been fundamentally reworked lately (object arguments in #800 + reference passing in #900 and #906), there is a lot that can be made more ergonomic and consistent in the future.