### PR TITLE
Add missing property u64 to export impls

### DIFF
--- a/godot-core/src/registry/property.rs
+++ b/godot-core/src/registry/property.rs
@@ -500,6 +500,7 @@ mod export_impls {
     // Primitives
     impl_property_by_godot_convert!(f64);
     impl_property_by_godot_convert!(i64);
+    impl_property_by_godot_convert!(u64);
     impl_property_by_godot_convert!(bool);
 
     // Godot uses f64 internally for floats, and if Godot tries to pass an invalid f32 into a rust property


### PR DESCRIPTION
Adds u64 to `export_impls`, fixing the following error:
```
#[var]` properties require `Var` trait; #[export] ones require `Export` trait
  --> crates\<example.rs>
   |
26 |     id: u64,
   |         ^^^ type cannot be used as a property
   |
   = help: the trait `Var` is not implemented for `u64`
   = note: see also: https://godot-rust.github.io/book/register/properties.html
   = help: the following other types implement trait `Var`:
             f32
             f64
             i16
             i32
             i64
             i8
             u16
             u32
             u8
```

Example:
```
#[derive(GodotClass)]
#[class(no_init, base=RefCounted)]
pub struct Entity {
    #[var]
    id: u64,
}
```