### PR TITLE
Require `AsObjectArg` pass-by-ref, consistent with `AsArg`

### DIFF
--- a/godot-core/src/meta/traits.rs
+++ b/godot-core/src/meta/traits.rs
@@ -175,6 +175,7 @@ pub trait ArrayElement: GodotType + ToGodot + FromGodot + sealed::Sealed + meta:
         builtin_type_string::<Self>()
     }
 
+    #[doc(hidden)]
     fn debug_validate_elements(_array: &builtin::Array<Self>) -> Result<(), ConvertError> {
         // No-op for most element types.
         Ok(())

--- a/godot-core/src/obj/object_arg.rs
+++ b/godot-core/src/obj/object_arg.rs
@@ -27,7 +27,9 @@ use std::ptr;
 /// </div>
 
 #[diagnostic::on_unimplemented(
-    message = "The provided argument of type `{Self}` cannot be converted to a `Gd<{T}>` parameter"
+    message = "Argument of type `{Self}` cannot be passed to an `impl AsObjectArg<{T}>` parameter",
+    note = "If you pass by value, consider borrowing instead.",
+    note = "See also `AsObjectArg` docs: https://godot-rust.github.io/docs/gdext/master/godot/meta/trait.AsObjectArg.html"
 )]
 pub trait AsObjectArg<T>
 where
@@ -40,6 +42,12 @@ where
     #[doc(hidden)]
     fn consume_arg(self) -> ObjectCow<T>;
 }
+
+/*
+Currently not implemented for values, to be consistent with AsArg for by-ref builtins. The idea is that this can discover patterns like
+api.method(refc.clone()), and encourage better performance with api.method(&refc). However, we need to see if there's a notable ergonomic
+impact, and consider that for nodes, Gd<T> copies are relatively cheap (no ref-counting). There is also some value in prematurely ending
+the lifetime of a Gd<T> by moving out, so it's not accidentally used later.
 
 impl<T, U> AsObjectArg<T> for Gd<U>
 where
@@ -54,6 +62,7 @@ where
         ObjectCow::Owned(self.upcast())
     }
 }
+*/
 
 impl<T, U> AsObjectArg<T> for &Gd<U>
 where

--- a/godot-core/src/obj/object_arg.rs
+++ b/godot-core/src/obj/object_arg.rs
@@ -25,7 +25,6 @@ use std::ptr;
 /// The GDExtension API does not inform about nullability of its function parameters. It is up to you to verify that the arguments you pass
 /// are only null when this is allowed. Doing this wrong should be safe, but can lead to the function call failing.
 /// </div>
-
 #[diagnostic::on_unimplemented(
     message = "Argument of type `{Self}` cannot be passed to an `impl AsObjectArg<{T}>` parameter",
     note = "If you pass by value, consider borrowing instead.",
@@ -77,22 +76,6 @@ where
 
     fn consume_arg(self) -> ObjectCow<T> {
         ObjectCow::Borrowed(self.as_object_arg())
-    }
-}
-
-impl<T, U> AsObjectArg<T> for &mut Gd<U>
-where
-    T: GodotClass + Bounds<Declarer = bounds::DeclEngine>,
-    U: Inherits<T>,
-{
-    // Delegate to &Gd impl.
-
-    fn as_object_arg(&self) -> ObjectArg<T> {
-        <&Gd<U>>::as_object_arg(&&**self)
-    }
-
-    fn consume_arg(self) -> ObjectCow<T> {
-        <&Gd<U>>::consume_arg(&*self)
     }
 }
 

--- a/godot-core/src/obj/script.rs
+++ b/godot-core/src/obj/script.rs
@@ -386,7 +386,7 @@ impl<'a, T: ScriptInstance> SiMut<'a, T> {
     ///         let name = this.base().get_name();
     ///         godot_print!("name is {name}");
     ///         // However, we cannot call methods that require `&mut Base`, such as:
-    ///         // this.base().add_child(node);
+    ///         // this.base().add_child(&node);
     ///         Ok(Variant::nil())
     ///     }
     ///     # fn class_name(&self) -> GString { todo!() }

--- a/godot-core/src/obj/traits.rs
+++ b/godot-core/src/obj/traits.rs
@@ -304,7 +304,7 @@ pub trait WithBaseField: GodotClass + Bounds<Declarer = bounds::DeclUser> {
     ///     fn process(&mut self, _delta: f64) {
     ///         let node = Node::new_alloc();
     ///         // fails because `add_child` requires a mutable reference.
-    ///         self.base().add_child(node);
+    ///         self.base().add_child(&node);
     ///     }
     /// }
     ///
@@ -344,7 +344,7 @@ pub trait WithBaseField: GodotClass + Bounds<Declarer = bounds::DeclUser> {
     /// impl INode for MyClass {
     ///     fn process(&mut self, _delta: f64) {
     ///         let node = Node::new_alloc();
-    ///         self.base_mut().add_child(node);
+    ///         self.base_mut().add_child(&node);
     ///     }
     /// }
     ///

--- a/godot-core/src/registry/property.rs
+++ b/godot-core/src/registry/property.rs
@@ -60,6 +60,7 @@ pub trait Export: Var {
     ///
     /// Only overridden for `Gd<T>`, to detect erroneous exports of `Node` inside a `Resource` class.
     #[allow(clippy::wrong_self_convention)]
+    #[doc(hidden)]
     fn as_node_class() -> Option<ClassName> {
         None
     }

--- a/godot-core/src/tools/save_load.rs
+++ b/godot-core/src/tools/save_load.rs
@@ -78,17 +78,18 @@ where
 /// See [`try_save`] for more information.
 ///
 /// # Panics
-/// If the resouce cannot be saved.
+/// If the resource cannot be saved.
 ///
 /// # Example
 /// ```no_run
 /// use godot::prelude::*;
 ///
-/// save(Resource::new_gd(), "res://BaseResource.tres")
+/// let obj = Resource::new_gd();
+/// save(&obj, "res://BaseResource.tres")
 /// ```
 /// use godot::
 #[inline]
-pub fn save<T>(obj: Gd<T>, path: impl AsArg<GString>)
+pub fn save<T>(obj: &Gd<T>, path: impl AsArg<GString>)
 where
     T: Inherits<Resource>,
 {
@@ -120,12 +121,12 @@ where
 /// };
 ///
 /// let save_state = SavedGame::new_gd();
-/// let res = try_save(save_state, "user://save.tres");
+/// let res = try_save(&save_state, "user://save.tres");
 ///
 /// assert!(res.is_ok());
 /// ```
 #[inline]
-pub fn try_save<T>(obj: Gd<T>, path: impl AsArg<GString>) -> Result<(), IoError>
+pub fn try_save<T>(obj: &Gd<T>, path: impl AsArg<GString>) -> Result<(), IoError>
 where
     T: Inherits<Resource>,
 {
@@ -163,7 +164,7 @@ where
     }
 }
 
-fn save_impl<T>(obj: Gd<T>, path: &GString) -> Result<(), IoError>
+fn save_impl<T>(obj: &Gd<T>, path: &GString) -> Result<(), IoError>
 where
     T: Inherits<Resource>,
 {

--- a/itest/rust/src/engine_tests/native_audio_structures_test.rs
+++ b/itest/rust/src/engine_tests/native_audio_structures_test.rs
@@ -113,7 +113,7 @@ fn native_audio_structure_out_parameter() {
         .cast::<SceneTree>();
 
     tree.get_root().unwrap().add_child(&player);
-    player.set_stream(generator);
+    player.set_stream(&generator);
 
     // Start playback so we can push audio frames through the audio pipeline.
     player.play();

--- a/itest/rust/src/engine_tests/node_test.rs
+++ b/itest/rust/src/engine_tests/node_test.rs
@@ -22,11 +22,11 @@ fn node_get_node() {
 
     let mut parent = Node3D::new_alloc();
     parent.set_name("parent");
-    parent.add_child(child);
+    parent.add_child(&child);
 
     let mut grandparent = Node::new_alloc();
     grandparent.set_name("grandparent");
-    grandparent.add_child(parent);
+    grandparent.add_child(&parent);
 
     // Directly on Gd<T>
     let found = grandparent.get_node_as::<Node3D>("parent/child");
@@ -74,7 +74,7 @@ fn node_scene_tree() {
     assert_eq!(err, global::Error::OK);
 
     let mut tree = SceneTree::new_alloc();
-    let err = tree.change_scene_to_packed(scene);
+    let err = tree.change_scene_to_packed(&scene);
     assert_eq!(err, global::Error::OK);
 
     // Note: parent + child are not owned by PackedScene, thus need to be freed

--- a/itest/rust/src/engine_tests/save_load_test.rs
+++ b/itest/rust/src/engine_tests/save_load_test.rs
@@ -34,13 +34,13 @@ fn save_test() {
 
     let resource = SavedGame::new_gd();
 
-    let res = try_save(resource.clone(), FAULTY_PATH);
+    let res = try_save(&resource, FAULTY_PATH);
     assert!(res.is_err());
 
-    let res = try_save(resource.clone(), &res_path);
+    let res = try_save(&resource, &res_path);
     assert!(res.is_ok());
 
-    save(resource.clone(), &res_path);
+    save(&resource, &res_path);
 
     remove_test_file(RESOURCE_NAME);
 }
@@ -53,7 +53,7 @@ fn load_test() {
     let mut resource = SavedGame::new_gd();
     resource.bind_mut().set_level(level);
 
-    save(resource.clone(), &res_path);
+    save(&resource, &res_path);
 
     let res = try_load::<SavedGame>(FAULTY_PATH);
     assert!(res.is_err());

--- a/itest/rust/src/object_tests/object_arg_test.rs
+++ b/itest/rust/src/object_tests/object_arg_test.rs
@@ -13,6 +13,7 @@ use godot::obj::{Gd, NewAlloc, NewGd};
 use crate::framework::itest;
 use crate::object_tests::object_test::{user_refc_instance, RefcPayload};
 
+/*
 #[itest]
 fn object_arg_owned() {
     with_objects(|manual, refc| {
@@ -22,6 +23,7 @@ fn object_arg_owned() {
         (a, b)
     });
 }
+*/
 
 #[itest]
 fn object_arg_borrowed() {
@@ -43,6 +45,7 @@ fn object_arg_borrowed_mut() {
     });
 }
 
+/*
 #[itest]
 fn object_arg_option_owned() {
     with_objects(|manual, refc| {
@@ -52,6 +55,7 @@ fn object_arg_option_owned() {
         (a, b)
     });
 }
+*/
 
 #[itest]
 fn object_arg_option_borrowed() {
@@ -80,10 +84,10 @@ fn object_arg_option_none() {
 
     // Will emit errors but should not crash.
     let db = ClassDb::singleton();
-    let error = db.class_set_property(manual, "name", &Variant::from("hello"));
+    let error = db.class_set_property(&manual, "name", &Variant::from("hello"));
     assert_eq!(error, global::Error::ERR_UNAVAILABLE);
 
-    let error = db.class_set_property(refc, "value", &Variant::from(-123));
+    let error = db.class_set_property(&refc, "value", &Variant::from(-123));
     assert_eq!(error, global::Error::ERR_UNAVAILABLE);
 }
 
@@ -106,14 +110,14 @@ fn object_arg_owned_default_params() {
     let b = ResourceFormatLoader::new_gd();
 
     // Use direct and explicit _ex() call syntax.
-    ResourceLoader::singleton().add_resource_format_loader(a.clone()); // by value
+    ResourceLoader::singleton().add_resource_format_loader(&a);
     ResourceLoader::singleton()
-        .add_resource_format_loader_ex(b.clone()) // by value
+        .add_resource_format_loader_ex(&b)
         .done();
 
     // Clean up (no leaks).
-    ResourceLoader::singleton().remove_resource_format_loader(a);
-    ResourceLoader::singleton().remove_resource_format_loader(b);
+    ResourceLoader::singleton().remove_resource_format_loader(&a);
+    ResourceLoader::singleton().remove_resource_format_loader(&b);
 }
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------

--- a/itest/rust/src/object_tests/object_arg_test.rs
+++ b/itest/rust/src/object_tests/object_arg_test.rs
@@ -71,6 +71,18 @@ fn object_arg_option_borrowed() {
     });
 }
 
+/*
+#[itest]
+fn object_arg_option_borrowed_outer() {
+    with_objects(|manual, refc| {
+        let db = ClassDb::singleton();
+        let a = db.class_set_property(&Some(manual), "name", &Variant::from("hello"));
+        let b = db.class_set_property(&Some(refc), "value", &Variant::from(-123));
+        (a, b)
+    });
+}
+*/
+
 #[itest]
 fn object_arg_option_borrowed_mut() {
     // If you have an Option<&mut Gd<T>>, you can use as_deref() to get Option<&Gd<T>>.
@@ -94,10 +106,10 @@ fn object_arg_option_none() {
 
     // Will emit errors but should not crash.
     let db = ClassDb::singleton();
-    let error = db.class_set_property(&manual, "name", &Variant::from("hello"));
+    let error = db.class_set_property(manual.as_ref(), "name", &Variant::from("hello"));
     assert_eq!(error, global::Error::ERR_UNAVAILABLE);
 
-    let error = db.class_set_property(&refc, "value", &Variant::from(-123));
+    let error = db.class_set_property(refc.as_ref(), "value", &Variant::from(-123));
     assert_eq!(error, global::Error::ERR_UNAVAILABLE);
 }
 

--- a/itest/rust/src/object_tests/object_arg_test.rs
+++ b/itest/rust/src/object_tests/object_arg_test.rs
@@ -39,8 +39,12 @@ fn object_arg_borrowed() {
 fn object_arg_borrowed_mut() {
     with_objects(|mut manual, mut refc| {
         let db = ClassDb::singleton();
-        let a = db.class_set_property(&mut manual, "name", &Variant::from("hello"));
-        let b = db.class_set_property(&mut refc, "value", &Variant::from(-123));
+
+        let manual_ref = &mut manual;
+        let refc_ref = &mut refc;
+
+        let a = db.class_set_property(&*manual_ref, "name", &Variant::from("hello"));
+        let b = db.class_set_property(&*refc_ref, "value", &Variant::from(-123));
         (a, b)
     });
 }
@@ -69,10 +73,16 @@ fn object_arg_option_borrowed() {
 
 #[itest]
 fn object_arg_option_borrowed_mut() {
+    // If you have an Option<&mut Gd<T>>, you can use as_deref() to get Option<&Gd<T>>.
+
     with_objects(|mut manual, mut refc| {
         let db = ClassDb::singleton();
-        let a = db.class_set_property(Some(&mut manual), "name", &Variant::from("hello"));
-        let b = db.class_set_property(Some(&mut refc), "value", &Variant::from(-123));
+
+        let manual_opt: Option<&mut Gd<Node>> = Some(&mut manual);
+        let refc_opt: Option<&mut Gd<RefcPayload>> = Some(&mut refc);
+
+        let a = db.class_set_property(manual_opt.as_deref(), "name", &Variant::from("hello"));
+        let b = db.class_set_property(refc_opt.as_deref(), "value", &Variant::from(-123));
         (a, b)
     });
 }

--- a/itest/rust/src/object_tests/object_swap_test.rs
+++ b/itest/rust/src/object_tests/object_swap_test.rs
@@ -119,7 +119,7 @@ fn object_subtype_swap_argument_passing(ctx: &TestContext) {
 
     let mut tree = ctx.scene_tree.clone();
     expect_panic("pass badly typed Gd<T> to Godot engine API", || {
-        tree.add_child(node);
+        tree.add_child(&node);
     });
 
     swapped_free!(obj, node2);

--- a/itest/rust/src/object_tests/object_test.rs
+++ b/itest/rust/src/object_tests/object_test.rs
@@ -294,7 +294,7 @@ fn object_engine_freed_argument_passing(ctx: &TestContext) {
     // Destroy object and then pass it to a Godot engine API.
     node.free();
     expect_panic("pass freed Gd<T> to Godot engine API (T=Node)", || {
-        tree.add_child(node2);
+        tree.add_child(&node2);
     });
 }
 
@@ -325,7 +325,7 @@ fn object_user_freed_argument_passing() {
     // Destroy object and then pass it to a Godot engine API (upcast itself works, see other tests).
     obj.free();
     expect_panic("pass freed Gd<T> to Godot engine API (T=user)", || {
-        engine.register_singleton("NeverRegistered", obj2);
+        engine.register_singleton("NeverRegistered", &obj2);
     });
 }
 
@@ -848,7 +848,7 @@ fn object_get_scene_tree(ctx: &TestContext) {
     let node = Node3D::new_alloc();
 
     let mut tree = ctx.scene_tree.clone();
-    tree.add_child(node);
+    tree.add_child(&node);
 
     let count = tree.get_child_count();
     assert_eq!(count, 1);

--- a/itest/rust/src/object_tests/onready_test.rs
+++ b/itest/rust/src/object_tests/onready_test.rs
@@ -157,7 +157,7 @@ fn init_attribute_node_key_lifecycle() {
 
     let mut child = Node::new_alloc();
     child.set_name("child");
-    obj.add_child(child);
+    obj.add_child(&child);
 
     obj.notify(NodeNotification::READY);
 

--- a/itest/rust/src/object_tests/virtual_methods_test.rs
+++ b/itest/rust/src/object_tests/virtual_methods_test.rs
@@ -519,7 +519,7 @@ fn test_format_loader(_test_context: &TestContext) {
         .unwrap();
     assert!(resource.try_cast::<BoxMesh>().is_ok());
 
-    loader.remove_resource_format_loader(format_loader);
+    loader.remove_resource_format_loader(&format_loader);
 }
 
 #[itest]

--- a/itest/rust/src/register_tests/rpc_test.rs
+++ b/itest/rust/src/register_tests/rpc_test.rs
@@ -77,12 +77,13 @@ impl RpcTest {
 fn node_enters_tree() {
     let node = RpcTest::new_alloc();
 
-    // Registering is done in `UserClass::__before_ready()`, and it requires a multiplayer api to exist.
+    // Registering is done in `UserClass::__before_ready()`, and it requires a multiplayer API to exist.
     let mut scene_tree = Engine::singleton()
         .get_main_loop()
         .unwrap()
         .cast::<SceneTree>();
-    scene_tree.set_multiplayer(&MultiplayerApi::create_default_interface());
+    scene_tree.set_multiplayer(MultiplayerApi::create_default_interface().as_ref());
+
     let mut root = scene_tree.get_root().unwrap();
     root.add_child(&node);
     root.remove_child(&node);

--- a/itest/rust/src/register_tests/rpc_test.rs
+++ b/itest/rust/src/register_tests/rpc_test.rs
@@ -82,7 +82,7 @@ fn node_enters_tree() {
         .get_main_loop()
         .unwrap()
         .cast::<SceneTree>();
-    scene_tree.set_multiplayer(MultiplayerApi::create_default_interface());
+    scene_tree.set_multiplayer(&MultiplayerApi::create_default_interface());
     let mut root = scene_tree.get_root().unwrap();
     root.add_child(&node);
     root.remove_child(&node);


### PR DESCRIPTION
A more conservative approach for initial v0.2, but more consistent with `AsArg` by-ref semantics and with the potential to expand in the future. Also cuts down on the number of monomorphizations without losing functionality. 

After this PR, you can pass object arguments as follows:

| Type              | Closest accepted type | How to transform |
|-------------------|-----------------------|------------------|
| `Gd`              | `&Gd`                 | `&arg`           |
| `&Gd`             | `&Gd`                 | `arg`            |
| `&mut Gd`         | `&Gd`                 | `&*arg`          |
| `Option<Gd>`      | `Option<&Gd>`         | `arg.as_ref()`   |
| `Option<&Gd>`     | `Option<&Gd>`         | `arg`            |
| `Option<&mut Gd>` | `Option<&Gd>`         | `arg.as_deref()` |
| (null literal)    |                       | `Gd::null_arg()` |

We'll need to check the ergonomic impact and see how arguments are typically being passed in practice.
Below more detailed rationale on individual `impl`s.

---


### Remove `impl AsObjectArg<T>` for `Gd<T>` values

Possibly controversial, but the idea is to require pass-by-value for objects, in order to discourage accidental/unnecessary cloning. This is also consistent with AsArg by-refs, in particular `impl AsArg<Gd<T>>` when used in arrays and packed arrays.

The downside is that it needs an extra `&` in some places, and one can no longer use pass-by-value to "consume" objects, ending their lifetime with the call. What is also unclear is whether there are situations where we can benefit from moving "into" the engine (perf-wise). So this may need some more discussion.

One option is also to move toward using `Copy` for manually managed `Gd<T>` types, which would mean a) those could be passed by-value, and b) we would anyway lose the "consume" semantics.



### Remove `impl AsObjectArg<T>` for `&mut Gd<T>` references

`&mut obj` args can only be passed once, since `&mut T: !Copy`. This means that passing it to a Godot API works once,
and then causes moved-out errors. This comes with a few issues:

* It either needs the `&*` pattern or not, depending on the order of calls. Reordering breaks them. 
*  It's inconsistent with `AsArg`, which is only implemented for `&T` in case of by-ref builtins. 
* Consuming `&mut T` should probably be allowed iff consuming `T` is allowed.


### Note about `impl AsObjectArg<T>` for `&Option<Gd<T>>` (outer reference)

It's relatively common that Godot APIs return `Option<Gd<T>>` or pass this type in virtual functions. To avoid excessive `as_ref()` calls, we **could** directly support `&Option<Gd>` in addition to `Option<&Gd>`. However, this is currently not done as it hides nullability, especially in situations where a return type is directly propagated:
```rs
    api(create_obj().as_ref());  // without &Option impl
    api(&create_obj());          // with &Option impl
```

While the first is slightly longer, it looks different from a function `create_obj()` that returns `Gd<T>` and thus can never be null. In some scenarios, it's better to immediately ensure non-null (e.g. through `unwrap()`) instead of propagating nulls.