### PR TITLE
`DynGd` trait support + `FromGodot` "re-enrichment" conversions

### DIFF
--- a/godot-core/src/builtin/collections/array.rs
+++ b/godot-core/src/builtin/collections/array.rs
@@ -109,6 +109,22 @@ use sys::{ffi_methods, interface_fn, GodotFfi};
 /// compiler will enforce this as long as you use only Rust threads, but it cannot protect against
 /// concurrent modification on other threads (e.g. created through GDScript).
 ///
+/// # Element type safety
+///
+/// We provide a richer set of element types than Godot, for convenience and stronger invariants in your _Rust_ code.
+/// This, however, means that the Godot representation of such arrays is not capable of incorporating the additional "Rust-side" information.
+/// This can lead to situations where GDScript code or the editor UI can insert values that do not fulfill the Rust-side invariants.
+/// The library offers some best-effort protection in Debug mode, but certain errors may only occur on element access, in the form of panics.
+///
+/// Concretely, the following types lose type information when passed to Godot. If you want 100% bullet-proof arrays, avoid those.
+/// - Non-`i64` integers: `i8`, `i16`, `i32`, `u8`, `u16`, `u32`. (`u64` is unsupported).
+/// - Non-`f64` floats: `f32`.
+/// - Non-null objects: [`Gd<T>`][crate::obj::Gd].
+///   Godot generally allows `null` in arrays due to default-constructability, e.g. when using `resize()`.
+///   The Godot-faithful (but less convenient) alternative is to use `Option<Gd<T>>` element types.
+/// - Objects with dyn-trait association: [`DynGd<T, D>`][crate::obj::DynGd].
+///   Godot doesn't know Rust traits and will only see the `T` part.
+///
 /// # Godot docs
 ///
 /// [`Array[T]` (stable)](https://docs.godotengine.org/en/stable/classes/class_array.html)

--- a/godot-core/src/classes/class_runtime.rs
+++ b/godot-core/src/classes/class_runtime.rs
@@ -7,7 +7,7 @@
 
 //! Runtime checks and inspection of Godot classes.
 
-use crate::builtin::GString;
+use crate::builtin::{GString, StringName};
 use crate::classes::{ClassDb, Object};
 use crate::meta::{CallContext, ClassName};
 use crate::obj::{bounds, Bounds, Gd, GodotClass, InstanceId};
@@ -19,8 +19,22 @@ pub(crate) fn debug_string<T: GodotClass>(
     ty: &str,
 ) -> std::fmt::Result {
     if let Some(id) = obj.instance_id_or_none() {
-        let class: GString = obj.raw.as_object().get_class();
+        let class: StringName = obj.dynamic_class_string();
         write!(f, "{ty} {{ id: {id}, class: {class} }}")
+    } else {
+        write!(f, "{ty} {{ freed obj }}")
+    }
+}
+
+pub(crate) fn debug_string_with_trait<T: GodotClass>(
+    obj: &Gd<T>,
+    f: &mut std::fmt::Formatter<'_>,
+    ty: &str,
+    trt: &str,
+) -> std::fmt::Result {
+    if let Some(id) = obj.instance_id_or_none() {
+        let class: StringName = obj.dynamic_class_string();
+        write!(f, "{ty} {{ id: {id}, class: {class}, trait: {trt} }}")
     } else {
         write!(f, "{ty} {{ freed obj }}")
     }

--- a/godot-core/src/meta/error/call_error.rs
+++ b/godot-core/src/meta/error/call_error.rs
@@ -188,9 +188,8 @@ impl CallError {
         expected: VariantType,
     ) -> Self {
         // Note: reason is same wording as in FromVariantError::description().
-        let reason = format!(
-            "parameter #{param_index} conversion -- expected type {expected:?}, got {actual:?}"
-        );
+        let reason =
+            format!("parameter #{param_index} -- cannot convert from {actual:?} to {expected:?}");
 
         Self::new(call_ctx, reason, None)
     }

--- a/godot-core/src/meta/error/convert_error.rs
+++ b/godot-core/src/meta/error/convert_error.rs
@@ -181,6 +181,12 @@ pub(crate) enum FromGodotError {
     /// InvalidEnum is also used by bitfields.
     InvalidEnum,
 
+    /// Cannot map object to `dyn Trait` because none of the known concrete classes implements it.
+    UnimplementedDynTrait {
+        trait_id: std::any::TypeId,
+        class_name: String,
+    },
+
     /// `InstanceId` cannot be 0.
     ZeroInstanceId,
 }
@@ -235,6 +241,15 @@ impl fmt::Display for FromGodotError {
             }
             Self::InvalidEnum => write!(f, "invalid engine enum value"),
             Self::ZeroInstanceId => write!(f, "`InstanceId` cannot be 0"),
+            Self::UnimplementedDynTrait {
+                trait_id,
+                class_name,
+            } => {
+                write!(
+                    f,
+                    "none of the derived classes from {class_name} have been registered with trait {trait_id:?}"
+                )
+            }
         }
     }
 }

--- a/godot-core/src/meta/error/convert_error.rs
+++ b/godot-core/src/meta/error/convert_error.rs
@@ -183,9 +183,12 @@ pub(crate) enum FromGodotError {
 
     /// Cannot map object to `dyn Trait` because none of the known concrete classes implements it.
     UnimplementedDynTrait {
-        trait_id: std::any::TypeId,
+        trait_name: String,
         class_name: String,
     },
+
+    /// Cannot map object to `dyn Trait` because none of the known concrete classes implements it.
+    UnregisteredDynTrait { trait_name: String },
 
     /// `InstanceId` cannot be 0.
     ZeroInstanceId,
@@ -242,12 +245,18 @@ impl fmt::Display for FromGodotError {
             Self::InvalidEnum => write!(f, "invalid engine enum value"),
             Self::ZeroInstanceId => write!(f, "`InstanceId` cannot be 0"),
             Self::UnimplementedDynTrait {
-                trait_id,
+                trait_name,
                 class_name,
             } => {
                 write!(
                     f,
-                    "none of the derived classes from {class_name} have been registered with trait {trait_id:?}"
+                    "none of the classes derived from `{class_name}` have been linked to trait `{trait_name}` with #[godot_dyn]"
+                )
+            }
+            FromGodotError::UnregisteredDynTrait { trait_name } => {
+                write!(
+                    f,
+                    "trait `{trait_name}` has not been registered with #[godot_dyn]"
                 )
             }
         }
@@ -328,11 +337,11 @@ impl fmt::Display for FromVariantError {
         match self {
             Self::BadType { expected, actual } => {
                 // Note: wording is the same as in CallError::failed_param_conversion_engine()
-                write!(f, "expected type {expected:?}, got {actual:?}")
+                write!(f, "cannot convert from {actual:?} to {expected:?}")
             }
             Self::BadValue => write!(f, "value cannot be represented in target type's domain"),
             Self::WrongClass { expected } => {
-                write!(f, "expected class {expected}")
+                write!(f, "cannot convert to class {expected}")
             }
         }
     }

--- a/godot-core/src/meta/sealed.rs
+++ b/godot-core/src/meta/sealed.rs
@@ -11,7 +11,7 @@
 use crate::builtin::*;
 use crate::meta;
 use crate::meta::traits::{ArrayElement, GodotNullableFfi, GodotType};
-use crate::obj::{Gd, GodotClass, RawGd};
+use crate::obj::{DynGd, Gd, GodotClass, RawGd};
 
 pub trait Sealed {}
 impl Sealed for Aabb {}
@@ -64,6 +64,7 @@ impl Sealed for Variant {}
 impl<T: ArrayElement> Sealed for Array<T> {}
 impl<T: GodotClass> Sealed for Gd<T> {}
 impl<T: GodotClass> Sealed for RawGd<T> {}
+impl<T: GodotClass, D: ?Sized> Sealed for DynGd<T, D> {}
 impl<T: GodotClass> Sealed for meta::ObjectArg<T> {}
 impl<T> Sealed for Option<T>
 where

--- a/godot-core/src/obj/dyn_gd.rs
+++ b/godot-core/src/obj/dyn_gd.rs
@@ -245,6 +245,37 @@ where
     }
 }
 
+impl<T, D> PartialEq for DynGd<T, D>
+where
+    T: GodotClass,
+    D: ?Sized,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.obj == other.obj
+    }
+}
+
+impl<T, D> Eq for DynGd<T, D>
+where
+    T: GodotClass,
+    D: ?Sized,
+{
+}
+
+impl<T, D> std::hash::Hash for DynGd<T, D>
+where
+    T: GodotClass,
+    D: ?Sized,
+{
+    /// ⚠️ Hashes this object based on its instance ID.
+    ///
+    /// # Panics
+    /// When `self` is dead.
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.obj.hash(state);
+    }
+}
+
 impl<T, D> ops::Deref for DynGd<T, D>
 where
     T: GodotClass,
@@ -275,6 +306,16 @@ where
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let trt = sys::short_type_name::<D>();
         crate::classes::debug_string_with_trait::<T>(self, f, "DynGd", &trt)
+    }
+}
+
+impl<T, D> fmt::Display for DynGd<T, D>
+where
+    T: GodotClass,
+    D: ?Sized,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        crate::classes::display_string(self, f)
     }
 }
 

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -320,6 +320,13 @@ impl<T: GodotClass> Gd<T> {
             .expect("Upcast failed. This is a bug; please report it.")
     }
 
+    /// Equivalent to [`upcast::<Object>()`][Self::upcast], but without bounds.
+    // Not yet public because it might need _mut/_ref overloads, and 6 upcast methods are a bit much...
+    pub(crate) fn upcast_object(self) -> Gd<classes::Object> {
+        self.owned_cast()
+            .expect("Upcast to Object failed. This is a bug; please report it.")
+    }
+
     /// **Upcast shared-ref:** access this object as a shared reference to a base class.
     ///
     /// This is semantically equivalent to multiple applications of [`Self::deref()`]. Not really useful on its own, but combined with
@@ -427,8 +434,9 @@ impl<T: GodotClass> Gd<T> {
         })
     }
 
-    /// Returns `Ok(cast_obj)` on success, `Err(self)` on error
-    fn owned_cast<U>(self) -> Result<Gd<U>, Self>
+    /// Returns `Ok(cast_obj)` on success, `Err(self)` on error.
+    // Visibility: used by DynGd.
+    pub(crate) fn owned_cast<U>(self) -> Result<Gd<U>, Self>
     where
         U: GodotClass,
     {

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -727,6 +727,7 @@ impl<T: GodotClass> FromGodot for Gd<T> {
     }
 }
 
+// Keep in sync with DynGd.
 impl<T: GodotClass> GodotType for Gd<T> {
     // Some #[doc(hidden)] are repeated despite already declared in trait; some IDEs suggest in auto-complete otherwise.
     type Ffi = RawGd<T>;

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -9,8 +9,7 @@ use std::fmt::{Debug, Display, Formatter, Result as FmtResult};
 use std::ops::{Deref, DerefMut};
 
 use godot_ffi as sys;
-
-use sys::{static_assert_eq_size_align, VariantType};
+use sys::{static_assert_eq_size_align, SysPtr as _, VariantType};
 
 use crate::builtin::{Callable, NodePath, StringName, Variant};
 use crate::global::PropertyHint;
@@ -276,6 +275,27 @@ impl<T: GodotClass> Gd<T> {
     /// runtime condition to check against.
     pub fn is_instance_valid(&self) -> bool {
         self.raw.is_instance_valid()
+    }
+
+    /// Returns the dynamic class name of the object as `StringName`.
+    ///
+    /// This method retrieves the class name of the object at runtime, which can be different from [`T::class_name()`] if derived
+    /// classes are involved.
+    ///
+    /// Unlike [`Object::get_class()`], this returns `StringName` instead of `GString` and needs no `Inherits<Object>` bound.
+    pub(crate) fn dynamic_class_string(&self) -> StringName {
+        unsafe {
+            StringName::new_with_string_uninit(|ptr| {
+                let success = sys::interface_fn!(object_get_class_name)(
+                    self.obj_sys().as_const(),
+                    sys::get_library(),
+                    ptr,
+                );
+
+                let success = sys::conv::bool_from_sys(success);
+                assert!(success, "failed to get class name for object {self:?}");
+            })
+        }
     }
 
     /// **Upcast:** convert into a smart pointer to a base class. Always succeeds.

--- a/godot-core/src/private.rs
+++ b/godot-core/src/private.rs
@@ -9,7 +9,7 @@ pub use crate::gen::classes::class_macros;
 pub use crate::obj::rtti::ObjectRtti;
 pub use crate::registry::callbacks;
 pub use crate::registry::plugin::{
-    ClassPlugin, ErasedRegisterFn, ErasedRegisterRpcsFn, InherentImpl, PluginItem,
+    ClassPlugin, ErasedDynGd, ErasedRegisterFn, ErasedRegisterRpcsFn, InherentImpl, PluginItem,
 };
 pub use crate::storage::{as_storage, Storage};
 pub use sys::out;
@@ -23,6 +23,7 @@ use crate::meta::CallContext;
 use crate::sys;
 use std::sync::{atomic, Arc, Mutex};
 use sys::Global;
+
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Global variables
 

--- a/godot-ffi/src/toolbox.rs
+++ b/godot-ffi/src/toolbox.rs
@@ -188,13 +188,13 @@ pub fn unqualified_type_name<T>() -> &'static str {
 */
 
 /// Like [`std::any::type_name`], but returns a short type name without module paths.
-pub fn short_type_name<T>() -> String {
+pub fn short_type_name<T: ?Sized>() -> String {
     let full_name = std::any::type_name::<T>();
     strip_module_paths(full_name)
 }
 
 /// Like [`std::any::type_name_of_val`], but returns a short type name without module paths.
-pub fn short_type_name_of_val<T>(val: &T) -> String {
+pub fn short_type_name_of_val<T: ?Sized>(val: &T) -> String {
     let full_name = std::any::type_name_of_val(val);
     strip_module_paths(full_name)
 }

--- a/godot-macros/src/util/mod.rs
+++ b/godot-macros/src/util/mod.rs
@@ -212,7 +212,7 @@ fn validate_self(original_impl: &venial::Impl, attr: &str) -> ParseResult<Ident>
 }
 
 /// Gets the right-most type name in the path.
-fn extract_typename(ty: &venial::TypeExpr) -> Option<venial::PathSegment> {
+pub(crate) fn extract_typename(ty: &venial::TypeExpr) -> Option<venial::PathSegment> {
     match ty.as_path() {
         Some(mut path) => path.segments.pop(),
         _ => None,

--- a/itest/rust/src/builtin_tests/containers/variant_test.rs
+++ b/itest/rust/src/builtin_tests/containers/variant_test.rs
@@ -131,6 +131,22 @@ fn variant_bad_conversions() {
 }
 
 #[itest]
+fn variant_bad_conversion_error_message() {
+    let variant = 123.to_variant();
+
+    let err = variant
+        .try_to::<GString>()
+        .expect_err("i32 -> GString conversion should fail");
+    assert_eq!(err.to_string(), "cannot convert from INT to STRING: 123");
+
+    // TODO this error isn't great, but unclear whether it can be improved. If not, document.
+    let err = variant
+        .try_to::<Gd<Node>>()
+        .expect_err("i32 -> Gd<Node> conversion should fail");
+    assert_eq!(err.to_string(), "`Gd` cannot be null: null");
+}
+
+#[itest]
 fn variant_array_bad_conversions() {
     let i32_array: Array<i32> = array![1, 2, 160, -40];
     let i32_variant = i32_array.to_variant();

--- a/itest/rust/src/object_tests/dyn_gd_test.rs
+++ b/itest/rust/src/object_tests/dyn_gd_test.rs
@@ -114,6 +114,51 @@ fn dyn_gd_debug() {
 }
 
 #[itest]
+fn dyn_gd_display() {
+    let obj = Gd::from_object(RefcHealth { hp: 55 }).into_dyn();
+
+    let actual = format!("{obj}");
+    let expected = "RefcHealth(hp=55)";
+
+    assert_eq!(actual, expected);
+}
+
+#[itest]
+fn dyn_gd_eq() {
+    let gd = Gd::from_object(RefcHealth { hp: 55 });
+    let a = gd.clone().into_dyn();
+    let b = gd.into_dyn();
+    let c = b.clone();
+
+    assert_eq!(a, b);
+    assert_eq!(a, c);
+    assert_eq!(b, c);
+
+    let x = Gd::from_object(RefcHealth { hp: 55 }).into_dyn();
+
+    assert_ne!(a, x);
+}
+
+#[itest]
+fn dyn_gd_hash() {
+    use godot::sys::hash_value;
+
+    let gd = Gd::from_object(RefcHealth { hp: 55 });
+    let a = gd.clone().into_dyn();
+    let b = gd.into_dyn();
+    let c = b.clone();
+
+    assert_eq!(hash_value(&a), hash_value(&b));
+    assert_eq!(hash_value(&a), hash_value(&c));
+    assert_eq!(hash_value(&b), hash_value(&c));
+
+    let x = Gd::from_object(RefcHealth { hp: 55 }).into_dyn();
+
+    // Not guaranteed, but exceedingly likely.
+    assert_ne!(hash_value(&a), hash_value(&x));
+}
+
+#[itest]
 fn dyn_gd_exclusive_guard() {
     let mut a = foreign::NodeHealth::new_alloc().into_dyn();
     let mut b = a.clone();
@@ -267,6 +312,13 @@ trait Health {
 #[class(init)]
 struct RefcHealth {
     hp: u8,
+}
+
+#[godot_api]
+impl IRefCounted for RefcHealth {
+    fn to_string(&self) -> GString {
+        format!("RefcHealth(hp={})", self.hp).into()
+    }
 }
 
 // Pretend NodeHealth is defined somewhere else, with a default constructor but

--- a/itest/rust/src/object_tests/dynamic_call_test.rs
+++ b/itest/rust/src/object_tests/dynamic_call_test.rs
@@ -133,7 +133,7 @@ fn dynamic_call_parameter_mismatch() {
         "godot-rust function call failed: Object::call(&\"take_1_int\", [va] \"string\")\
         \n  Source: ObjPayload::take_1_int()\
         \n    Reason: parameter #0 (i64) conversion\
-        \n  Source: expected type INT, got STRING: \"string\""
+        \n  Source: cannot convert from STRING to INT: \"string\""
     );
 
     obj.free();
@@ -271,7 +271,7 @@ fn dynamic_call_parameter_mismatch_engine() {
     assert_eq!(
         call_error.to_string(),
         "godot-rust function call failed: Object::call(&\"set_name\", [va] 123)\
-        \n    Reason: parameter #1 conversion -- expected type STRING, got INT"
+        \n    Reason: parameter #1 -- cannot convert from INT to STRING"
     );
 
     node.free();

--- a/itest/rust/src/object_tests/object_test.rs
+++ b/itest/rust/src/object_tests/object_test.rs
@@ -519,6 +519,20 @@ fn object_engine_convert_variant_nil() {
 }
 
 #[itest]
+fn object_engine_convert_variant_error() {
+    let refc = RefCounted::new_gd();
+    let variant = refc.to_variant();
+
+    let err = Gd::<Area2D>::try_from_variant(&variant)
+        .expect_err("`Gd<RefCounted>` should not convert to `Gd<Area2D>`");
+
+    assert_eq!(
+        err.to_string(),
+        format!("cannot convert to class Area2D: {refc:?}")
+    );
+}
+
+#[itest]
 fn object_engine_returned_refcount() {
     let Some(file) = FileAccess::open("res://itest.gdextension", file_access::ModeFlags::READ)
     else {


### PR DESCRIPTION
Follow-up to #953.

Many thanks to @Yarwin, who supported me throughout the design + implementation phase (also with great ideas from #930), and helped a lot with testing! :muscle: 

This enhances the bare-bones #953 with a ton of traits to integrate with Godot, most notably:
- `Debug`
- `Display`
- `Eq` + `PartialEq` + `Hash` (reference semantics like `Gd`)
- `ToGodot`, `GodotConvert` (pass as object to Godot)
- `FromGodot` (hard*)
- `ArrayElement`
- `AsArg` + `ParamType`.

The `DynGd` API is extended to include `cast` + `try_cast`, as well as a lot more documentation.

Also improves some error messages for existing conversions.

---
\* `FromGodot` was particularly difficult, because we need to obtain a `dyn Trait` pointer from the aether (Godot doesn't have it), and make sure it points to the correct `impl Trait` vtable. Thanks again for the digging, Yarwin!

