### PR TITLE
`#[gdextension(discovery)]` to expose static information about registered classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ Cargo.lock
 
 # This project: input JSONs and code generation
 gen
+discovered.txt
 
 # Temporary tweaks, remove later
 /script

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "itest/repo-tweak",
     "examples/dodge-the-creeps/rust",
     "examples/hot-reload/rust",
+    "examples/discovery",
 ]
 
 # Note about Jetbrains IDEs: "IDE Sync" (Refresh Cargo projects) may cause static analysis errors such as

--- a/examples/discovery/Cargo.toml
+++ b/examples/discovery/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "discovery"
+version = "0.1.0"
+edition = "2021"
+
+[build-dependencies]
+hot-reload = { path = "../hot-reload/rust" }
+# No direct dependency on godot crate.

--- a/examples/discovery/Cargo.toml
+++ b/examples/discovery/Cargo.toml
@@ -2,6 +2,9 @@
 name = "discovery"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.80"
+license = "MPL-2.0"
+publish = false
 
 [build-dependencies]
 hot-reload = { path = "../hot-reload/rust" }

--- a/examples/discovery/build.rs
+++ b/examples/discovery/build.rs
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use hot_reload::godot_discovery::ExtensionDiscovery;
+use hot_reload::HotReload;
+
+use std::fs::File;
+use std::io::Write;
+
+fn main() -> Result<(), std::io::Error> {
+    let mut f = File::create("discovered.txt")?;
+
+    for c in HotReload::discover_classes() {
+        writeln!(f, "Discovered: class {}, base {}", c.name(), c.base_class())?;
+    }
+
+    Ok(())
+}

--- a/examples/discovery/build.rs
+++ b/examples/discovery/build.rs
@@ -5,7 +5,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use hot_reload::godot_discovery::ExtensionDiscovery;
 use hot_reload::HotReload;
 
 use std::fs::File;
@@ -14,7 +13,7 @@ use std::io::Write;
 fn main() -> Result<(), std::io::Error> {
     let mut f = File::create("discovered.txt")?;
 
-    for c in HotReload::discover_classes() {
+    for c in HotReload::discover().classes() {
         writeln!(f, "Discovered: class {}, base {}", c.name(), c.base_class())?;
     }
 

--- a/examples/discovery/src/main.rs
+++ b/examples/discovery/src/main.rs
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+fn main() {
+    println!("Nothing to do at runtime; build.rs has written to `discovered.txt`.");
+}

--- a/examples/hot-reload/rust/Cargo.toml
+++ b/examples/hot-reload/rust/Cargo.toml
@@ -7,7 +7,8 @@ license = "MPL-2.0"
 publish = false
 
 [lib]
-crate-type = ["cdylib"]
+# The `rlib` type is not necessary for hot reload, but is used by the `discovery` crate.
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 godot = { path = "../../../godot", default-features = false }

--- a/examples/hot-reload/rust/src/lib.rs
+++ b/examples/hot-reload/rust/src/lib.rs
@@ -7,9 +7,11 @@
 
 use godot::prelude::*;
 
-struct HotReload;
+pub struct HotReload;
 
-#[gdextension]
+// The `discover` attribute is used by the discovery crate, not needed for hot reload.
+// That's also the reason why `HotReload` is public.
+#[gdextension(discover)]
 unsafe impl ExtensionLibrary for HotReload {
     fn on_level_init(_level: InitLevel) {
         println!("[Rust]      Init level {:?}", _level);

--- a/examples/hot-reload/rust/src/lib.rs
+++ b/examples/hot-reload/rust/src/lib.rs
@@ -9,9 +9,9 @@ use godot::prelude::*;
 
 pub struct HotReload;
 
-// The `discover` attribute is used by the discovery crate, not needed for hot reload.
+// The `discovery` attribute is used by the discovery crate, not needed for hot reload.
 // That's also the reason why `HotReload` is public.
-#[gdextension(discover)]
+#[gdextension(discovery)]
 unsafe impl ExtensionLibrary for HotReload {
     fn on_level_init(_level: InitLevel) {
         println!("[Rust]      Init level {:?}", _level);

--- a/godot-core/src/init/discovery.rs
+++ b/godot-core/src/init/discovery.rs
@@ -5,11 +5,66 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+//! Allows dependent crates to statically discover classes registered by this extension.
+//!
+//! # Rationale
+//!
+//! The idea is to provide a mechanism that allows tools and integrations to query information about an extension _at build time_.
+//! For example, this allows validations, data extraction/generation, etc. It is limited to downstream crates depending on the crate declaring
+//! the extension, in particular their `build.rs` file. If a crate is used for discovery, then it must declare `crate-type = ["cdylib", "rlib"]`,
+//! i.e. both a C dynamic library for GDExtension and a Rust library.
+//!
+//! The API is kept deliberately minimal -- it does not strive to cover the entire reflection API that Godot provides. Many tools may be better
+//! fitted as a direct integration into the Godot editor, or as runtime code querying Godot's `ClassDB` API. If you believe this API is lacking,
+//! please provide a detailed use case.
+//!
+//! # Usage
+//!
+//! To make use of discovery, your entry point trait needs to have the `discover` attribute:
+//! ```no_run
+//! # use godot::prelude::*;
+//! /// Your tag must be public.
+//! pub struct MyCoolGame;
+//!
+//! /// The `discovery` attributes adds an associated `MyExtension::discover()` function to the `MyExtension` tag.
+//! /// It also declares a module `godot_discovery` in the current scope, which re-exports symbols from `godot::init::discovery`.
+//! /// This allows your dependent crate to not depend on `godot` directly.
+//! #[gdextension(discovery)]
+//! unsafe impl ExtensionLibrary for MyCoolGame {}
+//! ```
+//!
+//! To access the exposed API in a dependent crate in `build.rs`, you can call `MyExtension::discover()`:
+//! ```no_run
+//! # mod my_crate {
+//! # use godot::init::gdextension;
+//! # pub struct MyCoolGame;
+//! # #[gdextension(discovery)]
+//! # unsafe impl godot::init::ExtensionLibrary for MyCoolGame {}
+//! # }
+//! use my_crate::MyCoolGame;
+//! use my_crate::godot_discovery::DiscoveredExtension;
+//!
+//! fn main() {
+//!    let api: DiscoveredExtension = MyCoolGame::discover();
+//!    for c in api.classes() {
+//!        println!("Discovered class {}.", c.name());
+//!    }
+//! }
+//! ```
+
 use crate::private::{ClassPlugin, PluginItem};
 
-pub trait ExtensionDiscovery {
-    fn discover_classes() -> Vec<DiscoveredClass>;
+pub struct DiscoveredExtension {
+    classes: Vec<DiscoveredClass>,
 }
+
+impl DiscoveredExtension {
+    pub fn classes(&self) -> &[DiscoveredClass] {
+        &self.classes
+    }
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
 
 pub struct DiscoveredClass {
     name: String,
@@ -26,8 +81,10 @@ impl DiscoveredClass {
     }
 }
 
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+
 #[doc(hidden)]
-pub fn __discover() -> Vec<DiscoveredClass> {
+pub fn __discover() -> DiscoveredExtension {
     let mut classes = vec![];
 
     crate::private::iterate_plugins(|elem: &ClassPlugin| {
@@ -46,5 +103,5 @@ pub fn __discover() -> Vec<DiscoveredClass> {
         classes.push(class);
     });
 
-    classes
+    DiscoveredExtension { classes }
 }

--- a/godot-core/src/init/discovery.rs
+++ b/godot-core/src/init/discovery.rs
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use crate::private::{ClassPlugin, PluginItem};
+
+pub trait ExtensionDiscovery {
+    fn discover_classes() -> Vec<DiscoveredClass>;
+}
+
+pub struct DiscoveredClass {
+    name: String,
+    base_class: String,
+}
+
+impl DiscoveredClass {
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn base_class(&self) -> &str {
+        &self.base_class
+    }
+}
+
+#[doc(hidden)]
+pub fn __discover() -> Vec<DiscoveredClass> {
+    let mut classes = vec![];
+
+    crate::private::iterate_plugins(|elem: &ClassPlugin| {
+        let PluginItem::Struct {
+            base_class_name, ..
+        } = elem.item
+        else {
+            return;
+        };
+
+        let class = DiscoveredClass {
+            name: elem.class_name.to_string(),
+            base_class: base_class_name.to_string(),
+        };
+
+        classes.push(class);
+    });
+
+    classes
+}

--- a/godot-core/src/init/mod.rs
+++ b/godot-core/src/init/mod.rs
@@ -16,6 +16,8 @@ use crate::out;
 
 pub use sys::GdextBuild;
 
+pub mod discovery;
+
 #[doc(hidden)]
 #[deny(unsafe_op_in_unsafe_fn)]
 pub unsafe fn __gdext_load_library<E: ExtensionLibrary>(

--- a/godot-core/src/meta/class_name.rs
+++ b/godot-core/src/meta/class_name.rs
@@ -101,7 +101,7 @@ impl ClassNameSource {
 ///
 /// `ClassName`s are **not** ordered lexicographically, and the ordering relation is **not** stable across multiple runs of your
 /// application. When lexicographical order is needed, it's possible to convert this type to [`GString`] or [`String`].
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct ClassName {
     global_index: u16,
 }
@@ -230,7 +230,16 @@ impl ClassName {
 
 impl fmt::Display for ClassName {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.with_string_name(|s| s.fmt(f))
+        write!(f, "{}", self.to_cow_str())
+    }
+}
+
+impl fmt::Debug for ClassName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ClassName")
+            .field("id", &self.global_index)
+            .field("name", &self.to_cow_str())
+            .finish()
     }
 }
 

--- a/godot-macros/src/gdextension.rs
+++ b/godot-macros/src/gdextension.rs
@@ -32,8 +32,8 @@ pub fn attribute_gdextension(item: venial::Item) -> ParseResult<TokenStream> {
     let entry_point = parser.handle_ident("entry_point")?;
     let entry_symbol = parser.handle_ident("entry_symbol")?;
 
-    // #[gdextension(discover)]
-    let discover = parser.handle_alone("discover")?;
+    // #[gdextension(discovery)]
+    let discover = parser.handle_alone("discovery")?;
 
     parser.finish()?;
 
@@ -102,8 +102,8 @@ fn make_discovery(discovery: bool, impl_ty: &TypeExpr) -> TokenStream {
         /// Re-export of Godot's discovery module.
         pub use ::godot::init::discovery as godot_discovery;
 
-        impl ::godot::init::discovery::ExtensionDiscovery for #impl_ty {
-            fn discover_classes() -> Vec<::godot::init::discovery::DiscoveredClass> {
+        impl #impl_ty {
+            pub fn discover() -> ::godot::init::discovery::DiscoveredExtension {
                ::godot::init::discovery::__discover()
             }
         }

--- a/itest/rust/src/object_tests/class_name_test.rs
+++ b/itest/rust/src/object_tests/class_name_test.rs
@@ -48,6 +48,18 @@ fn class_name_dynamic() {
     assert_eq!(a.to_cow_str(), Cow::<'static, str>::Owned("A".to_string()));
 }
 
+#[itest]
+fn class_name_display() {
+    let a = A::class_name();
+    assert_eq!(format!("{a}"), "A");
+
+    // Use fmt::ToString trait.
+    #[cfg(since_api = "4.4")]
+    assert_eq!(统一码::class_name().to_string(), "统一码");
+}
+
+// No test for fmt::Debug (index is unspecified).
+
 #[cfg(since_api = "4.4")]
 #[itest]
 fn class_name_dynamic_unicode() {


### PR DESCRIPTION
> [!note]
> It's completely unclear if we can merge this feature, and in which form. There are quite a few open points, and there may be better approaches to achieve the same.

---

 Allows dependent crates to statically discover classes registered by a Rust extension.

## Rationale

 The idea is to provide a mechanism that allows tools and integrations to query information about an extension _at build time_. For example, this allows validations, data extraction/generation, etc. It is limited to downstream crates depending on the crate declaring the extension, in particular their `build.rs` file. If a crate is used for discovery, then it must declare `crate-type = ["cdylib", "rlib"]`, i.e. both a C dynamic library for GDExtension and a Rust library.

 The API is kept deliberately minimal -- it does not strive to cover the entire reflection API that Godot provides. Many tools may be better fitted as a direct integration into the Godot editor, or as runtime code querying Godot's `ClassDB` API.

 ## Usage

 To make use of discovery, your entry point trait needs to have the `discover` attribute:
 ```rs

 /// Your tag must be public.
 pub struct MyCoolGame;

 /// The `discovery` attributes adds an associated `MyExtension::discover()` function to the `MyExtension` 
 /// tag. It also declares a module `godot_discovery` in the current scope, which re-exports symbols
 /// from `godot::init::discovery`. This allows your dependent crate to not depend on `godot` directly.
 #[gdextension(discovery)]
 unsafe impl ExtensionLibrary for MyCoolGame {}
 ```

 To access the exposed API in a dependent crate in `build.rs`, you can call `MyExtension::discover()`:
 ```rs
 use my_crate::MyCoolGame;
 use my_crate::godot_discovery::DiscoveredExtension;

 fn main() {
    let api: DiscoveredExtension = MyCoolGame::discover();
    for c in api.classes() {
        println!("Discovered class {}.", c.name());
    }
 }
 ```

## Problems

On one hand, the `Cargo.toml` option
```toml
[lib]
crate-type = ["cdylib", "rlib"]
```

causes the following warning:

> The lib target my_crate in package my-crate v0.1.0 (.. path ..) has the same output filename as the lib target my_crate in package my-crate v0.1.0 (.. same path ..).
> Colliding filename is: /path/to/libmy_crate.so.dwp
> The targets should have unique names.
> Consider changing their names to be unique or compiling them separately.

On the other, there are several CI issues. I'm also not sure if `hot-reload` is a good place, but I'd rather add _two_ extra crates just for this.

The reason for choosing this approach is to enable post-build actions (by moving them into a dependent crate). Given the issues and the need for another crate just for this, I'm not fully convinced this is the best approach. Maybe a custom tool as _actual_ post-build step, which can invoke headless Godot via `ClassDB` introspection, is more versatile. Or maybe a binary which loads the `cdylib` via existing or separate entry point, thus not causing the `rlib` conflict.