### PR TITLE
Clippy (elided lifetimes) + rustfmt

### DIFF
--- a/godot-cell/src/blocking_guards.rs
+++ b/godot-cell/src/blocking_guards.rs
@@ -43,7 +43,7 @@ impl<'a, T> Deref for RefGuardBlocking<'a, T> {
     }
 }
 
-impl<'a, T> Drop for RefGuardBlocking<'a, T> {
+impl<T> Drop for RefGuardBlocking<'_, T> {
     fn drop(&mut self) {
         let mut state_lock = self.state.lock().unwrap();
 
@@ -88,13 +88,13 @@ impl<'a, T> Deref for MutGuardBlocking<'a, T> {
     }
 }
 
-impl<'a, T> DerefMut for MutGuardBlocking<'a, T> {
+impl<T> DerefMut for MutGuardBlocking<'_, T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.inner.as_mut().unwrap().deref_mut()
     }
 }
 
-impl<'a, T> Drop for MutGuardBlocking<'a, T> {
+impl<T> Drop for MutGuardBlocking<'_, T> {
     fn drop(&mut self) {
         drop(self.inner.take());
 

--- a/godot-cell/src/guards.rs
+++ b/godot-cell/src/guards.rs
@@ -45,7 +45,7 @@ impl<'a, T> RefGuard<'a, T> {
     }
 }
 
-impl<'a, T> Deref for RefGuard<'a, T> {
+impl<T> Deref for RefGuard<'_, T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
@@ -54,7 +54,7 @@ impl<'a, T> Deref for RefGuard<'a, T> {
     }
 }
 
-impl<'a, T> Drop for RefGuard<'a, T> {
+impl<T> Drop for RefGuard<'_, T> {
     fn drop(&mut self) {
         self.state
             .lock()
@@ -122,7 +122,7 @@ impl<'a, T> MutGuard<'a, T> {
     }
 }
 
-impl<'a, T> Deref for MutGuard<'a, T> {
+impl<T> Deref for MutGuard<'_, T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
@@ -150,7 +150,7 @@ impl<'a, T> Deref for MutGuard<'a, T> {
     }
 }
 
-impl<'a, T> DerefMut for MutGuard<'a, T> {
+impl<T> DerefMut for MutGuard<'_, T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         let count = self.state.lock().unwrap().borrow_state.mut_count();
         // This is just a best-effort error check. It should never be triggered.
@@ -177,7 +177,7 @@ impl<'a, T> DerefMut for MutGuard<'a, T> {
     }
 }
 
-impl<'a, T> Drop for MutGuard<'a, T> {
+impl<T> Drop for MutGuard<'_, T> {
     fn drop(&mut self) {
         self.state
             .lock()
@@ -276,7 +276,7 @@ impl<'a, T> InaccessibleGuard<'a, T> {
     }
 }
 
-impl<'a, T> Drop for InaccessibleGuard<'a, T> {
+impl<T> Drop for InaccessibleGuard<'_, T> {
     fn drop(&mut self) {
         // Default behavior of drop-logic simply panics and poisons the cell on failure. This is appropriate
         // for single-threaded code where no errors should happen here.

--- a/godot-codegen/src/context.rs
+++ b/godot-codegen/src/context.rs
@@ -274,7 +274,7 @@ impl<'a> Context<'a> {
         self.cached_rust_types.get(ty)
     }
 
-    pub fn notification_constants(&'a self, class_name: &TyName) -> Option<&Vec<(Ident, i32)>> {
+    pub fn notification_constants(&'a self, class_name: &TyName) -> Option<&'a Vec<(Ident, i32)>> {
         self.notifications_by_class.get(class_name)
     }
 

--- a/godot-core/src/builder/mod.rs
+++ b/godot-core/src/builder/mod.rs
@@ -22,7 +22,7 @@ where
         Self { _c: PhantomData }
     }
 
-    pub fn virtual_method<'cb, F>(&'cb mut self, name: &'cb str, method: F) -> MethodBuilder<C, F> {
+    pub fn virtual_method<'cb, F>(&'cb mut self, name: &'cb str, method: F) -> MethodBuilder<'cb, C, F> {
         MethodBuilder::new(self, name, method)
     }
 }

--- a/godot-core/src/builder/mod.rs
+++ b/godot-core/src/builder/mod.rs
@@ -22,7 +22,11 @@ where
         Self { _c: PhantomData }
     }
 
-    pub fn virtual_method<'cb, F>(&'cb mut self, name: &'cb str, method: F) -> MethodBuilder<'cb, C, F> {
+    pub fn virtual_method<'cb, F>(
+        &'cb mut self,
+        name: &'cb str,
+        method: F,
+    ) -> MethodBuilder<'cb, C, F> {
         MethodBuilder::new(self, name, method)
     }
 }

--- a/godot-core/src/builtin/collections/array.rs
+++ b/godot-core/src/builtin/collections/array.rs
@@ -1250,7 +1250,7 @@ pub struct Iter<'a, T: ArrayElement> {
     next_idx: usize,
 }
 
-impl<'a, T: ArrayElement + FromGodot> Iterator for Iter<'a, T> {
+impl<T: ArrayElement + FromGodot> Iterator for Iter<'_, T> {
     type Item = T;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/godot-core/src/builtin/collections/array.rs
+++ b/godot-core/src/builtin/collections/array.rs
@@ -1102,8 +1102,10 @@ impl<T: ArrayElement> Drop for Array<T> {
 impl<T: ArrayElement> GodotType for Array<T> {
     type Ffi = Self;
 
-    type ToFfi<'f> = RefArg<'f, Array<T>>
-    where Self: 'f;
+    type ToFfi<'f>
+        = RefArg<'f, Array<T>>
+    where
+        Self: 'f;
 
     fn to_ffi(&self) -> Self::ToFfi<'_> {
         RefArg::new(self)

--- a/godot-core/src/builtin/collections/dictionary.rs
+++ b/godot-core/src/builtin/collections/dictionary.rs
@@ -572,7 +572,7 @@ impl<'a> Iter<'a> {
     }
 }
 
-impl<'a> Iterator for Iter<'a> {
+impl Iterator for Iter<'_> {
     type Item = (Variant, Variant);
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -614,7 +614,7 @@ impl<'a> Keys<'a> {
     }
 }
 
-impl<'a> Iterator for Keys<'a> {
+impl Iterator for Keys<'_> {
     type Item = Variant;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -647,7 +647,7 @@ impl<'a, K, V> TypedIter<'a, K, V> {
     }
 }
 
-impl<'a, K: FromGodot, V: FromGodot> Iterator for TypedIter<'a, K, V> {
+impl<K: FromGodot, V: FromGodot> Iterator for TypedIter<'_, K, V> {
     type Item = (K, V);
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -680,7 +680,7 @@ impl<'a, K> TypedKeys<'a, K> {
     }
 }
 
-impl<'a, K: FromGodot> Iterator for TypedKeys<'a, K> {
+impl<K: FromGodot> Iterator for TypedKeys<'_, K> {
     type Item = K;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/godot-core/src/builtin/string/mod.rs
+++ b/godot-core/src/builtin/string/mod.rs
@@ -24,8 +24,10 @@ impl GodotConvert for &str {
 }
 
 impl ToGodot for &str {
-    type ToVia<'v> = GString
-    where Self: 'v;
+    type ToVia<'v>
+        = GString
+    where
+        Self: 'v;
 
     fn to_godot(&self) -> Self::ToVia<'_> {
         GString::from(*self)

--- a/godot-core/src/builtin/string/string_name.rs
+++ b/godot-core/src/builtin/string/string_name.rs
@@ -344,22 +344,22 @@ impl From<&'static std::ffi::CStr> for StringName {
 /// See [`StringName::transient_ord()`].
 pub struct TransientStringNameOrd<'a>(&'a StringName);
 
-impl<'a> PartialEq for TransientStringNameOrd<'a> {
+impl PartialEq for TransientStringNameOrd<'_> {
     fn eq(&self, other: &Self) -> bool {
         self.0 == other.0
     }
 }
 
-impl<'a> Eq for TransientStringNameOrd<'a> {}
+impl Eq for TransientStringNameOrd<'_> {}
 
-impl<'a> PartialOrd for TransientStringNameOrd<'a> {
+impl PartialOrd for TransientStringNameOrd<'_> {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
     }
 }
 
 // implement Ord like above
-impl<'a> Ord for TransientStringNameOrd<'a> {
+impl Ord for TransientStringNameOrd<'_> {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         // SAFETY: builtin operator provided by Godot.
         let op_less = |lhs, rhs| unsafe {

--- a/godot-core/src/meta/args/as_arg.rs
+++ b/godot-core/src/meta/args/as_arg.rs
@@ -179,7 +179,7 @@ macro_rules! declare_arg_method {
 ///
 /// Allows forwarding of `impl AsArg<T>` arguments to both another signature of `impl AsArg<T>` and signature of `T` for `Copy` types.
 /// This is necessary for packed array dispatching to different "inner" backend signatures.
-impl<'a, T> AsArg<T> for CowArg<'a, T>
+impl<T> AsArg<T> for CowArg<'_, T>
 where
     for<'r> T: ParamType<Arg<'r> = CowArg<'r, T>> + 'r,
 {

--- a/godot-core/src/meta/args/cow_arg.rs
+++ b/godot-core/src/meta/args/cow_arg.rs
@@ -82,8 +82,10 @@ impl<T> ToGodot for CowArg<'_, T>
 where
     T: ToGodot,
 {
-    type ToVia<'v> = T::ToVia<'v>
-    where Self: 'v;
+    type ToVia<'v>
+        = T::ToVia<'v>
+    where
+        Self: 'v;
 
     fn to_godot(&self) -> Self::ToVia<'_> {
         self.cow_as_ref().to_godot()

--- a/godot-core/src/meta/args/cow_arg.rs
+++ b/godot-core/src/meta/args/cow_arg.rs
@@ -20,7 +20,7 @@ pub enum CowArg<'r, T> {
     Borrowed(&'r T),
 }
 
-impl<'r, T> CowArg<'r, T> {
+impl<T> CowArg<'_, T> {
     pub fn cow_into_owned(self) -> T
     where
         T: Clone,
@@ -53,7 +53,7 @@ impl<'r, T> CowArg<'r, T> {
 ///
 /// `Borrow` may not be the most idiomatic trait for this, but it has the convenient feature that it's implemented for both `T` and `&T`.
 /// Since this is a hidden API, it doesn't matter.
-impl<'r, T> std::borrow::Borrow<T> for CowArg<'r, T> {
+impl<T> std::borrow::Borrow<T> for CowArg<'_, T> {
     fn borrow(&self) -> &T {
         match self {
             CowArg::Owned(v) => v,
@@ -71,14 +71,14 @@ macro_rules! wrong_direction {
     };
 }
 
-impl<'r, T> GodotConvert for CowArg<'r, T>
+impl<T> GodotConvert for CowArg<'_, T>
 where
     T: GodotConvert,
 {
     type Via = T::Via;
 }
 
-impl<'r, T> ToGodot for CowArg<'r, T>
+impl<T> ToGodot for CowArg<'_, T>
 where
     T: ToGodot,
 {
@@ -91,7 +91,7 @@ where
 }
 
 // TODO refactor signature tuples into separate in+out traits, so FromGodot is no longer needed.
-impl<'r, T> FromGodot for CowArg<'r, T>
+impl<T> FromGodot for CowArg<'_, T>
 where
     T: FromGodot,
 {
@@ -100,7 +100,7 @@ where
     }
 }
 
-impl<'r, T> fmt::Debug for CowArg<'r, T>
+impl<T> fmt::Debug for CowArg<'_, T>
 where
     T: fmt::Debug,
 {
@@ -113,7 +113,7 @@ where
 }
 
 // SAFETY: delegated to T.
-unsafe impl<'r, T> GodotFfi for CowArg<'r, T>
+unsafe impl<T> GodotFfi for CowArg<'_, T>
 where
     T: GodotFfi,
 {
@@ -157,7 +157,7 @@ where
     }
 }
 
-impl<'r, T> GodotFfiVariant for CowArg<'r, T>
+impl<T> GodotFfiVariant for CowArg<'_, T>
 where
     T: GodotFfiVariant,
 {
@@ -170,7 +170,7 @@ where
     }
 }
 
-impl<'r, T> GodotNullableFfi for CowArg<'r, T>
+impl<T> GodotNullableFfi for CowArg<'_, T>
 where
     T: GodotNullableFfi,
 {

--- a/godot-core/src/meta/args/ref_arg.rs
+++ b/godot-core/src/meta/args/ref_arg.rs
@@ -73,14 +73,14 @@ macro_rules! wrong_direction {
     };
 }
 
-impl<'r, T> GodotConvert for RefArg<'r, T>
+impl<T> GodotConvert for RefArg<'_, T>
 where
     T: GodotConvert,
 {
     type Via = T::Via;
 }
 
-impl<'r, T> ToGodot for RefArg<'r, T>
+impl<T> ToGodot for RefArg<'_, T>
 where
     T: ToGodot,
 {
@@ -97,7 +97,7 @@ where
 }
 
 // TODO refactor signature tuples into separate in+out traits, so FromGodot is no longer needed.
-impl<'r, T> FromGodot for RefArg<'r, T>
+impl<T> FromGodot for RefArg<'_, T>
 where
     T: FromGodot,
 {
@@ -106,7 +106,7 @@ where
     }
 }
 
-impl<'r, T> fmt::Debug for RefArg<'r, T>
+impl<T> fmt::Debug for RefArg<'_, T>
 where
     T: fmt::Debug,
 {
@@ -116,7 +116,7 @@ where
 }
 
 // SAFETY: delegated to T.
-unsafe impl<'r, T> GodotFfi for RefArg<'r, T>
+unsafe impl<T> GodotFfi for RefArg<'_, T>
 where
     T: GodotFfi,
 {
@@ -166,7 +166,7 @@ where
     }
 }
 
-impl<'r, T> GodotFfiVariant for RefArg<'r, T>
+impl<T> GodotFfiVariant for RefArg<'_, T>
 where
     T: GodotFfiVariant,
 {
@@ -182,7 +182,7 @@ where
     }
 }
 
-impl<'r, T> GodotNullableFfi for RefArg<'r, T>
+impl<T> GodotNullableFfi for RefArg<'_, T>
 where
     T: GodotNullableFfi,
 {

--- a/godot-core/src/meta/args/ref_arg.rs
+++ b/godot-core/src/meta/args/ref_arg.rs
@@ -84,8 +84,10 @@ impl<T> ToGodot for RefArg<'_, T>
 where
     T: ToGodot,
 {
-    type ToVia<'v> = T::ToVia<'v>
-    where Self: 'v;
+    type ToVia<'v>
+        = T::ToVia<'v>
+    where
+        Self: 'v;
 
     fn to_godot(&self) -> Self::ToVia<'_> {
         let shared_ref = self

--- a/godot-core/src/meta/godot_convert/impls.rs
+++ b/godot-core/src/meta/godot_convert/impls.rs
@@ -100,9 +100,11 @@ where
         ToFfi<'f>: GodotNullableFfi,
     >,
 {
-    type ToVia<'v> = Option<T::ToVia<'v>>
+    type ToVia<'v>
+        = Option<T::ToVia<'v>>
     // type ToVia<'v> = Self::Via
-    where Self: 'v;
+    where
+        Self: 'v;
 
     fn to_godot(&self) -> Self::ToVia<'_> {
         self.as_ref().map(ToGodot::to_godot)
@@ -421,8 +423,10 @@ impl<T: ArrayElement> GodotConvert for &[T] {
 }
 
 impl<T: ArrayElement> ToGodot for &[T] {
-    type ToVia<'v> = Array<T>
-    where Self: 'v;
+    type ToVia<'v>
+        = Array<T>
+    where
+        Self: 'v;
 
     fn to_godot(&self) -> Self::ToVia<'_> {
         Array::from(*self)

--- a/godot-core/src/meta/signature.rs
+++ b/godot-core/src/meta/signature.rs
@@ -654,7 +654,7 @@ impl<'a> CallContext<'a> {
     }
 }
 
-impl<'a> fmt::Display for CallContext<'a> {
+impl fmt::Display for CallContext<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}::{}", self.class_name, self.function_name)
     }

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -793,7 +793,7 @@ impl<T: GodotClass> ParamType for Gd<T> {
     }
 }
 
-impl<'r, T: GodotClass> AsArg<Option<Gd<T>>> for Option<&'r Gd<T>> {
+impl<T: GodotClass> AsArg<Option<Gd<T>>> for Option<&Gd<T>> {
     fn into_arg<'cow>(self) -> CowArg<'cow, Option<Gd<T>>> {
         // TODO avoid cloning.
         match self {

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -696,8 +696,10 @@ impl<T: GodotClass> FromGodot for Gd<T> {
 impl<T: GodotClass> GodotType for Gd<T> {
     type Ffi = RawGd<T>;
 
-    type ToFfi<'f> = RefArg<'f, RawGd<T>>
-    where Self: 'f;
+    type ToFfi<'f>
+        = RefArg<'f, RawGd<T>>
+    where
+        Self: 'f;
 
     fn to_ffi(&self) -> Self::ToFfi<'_> {
         RefArg::new(&self.raw)

--- a/godot-core/src/obj/raw_gd.rs
+++ b/godot-core/src/obj/raw_gd.rs
@@ -544,8 +544,10 @@ impl<T: GodotClass> FromGodot for RawGd<T> {
 impl<T: GodotClass> GodotType for RawGd<T> {
     type Ffi = Self;
 
-    type ToFfi<'f> = RefArg<'f, RawGd<T>>
-    where Self: 'f;
+    type ToFfi<'f>
+        = RefArg<'f, RawGd<T>>
+    where
+        Self: 'f;
 
     fn to_ffi(&self) -> Self::ToFfi<'_> {
         RefArg::new(self)

--- a/godot-core/src/obj/script.rs
+++ b/godot-core/src/obj/script.rs
@@ -474,7 +474,7 @@ impl<'a, T: ScriptInstance> SiMut<'a, T> {
     }
 }
 
-impl<'a, T: ScriptInstance> Deref for SiMut<'a, T> {
+impl<T: ScriptInstance> Deref for SiMut<'_, T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
@@ -482,7 +482,7 @@ impl<'a, T: ScriptInstance> Deref for SiMut<'a, T> {
     }
 }
 
-impl<'a, T: ScriptInstance> DerefMut for SiMut<'a, T> {
+impl<T: ScriptInstance> DerefMut for SiMut<'_, T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.mut_ref
     }

--- a/godot-core/src/registry/property.rs
+++ b/godot-core/src/registry/property.rs
@@ -21,7 +21,6 @@ use crate::meta::{ClassName, FromGodot, GodotConvert, GodotType, PropertyHintInf
 ///
 /// This does not require [`FromGodot`] or [`ToGodot`], so that something can be used as a property even if it can't be used in function
 /// arguments/return types.
-
 // on_unimplemented: we also mention #[export] here, because we can't control the order of error messages.
 // Missing Export often also means missing Var trait, and so the Var error message appears first.
 #[diagnostic::on_unimplemented(

--- a/godot-ffi/src/plugins.rs
+++ b/godot-ffi/src/plugins.rs
@@ -5,7 +5,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-/// Distributed self-registration of "plugins" without central list
+//! Distributed self-registration of "plugins" without central list
 
 // Note: code in this file is safe, however it seems that some annotations fall into the "unsafe" category.
 // For example, adding #![forbid(unsafe_code)] causes this error:

--- a/godot-ffi/src/string_cache.rs
+++ b/godot-ffi/src/string_cache.rs
@@ -102,7 +102,7 @@ impl<'a> StringCache<'a> {
 }
 
 /// Destroy all string names.
-impl<'a> Drop for StringCache<'a> {
+impl Drop for StringCache<'_> {
     fn drop(&mut self) {
         let string_name_destroy = self.builtin_lifecycle.string_name_destroy;
 

--- a/godot-macros/src/derive/derive_godot_convert.rs
+++ b/godot-macros/src/derive/derive_godot_convert.rs
@@ -54,7 +54,7 @@ impl EnumeratorExprCache {
         int: &'ords Ident,
         names: &'ords [Ident],
         ord_exprs: &'ords [TokenStream],
-    ) -> impl Iterator<Item = &TokenStream> + 'cache {
+    ) -> impl Iterator<Item = &'cache TokenStream> + 'cache {
         self.ensure_initialized(int, names, ord_exprs);
 
         names


### PR DESCRIPTION
Follow clippy lints which seem to be newly enforced as of Rust 1.83:
- `clippy::needless-lifetimes`
- `clippy::elided-named-lifetimes`
- `clippy::empty-line-after-doc-comments`

Also, rustfmt requires changes in several parts.