### PR TITLE
[FIX] [WASM-Export] Unable to use multiple rust GDExtensions at the same time

### DIFF
--- a/godot-core/src/meta/class_name.rs
+++ b/godot-core/src/meta/class_name.rs
@@ -41,9 +41,9 @@ pub unsafe fn cleanup() {
 /// Entry in the class name cache.
 ///
 /// `StringName` needs to be lazy-initialized because the Godot binding may not be initialized yet.
-struct ClassNameEntry {
-    rust_str: ClassNameSource,
-    godot_str: OnceCell<StringName>,
+pub struct ClassNameEntry {
+    pub rust_str: ClassNameSource,
+    pub godot_str: OnceCell<StringName>,
 }
 
 impl ClassNameEntry {
@@ -62,13 +62,13 @@ impl ClassNameEntry {
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 
 /// `Cow`-like enum for class names, but with C strings as the borrowed variant.
-enum ClassNameSource {
+pub enum ClassNameSource {
     Owned(String),
     Borrowed(&'static CStr),
 }
 
 impl ClassNameSource {
-    fn to_string_name(&self) -> StringName {
+    pub fn to_string_name(&self) -> StringName {
         match self {
             ClassNameSource::Owned(s) => StringName::from(s),
 
@@ -107,6 +107,17 @@ pub struct ClassName {
 }
 
 impl ClassName {
+    pub fn iter_all<F>(f: F)
+    where
+        F: Fn(&ClassNameEntry),
+    {
+        let guard = CLASS_NAMES.lock();
+
+        for name in guard.iter() {
+            f(name);
+        }
+    }
+
     /// Construct a new class name.
     ///
     /// This is expensive the first time it called for a given `T`, but will be cached for subsequent calls.

--- a/godot-ffi/src/binding/mod.rs
+++ b/godot-ffi/src/binding/mod.rs
@@ -11,6 +11,9 @@ use crate::{
     GdextRuntimeMetadata, ManualInitCell, UtilityFunctionTable,
 };
 
+#[macro_use]
+use crate::out;
+
 #[cfg(feature = "experimental-threads")]
 mod multi_threaded;
 #[cfg(not(feature = "experimental-threads"))]
@@ -84,6 +87,11 @@ unsafe impl Send for ClassLibraryPtr {}
 /// # Safety
 /// The table must not have been initialized yet.
 unsafe fn initialize_table<T>(table: &ManualInitCell<T>, value: T, what: &str) {
+    if table.is_initialized() {
+        out!("Table for {} is already initialized!", what);
+        return;
+    }
+
     debug_assert!(
         !table.is_initialized(),
         "method table for {what} should only be initialized once"


### PR DESCRIPTION
It runs...!

When I was running it past engine initialization, I encountered an error that registered the two seperate plugins as though they were the same. So there was a Node `TestNodeFromClient` and a Node `TestNodeFromShared`, but both element's `ClassPlugin` was referring to the name `TestNodeFromClient`. I thought this was a strange issue and investigated. After changing some code to let the runtime print me a list of registered class names, I noticed that the error was gone. So for some strange reason iterating through all the class names made them "correct", as the runtime previously complained that it's trying to register classes with the same name. I suspect this is due to the line 
```
let string_name = entry
                .godot_str
                .get_or_init(|| entry.rust_str.to_string_name());
```
which might have corrected the previous wrongly set class name? I'm not really sure. (Edit: Could  #834 have to do something with it?)

For now, it runs with a ton of errors about double registering methods; this is probably due to the runtime registering the methods twice. It does run however, and it seems to give the correct output.

Please do not actually merge this, as it isn't pretty. I'm looking for ways to improve this.

I suspect there needs to be a bigger refactor to make this production worthy code. It seems as though there's only one runtime in WASM, when on Linux I have no issues with the same code. This means that even though the runtime in WASM shares it's memory (as I could use a `static` to see if the iniitalization code already ran), however it runs `auto_register_classes` for every plugin. I'm not sure how to mitigate this really...