### PR TITLE
API consistency for bounding boxes

### DIFF
--- a/godot-core/src/builtin/aabb.rs
+++ b/godot-core/src/builtin/aabb.rs
@@ -174,10 +174,10 @@ impl Aabb {
 
     /// Returns the intersection between two AABBs.
     ///
-    /// # Panics
+    /// # Panics (Debug)
     /// If `self.size` is negative.
     #[inline]
-    pub fn intersection(self, b: Aabb) -> Option<Self> {
+    pub fn intersect(self, b: Aabb) -> Option<Self> {
         self.assert_nonnegative();
 
         if !self.intersects(b) {
@@ -192,6 +192,11 @@ impl Aabb {
         rect.size = end.coord_min(end_b) - rect.position;
 
         Some(rect)
+    }
+
+    #[deprecated = "Renamed to `intersect()`"]
+    pub fn intersection(self, b: Aabb) -> Option<Self> {
+        self.intersect(b)
     }
 
     /// Returns `true` if this AABB is finite, by calling `@GlobalScope.is_finite` on each component.
@@ -434,6 +439,7 @@ impl Aabb {
     ///
     /// Most functions will fail to give a correct result if the size is negative.
     #[inline]
+    /// TODO(v0.3): make private, change to debug_assert().
     pub fn assert_nonnegative(self) {
         assert!(
             self.size.x >= 0.0 && self.size.y >= 0.0 && self.size.z >= 0.0,
@@ -529,27 +535,27 @@ mod test {
             size: Vector3::new(1.0, 1.0, 1.0),
         };
 
-        // Check for intersection including border
+        // Check for intersection including border.
         assert!(aabb1.intersects(aabb2));
         assert!(aabb2.intersects(aabb1));
 
-        // Check for non-intersection including border
+        // Check for non-intersection including border.
         assert!(!aabb1.intersects(aabb3));
         assert!(!aabb3.intersects(aabb1));
 
-        // Check for intersection excluding border
+        // Check for intersection excluding border.
         assert!(aabb1.intersects_exclude_borders(aabb2));
         assert!(aabb2.intersects_exclude_borders(aabb1));
 
-        // Check for non-intersection excluding border
+        // Check for non-intersection excluding border.
         assert!(!aabb1.intersects_exclude_borders(aabb3));
         assert!(!aabb3.intersects_exclude_borders(aabb1));
 
-        // Check for non-intersection excluding border
+        // Check for non-intersection excluding border.
         assert!(!aabb1.intersects_exclude_borders(aabb4));
         assert!(!aabb4.intersects_exclude_borders(aabb1));
 
-        // Check for intersection with same AABB including border
+        // Check for intersection with same AABB including border.
         assert!(aabb1.intersects(aabb1));
     }
 
@@ -576,19 +582,18 @@ mod test {
             size: Vector3::new(1.0, 1.0, 1.0),
         };
 
-        // Test cases
         assert_eq!(
-            aabb1.intersection(aabb2),
+            aabb1.intersect(aabb2),
             Some(Aabb {
                 position: Vector3::new(1.0, 1.0, 1.0),
                 size: Vector3::new(1.0, 1.0, 1.0),
             })
         );
 
-        assert_eq!(aabb1.intersection(aabb3), None);
+        assert_eq!(aabb1.intersect(aabb3), None);
 
         assert_eq!(
-            aabb1.intersection(aabb4),
+            aabb1.intersect(aabb4),
             Some(Aabb {
                 position: Vector3::new(0.0, 0.0, 0.0),
                 size: Vector3::new(0.0, 0.0, 0.0),
@@ -598,7 +603,7 @@ mod test {
 
     #[test]
     fn test_intersects_ray() {
-        // Test case 1: Ray intersects the AABB
+        // Test case 1: Ray intersects the AABB.
         let aabb1 = Aabb {
             position: Vector3::new(0.0, 0.0, 0.0),
             size: Vector3::new(2.0, 2.0, 2.0),
@@ -608,7 +613,7 @@ mod test {
 
         assert!(aabb1.intersects_ray(from1, dir1));
 
-        // Test case 2: Ray misses the AABB
+        // Test case 2: Ray misses the AABB.
         let aabb2 = Aabb {
             position: Vector3::new(0.0, 0.0, 0.0),
             size: Vector3::new(2.0, 2.0, 2.0),
@@ -617,7 +622,7 @@ mod test {
         let dir2 = Vector3::new(0.0, 0.0, 1.0);
         assert!(!aabb2.intersects_ray(from2, dir2));
 
-        // Test case 3: Ray starts inside the AABB
+        // Test case 3: Ray starts inside the AABB.
         let aabb3 = Aabb {
             position: Vector3::new(0.0, 0.0, 0.0),
             size: Vector3::new(2.0, 2.0, 2.0),
@@ -626,7 +631,7 @@ mod test {
         let dir3 = Vector3::new(0.0, 0.0, 1.0);
         assert!(aabb3.intersects_ray(from3, dir3));
 
-        // Test case 4: Ray direction parallel to AABB
+        // Test case 4: Ray direction parallel to AABB.
         let aabb4 = Aabb {
             position: Vector3::new(0.0, 0.0, 0.0),
             size: Vector3::new(2.0, 2.0, 2.0),
@@ -635,7 +640,7 @@ mod test {
         let dir4 = Vector3::new(1.0, 0.0, 0.0);
         assert!(aabb4.intersects_ray(from4, dir4));
 
-        // Test case 5: Ray direction diagonal through the AABB
+        // Test case 5: Ray direction diagonal through the AABB.
         let aabb5 = Aabb {
             position: Vector3::new(0.0, 0.0, 0.0),
             size: Vector3::new(2.0, 2.0, 2.0),
@@ -644,7 +649,7 @@ mod test {
         let dir5 = Vector3::new(1.0, 1.0, 1.0);
         assert!(aabb5.intersects_ray(from5, dir5));
 
-        // Test case 6: Ray origin on an AABB face
+        // Test case 6: Ray origin on an AABB face.
         let aabb6 = Aabb {
             position: Vector3::new(0.0, 0.0, 0.0),
             size: Vector3::new(2.0, 2.0, 2.0),
@@ -745,10 +750,10 @@ mod test {
             position: Vector3::new(-1.5, 2.0, -2.5),
             size: Vector3::ONE,
         };
-        let inter = aabb_big.intersection(aabb_small);
+        let inter = aabb_big.intersect(aabb_small);
         assert!(
             inter.unwrap().approx_eq(&aabb_small),
-            "intersection() with fully contained AABB should return the smaller AABB."
+            "intersect() with fully contained AABB should return the smaller AABB."
         );
 
         let aabb_small = Aabb {
@@ -759,7 +764,7 @@ mod test {
             position: Vector3::new(0.5, 2.0, -2.0),
             size: Vector3::new(1.0, 0.5, 1.0),
         };
-        let inter = aabb_big.intersection(aabb_small);
+        let inter = aabb_big.intersect(aabb_small);
         assert!(
             inter.unwrap().approx_eq(&expected),
             "intersect() with partially contained AABB (overflowing on Y axis) should match expected."
@@ -769,7 +774,7 @@ mod test {
             position: Vector3::new(10.0, -10.0, -10.0),
             size: Vector3::ONE,
         };
-        let inter = aabb_big.intersection(aabb_small);
+        let inter = aabb_big.intersect(aabb_small);
         assert!(
             inter.is_none(),
             "intersect() with non-contained AABB should return None."

--- a/godot-core/src/builtin/aabb.rs
+++ b/godot-core/src/builtin/aabb.rs
@@ -128,13 +128,15 @@ impl Aabb {
         Self { position, size }
     }
 
-    /// Returns `true` if the AABB contains a point. By convention,
-    /// the right and bottom edges of the AABB are considered exclusive, so points on these edges are not included.
+    /// Returns `true` if the AABB contains a point (excluding right/bottom edge).
+    ///
+    /// By convention, the right and bottom edges of the AABB are considered exclusive, so points on these edges are not included.
     ///
     /// # Panics
     /// If `self.size` is negative.
     #[inline]
-    pub fn has_point(self, point: Vector3) -> bool {
+    #[doc(alias = "has_point")]
+    pub fn contains_point(self, point: Vector3) -> bool {
         self.assert_nonnegative();
 
         let point = point - self.position;
@@ -143,6 +145,12 @@ impl Aabb {
             && point.x < self.size.x
             && point.y < self.size.y
             && point.z < self.size.z
+    }
+
+    #[inline]
+    #[deprecated = "Renamed to `contains_point()`, for consistency with `Rect2i`"]
+    pub fn has_point(self, point: Vector3) -> bool {
+        self.contains_point(point)
     }
 
     /// Returns `true` if the AABB has area, and `false` if the AABB is linear, empty, or has a negative size. See also `Aabb.area()`.

--- a/godot-core/src/builtin/aabb.rs
+++ b/godot-core/src/builtin/aabb.rs
@@ -153,8 +153,15 @@ impl Aabb {
         self.contains_point(point)
     }
 
-    /// Returns `true` if the AABB has area, and `false` if the AABB is linear, empty, or has a negative size. See also `Aabb.area()`.
+    /// Returns if this bounding box has a surface or a length, i.e. at least one component of [`Self::size`] is greater than 0.
     #[inline]
+    pub fn has_surface(self) -> bool {
+        (self.size.x > 0.0) || (self.size.y > 0.0) || (self.size.z > 0.0)
+    }
+
+    /// Returns true if at least one of the size's components (X, Y, Z) is greater than 0.
+    #[inline]
+    #[deprecated = "Replaced with `has_surface()`, which has different semantics"]
     pub fn has_area(self) -> bool {
         ((self.size.x > 0.0) as u8 + (self.size.y > 0.0) as u8 + (self.size.z > 0.0) as u8) >= 2
     }
@@ -226,7 +233,8 @@ impl Aabb {
     /// Returns the scalar length of the longest axis of the AABB.
     #[inline]
     pub fn longest_axis_size(self) -> real {
-        self.size.x.max(self.size.y.max(self.size.z))
+        let size = self.size;
+        size.x.max(size.y).max(size.z)
     }
 
     /// Returns the normalized shortest axis of the AABB.
@@ -253,6 +261,7 @@ impl Aabb {
 
     /// Returns the support point in a given direction. This is useful for collision detection algorithms.
     #[inline]
+    #[doc(alias = "get_support")]
     pub fn support(self, dir: Vector3) -> Vector3 {
         let half_extents = self.size * 0.5;
         let relative_center_point = self.position + half_extents;

--- a/godot-core/src/builtin/rect2.rs
+++ b/godot-core/src/builtin/rect2.rs
@@ -181,10 +181,17 @@ impl Rect2 {
     ///
     /// Note: This method is not reliable for Rect2 with a negative size. Use `abs` to get a positive sized equivalent rectangle to check for contained points.
     #[inline]
-    pub fn has_point(self, point: Vector2) -> bool {
+    #[doc(alias = "has_point")]
+    pub fn contains_point(self, point: Vector2) -> bool {
         let point = point - self.position;
 
         point.abs() == point && point.x < self.size.x && point.y < self.size.y
+    }
+
+    #[inline]
+    #[deprecated = "Renamed to `contains_point()`, for consistency with `Rect2i`"]
+    pub fn has_point(self, point: Vector2) -> bool {
+        self.contains_point(point)
     }
 
     /// Returns the intersection of this Rect2 and `b`. If the rectangles do not intersect, an empty Rect2 is returned.

--- a/godot-core/src/builtin/rect2.rs
+++ b/godot-core/src/builtin/rect2.rs
@@ -177,7 +177,9 @@ impl Rect2 {
         self.size.x > 0.0 && self.size.y > 0.0
     }
 
-    /// Returns `true` if the Rect2 contains a point. By convention, the right and bottom edges of the Rect2 are considered exclusive, so points on these edges are not included.
+    /// Returns `true` if the Rect2 contains a point (excluding right/bottom edges).
+    ///
+    /// By convention, the right and bottom edges of the Rect2 are considered exclusive, so points on these edges are not included.
     ///
     /// Note: This method is not reliable for Rect2 with a negative size. Use `abs` to get a positive sized equivalent rectangle to check for contained points.
     #[inline]

--- a/godot-core/src/builtin/rect2.rs
+++ b/godot-core/src/builtin/rect2.rs
@@ -198,7 +198,7 @@ impl Rect2 {
 
     /// Returns the intersection of this Rect2 and `b`. If the rectangles do not intersect, an empty Rect2 is returned.
     #[inline]
-    pub fn intersection(self, b: Self) -> Option<Self> {
+    pub fn intersect(self, b: Self) -> Option<Self> {
         if !self.intersects(b) {
             return None;
         }
@@ -211,6 +211,11 @@ impl Rect2 {
         rect.size = end.coord_min(end_b) - rect.position;
 
         Some(rect)
+    }
+
+    #[deprecated = "Renamed to `intersect()`"]
+    pub fn intersection(self, b: Rect2) -> Option<Self> {
+        self.intersect(b)
     }
 
     /// Checks whether two rectangles have at least one point in common.

--- a/godot-core/src/builtin/rect2i.rs
+++ b/godot-core/src/builtin/rect2i.rs
@@ -223,7 +223,7 @@ impl Rect2i {
     ///
     /// Note that rectangles that only share a border do not intersect.
     #[inline]
-    pub fn intersection(self, b: Self) -> Option<Self> {
+    pub fn intersect(self, b: Self) -> Option<Self> {
         self.assert_nonnegative();
         b.assert_nonnegative();
 
@@ -243,11 +243,16 @@ impl Rect2i {
         Some(Self::from_corners(new_pos, new_end))
     }
 
+    #[deprecated = "Renamed to `intersect()`"]
+    pub fn intersection(self, b: Self) -> Option<Self> {
+        self.intersect(b)
+    }
+
     /// Returns `true` if the `Rect2i` overlaps with `b` (i.e. they have at least one
     /// point in common)
     #[inline]
     pub fn intersects(self, b: Self) -> bool {
-        self.intersection(b).is_some()
+        self.intersect(b).is_some()
     }
 
     /// Returns a larger `Rect2i` that contains this `Rect2i` and `b`.
@@ -554,19 +559,19 @@ mod test {
         let d = Rect2i::from_components(8, 8, 2, 3);
 
         assert!(a.intersects(b));
-        assert_eq!(a.intersection(b), Some(b));
+        assert_eq!(a.intersect(b), Some(b));
         assert!(a.intersects(c));
-        assert_eq!(a.intersection(c), Some(c));
+        assert_eq!(a.intersect(c), Some(c));
         assert!(a.intersects(d));
-        assert_eq!(a.intersection(d), Some(c));
+        assert_eq!(a.intersect(d), Some(c));
 
         assert!(!b.intersects(c));
-        assert_eq!(b.intersection(c), None);
+        assert_eq!(b.intersect(c), None);
         assert!(!b.intersects(d));
-        assert_eq!(b.intersection(d), None);
+        assert_eq!(b.intersect(d), None);
 
         assert!(c.intersects(d));
-        assert_eq!(c.intersection(d), Some(c));
+        assert_eq!(c.intersect(d), Some(c));
     }
 
     #[test]

--- a/itest/rust/src/builtin_tests/geometry/rect2_test.rs
+++ b/itest/rust/src/builtin_tests/geometry/rect2_test.rs
@@ -48,7 +48,7 @@ fn rect2_inner_equivalence() {
                 inner_rect.intersects(other, false),
             );
             assert_eq!(
-                rect.intersection(other).unwrap_or_default(),
+                rect.intersect(other).unwrap_or_default(),
                 inner_rect.intersection(other),
             );
             assert_eq_approx!(rect.merge(other), inner_rect.merge(other));

--- a/itest/rust/src/builtin_tests/geometry/rect2_test.rs
+++ b/itest/rust/src/builtin_tests/geometry/rect2_test.rs
@@ -56,7 +56,7 @@ fn rect2_inner_equivalence() {
 
         for vec in vectors {
             assert_eq_approx!(rect.expand(vec), inner_rect.expand(vec));
-            assert_eq!(rect.has_point(vec), inner_rect.has_point(vec));
+            assert_eq!(rect.contains_point(vec), inner_rect.has_point(vec));
         }
 
         for grow in grow_values {

--- a/itest/rust/src/builtin_tests/geometry/rect2i_test.rs
+++ b/itest/rust/src/builtin_tests/geometry/rect2i_test.rs
@@ -50,8 +50,8 @@ fn rect2i_equiv_unary() {
             evaluate_mappings("encloses", a.encloses(b), inner_a.encloses(b));
             evaluate_mappings("intersects", a.intersects(b), inner_a.intersects(b));
             evaluate_mappings(
-                "intersection",
-                a.intersection(b).unwrap_or_default(),
+                "intersect",
+                a.intersect(b).unwrap_or_default(),
                 inner_a.intersection(b),
             );
             evaluate_mappings("merge", a.merge(b), inner_a.merge(b));


### PR DESCRIPTION
Cleans up some APIs regarding `Aabb` + `Rect2`.

Implements part of https://github.com/godot-rust/gdext/issues/887.