### PR TITLE
Add test that checks if custom callables don't crash when Err() is returned.

### DIFF
--- a/itest/rust/src/builtin_tests/containers/callable_test.rs
+++ b/itest/rust/src/builtin_tests/containers/callable_test.rs
@@ -109,7 +109,7 @@ fn callable_call_return() {
         callable.callv(&varray![10]),
         10.to_variant().stringify().to_variant()
     );
-    // errors in godot but does not crash
+    // Errors in Godot, but should not crash.
     assert_eq!(callable.callv(&varray!["string"]), Variant::nil());
 }
 
@@ -188,6 +188,14 @@ pub mod custom_callable {
         // Important to test 0 arguments, as the FFI call passes a null pointer for the argument array.
         let sum3 = callable.callv(&varray![]);
         assert_eq!(sum3, 0.to_variant());
+    }
+
+    #[itest]
+    fn callable_custom_with_err() {
+        let callable_with_err =
+            Callable::from_fn("on_error_doesnt_crash", |_args: &[&Variant]| Err(()));
+        // Errors in Godot, but should not crash.
+        assert_eq!(callable_with_err.callv(&varray![]), Variant::nil());
     }
 
     #[itest]


### PR DESCRIPTION
Before #944 returning Err() with custom callable was causing crash without any sensible backtrace (both on windows 10 and linux):

```
================================================================
handle_crash: Program crashed with signal 11
Engine version: Godot Engine v4.3.stable.official (77dcf97d82cbfe4e4615475fa52ca03da645dbd8)
Dumping the backtrace. Please include this when reporting the bug to the project developer.
[1] /lib/x86_64-linux-gnu/libc.so.6(+0x42520) [0x7f64ce442520] (??:0)
[2] /home/irwin/apps/godot/godot/G4/Godot_v4.3-stable_linux.x86_64() [0x410be5c] (??:0)
[3] /home/irwin/apps/godot/godot/G4/Godot_v4.3-stable_linux.x86_64() [0x410c4a9] (??:0)
[4] /home/irwin/apps/godot/godot/G4/Godot_v4.3-stable_linux.x86_64() [0x4318e70] (??:0)
[5] /home/irwin/apps/godot/godot/G4/Godot_v4.3-stable_linux.x86_64() [0x232bafa] (??:0)
[6] /home/irwin/apps/godot/godot/G4/Godot_v4.3-stable_linux.x86_64() [0x232ba0e] (??:0)
[7] /home/irwin/apps/godot/godot/G4/Godot_v4.3-stable_linux.x86_64() [0x232ba0e] (??:0)
[8] /home/irwin/apps/godot/godot/G4/Godot_v4.3-stable_linux.x86_64() [0x232ba0e] (??:0)
[9] /home/irwin/apps/godot/godot/G4/Godot_v4.3-stable_linux.x86_64() [0x232ba0e] (??:0)
[10] /home/irwin/apps/godot/godot/G4/Godot_v4.3-stable_linux.x86_64() [0x232ba0e] (??:0)
[11] /home/irwin/apps/godot/godot/G4/Godot_v4.3-stable_linux.x86_64() [0x232ba0e] (??:0)
[12] /home/irwin/apps/godot/godot/G4/Godot_v4.3-stable_linux.x86_64() [0x232d0f8] (??:0)
[13] /home/irwin/apps/godot/godot/G4/Godot_v4.3-stable_linux.x86_64() [0x2347885] (??:0)
[14] /home/irwin/apps/godot/godot/G4/Godot_v4.3-stable_linux.x86_64() [0x4fe39a] (??:0)
[15] /home/irwin/apps/godot/godot/G4/Godot_v4.3-stable_linux.x86_64() [0x235e7fc] (??:0)
[16] /home/irwin/apps/godot/godot/G4/Godot_v4.3-stable_linux.x86_64() [0x23b64a5] (??:0)
[17] /home/irwin/apps/godot/godot/G4/Godot_v4.3-stable_linux.x86_64() [0x527ab4] (??:0)
[18] /home/irwin/apps/godot/godot/G4/Godot_v4.3-stable_linux.x86_64() [0x4202a2] (??:0)
[19] /lib/x86_64-linux-gnu/libc.so.6(+0x29d90) [0x7f64ce429d90] (??:0)
[20] /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0x80) [0x7f64ce429e40] (??:0)
[21] /home/irwin/apps/godot/godot/G4/Godot_v4.3-stable_linux.x86_64() [0x43d44a] (??:0)
-- END OF BACKTRACE --
================================================================
```

This PR adds an extra test case that should shield against the regression in the future.