### PR TITLE
Improve some proc-macro attribute error messages

### DIFF
--- a/godot-codegen/src/models/domain_mapping.rs
+++ b/godot-codegen/src/models/domain_mapping.rs
@@ -420,7 +420,7 @@ impl ClassMethod {
             "hash present for virtual class method"
         );
 
-        let rust_method_name = Self::make_virtual_method_name(&method.name);
+        let rust_method_name = Self::make_virtual_method_name(class_name, &method.name);
 
         Self::from_json_inner(
             method,
@@ -488,13 +488,13 @@ impl ClassMethod {
         })
     }
 
-    fn make_virtual_method_name(godot_method_name: &str) -> &str {
+    fn make_virtual_method_name<'m>(class_name: &TyName, godot_method_name: &'m str) -> &'m str {
         // Remove leading underscore from virtual method names.
         let method_name = godot_method_name
             .strip_prefix('_')
             .unwrap_or(godot_method_name);
 
-        special_cases::maybe_rename_virtual_method(method_name)
+        special_cases::maybe_rename_virtual_method(class_name, method_name)
     }
 }
 

--- a/godot-codegen/src/special_cases/special_cases.rs
+++ b/godot-codegen/src/special_cases/special_cases.rs
@@ -349,19 +349,26 @@ pub fn is_utility_function_deleted(function: &JsonUtilityFunction, ctx: &mut Con
 }
 
 pub fn maybe_rename_class_method<'m>(class_name: &TyName, godot_method_name: &'m str) -> &'m str {
+    // This is for non-virtual methods only. For virtual methods, use other handler below.
+
     match (class_name.godot_ty.as_str(), godot_method_name) {
         // GDScript, GDScriptNativeClass, possibly more in the future
         (_, "new") => "instantiate",
+
         _ => godot_method_name,
     }
 }
 
 // Maybe merge with above?
-pub fn maybe_rename_virtual_method(rust_method_name: &str) -> &str {
-    // A few classes define a virtual method called "_init" (distinct from the constructor)
-    // -> rename those to avoid a name conflict in I* interface trait.
-    match rust_method_name {
-        "init" => "init_ext",
+pub fn maybe_rename_virtual_method<'m>(class_name: &TyName, rust_method_name: &'m str) -> &'m str {
+    match (class_name.godot_ty.as_str(), rust_method_name) {
+        // Workaround for 2 methods of same name; see https://github.com/godotengine/godot/pull/99181#issuecomment-2543311415.
+        ("AnimationNodeExtension", "process") => "process_animation",
+
+        // A few classes define a virtual method called "_init" (distinct from the constructor)
+        // -> rename those to avoid a name conflict in I* interface trait.
+        (_, "init") => "init_ext",
+
         _ => rust_method_name,
     }
 }

--- a/godot-macros/src/class/godot_api.rs
+++ b/godot-macros/src/class/godot_api.rs
@@ -37,7 +37,7 @@ pub fn attribute_godot_api(
     if decl.impl_generic_params.is_some() {
         bail!(
             &decl,
-            "#[godot_api] currently does not support generic parameters",
+            "#[godot_api] does not support lifetimes or generic parameters",
         )?;
     }
 

--- a/godot-macros/src/class/godot_dyn.rs
+++ b/godot-macros/src/class/godot_dyn.rs
@@ -21,7 +21,7 @@ pub fn attribute_godot_dyn(input_decl: venial::Item) -> ParseResult<TokenStream>
     if decl.impl_generic_params.is_some() {
         bail!(
             &decl,
-            "#[godot_dyn] currently does not support generic parameters",
+            "#[godot_dyn] does not support lifetimes or generic parameters",
         )?;
     }
 


### PR DESCRIPTION
For `#[derive(GodotClass)]`, catch errors like generic args already at macro stage.