### PR TITLE
`Callable::from_local_fn()` + `Callable::from_sync_fn()`

### DIFF
--- a/itest/rust/src/builtin_tests/containers/array_test.rs
+++ b/itest/rust/src/builtin_tests/containers/array_test.rs
@@ -494,7 +494,7 @@ fn array_binary_search_custom() {
 
 #[cfg(since_api = "4.2")]
 fn backwards_sort_callable() -> Callable {
-    Callable::from_fn("sort backwards", |args: &[&Variant]| {
+    Callable::from_local_fn("sort backwards", |args: &[&Variant]| {
         let res = args[0].to::<i32>() > args[1].to::<i32>();
         Ok(res.to_variant())
     })

--- a/itest/rust/src/builtin_tests/containers/signal_test.rs
+++ b/itest/rust/src/builtin_tests/containers/signal_test.rs
@@ -247,7 +247,7 @@ mod custom_callable {
     }
 
     fn connect_signal_panic_from_fn(received: Arc<AtomicU32>) -> Callable {
-        Callable::from_fn("test", move |_args| {
+        Callable::from_local_fn("test", move |_args| {
             panic!("TEST: {}", received.fetch_add(1, Ordering::SeqCst))
         })
     }

--- a/itest/rust/src/framework/mod.rs
+++ b/itest/rust/src/framework/mod.rs
@@ -77,6 +77,25 @@ pub struct TestContext {
     pub property_tests: Gd<Node>,
 }
 
+/// Utility to assert that something can be sent between threads.
+pub struct ThreadCrosser<T> {
+    value: T,
+}
+
+impl<T> ThreadCrosser<T> {
+    pub fn new(value: T) -> Self {
+        Self { value }
+    }
+
+    /// # Safety
+    /// Bypasses `Send` checks, user's responsibility.
+    pub unsafe fn extract(self) -> T {
+        self.value
+    }
+}
+
+unsafe impl<T> Send for ThreadCrosser<T> {}
+
 #[derive(Copy, Clone)]
 pub struct RustTestCase {
     pub name: &'static str,
@@ -123,6 +142,29 @@ pub fn expect_panic(context: &str, code: impl FnOnce()) {
         panic.is_err(),
         "code should have panicked but did not: {context}",
     );
+}
+
+/// Synchronously run a thread and return result. Panics are propagated to caller thread.
+#[track_caller]
+pub fn quick_thread<R, F>(f: F) -> R
+where
+    F: FnOnce() -> R + Send + 'static,
+    R: Send + 'static,
+{
+    let handle = std::thread::spawn(f);
+
+    match handle.join() {
+        Ok(result) => result,
+        Err(panic_payload) => {
+            if let Some(s) = panic_payload.downcast_ref::<&str>() {
+                panic!("quick_thread panicked: {s}")
+            } else if let Some(s) = panic_payload.downcast_ref::<String>() {
+                panic!("quick_thread panicked: {s}")
+            } else {
+                panic!("quick_thread panicked with unknown type.")
+            };
+        }
+    }
 }
 
 /// Disable printing errors from Godot. Ideally we should catch and handle errors, ensuring they happen when


### PR DESCRIPTION
Closes #588.

Deprecates `Callable::from_fn()` which required `Send` + `Sync` bounds.
You can now choose:
1. For thread-local callables, use `from_local_fn()`.
    - No bounds.
    - Fails when invoked on other thread (no panic propagated to caller at the moment).
2. For cross-thread callables, use `from_sync_fn()`.
    - Requires `Send` + `Sync`.
    - Requires `experimental-threads` crate feature.
    - Can be called anywhere, passed around in Godot freely, etc.

Also fixes an issue with FFI threading check (if a panic was already in progress, the next check would fail hard, aborting without ever printing the first panic's message).