### PR TITLE
Provide feature parity for `NodePath` with `Godot`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ exp.rs
 
 # Mac specific
 .DS_Store
+
+# Windows specific
+desktop.ini

--- a/godot-codegen/src/special_cases/special_cases.rs
+++ b/godot-codegen/src/special_cases/special_cases.rs
@@ -395,6 +395,11 @@ pub fn is_builtin_method_exposed(builtin_ty: &TyName, godot_method_name: &str) -
         | ("StringName", "to_wchar_buffer")
 
         // NodePath
+        | ("NodePath", "is_absolute")
+        | ("NodePath", "is_empty")
+        | ("NodePath", "get_concatenated_names")
+        | ("NodePath", "get_concatenated_subnames")
+        //| ("NodePath", "get_as_property_path")
 
         // Callable
         | ("Callable", "call")

--- a/godot-core/src/builtin/collections/array.rs
+++ b/godot-core/src/builtin/collections/array.rs
@@ -495,7 +495,10 @@ impl<T: ArrayElement> Array<T> {
     /// Array elements are copied to the slice, but any reference types (such as `Array`,
     /// `Dictionary` and `Object`) will still refer to the same value. To create a deep copy, use
     /// [`subarray_deep()`][Self::subarray_deep] instead.
+    ///
+    /// _Godot equivalent: `slice`_
     #[doc(alias = "slice")]
+    // TODO(v0.3): change to i32 like NodePath::slice/subpath() and support+test negative indices.
     pub fn subarray_shallow(&self, begin: usize, end: usize, step: Option<isize>) -> Self {
         self.subarray_impl(begin, end, step, false)
     }
@@ -511,7 +514,10 @@ impl<T: ArrayElement> Array<T> {
     /// All nested arrays and dictionaries are duplicated and will not be shared with the original
     /// array. Note that any `Object`-derived elements will still be shallow copied. To create a
     /// shallow copy, use [`subarray_shallow()`][Self::subarray_shallow] instead.
+    ///
+    /// _Godot equivalent: `slice`_
     #[doc(alias = "slice")]
+    // TODO(v0.3): change to i32 like NodePath::slice/subpath() and support+test negative indices.
     pub fn subarray_deep(&self, begin: usize, end: usize, step: Option<isize>) -> Self {
         self.subarray_impl(begin, end, step, true)
     }

--- a/godot-core/src/builtin/collections/packed_array.rs
+++ b/godot-core/src/builtin/collections/packed_array.rs
@@ -212,6 +212,7 @@ macro_rules! impl_packed_array {
             ///
             /// To obtain Rust slices, see [`as_slice`][Self::as_slice] and [`as_mut_slice`][Self::as_mut_slice].
             #[doc(alias = "slice")]
+            // TODO(v0.3): change to i32 like NodePath::slice/subpath() and support+test negative indices.
             pub fn subarray(&self, begin: usize, end: usize) -> Self {
                 let len = self.len();
                 let begin = begin.min(len);

--- a/godot-core/src/builtin/string/node_path.rs
+++ b/godot-core/src/builtin/string/node_path.rs
@@ -5,7 +5,13 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::fmt;
+use std::{
+    fmt,
+    ops::{
+        Bound::{Excluded, Included, Unbounded},
+        RangeBounds,
+    },
+};
 
 use godot_ffi as sys;
 use godot_ffi::{ffi_methods, GodotFfi};
@@ -41,8 +47,33 @@ impl NodePath {
         Self { opaque }
     }
 
-    pub fn is_empty(&self) -> bool {
-        self.as_inner().is_empty()
+    /// Returns the number of node names in the path. Property subnames are not included.
+    pub fn get_name_count(&self) -> u32 {
+        self.as_inner()
+            .get_name_count()
+            .try_into()
+            .expect("Godot name counts are non negative int")
+    }
+
+    /// Returns the node name indicated by `idx`, starting from 0. If `idx` is out of bounds, [`None`] is returned.
+    /// See also [`NodePath::get_subname_count`] and [`NodePath::get_name_count`].
+    pub fn get_name(&self, idx: u32) -> Option<StringName> {
+        let inner = self.as_inner();
+        let idx = idx as i64;
+        // This check checks both data being empty (get_name_count returns 0) and index out of bounds.
+        if idx >= inner.get_name_count() {
+            None
+        } else {
+            Some(inner.get_name(idx))
+        }
+    }
+
+    /// Returns the number of property names ("subnames") in the path. Each subname in the node path is listed after a colon character (`:`).
+    pub fn get_subname_count(&self) -> u32 {
+        self.as_inner()
+            .get_subname_count()
+            .try_into()
+            .expect("Godot subname counts are non negative int")
     }
 
     /// Returns a 32-bit integer hash value representing the string.
@@ -51,6 +82,50 @@ impl NodePath {
             .hash()
             .try_into()
             .expect("Godot hashes are uint32_t")
+    }
+
+    /// Returns the property name indicated by `idx`, starting from 0. If `idx` is out of bounds, [`None`] is returned.
+    /// See also [`NodePath::get_subname_count`].
+    pub fn get_subname(&self, idx: u32) -> Option<StringName> {
+        let inner = self.as_inner();
+        let idx = idx as i64;
+        // This check checks both data being empty (get_subname_count returns 0) and index out of bounds.
+        if idx >= inner.get_subname_count() {
+            None
+        } else {
+            Some(inner.get_subname(idx))
+        }
+    }
+
+    /// Returns the slice of the [`NodePath`] as a new [`NodePath`]
+    pub fn slice(&self, range: impl RangeBounds<i64>) -> NodePath {
+        self.as_inner().slice(
+            match range.start_bound() {
+                Excluded(&start) => {
+                    if start == -1 {
+                        // Default end from godot, since the start is excluded.
+                        i32::MAX as i64
+                    } else {
+                        start + 1
+                    }
+                }
+                Included(&start) => start,
+                Unbounded => 0,
+            },
+            match range.end_bound() {
+                Excluded(&end) => end,
+                Included(&end) => {
+                    if end == -1 {
+                        // Default end from godot, since the end is excluded.
+                        i32::MAX as i64
+                    } else {
+                        end + 1
+                    }
+                }
+                // Default end from godot.
+                Unbounded => i32::MAX as i64,
+            },
+        )
     }
 
     crate::meta::declare_arg_method! {

--- a/itest/rust/src/builtin_tests/string/gstring_test.rs
+++ b/itest/rust/src/builtin_tests/string/gstring_test.rs
@@ -7,7 +7,7 @@
 
 use std::collections::HashSet;
 
-use crate::framework::{expect_panic, itest};
+use crate::framework::{expect_debug_panic_or_release_ok, itest};
 use godot::builtin::{GString, PackedStringArray};
 
 // TODO use tests from godot-rust/gdnative
@@ -98,14 +98,10 @@ fn string_unicode_at() {
     assert_eq!(s.unicode_at(2), 'A');
     assert_eq!(s.unicode_at(3), '💡');
 
-    #[cfg(debug_assertions)]
-    expect_panic("Debug mode: unicode_at() out-of-bounds panics", || {
-        s.unicode_at(4);
-    });
-
     // Release mode: out-of-bounds prints Godot error, but returns 0.
-    #[cfg(not(debug_assertions))]
-    assert_eq!(s.unicode_at(4), '\0');
+    expect_debug_panic_or_release_ok("unicode_at() out-of-bounds panics", || {
+        assert_eq!(s.unicode_at(4), '\0');
+    });
 }
 
 #[itest]

--- a/itest/rust/src/framework/mod.rs
+++ b/itest/rust/src/framework/mod.rs
@@ -144,6 +144,14 @@ pub fn expect_panic(context: &str, code: impl FnOnce()) {
     );
 }
 
+pub fn expect_debug_panic_or_release_ok(_context: &str, code: impl FnOnce()) {
+    #[cfg(debug_assertions)]
+    expect_panic(_context, code);
+
+    #[cfg(not(debug_assertions))]
+    code()
+}
+
 /// Synchronously run a thread and return result. Panics are propagated to caller thread.
 #[track_caller]
 pub fn quick_thread<R, F>(f: F) -> R


### PR DESCRIPTION
# TODO
- [ ] `#[itest]` for NodePath
- [x] `operator==` and `operator!=`
- [x] Decide what to do with get_as_property_path, whether it's dangerous to use the C++ approach and it needs reimplementing or if it's okay
- [ ] Change u32 for usizes and isizes for i32
- [ ] Improve documentation for the implemented methods
- [ ] Look into a better way to do slice (subpath)
- [ ] Simplify get_[sub]name, take out Option

# Considerations
- The `get_[sub]name_count` functions return a `u32`, because the ffi indicates an `i64` but a count is always positive, it comes from a sum of `size`, unless it overflows, in which case the functions from Godot side break.
- The `get_[sub]name` functions return an `Option` instead of an empty `StringName` on failure, which is expected behavior in a `Rust` crate. It also takes a `u32` as a parameter for the considerations above. It should not take a `usize` since a `usize` can be either 32 bits or 64 bits in the supported architectures of Godot.
- The `slice` function takes a range since it makes more sense in a Rust crate. This range can have negative start or end, for the sake of feature parity with Godot's. To make inclusive ranges and unbounded ranges possible, it uses the default end value written in the Godot documentation.
- The functions `is_empty` and `is_absolute` need no changes from Rust's side, so they're called as are.
- The `get_concatenated_[sub]names` functions are taken as are because there's no need to eliminate the error messages even though they make little sense, a path that contains nothing should just return an empty string when it's joined. They can be useful if someone wants them, though, so erasing them for the sake of erasing them does not make much sense either. If this is thought otherwise, I'll reimplement them myself.