### PR TITLE
Clean up `Callable` + tests, fix `check.sh test`

### DIFF
--- a/godot-core/src/builtin/callable.rs
+++ b/godot-core/src/builtin/callable.rs
@@ -307,6 +307,7 @@ impl Callable {
     /// _Godot equivalent: `get_method`_
     ///
     /// [godot#73052]: https://github.com/godotengine/godot/issues/73052
+    #[doc(alias = "get_method")]
     pub fn method_name(&self) -> Option<StringName> {
         let method_name = self.as_inner().get_method();
         if method_name.is_empty() {
@@ -389,14 +390,15 @@ impl Callable {
     }
 
     #[cfg(since_api = "4.3")]
-    #[doc(alias = "get_argument_count")]
-    pub fn arg_len(&self) -> usize {
+    pub fn get_argument_count(&self) -> usize {
         self.as_inner().get_argument_count() as usize
     }
 
-    #[doc(alias = "get_bound_arguments_count")]
-    pub fn bound_args_len(&self) -> i64 {
-        self.as_inner().get_bound_arguments_count()
+    pub fn get_bound_arguments_count(&self) -> usize {
+        // To consistently return usize, we already fix the bug https://github.com/godotengine/godot/pull/98713 before Godot 4.4.
+        let alleged_count = self.as_inner().get_bound_arguments_count();
+
+        alleged_count.max(0) as usize
     }
 
     #[doc(hidden)]

--- a/godot-core/src/builtin/callable.rs
+++ b/godot-core/src/builtin/callable.rs
@@ -385,6 +385,10 @@ impl Callable {
         self.as_inner().is_valid()
     }
 
+    /// Returns a copy of the callable, ignoring `args` user arguments.
+    ///
+    /// Despite its name, this does **not** directly undo previous `bind()` calls. See
+    /// [Godot docs](https://docs.godotengine.org/en/latest/classes/class_callable.html#class-callable-method-unbind) for up-to-date semantics.
     pub fn unbind(&self, args: usize) -> Callable {
         self.as_inner().unbind(args as i64)
     }
@@ -394,8 +398,12 @@ impl Callable {
         self.as_inner().get_argument_count() as usize
     }
 
+    /// Get number of bound arguments.
+    ///
+    /// Note: for Godot < 4.4, this function returns incorrect results when applied on a callable that used `unbind()`.
+    /// See [#98713](https://github.com/godotengine/godot/pull/98713) for details.
     pub fn get_bound_arguments_count(&self) -> usize {
-        // To consistently return usize, we already fix the bug https://github.com/godotengine/godot/pull/98713 before Godot 4.4.
+        // This does NOT fix the bug before Godot 4.4, just cap it at zero. unbind() will still erroneously decrease the bound arguments count.
         let alleged_count = self.as_inner().get_bound_arguments_count();
 
         alleged_count.max(0) as usize

--- a/godot-macros/src/lib.rs
+++ b/godot-macros/src/lib.rs
@@ -710,10 +710,23 @@ pub fn derive_godot_class(input: TokenStream) -> TokenStream {
 /// `#[rpc]` implies `#[func]`. You can use both attributes together, if you need to configure other `#[func]`-specific keys.
 ///
 /// For example, the following method declarations are all equivalent:
-/// ```
+/// ```no_run
+/// # // Polyfill without full codegen.
+/// # #![allow(non_camel_case_types)]
+/// # #[cfg(not(feature = "codegen-full"))]
+/// # enum RpcMode { DISABLED, ANY_PEER, AUTHORITY }
+/// # #[cfg(not(feature = "codegen-full"))]
+/// # enum TransferMode { UNRELIABLE, UNRELIABLE_ORDERED, RELIABLE }
+/// # #[cfg(not(feature = "codegen-full"))]
+/// # pub struct RpcConfig { pub rpc_mode: RpcMode, pub transfer_mode: TransferMode, pub call_local: bool, pub channel: u32 }
+/// # #[cfg(not(feature = "codegen-full"))]
+/// # impl Default for RpcConfig { fn default() -> Self { todo!("never called") } }
+/// # #[cfg(feature = "codegen-full")]
 /// use godot::classes::multiplayer_api::RpcMode;
+/// # #[cfg(feature = "codegen-full")]
 /// use godot::classes::multiplayer_peer::TransferMode;
 /// use godot::prelude::*;
+/// # #[cfg(feature = "codegen-full")]
 /// use godot::register::RpcConfig;
 ///
 /// # #[derive(GodotClass)]


### PR DESCRIPTION
Renames the `Callable` methods back to their original Godot counterparts:
- `arg_len` -> `get_argument_count`
- `bound_args_len` -> `get_bound_arguments_count`
   - returns `usize` instead of `i64`, capping buggy negatives (<4.4) at 0

Running unit tests from `check.sh` was broken due to a doctest not working without `codegen-full`, this PR also fixes that.