### PR TITLE
CI runner updates

### DIFF
--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -237,19 +237,19 @@ jobs:
           # macOS -- for the unintuitive naming, see https://github.com/actions/runner-images?tab=readme-ov-file#available-images
 
           - name: macos-x86
-            os: macos-12
+            os: macos-13
             artifact-name: macos-x86-nightly
             godot-binary: godot.macos.editor.dev.x86_64
             with-hot-reload: true
 
           - name: macos-double-x86
-            os: macos-12
+            os: macos-13
             artifact-name: macos-double-x86-nightly
             godot-binary: godot.macos.editor.dev.double.x86_64
             rust-extra-args: --features godot/api-custom,godot/double-precision
 
           - name: macos-x86-4.2
-            os: macos-12
+            os: macos-13
             artifact-name: macos-x86-4.2
             godot-binary: godot.macos.editor.dev.x86_64
             godot-prebuilt-patch: '4.2.2'

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -21,8 +21,8 @@ env:
   # * report_objects: list individual leaked objects when running LeakSanitizer
   LSAN_OPTIONS: report_objects=1
 
-  CARGO_DENY_VERSION: "0.15.1"
-  CARGO_MACHETE_VERSION: "0.6.2"
+  CARGO_DENY_VERSION: "0.16.1"
+  CARGO_MACHETE_VERSION: "0.7.0"
 
 
 defaults:

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -37,7 +37,7 @@ defaults:
 jobs:
   # Keep all in sync with minimal-ci and release-version.
   rustfmt:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -64,7 +64,7 @@ jobs:
 
   # Needs to be its own job (apart from sync-doc), because lints don't work with --no-deps, and because it contributes to ci-status.
   doc-lints:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
 
@@ -84,7 +84,7 @@ jobs:
 
 
   clippy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -129,16 +129,16 @@ jobs:
           # Don't use latest Ubuntu (22.04) as it breaks lots of ecosystem compatibility.
           # If ever moving to ubuntu-latest, need to manually install libtinfo5 for LLVM.
           - name: linux
-            os: ubuntu-20.04
+            os: ubuntu-22.04
 
           - name: linux
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             rust-toolchain: nightly
             rust-special: -minimal-deps
             rust-cache-key: minimal-deps
 
           - name: linux
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             rust-toolchain: "1.80"
             rust-special: -msrv
 
@@ -169,7 +169,7 @@ jobs:
 
   miri-test:
     name: miri-test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -193,7 +193,7 @@ jobs:
 
   proptest:
     name: proptest
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -307,7 +307,7 @@ jobs:
           # Uses full+experimental codegen, so that compatibility breakage towards nightly is detected.
           # If the experimental part causes problems, consider using only godot/__codegen-full.
           - name: linux-full
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             artifact-name: linux-nightly
             godot-binary: godot.linuxbsd.editor.dev.x86_64
             rust-extra-args: --features itest/codegen-full
@@ -315,19 +315,19 @@ jobs:
 
           # Combines now a lot of features, but should be OK. lazy-function-tables doesn't work with experimental-threads.
           - name: linux-double-lazy
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             artifact-name: linux-double-nightly
             godot-binary: godot.linuxbsd.editor.dev.double.x86_64
             rust-extra-args: --features godot/api-custom,godot/double-precision,itest/codegen-full,godot/lazy-function-tables
 
           - name: linux-features-experimental
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             artifact-name: linux-nightly
             godot-binary: godot.linuxbsd.editor.dev.x86_64
             rust-extra-args: --features itest/experimental-threads,itest/codegen-full-experimental,godot/api-custom,godot/serde,itest/register-docs
 
           - name: linux-release
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             artifact-name: linux-release-nightly
             godot-binary: godot.linuxbsd.template_release.x86_64
             rust-extra-args: --release
@@ -336,13 +336,13 @@ jobs:
           # Linux compat (4.1 disabled, already covered by memcheck)
 
           - name: linux-4.3
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             artifact-name: linux-4.3
             godot-binary: godot.linuxbsd.editor.dev.x86_64
             #godot-prebuilt-patch: '4.3.x'
 
           - name: linux-4.2
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             artifact-name: linux-4.2
             godot-binary: godot.linuxbsd.editor.dev.x86_64
             godot-prebuilt-patch: '4.2.2'
@@ -355,7 +355,7 @@ jobs:
           #
           # There is also a gcc variant besides clang, which is currently not used.
           - name: linux-memcheck-nightly
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             artifact-name: linux-memcheck-nightly
             godot-binary: godot.linuxbsd.editor.dev.x86_64.llvm.san
             rust-toolchain: nightly
@@ -365,7 +365,7 @@ jobs:
             rust-target: x86_64-unknown-linux-gnu
 
           - name: linux-memcheck-4.1
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             artifact-name: linux-memcheck-4.1
             godot-binary: godot.linuxbsd.editor.dev.x86_64.llvm.san
             godot-prebuilt-patch: '4.1' # check compat of API 4.1.0 with newer binaries.
@@ -401,7 +401,7 @@ jobs:
 
 
   run-examples:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -423,7 +423,7 @@ jobs:
 
 
   cargo-deny-machete:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -449,7 +449,7 @@ jobs:
 
 
   license-guard:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -483,7 +483,7 @@ jobs:
       - cargo-deny-machete
       - license-guard
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       # Deliberate choice to use bash script and not GitHub Action glob syntax, as that is not well-documented and hard to get right.
       # For example: contains(needs.*.result, 'success') does NOT work because * is a logical OR, thus true if a single job succeeds.

--- a/.github/workflows/minimal-ci.yml
+++ b/.github/workflows/minimal-ci.yml
@@ -39,7 +39,7 @@ concurrency:
 jobs:
 
   rustfmt:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -65,7 +65,7 @@ jobs:
 
   # Needs to be its own job (apart from sync-doc), because lints don't work with --no-deps, and because it contributes to ci-status.
   doc-lints:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -82,7 +82,7 @@ jobs:
 
 
   clippy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -109,7 +109,7 @@ jobs:
 
   unit-test:
     name: unit-test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -154,14 +154,14 @@ jobs:
           # Linux
 
           - name: linux-full
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             artifact-name: linux-nightly
             godot-binary: godot.linuxbsd.editor.dev.x86_64
             rust-extra-args: --features itest/codegen-full
             with-hot-reload: true
 
           - name: linux-features-experimental
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             artifact-name: linux-nightly
             godot-binary: godot.linuxbsd.editor.dev.x86_64
             rust-extra-args: --features itest/experimental-threads,itest/codegen-full-experimental,godot/api-custom,godot/serde,itest/register-docs
@@ -169,13 +169,13 @@ jobs:
           # Linux compat
 
           - name: linux-4.1
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             artifact-name: linux-4.1
             godot-binary: godot.linuxbsd.editor.dev.x86_64
             godot-prebuilt-patch: '4.1.4'
 
           - name: linux-4.2
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             artifact-name: linux-4.2
             godot-binary: godot.linuxbsd.editor.dev.x86_64
             godot-prebuilt-patch: '4.2.2'
@@ -183,7 +183,7 @@ jobs:
           # Memory checkers
 
           - name: linux-memcheck
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             artifact-name: linux-memcheck-nightly
             godot-binary: godot.linuxbsd.editor.dev.x86_64.llvm.san
             rust-toolchain: nightly
@@ -216,7 +216,7 @@ jobs:
         shell: bash
 
   run-examples:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -238,7 +238,7 @@ jobs:
 
 
   license-guard:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -269,7 +269,7 @@ jobs:
       - run-examples
       - license-guard
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: "Determine success or failure"
         run: |

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -23,7 +23,7 @@ env:
 
 jobs:
   notify-docs:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       # Checkout is always needed, for the notify step
       - name: "Checkout"


### PR DESCRIPTION
Updates runner images:
* Ubuntu 20.04 -> 22.04
* macOS 12 -> 13 (still x86)

Reacting to GitHub's brownouts announcing `macos-12` deprecation (https://github.com/actions/runner-images/issues/10721).

It seems like `macos-13` is the last Intel/x86 macOS available for open-source usage (according to [this page](https://github.com/actions/runner-images?tab=readme-ov-file#available-images)), as the `macos-14-large` runners are paid. Once `macos-13` starts deprecation, we may need to discontinue Intel/x86 CI support.