### PR TITLE
Fix nightly compiler warnings about `#[cfg(before_api = "4.3")]` in the generated `#[godot_api]` impl

### DIFF
--- a/examples/dodge-the-creeps/rust/src/main_scene.rs
+++ b/examples/dodge-the-creeps/rust/src/main_scene.rs
@@ -5,6 +5,7 @@ use crate::player;
 use godot::classes::{Marker2D, PathFollow2D, RigidBody2D, Timer};
 use godot::prelude::*;
 
+use godot::classes::notify::NodeNotification;
 use rand::Rng as _;
 use std::f32::consts::PI;
 
@@ -116,6 +117,8 @@ impl Main {
 
 #[godot_api]
 impl INode for Main {
+    fn on_notification(&mut self, _what: NodeNotification) {}
+
     fn init(base: Base<Node>) -> Self {
         Main {
             mob_scene: PackedScene::new_gd(),


### PR DESCRIPTION
With a nightly compiler and current master, every `#[godot_api] impl ISomeGodotClass for ...` block with an `on_notification` method triggers a compiler warning:

```text
   |
66 | #[godot_api]
   | ^^^^^^^^^^^^
   |
   = note: using a cfg inside a attribute macro will use the cfgs from the destination crate and not the ones from the defining crate
   = help: try referring to `godot_api` crate for guidance on how handle this unexpected cfg
   = help: the attribute macro `godot_api` may come from an old version of the `godot_macros` crate, try updating your dependency with `cargo update -p godot_macros`
   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
   = note: this warning originates in the attribute macro `godot_api` (in Nightly builds, run with -Z macro-backtrace for more info)
```

This doesn't happen in `itest` because its `build.rs` defines those cfgs.
