### PR TITLE
Remove `to_2d()` + `to_3d()`; clean up `ApiParam`

### DIFF
--- a/godot-core/src/builtin/collections/array.rs
+++ b/godot-core/src/builtin/collections/array.rs
@@ -947,7 +947,7 @@ impl<'r, T: ArrayElement> AsArg<Array<T>> for &'r Array<T> {
 impl<T: ArrayElement> ApiParam for Array<T> {
     type Arg<'v> = CowArg<'v, Self>;
 
-    fn value_to_arg<'v>(self) -> Self::Arg<'v> {
+    fn owned_to_arg<'v>(self) -> Self::Arg<'v> {
         CowArg::Owned(self)
     }
 
@@ -1221,7 +1221,7 @@ impl<T: ArrayElement + ToGodot> Extend<T> for Array<T> {
         // A faster implementation using `resize()` and direct pointer writes might still be possible.
         // Note that this could technically also use iter(), since no moves need to happen (however Extend requires IntoIterator).
         for item in iter.into_iter() {
-            self.push(ApiParam::value_to_arg(item));
+            self.push(ApiParam::owned_to_arg(item));
         }
     }
 }

--- a/godot-core/src/builtin/collections/packed_array.rs
+++ b/godot-core/src/builtin/collections/packed_array.rs
@@ -491,7 +491,7 @@ macro_rules! impl_packed_array {
                 // A faster implementation using `resize()` and direct pointer writes might still be
                 // possible.
                 for item in iter.into_iter() {
-                    self.push(meta::ApiParam::value_to_arg(item));
+                    self.push(meta::ApiParam::owned_to_arg(item));
                 }
             }
         }

--- a/godot-core/src/builtin/vectors/vector2.rs
+++ b/godot-core/src/builtin/vectors/vector2.rs
@@ -11,7 +11,7 @@ use sys::{ffi_methods, GodotFfi};
 
 use crate::builtin::math::{FloatExt, GlamConv, GlamType};
 use crate::builtin::vectors::Vector2Axis;
-use crate::builtin::{inner, real, RAffine2, RVec2, Vector2i, Vector3};
+use crate::builtin::{inner, real, RAffine2, RVec2, Vector2i};
 
 use std::fmt;
 
@@ -44,7 +44,7 @@ use std::fmt;
 /// | 3D        | [`Vector3`][crate::builtin::Vector3] | [`Vector3i`][crate::builtin::Vector3i] |
 /// | 4D        | [`Vector4`][crate::builtin::Vector4] | [`Vector4i`][crate::builtin::Vector4i] |
 ///
-/// <br>You can convert to 3D vectors using [`to_3d(z)`][Self::to_3d], and to `Vector2i` using [`cast_int()`][Self::cast_int].
+/// <br>You can convert to `Vector2i` using [`cast_int()`][Self::cast_int].
 ///
 /// # Godot docs
 ///

--- a/godot-core/src/builtin/vectors/vector2i.rs
+++ b/godot-core/src/builtin/vectors/vector2i.rs
@@ -10,7 +10,7 @@ use std::cmp::Ordering;
 use sys::{ffi_methods, GodotFfi};
 
 use crate::builtin::math::{GlamConv, GlamType};
-use crate::builtin::{inner, real, RVec2, Vector2, Vector2Axis, Vector3i};
+use crate::builtin::{inner, real, RVec2, Vector2, Vector2Axis};
 
 use std::fmt;
 
@@ -42,7 +42,7 @@ use std::fmt;
 /// | 3D        | [`Vector3`][crate::builtin::Vector3] | [`Vector3i`][crate::builtin::Vector3i] |
 /// | 4D        | [`Vector4`][crate::builtin::Vector4] | [`Vector4i`][crate::builtin::Vector4i] |
 ///
-/// <br>You can convert to 3D vectors using [`to_3d(z)`][Self::to_3d], and to `Vector2` using [`cast_float()`][Self::cast_float].
+/// <br>You can convert to `Vector2` using [`cast_float()`][Self::cast_float].
 ///
 /// # Godot docs
 ///

--- a/godot-core/src/builtin/vectors/vector3.rs
+++ b/godot-core/src/builtin/vectors/vector3.rs
@@ -45,7 +45,7 @@ use std::fmt;
 /// | 3D        | **`Vector3`**                        | [`Vector3i`][crate::builtin::Vector3i] |
 /// | 4D        | [`Vector4`][crate::builtin::Vector4] | [`Vector4i`][crate::builtin::Vector4i] |
 ///
-/// <br>You can convert to 2D vectors using [`to_2d()`][Self::to_2d], and to `Vector3i` using [`cast_int()`][Self::cast_int].
+/// <br>You can convert to `Vector3i` using [`cast_int()`][Self::cast_int].
 ///
 /// # Godot docs
 ///

--- a/godot-core/src/builtin/vectors/vector3i.rs
+++ b/godot-core/src/builtin/vectors/vector3i.rs
@@ -12,7 +12,7 @@ use godot_ffi as sys;
 use sys::{ffi_methods, GodotFfi};
 
 use crate::builtin::math::{GlamConv, GlamType};
-use crate::builtin::{inner, real, RVec3, Vector2i, Vector3, Vector3Axis};
+use crate::builtin::{inner, real, RVec3, Vector3, Vector3Axis};
 
 /// Vector used for 3D math using integer coordinates.
 ///
@@ -42,7 +42,7 @@ use crate::builtin::{inner, real, RVec3, Vector2i, Vector3, Vector3Axis};
 /// | 3D        | [`Vector3`][crate::builtin::Vector3] | **`Vector3i`**                         |
 /// | 4D        | [`Vector4`][crate::builtin::Vector4] | [`Vector4i`][crate::builtin::Vector4i] |
 ///
-/// <br>You can convert to 2D vectors using [`to_2d()`][Self::to_2d], and to `Vector3` using [`cast_float()`][Self::cast_float].
+/// <br>You can convert to `Vector3` using [`cast_float()`][Self::cast_float].
 ///
 /// # Godot docs
 ///

--- a/godot-core/src/builtin/vectors/vector_macros.rs
+++ b/godot-core/src/builtin/vectors/vector_macros.rs
@@ -791,12 +791,6 @@ macro_rules! impl_vector2x_fns {
         /// # 2D functions
         /// The following methods are only available on 2D vectors (for both float and int).
         impl $Vector {
-            /// Increases dimension to 3D, accepting a new value for the Z component.
-            #[inline]
-            pub fn to_3d(self, z: $Scalar) -> $Vector3D {
-                <$Vector3D>::new(self.x, self.y, z)
-            }
-
             /// Returns the aspect ratio of this vector, the ratio of [`Self::x`] to [`Self::y`].
             #[inline]
             pub fn aspect(self) -> real {
@@ -853,15 +847,6 @@ macro_rules! impl_vector3x_fns {
         /// # 3D functions
         /// The following methods are only available on 3D vectors (for both float and int).
         impl $Vector {
-            /// Reduces dimension to 2D, discarding the Z component.
-            ///
-            /// See also [`swizzle!`][crate::builtin::swizzle] for a more general way to extract components.
-            /// `self.to_2d()` is equivalent to `swizzle!(self => x, y)`.
-            #[inline]
-            pub fn to_2d(self) -> $Vector2D {
-                <$Vector2D>::new(self.x, self.y)
-            }
-
             /// Returns the axis of the vector's highest value. See [`Vector3Axis`] enum. If all components are equal, this method returns [`None`].
             ///
             /// To mimic Godot's behavior, unwrap this function's result with `unwrap_or(Vector3Axis::X)`.

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -784,7 +784,7 @@ impl<'r, T: GodotClass> AsArg<Gd<T>> for &'r Gd<T> {
 impl<T: GodotClass> ApiParam for Gd<T> {
     type Arg<'v> = CowArg<'v, Gd<T>>;
 
-    fn value_to_arg<'v>(self) -> Self::Arg<'v> {
+    fn owned_to_arg<'v>(self) -> Self::Arg<'v> {
         CowArg::Owned(self)
     }
 
@@ -806,7 +806,7 @@ impl<'r, T: GodotClass> AsArg<Option<Gd<T>>> for Option<&'r Gd<T>> {
 impl<T: GodotClass> ApiParam for Option<Gd<T>> {
     type Arg<'v> = CowArg<'v, Option<Gd<T>>>;
 
-    fn value_to_arg<'v>(self) -> Self::Arg<'v> {
+    fn owned_to_arg<'v>(self) -> Self::Arg<'v> {
         CowArg::Owned(self)
     }
 


### PR DESCRIPTION
### Remove vector `to_2d()` + `to_3d()` methods

Semantics aren't obvious -- while Z component is the mathematically natural extension, in Godot Y would be more typical (being the up/down axis in 3D). There's also the topic of +/- signs... Maybe it can be re-added once there are clearer use cases.

Alternatively, a more flexible swizzle! macro supporting 0 when extending is possible.


### `ApiParam` cleanups

- Rename `ApiParam::value_to_arg()` -> `owned_to_arg()`
- Hide associated `Arg` type (not intended to be used directly)
- Minor docs