### PR TITLE
Add required virtual method `IScriptInstance::get_doc_class_name()` in test

### DIFF
--- a/itest/rust/src/builtin_tests/script/script_instance_tests.rs
+++ b/itest/rust/src/builtin_tests/script/script_instance_tests.rs
@@ -64,6 +64,9 @@ impl IScriptExtension for TestScript {
     fn get_members(&self) -> godot::prelude::Array<StringName> { unreachable!() }
     fn is_placeholder_fallback_enabled(&self) -> bool { unreachable!() }
     fn get_rpc_config(&self) -> Variant { unreachable!() }
+    
+    #[cfg(since_api = "4.4")]
+    fn get_doc_class_name(&self) -> StringName { unreachable!() }
 }
 
 struct TestScriptInstance {


### PR DESCRIPTION
Since this virtual method is **required**, our test implementing the trait won't compile without it.
Conditionally enabled for 4.4+.