### PR TITLE
CI: skip `notify-docs` job when running in a fork

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -23,6 +23,8 @@ env:
 
 jobs:
   notify-docs:
+    # do not run this job in a fork
+    if: github.repository_owner == 'godot-rust'
     runs-on: ubuntu-22.04
     steps:
       # Checkout is always needed, for the notify step


### PR DESCRIPTION
see my comment here https://github.com/godot-rust/gdext/pull/933#issuecomment-2458626303

This workflow currently also gets triggered in a fork (if the fork has Actions enabled) because of:

```yaml
  push:
    branches:
      - master
```

running the workflow in a fork doesn't hurt, since the fork can't actually update the docs, but not running it feels a little cleaner