### PR TITLE
Use `GDExtensionCallableCustomInfo2` instead of deprecated `GDExtensionCallableCustomInfo`.

### DIFF
--- a/.github/other/deny.toml
+++ b/.github/other/deny.toml
@@ -104,6 +104,7 @@ allow = [
     "BSD-3-Clause",
     "ISC",
     "Unicode-DFS-2016",
+    "Unicode-3.0", # unicode-ident
     "MPL-2.0",
     #"Apache-2.0 WITH LLVM-exception",
 ]


### PR DESCRIPTION
The only difference between old and new `GDExtensionCallableCustomInfo` is an addition of `get_argument_count_func`. In [godot-cpp](https://github.com/godotengine/godot-cpp/blob/master/src/variant/callable_custom.cpp#L38) implementation the only way to provide an argument count is overriding the method in a question.

For now I'm leaving the nullptr – consider implementing builder pattern for the Callable (`Callable::from_…ex(…).arg_count(n).done()`) if the need to do so arise (would require changes to userdata stored with the callable). 

One could provide blanket implementation, but IMO it would be only more confusing. Gdext checks if given function is present https://github.com/godotengine/godot/blob/0c45ace151f25de2ca54fe7a46b6f077be32ba6f/core/extension/gdextension_interface.cpp#L149, executes it and returns the result if it is valid (`r_is_valid`) – otherwise it returns "0" (in other words, the default implementation is already provided by the engine itself).