### PR TITLE
Codegen can directly expose `Inner*` builtin methods

### DIFF
--- a/godot-codegen/src/generator/functions_common.rs
+++ b/godot-codegen/src/generator/functions_common.rs
@@ -79,11 +79,11 @@ impl FnDefinitions {
         // Collect needed because borrowed by 2 closures
         let definitions: Vec<_> = definitions.collect();
         let functions = definitions.iter().map(|def| &def.functions);
-        let structs = definitions.iter().map(|def| &def.builders);
+        let builder_structs = definitions.iter().map(|def| &def.builders);
 
         FnDefinitions {
             functions: quote! { #( #functions )* },
-            builders: quote! { #( #structs )* },
+            builders: quote! { #( #builder_structs )* },
         }
     }
 }

--- a/godot-codegen/src/models/domain.rs
+++ b/godot-codegen/src/models/domain.rs
@@ -363,6 +363,8 @@ pub struct BuiltinMethod {
     pub common: FunctionCommon,
     pub qualifier: FnQualifier,
     pub surrounding_class: TyName,
+    /// Whether the method is directly exposed in the public-facing API, instead of the `Inner*` private struct.
+    pub is_exposed_in_outer: bool,
 }
 
 impl BuiltinMethod {

--- a/godot-codegen/src/models/domain_mapping.rs
+++ b/godot-codegen/src/models/domain_mapping.rs
@@ -357,7 +357,7 @@ impl BuiltinMethod {
                 parameters: FnParam::new_range_no_defaults(&method.arguments, ctx),
                 return_value: FnReturn::new(&return_value, ctx),
                 is_vararg: method.is_vararg,
-                is_private: special_cases::is_method_private(builtin_name, &method.name),
+                is_private: false, // See 'exposed' below. Could be special_cases::is_method_private(builtin_name, &method.name),
                 is_virtual_required: false,
                 direction: FnDirection::Outbound {
                     hash: method.hash.expect("hash absent for builtin method"),
@@ -365,6 +365,10 @@ impl BuiltinMethod {
             },
             qualifier: FnQualifier::from_const_static(method.is_const, method.is_static),
             surrounding_class: inner_class_name.clone(),
+            is_exposed_in_outer: special_cases::is_builtin_method_exposed(
+                builtin_name,
+                &method.name,
+            ),
         })
     }
 }

--- a/godot-codegen/src/special_cases/special_cases.rs
+++ b/godot-codegen/src/special_cases/special_cases.rs
@@ -212,6 +212,9 @@ pub fn is_named_accessor_in_table(class_or_builtin_ty: &TyName, godot_method_nam
 }
 
 /// Whether a class or builtin method should be hidden from the public API.
+///
+/// Builtin class methods are all private by default, due to being declared in an `Inner*` struct. A separate mechanism is used
+/// to make them public, see [`is_builtin_method_exposed`].
 #[rustfmt::skip]
 pub fn is_method_private(class_or_builtin_ty: &TyName, godot_method_name: &str) -> bool {
     match (class_or_builtin_ty.godot_ty.as_str(), godot_method_name) {
@@ -221,6 +224,24 @@ pub fn is_method_private(class_or_builtin_ty: &TyName, godot_method_name: &str) 
         | ("RefCounted", "reference")
         | ("RefCounted", "unreference")
         | ("Object", "notification")
+
+        => true, _ => false
+    }
+}
+
+#[rustfmt::skip]
+pub fn is_builtin_method_exposed(builtin_ty: &TyName, godot_method_name: &str) -> bool {
+    match (builtin_ty.godot_ty.as_str(), godot_method_name) {
+        // GString
+        | ("String", "casecmp_to")
+        | ("String", "nocasecmp_to")
+
+        // StringName
+        | ("StringName", "casecmp_to")
+
+        // NodePath
+
+        // (add more builtin types below)
 
         => true, _ => false
     }

--- a/godot-core/src/lib.rs
+++ b/godot-core/src/lib.rs
@@ -54,6 +54,10 @@ mod gen {
     include!(concat!(env!("OUT_DIR"), "/mod.rs"));
 }
 
+pub mod inners {
+    pub use crate::gen::*;
+}
+
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Hidden but accessible symbols
 


### PR DESCRIPTION
Allows generated methods from `extension_api.json` to be directly used in "front-end" APIs such as `GString`, not only the private `InnerString`.

This is currently either-or: those that are marked as _exposed_ will no longer be part of an inner builtin.