### PR TITLE
Document and refactor `PluginItem` related stuff

### DIFF
--- a/godot-core/src/builder/mod.rs
+++ b/godot-core/src/builder/mod.rs
@@ -10,6 +10,9 @@ use std::marker::PhantomData;
 
 mod method;
 
+/// Class builder to store state for registering a class with Godot.
+///
+/// In the future this will be used, but for now it's a dummy struct.
 pub struct ClassBuilder<C> {
     _c: PhantomData<C>,
 }

--- a/godot-core/src/docs.rs
+++ b/godot-core/src/docs.rs
@@ -6,7 +6,7 @@
  */
 
 use crate::meta::ClassName;
-use crate::registry::plugin::{InherentImpl, PluginItem};
+use crate::registry::plugin::{ITraitImpl, InherentImpl, PluginItem, Struct};
 use std::collections::HashMap;
 
 /// Created for documentation on
@@ -81,14 +81,14 @@ pub fn gather_xml_docs() -> impl Iterator<Item = String> {
                 map.entry(class_name).or_default().inherent = docs
             }
 
-            PluginItem::ITraitImpl {
+            PluginItem::ITraitImpl(ITraitImpl {
                 virtual_method_docs,
                 ..
-            } => map.entry(class_name).or_default().virtual_methods = virtual_method_docs,
+            }) => map.entry(class_name).or_default().virtual_methods = virtual_method_docs,
 
-            PluginItem::Struct {
+            PluginItem::Struct(Struct {
                 docs: Some(docs), ..
-            } => map.entry(class_name).or_default().definition = docs,
+            }) => map.entry(class_name).or_default().definition = docs,
 
             _ => (),
         }

--- a/godot-core/src/private.rs
+++ b/godot-core/src/private.rs
@@ -9,7 +9,8 @@ pub use crate::gen::classes::class_macros;
 pub use crate::obj::rtti::ObjectRtti;
 pub use crate::registry::callbacks;
 pub use crate::registry::plugin::{
-    ClassPlugin, ErasedDynGd, ErasedRegisterFn, ErasedRegisterRpcsFn, InherentImpl, PluginItem,
+    ClassPlugin, DynTraitImpl, ErasedDynGd, ErasedRegisterFn, ITraitImpl, InherentImpl, PluginItem,
+    Struct,
 };
 pub use crate::storage::{as_storage, Storage};
 pub use sys::out;

--- a/godot-core/src/registry/plugin.rs
+++ b/godot-core/src/registry/plugin.rs
@@ -9,11 +9,13 @@
 use crate::docs::*;
 use crate::init::InitLevel;
 use crate::meta::ClassName;
-use crate::obj::Gd;
+use crate::obj::{bounds, cap, Bounds, DynGd, Gd, GodotClass, Inherits, UserClass};
+use crate::registry::callbacks;
 use crate::registry::class::GodotGetVirtual;
 use crate::{classes, sys};
 use std::any::Any;
 use std::{any, fmt};
+
 // TODO(bromeon): some information coming from the proc-macro API is deferred through PluginItem, while others is directly
 // translated to code. Consider moving more code to the PluginItem, which allows for more dynamic registration and will
 // be easier for a future builder API.
@@ -21,22 +23,48 @@ use std::{any, fmt};
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 
 /// Piece of information that is gathered by the self-registration ("plugin") system.
+///
+/// You should not manually construct this struct, but rather use [`ClassPlugin::new()`].
 #[derive(Debug)]
 pub struct ClassPlugin {
-    pub class_name: ClassName,
-    pub item: PluginItem,
+    /// The name of the class to register plugins for.
+    ///
+    /// This is used to group plugins so that all class properties for a single class can be registered at the same time.
+    /// Incorrectly setting this value should not cause any UB but will likely cause errors during registration time.
+    pub(crate) class_name: ClassName,
 
+    /// Which [`InitLevel`] this plugin should be registered at.
+    ///
+    /// Incorrectly setting this value should not cause any UB but will likely cause errors during registration time.
     // Init-level is per ClassPlugin and not per PluginItem, because all components of all classes are mixed together in one
     // huge linker list. There is no per-class aggregation going on, so this allows to easily filter relevant classes.
-    pub init_level: InitLevel,
+    pub(crate) init_level: InitLevel,
+
+    /// The actual item being registered.
+    pub(crate) item: PluginItem,
 }
 
-/// Type-erased function object, holding a `register_class` function.
+impl ClassPlugin {
+    /// Creates a new `ClassPlugin`, automatically setting the `class_name` and `init_level` to the values defined in [`GodotClass`].
+    pub fn new<T: GodotClass>(item: PluginItem) -> Self {
+        Self {
+            class_name: T::class_name(),
+            init_level: T::INIT_LEVEL,
+            item,
+        }
+    }
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// Type-erased values
+
+/// Type-erased function object, holding a function which should called during class registration.
 #[derive(Copy, Clone)]
 pub struct ErasedRegisterFn {
-    // Wrapper needed because Debug can't be derived on function pointers with reference parameters, so this won't work:
+    // A wrapper is needed here because Debug can't be derived on function pointers with reference parameters, so this won't work:
     // pub type ErasedRegisterFn = fn(&mut dyn std::any::Any);
     // (see https://stackoverflow.com/q/53380040)
+    /// The actual function to be called during class registration.
     pub raw: fn(&mut dyn Any),
 }
 
@@ -46,8 +74,15 @@ impl fmt::Debug for ErasedRegisterFn {
     }
 }
 
+/// Type-erased function object, holding a function which should be called during RPC function registration.
 #[derive(Copy, Clone)]
 pub struct ErasedRegisterRpcsFn {
+    // A wrapper is needed here because Debug can't be derived on function pointers with reference parameters, so this won't work:
+    // pub type ErasedRegisterFn = fn(&mut dyn std::any::Any);
+    // (see https://stackoverflow.com/q/53380040)
+    /// The actual function to be called during RPC function registration.
+    ///
+    /// This should be called with a reference to the object that we want to register RPC functions for.
     pub raw: fn(&mut dyn Any),
 }
 
@@ -57,28 +92,25 @@ impl fmt::Debug for ErasedRegisterRpcsFn {
     }
 }
 
-pub type ErasedDynifyFn = fn(Gd<classes::Object>) -> ErasedDynGd;
+/// Type-erased function which converts a `Gd<Object>` into a `DynGd<Object, D>` for some trait object `D`.
+///
+/// See [`DynTraitImpl`] for usage.
+pub type ErasedDynifyFn = unsafe fn(Gd<classes::Object>) -> ErasedDynGd;
+
+/// Type-erased `DynGd<Object, D>` for some trait object `D`.
+///
+/// See [`DynTraitImpl`] for usage.
+pub struct ErasedDynGd {
+    pub boxed: Box<dyn Any>,
+}
 
 type GodotCreateFn = unsafe extern "C" fn(
     _class_userdata: *mut std::ffi::c_void,
     #[cfg(since_api = "4.4")] _notify_postinitialize: sys::GDExtensionBool,
 ) -> sys::GDExtensionObjectPtr;
 
-#[derive(Clone, Debug)]
-pub struct InherentImpl {
-    /// Callback to library-generated function which registers functions and constants in the `impl` block.
-    ///
-    /// Always present since that's the entire point of this `impl` block.
-    pub register_methods_constants_fn: ErasedRegisterFn,
-
-    /// Callback to library-generated function which calls [`Node::rpc_config`](crate::classes::Node::rpc_config) for each function annotated with `#[rpc]` on the `impl` block.
-    ///
-    /// This function is called in [`UserClass::__before_ready()`](crate::obj::UserClass::__before_ready) definitions generated by the `#[derive(GodotClass)]` macro.
-    pub register_rpcs_fn: Option<ErasedRegisterRpcsFn>,
-
-    #[cfg(all(since_api = "4.3", feature = "register-docs"))]
-    pub docs: InherentImplDocs,
-}
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// Plugin items
 
 /// Represents the data part of a [`ClassPlugin`] instance.
 ///
@@ -87,165 +119,448 @@ pub struct InherentImpl {
 #[derive(Clone, Debug)]
 pub enum PluginItem {
     /// Class definition itself, must always be available -- created by `#[derive(GodotClass)]`.
-    Struct {
-        base_class_name: ClassName,
-
-        /// Godot low-level `create` function, wired up to library-generated `init`.
-        generated_create_fn: Option<GodotCreateFn>,
-
-        generated_recreate_fn: Option<
-            unsafe extern "C" fn(
-                p_class_userdata: *mut std::ffi::c_void,
-                p_object: sys::GDExtensionObjectPtr,
-            ) -> sys::GDExtensionClassInstancePtr,
-        >,
-
-        /// Callback to library-generated function which registers properties in the `struct` definition.
-        register_properties_fn: ErasedRegisterFn,
-
-        free_fn: unsafe extern "C" fn(
-            _class_user_data: *mut std::ffi::c_void,
-            instance: sys::GDExtensionClassInstancePtr,
-        ),
-
-        /// Calls `__before_ready()`, if there is at least one `OnReady` field. Used if there is no `#[godot_api] impl` block
-        /// overriding ready.
-        default_get_virtual_fn: Option<GodotGetVirtual>,
-
-        /// Whether `#[class(tool)]` was used.
-        is_tool: bool,
-
-        /// Whether the base class is an `EditorPlugin`.
-        is_editor_plugin: bool,
-
-        /// Whether `#[class(internal)]` was used.
-        is_internal: bool,
-
-        /// Whether the class has a default constructor.
-        is_instantiable: bool,
-
-        #[cfg(all(since_api = "4.3", feature = "register-docs"))]
-        docs: Option<StructDocs>,
-    },
+    Struct(Struct),
 
     /// Collected from `#[godot_api] impl MyClass`.
     InherentImpl(InherentImpl),
 
     /// Collected from `#[godot_api] impl I... for MyClass`.
-    ITraitImpl {
-        /// Virtual method documentation.
-        #[cfg(all(since_api = "4.3", feature = "register-docs"))]
-        virtual_method_docs: &'static str,
+    ITraitImpl(ITraitImpl),
 
-        /// Callback to user-defined `register_class` function.
-        user_register_fn: Option<ErasedRegisterFn>,
-
-        /// Godot low-level `create` function, wired up to the user's `init`.
-        user_create_fn: Option<GodotCreateFn>,
-
-        user_recreate_fn: Option<
-            unsafe extern "C" fn(
-                p_class_userdata: *mut ::std::os::raw::c_void,
-                p_object: sys::GDExtensionObjectPtr,
-            ) -> sys::GDExtensionClassInstancePtr,
-        >,
-
-        /// User-defined `to_string` function.
-        user_to_string_fn: Option<
-            unsafe extern "C" fn(
-                p_instance: sys::GDExtensionClassInstancePtr,
-                r_is_valid: *mut sys::GDExtensionBool,
-                r_out: sys::GDExtensionStringPtr,
-            ),
-        >,
-
-        /// User-defined `on_notification` function.
-        #[cfg(before_api = "4.2")]
-        user_on_notification_fn: Option<
-            unsafe extern "C" fn(
-                p_instance: sys::GDExtensionClassInstancePtr, //
-                p_what: i32,
-            ),
-        >,
-        #[cfg(since_api = "4.2")]
-        user_on_notification_fn: Option<
-            unsafe extern "C" fn(
-                p_instance: sys::GDExtensionClassInstancePtr, //
-                p_what: i32,
-                p_reversed: sys::GDExtensionBool,
-            ),
-        >,
-
-        user_set_fn: Option<
-            unsafe extern "C" fn(
-                p_instance: sys::GDExtensionClassInstancePtr,
-                p_name: sys::GDExtensionConstStringNamePtr,
-                p_value: sys::GDExtensionConstVariantPtr,
-            ) -> sys::GDExtensionBool,
-        >,
-
-        user_get_fn: Option<
-            unsafe extern "C" fn(
-                p_instance: sys::GDExtensionClassInstancePtr,
-                p_name: sys::GDExtensionConstStringNamePtr,
-                r_ret: sys::GDExtensionVariantPtr,
-            ) -> sys::GDExtensionBool,
-        >,
-
-        /// Callback for other virtuals.
-        get_virtual_fn: GodotGetVirtual,
-
-        /// Callback for other virtuals.
-        user_get_property_list_fn: Option<
-            unsafe extern "C" fn(
-                p_instance: sys::GDExtensionClassInstancePtr,
-                r_count: *mut u32,
-            ) -> *const sys::GDExtensionPropertyInfo,
-        >,
-
-        // We do not support using this in Godot < 4.3, however it's easier to leave this in and fail elsewhere when attempting to use
-        // this in Godot < 4.3.
-        #[cfg(before_api = "4.3")]
-        user_free_property_list_fn: Option<
-            unsafe extern "C" fn(
-                p_instance: sys::GDExtensionClassInstancePtr,
-                p_list: *const sys::GDExtensionPropertyInfo,
-            ),
-        >,
-        #[cfg(since_api = "4.3")]
-        user_free_property_list_fn: Option<
-            unsafe extern "C" fn(
-                p_instance: sys::GDExtensionClassInstancePtr,
-                p_list: *const sys::GDExtensionPropertyInfo,
-                p_count: u32,
-            ),
-        >,
-
-        user_property_can_revert_fn: Option<
-            unsafe extern "C" fn(
-                p_instance: sys::GDExtensionClassInstancePtr,
-                p_name: sys::GDExtensionConstStringNamePtr,
-            ) -> sys::GDExtensionBool,
-        >,
-
-        user_property_get_revert_fn: Option<
-            unsafe extern "C" fn(
-                p_instance: sys::GDExtensionClassInstancePtr,
-                p_name: sys::GDExtensionConstStringNamePtr,
-                r_ret: sys::GDExtensionVariantPtr,
-            ) -> sys::GDExtensionBool,
-        >,
-    },
-
-    DynTraitImpl {
-        /// TypeId of the `dyn Trait` object.
-        dyn_trait_typeid: any::TypeId,
-
-        /// Function that converts a `Gd<Object>` to a type-erased `DynGd<Object, dyn Trait>` (with the latter erased for common storage).
-        erased_dynify_fn: fn(Gd<classes::Object>) -> ErasedDynGd,
-    },
+    /// Collected from `#[godot_dyn]` macro invocations.
+    DynTraitImpl(DynTraitImpl),
 }
 
-pub struct ErasedDynGd {
-    pub boxed: Box<dyn Any>,
+/// Helper function which checks that the field has not been set before.
+fn set<T>(field: &mut Option<T>, value: T) {
+    assert!(field.is_none(), "attempted to set field more than once",);
+    *field = Some(value);
+}
+
+/// The data for a class definition.
+#[derive(Clone, Debug)]
+pub struct Struct {
+    /// The name of the base class in Godot.
+    ///
+    /// This must match [`GodotClass::Base`]'s class name.
+    pub(crate) base_class_name: ClassName,
+
+    /// Godot low-level `create` function, wired up to library-generated `init`.
+    ///
+    /// This is mutually exclusive with [`ITraitImpl::user_create_fn`].
+    pub(crate) generated_create_fn: Option<GodotCreateFn>,
+
+    /// Godot low-level `recreate` function, used when hot-reloading a user class.
+    ///
+    /// This is mutually exclusive with [`ITraitImpl::user_recreate_fn`].
+    pub(crate) generated_recreate_fn: Option<
+        unsafe extern "C" fn(
+            p_class_userdata: *mut std::ffi::c_void,
+            p_object: sys::GDExtensionObjectPtr,
+        ) -> sys::GDExtensionClassInstancePtr,
+    >,
+
+    /// Callback to library-generated function which registers properties in the `struct` definition.
+    pub(crate) register_properties_fn: ErasedRegisterFn,
+
+    /// Function called by Godot when an object of this class is freed.
+    ///
+    /// Always implemented as [`callbacks::free`].
+    pub(crate) free_fn: unsafe extern "C" fn(
+        _class_user_data: *mut std::ffi::c_void,
+        instance: sys::GDExtensionClassInstancePtr,
+    ),
+
+    /// Calls `__before_ready()`, if there is at least one `OnReady` field. Used if there is no `#[godot_api] impl` block
+    /// overriding ready.
+    pub(crate) default_get_virtual_fn: Option<GodotGetVirtual>,
+
+    /// Whether `#[class(tool)]` was used.
+    pub(crate) is_tool: bool,
+
+    /// Whether the base class is an `EditorPlugin`.
+    pub(crate) is_editor_plugin: bool,
+
+    /// Whether `#[class(internal)]` was used.
+    pub(crate) is_internal: bool,
+
+    /// Whether the class has a default constructor.
+    pub(crate) is_instantiable: bool,
+
+    /// Documentation extracted from the struct's RustDoc.
+    #[cfg(all(since_api = "4.3", feature = "register-docs"))]
+    pub(crate) docs: Option<StructDocs>,
+}
+
+impl Struct {
+    pub fn new<T: GodotClass + cap::ImplementsGodotExports>(
+        #[cfg(all(since_api = "4.3", feature = "register-docs"))] docs: Option<StructDocs>,
+    ) -> Self {
+        Self {
+            base_class_name: T::Base::class_name(),
+            generated_create_fn: None,
+            generated_recreate_fn: None,
+            register_properties_fn: ErasedRegisterFn {
+                raw: callbacks::register_user_properties::<T>,
+            },
+            free_fn: callbacks::free::<T>,
+            default_get_virtual_fn: None,
+            is_tool: false,
+            is_editor_plugin: false,
+            is_internal: false,
+            is_instantiable: false,
+            #[cfg(all(since_api = "4.3", feature = "register-docs"))]
+            docs,
+        }
+    }
+
+    pub fn with_generated<T: GodotClass + cap::GodotDefault>(mut self) -> Self {
+        set(&mut self.generated_create_fn, callbacks::create::<T>);
+
+        #[cfg(since_api = "4.2")]
+        set(&mut self.generated_recreate_fn, callbacks::recreate::<T>);
+        self
+    }
+
+    pub fn with_default_get_virtual_fn<T: GodotClass + UserClass>(mut self) -> Self {
+        set(
+            &mut self.default_get_virtual_fn,
+            callbacks::default_get_virtual::<T>,
+        );
+        self
+    }
+
+    pub fn with_tool(mut self) -> Self {
+        self.is_tool = true;
+        self
+    }
+
+    pub fn with_editor_plugin(mut self) -> Self {
+        self.is_editor_plugin = true;
+        self
+    }
+
+    pub fn with_internal(mut self) -> Self {
+        self.is_internal = true;
+        self
+    }
+
+    pub fn with_instantiable(mut self) -> Self {
+        self.is_instantiable = true;
+        self
+    }
+}
+
+/// Stores registration functions for methods, constants, and documentation from inherent `#[godot_api]` impl blocks.
+#[derive(Clone, Debug)]
+pub struct InherentImpl {
+    /// Callback to library-generated function which registers functions and constants in the `impl` block.
+    ///
+    /// Always present since that's the entire point of this `impl` block.
+    pub(crate) register_methods_constants_fn: ErasedRegisterFn,
+
+    /// Callback to library-generated function which calls [`Node::rpc_config`](crate::classes::Node::rpc_config) for each function annotated
+    /// with `#[rpc]` on the `impl` block.
+    ///
+    /// This function is called in [`UserClass::__before_ready()`](crate::obj::UserClass::__before_ready) definitions generated by the
+    /// `#[derive(GodotClass)]` macro.
+    // This field is only used during codegen-full.
+    #[cfg_attr(not(feature = "codegen-full"), expect(dead_code))]
+    pub(crate) register_rpcs_fn: Option<ErasedRegisterRpcsFn>,
+
+    #[cfg(all(since_api = "4.3", feature = "register-docs"))]
+    pub docs: InherentImplDocs,
+}
+
+impl InherentImpl {
+    pub fn new<T: cap::ImplementsGodotApi>(
+        #[cfg(all(since_api = "4.3", feature = "register-docs"))] docs: InherentImplDocs,
+    ) -> Self {
+        Self {
+            register_methods_constants_fn: ErasedRegisterFn {
+                raw: callbacks::register_user_methods_constants::<T>,
+            },
+            register_rpcs_fn: Some(ErasedRegisterRpcsFn {
+                raw: callbacks::register_user_rpcs::<T>,
+            }),
+            #[cfg(all(since_api = "4.3", feature = "register-docs"))]
+            docs,
+        }
+    }
+}
+
+#[derive(Default, Clone, Debug)]
+pub struct ITraitImpl {
+    #[cfg(all(since_api = "4.3", feature = "register-docs"))]
+    /// Virtual method documentation.
+    pub(crate) virtual_method_docs: &'static str,
+
+    /// Callback to user-defined `register_class` function.
+    pub(crate) user_register_fn: Option<ErasedRegisterFn>,
+
+    /// Godot low-level `create` function, wired up to the user's `init`.
+    ///
+    /// This is mutually exclusive with [`Struct::generated_create_fn`].
+    pub(crate) user_create_fn: Option<GodotCreateFn>,
+
+    /// Godot low-level `recreate` function, used when hot-reloading a user class.
+    ///
+    /// This is mutually exclusive with [`Struct::generated_recreate_fn`].
+    pub(crate) user_recreate_fn: Option<
+        unsafe extern "C" fn(
+            p_class_userdata: *mut ::std::os::raw::c_void,
+            p_object: sys::GDExtensionObjectPtr,
+        ) -> sys::GDExtensionClassInstancePtr,
+    >,
+
+    /// User-defined `to_string` function.
+    pub(crate) user_to_string_fn: Option<
+        unsafe extern "C" fn(
+            p_instance: sys::GDExtensionClassInstancePtr,
+            r_is_valid: *mut sys::GDExtensionBool,
+            r_out: sys::GDExtensionStringPtr,
+        ),
+    >,
+
+    /// User-defined `on_notification` function.
+    #[cfg(before_api = "4.2")]
+    pub(crate) user_on_notification_fn:
+        Option<unsafe extern "C" fn(p_instance: sys::GDExtensionClassInstancePtr, p_what: i32)>,
+    #[cfg(since_api = "4.2")]
+    pub(crate) user_on_notification_fn: Option<
+        unsafe extern "C" fn(
+            p_instance: sys::GDExtensionClassInstancePtr,
+            p_what: i32,
+            p_reversed: sys::GDExtensionBool,
+        ),
+    >,
+
+    /// User-defined `set_property` function.
+    pub(crate) user_set_fn: Option<
+        unsafe extern "C" fn(
+            p_instance: sys::GDExtensionClassInstancePtr,
+            p_name: sys::GDExtensionConstStringNamePtr,
+            p_value: sys::GDExtensionConstVariantPtr,
+        ) -> sys::GDExtensionBool,
+    >,
+
+    /// User-defined `get_property` function.
+    pub(crate) user_get_fn: Option<
+        unsafe extern "C" fn(
+            p_instance: sys::GDExtensionClassInstancePtr,
+            p_name: sys::GDExtensionConstStringNamePtr,
+            r_ret: sys::GDExtensionVariantPtr,
+        ) -> sys::GDExtensionBool,
+    >,
+
+    /// Callback for other virtual methods specific to each class.
+    pub(crate) get_virtual_fn: Option<GodotGetVirtual>,
+
+    /// User-defined `get_property_list` function.
+    pub(crate) user_get_property_list_fn: Option<
+        unsafe extern "C" fn(
+            p_instance: sys::GDExtensionClassInstancePtr,
+            r_count: *mut u32,
+        ) -> *const sys::GDExtensionPropertyInfo,
+    >,
+
+    // We do not support using this in Godot < 4.3, however it's easier to leave this in and fail elsewhere when attempting to use
+    // this in Godot < 4.3.
+    #[cfg(before_api = "4.3")]
+    pub(crate) user_free_property_list_fn: Option<
+        unsafe extern "C" fn(
+            p_instance: sys::GDExtensionClassInstancePtr,
+            p_list: *const sys::GDExtensionPropertyInfo,
+        ),
+    >,
+    /// Frees the property list created in the user-defined `get_property_list` function.
+    #[cfg(since_api = "4.3")]
+    pub(crate) user_free_property_list_fn: Option<
+        unsafe extern "C" fn(
+            p_instance: sys::GDExtensionClassInstancePtr,
+            p_list: *const sys::GDExtensionPropertyInfo,
+            p_count: u32,
+        ),
+    >,
+
+    /// Part of user-defined `property_get_revert` function.
+    ///
+    /// This effectively just calls [`Option::is_some`] on the return value of the `property_get_revert` function.
+    pub(crate) user_property_can_revert_fn: Option<
+        unsafe extern "C" fn(
+            p_instance: sys::GDExtensionClassInstancePtr,
+            p_name: sys::GDExtensionConstStringNamePtr,
+        ) -> sys::GDExtensionBool,
+    >,
+
+    /// Part of user-defined `property_get_revert` function.
+    ///
+    /// This returns null when the return value of `property_get_revert` is `None`, and otherwise returns the value contained
+    /// within the `Some`.
+    pub(crate) user_property_get_revert_fn: Option<
+        unsafe extern "C" fn(
+            p_instance: sys::GDExtensionClassInstancePtr,
+            p_name: sys::GDExtensionConstStringNamePtr,
+            r_ret: sys::GDExtensionVariantPtr,
+        ) -> sys::GDExtensionBool,
+    >,
+}
+
+impl ITraitImpl {
+    pub fn new<T: GodotClass + cap::ImplementsGodotVirtual>(
+        #[cfg(all(since_api = "4.3", feature = "register-docs"))] virtual_method_docs: &'static str,
+    ) -> Self {
+        Self {
+            #[cfg(all(since_api = "4.3", feature = "register-docs"))]
+            virtual_method_docs,
+            get_virtual_fn: Some(callbacks::get_virtual::<T>),
+            ..Default::default()
+        }
+    }
+
+    pub fn with_register<T: GodotClass + cap::GodotRegisterClass>(mut self) -> Self {
+        set(
+            &mut self.user_register_fn,
+            ErasedRegisterFn {
+                raw: callbacks::register_class_by_builder::<T>,
+            },
+        );
+
+        self
+    }
+
+    pub fn with_create<T: GodotClass + cap::GodotDefault>(mut self) -> Self {
+        set(&mut self.user_create_fn, callbacks::create::<T>);
+
+        #[cfg(since_api = "4.3")]
+        set(&mut self.user_recreate_fn, callbacks::recreate::<T>);
+        self
+    }
+
+    pub fn with_string<T: GodotClass + cap::GodotToString>(mut self) -> Self {
+        set(&mut self.user_to_string_fn, callbacks::to_string::<T>);
+        self
+    }
+
+    pub fn with_on_notification<T: GodotClass + cap::GodotNotification>(mut self) -> Self {
+        set(
+            &mut self.user_on_notification_fn,
+            callbacks::on_notification::<T>,
+        );
+        self
+    }
+
+    pub fn with_get_property<T: GodotClass + cap::GodotGet>(mut self) -> Self {
+        set(&mut self.user_get_fn, callbacks::get_property::<T>);
+        self
+    }
+
+    pub fn with_set_property<T: GodotClass + cap::GodotSet>(mut self) -> Self {
+        set(&mut self.user_set_fn, callbacks::set_property::<T>);
+        self
+    }
+
+    pub fn with_get_property_list<T: GodotClass + cap::GodotGetPropertyList>(mut self) -> Self {
+        set(
+            &mut self.user_get_property_list_fn,
+            callbacks::get_property_list::<T>,
+        );
+
+        #[cfg(since_api = "4.3")]
+        set(
+            &mut self.user_free_property_list_fn,
+            callbacks::free_property_list::<T>,
+        );
+        self
+    }
+
+    pub fn with_property_get_revert<T: GodotClass + cap::GodotPropertyGetRevert>(mut self) -> Self {
+        set(
+            &mut self.user_property_get_revert_fn,
+            callbacks::property_get_revert::<T>,
+        );
+        set(
+            &mut self.user_property_can_revert_fn,
+            callbacks::property_can_revert::<T>,
+        );
+        self
+    }
+}
+
+/// Representation of a `#[godot_dyn]` invocation.
+///
+/// Stores all the information needed for `DynGd` re-enrichment.
+#[derive(Clone, Debug)]
+pub struct DynTraitImpl {
+    /// The class that this `dyn Trait` implementation corresponds to.
+    class_name: ClassName,
+
+    /// TypeId of the `dyn Trait` object.
+    dyn_trait_typeid: any::TypeId,
+
+    /// Function used to get a `DynGd<T,D>` from a `Gd<Object>`. This is used in the [`FromGodot`](crate::meta::FromGodot) implementation
+    /// of [`DynGd`]. This function is always implemented as [`callbacks::dynify_fn::<T, D>`] where `T` is the class represented by `class_name`
+    /// and `D` is the trait object corresponding to `dyn_trait_typeid`.
+    ///
+    /// Function that converts a `Gd<Object>` to a type-erased `DynGd<Object, dyn Trait>` (with the latter erased for common storage).
+    erased_dynify_fn: ErasedDynifyFn,
+}
+
+impl DynTraitImpl {
+    pub fn new<T, D>() -> Self
+    where
+        T: GodotClass
+            + Inherits<classes::Object>
+            + crate::obj::AsDyn<D>
+            + Bounds<Declarer = bounds::DeclUser>,
+        D: ?Sized + 'static,
+    {
+        Self {
+            class_name: T::class_name(),
+            dyn_trait_typeid: std::any::TypeId::of::<D>(),
+            erased_dynify_fn: callbacks::dynify_fn::<T, D>,
+        }
+    }
+
+    /// The class that this `dyn Trait` implementation corresponds to.
+    pub fn class_name(&self) -> &ClassName {
+        &self.class_name
+    }
+
+    /// The type id of the trait object this was registered with.
+    pub fn dyn_trait_typeid(&self) -> any::TypeId {
+        self.dyn_trait_typeid
+    }
+
+    /// Convert a [`Gd<T>`] to a [`DynGd<T, D>`] using `self`.
+    ///
+    /// This will fail with `Err(object)` if the dynamic class of `object` does not match the [`ClassName`] stored in `self`.
+    pub fn get_dyn_gd<T: GodotClass, D: ?Sized + 'static>(
+        &self,
+        object: Gd<T>,
+    ) -> Result<DynGd<T, D>, Gd<T>> {
+        let dynamic_class = object.dynamic_class_string();
+
+        if dynamic_class != self.class_name.to_string_name() {
+            return Err(object);
+        }
+
+        let object = object.upcast_object();
+
+        // SAFETY: `DynTraitImpl::new` ensures that this function is safe to call when `object` is castable to `self.class_name`.
+        // Since the dynamic class of `object` is `self.class_name`, it must be castable to `self.class_name`.
+        let erased_dyn = unsafe { (self.erased_dynify_fn)(object) };
+
+        let dyn_gd_object = erased_dyn.boxed.downcast::<DynGd<classes::Object, D>>();
+
+        // SAFETY: `callbacks::dynify_fn` returns a `DynGd<Object, D>` which has been type erased. So this downcast will always succeed.
+        let dyn_gd_object = unsafe { dyn_gd_object.unwrap_unchecked() };
+
+        // SAFETY: This is effectively upcasting a value which has class equal to `self.class_name` to a `DynGd<T, D>`. Since the class of
+        // `object` is `T` and its dynamic class is `self.class_name`, this means that `T` must be a superclass of `self.class_name`. Thus
+        // this upcast is safe.
+        let dyn_gd_t = unsafe { dyn_gd_object.cast_unchecked::<T>() };
+
+        Ok(dyn_gd_t)
+    }
 }

--- a/godot-macros/src/class/data_models/inherent_impl.rs
+++ b/godot-macros/src/class/data_models/inherent_impl.rs
@@ -153,19 +153,9 @@ pub fn transform_inherent_impl(
         };
 
         let class_registration = quote! {
-            ::godot::sys::plugin_add!(__GODOT_PLUGIN_REGISTRY in #prv; #prv::ClassPlugin {
-                class_name: #class_name_obj,
-                item: #prv::PluginItem::InherentImpl(#prv::InherentImpl {
-                    register_methods_constants_fn: #prv::ErasedRegisterFn {
-                        raw: #prv::callbacks::register_user_methods_constants::<#class_name>,
-                    },
-                    register_rpcs_fn: Some(#prv::ErasedRegisterRpcsFn {
-                        raw: #prv::callbacks::register_user_rpcs::<#class_name>,
-                    }),
-                    #docs
-                }),
-                init_level: <#class_name as ::godot::obj::GodotClass>::INIT_LEVEL,
-            });
+            ::godot::sys::plugin_add!(__GODOT_PLUGIN_REGISTRY in #prv; #prv::ClassPlugin::new::<#class_name>(
+                #prv::PluginItem::InherentImpl(#prv::InherentImpl::new::<#class_name>(#docs))
+            ));
         };
 
         let result = quote! {

--- a/godot-macros/src/docs.rs
+++ b/godot-macros/src/docs.rs
@@ -17,23 +17,24 @@ pub fn make_definition_docs(
     description: &[Attribute],
     members: &[Field],
 ) -> TokenStream {
-    (|| {
-        let base_escaped = xml_escape(base);
-        let desc_escaped = xml_escape(make_docs_from_attributes(description)?);
-        let members = members
-            .iter()
-            .filter(|x| x.var.is_some() | x.export.is_some())
-            .filter_map(member)
-            .collect::<String>();
-        Some(quote! {
-            docs: ::godot::docs::StructDocs {
+    let base_escaped = xml_escape(base);
+    let Some(desc_escaped) = make_docs_from_attributes(description).map(xml_escape) else {
+        return quote! { None };
+    };
+    let members = members
+        .iter()
+        .filter(|x| x.var.is_some() | x.export.is_some())
+        .filter_map(member)
+        .collect::<String>();
+    quote! {
+        Some(
+            ::godot::docs::StructDocs {
                 base: #base_escaped,
                 description: #desc_escaped,
                 members: #members,
-            }.into()
-        })
-    })()
-    .unwrap_or(quote! { docs: None })
+            }
+        )
+    }
 }
 
 pub fn make_inherent_impl_docs(
@@ -77,7 +78,7 @@ pub fn make_inherent_impl_docs(
             .collect::<String>();
 
         quote! {
-            docs: ::godot::docs::InherentImplDocs {
+            ::godot::docs::InherentImplDocs {
                 methods: #methods,
                 signals_block: #signals_block,
                 constants_block: #constants_block,
@@ -97,7 +98,7 @@ pub fn make_virtual_impl_docs(vmethods: &[ImplMember]) -> TokenStream {
         .filter_map(make_virtual_method_docs)
         .collect::<String>();
 
-    quote! { virtual_method_docs: #virtual_methods, }
+    quote! { #virtual_methods }
 }
 
 /// `///` is expanded to `#[doc = "…"]`.

--- a/itest/rust/src/register_tests/constant_test.rs
+++ b/itest/rust/src/register_tests/constant_test.rs
@@ -167,18 +167,14 @@ impl godot::obj::cap::ImplementsGodotApi for HasOtherConstants {
 // TODO once this is done via proc-macro, see if `register-docs` is still used in register_docs_test.rs. Otherwise, remove feature from Cargo.toml.
 godot::sys::plugin_add!(
     __GODOT_PLUGIN_REGISTRY in ::godot::private;
-    ::godot::private::ClassPlugin {
-        class_name: HasOtherConstants::class_name(),
-        item: ::godot::private::PluginItem::InherentImpl(::godot::private::InherentImpl {
-            register_methods_constants_fn: ::godot::private::ErasedRegisterFn {
-                raw: ::godot::private::callbacks::register_user_methods_constants::<HasOtherConstants>,
-            },
-            register_rpcs_fn: None,
-            #[cfg(feature = "register-docs")]
-            docs: ::godot::docs::InherentImplDocs::default(),
-        }),
-        init_level: HasOtherConstants::INIT_LEVEL,
-    }
+    ::godot::private::ClassPlugin::new::<HasOtherConstants>(
+        ::godot::private::PluginItem::InherentImpl(
+            ::godot::private::InherentImpl::new::<HasOtherConstants>(
+                #[cfg(feature = "register-docs")]
+                Default::default()
+            )
+        )
+    )
 );
 
 macro_rules! test_enum_export {


### PR DESCRIPTION
- Split `PluginItem` into separate structs per variant
- Make constructors + builders for the structs
- Move more things out of proc-macros and into struct constructors/builders 
- Rework the safety invariants of `godot_dyn`
- Document many of these apis better

Whether using builders in here is an improvement isn't 100% clear always. It could be used for the builder-api later, but it's also a bit low-level at the moment. And may be split at the wrong level of granularity. It does however reduce a lot of code in the proc-macros, which is an advantage. 

The `DynTraitImpl` refactor i think works pretty well, a lot of the safety invariants have been moved into the type system, and we dont need to generate much unsafe code in the proc-macro anymore. I also removed `DynToClassRelation` and replaced it with `DynTraitImpl` to simplify some of the code.

We could maybe make a util-struct that generates code to use the builders, however currently it's only used in two places so im not sure it's much of an advantage yet. However in the future it may be useful if we're gonna be using the builder-api under the hood.

Git is very confused by the `PluginItem` refactor unfortunately. It should largely be the same as it was before but just split up, except for `DynTraitImpl`. However there was an upstream change to the plugin items while i was working on this which made a bit of a messy merge, but i think i resolved it properly.