### PR TITLE
Provide feature parity for `Vector2i` with Godot

### DIFF
--- a/godot-codegen/src/special_cases/special_cases.rs
+++ b/godot-codegen/src/special_cases/special_cases.rs
@@ -243,6 +243,14 @@ pub fn is_builtin_method_exposed(builtin_ty: &TyName, godot_method_name: &str) -
 
         // (add more builtin types below)
 
+	// Vector2i
+	| ("Vector2i", "clampi")
+	| ("Vector2i", "distance_squared_to")
+	| ("Vector2i", "distance_to")
+	| ("Vector2i", "maxi")
+        | ("Vector2i", "mini")
+        | ("Vector2i", "snappedi")
+
         => true, _ => false
     }
 }

--- a/godot-core/src/builtin/vectors/vector_macros.rs
+++ b/godot-core/src/builtin/vectors/vector_macros.rs
@@ -800,6 +800,8 @@ macro_rules! impl_vector2x_fns {
             /// Returns the axis of the vector's highest value. See [`Vector2Axis`] enum. If all components are equal, this method returns [`None`].
             ///
             /// To mimic Godot's behavior, unwrap this function's result with `unwrap_or(Vector2Axis::X)`.
+            ///
+            #[doc = concat!("*Godot equivalent: `", stringify!($Vector), ".max_axis_index`*")]
             #[inline]
             #[doc(alias = "max_axis_index")]
             pub fn max_axis(self) -> Option<Vector2Axis> {
@@ -814,6 +816,8 @@ macro_rules! impl_vector2x_fns {
             /// Returns the axis of the vector's lowest value. See [`Vector2Axis`] enum. If all components are equal, this method returns [`None`].
             ///
             /// To mimic Godot's behavior, unwrap this function's result with `unwrap_or(Vector2Axis::Y)`.
+            ///
+            #[doc = concat!("*Godot equivalent: `", stringify!($Vector), ".min_axis_index`*")]
             #[inline]
             #[doc(alias = "min_axis_index")]
             pub fn min_axis(self) -> Option<Vector2Axis> {


### PR DESCRIPTION
This implements all remaining functions for Vector2i that Godot has, with a couple intentional exceptions.  float scalar arithmetic won't be added because in Rust one should be explicit about int/float conversions.  The `AXIS_X` and `AXIS_Y` constant also won't be added as they are shared with `Vector2`.

This is a part of the December 2024 gdext Mini Hackathon.