### PR TITLE
Correct `ConnectFlags` classification (enum -> bitfield)

### DIFF
--- a/godot-codegen/src/models/domain_mapping.rs
+++ b/godot-codegen/src/models/domain_mapping.rs
@@ -559,7 +559,8 @@ impl UtilityFunction {
 impl Enum {
     pub fn from_json(json_enum: &JsonEnum, surrounding_class: Option<&TyName>) -> Self {
         let godot_name = &json_enum.name;
-        let is_bitfield = json_enum.is_bitfield;
+        let is_bitfield = special_cases::is_enum_bitfield(surrounding_class, godot_name)
+            .unwrap_or(json_enum.is_bitfield);
         let is_private = special_cases::is_enum_private(surrounding_class, godot_name);
         let is_exhaustive = special_cases::is_enum_exhaustive(surrounding_class, godot_name);
 

--- a/godot-codegen/src/special_cases/special_cases.rs
+++ b/godot-codegen/src/special_cases/special_cases.rs
@@ -855,6 +855,21 @@ pub fn is_enum_exhaustive(class_name: Option<&TyName>, enum_name: &str) -> bool 
     }
 }
 
+/// Overrides Godot's enum/bitfield status.
+/// * `Some(true)` -> bitfield
+/// * `Some(false)` -> enum
+/// * `None` -> keep default
+#[rustfmt::skip]
+pub fn is_enum_bitfield(class_name: Option<&TyName>, enum_name: &str) -> Option<bool> {
+    let class_name = class_name.map(|c| c.godot_ty.as_str());
+    match (class_name, enum_name) {
+        | (Some("Object"), "ConnectFlags")
+
+        => Some(true), 
+        _ => None
+    }
+}
+
 /// Whether an enum can be combined with another enum (return value) for bitmasking purposes.
 ///
 /// If multiple masks are ever necessary, this can be extended to return a slice instead of Option.


### PR DESCRIPTION
Works around `ConnectFlags` being exported as enum instead of bitfield in Godot.

Also adds a general mechanism in `special_cases.rs` to override this property.