### PR TITLE
Re-integrate virtual compat methods

### DIFF
--- a/godot-codegen/src/models/domain_mapping.rs
+++ b/godot-codegen/src/models/domain_mapping.rs
@@ -424,15 +424,12 @@ impl ClassMethod {
         let direction = FnDirection::Virtual {
             #[cfg(since_api = "4.4")]
             hash: {
-                // TODO(v0.3,virtual-compat): re-enable this in favor of 0 fallback.
-                /*let hash_i64 = method.hash.unwrap_or_else(|| {
+                let hash_i64 = method.hash.unwrap_or_else(|| {
                     panic!(
                         "virtual class methods must have a hash since Godot 4.4; missing: {}.{}",
                         class_name.godot_ty, method.name
                     )
-                });*/
-                // Temporarily use hash 0 until upstream PR is merged.
-                let hash_i64 = method.hash.unwrap_or(0);
+                });
 
                 // TODO see if we can use u32 everywhere.
                 hash_i64.try_into().unwrap_or_else(|_| {

--- a/godot-core/src/registry/callbacks.rs
+++ b/godot-core/src/registry/callbacks.rs
@@ -113,15 +113,12 @@ pub unsafe extern "C" fn free<T: GodotClass>(
 pub unsafe extern "C" fn get_virtual<T: cap::ImplementsGodotVirtual>(
     _class_user_data: *mut std::ffi::c_void,
     name: sys::GDExtensionConstStringNamePtr,
-    // TODO(v0.3,virtual-compat): re-enable parameter
-    //hash: u32,
+    hash: u32,
 ) -> sys::GDExtensionClassCallVirtual {
     // This string is not ours, so we cannot call the destructor on it.
     let borrowed_string = StringName::borrow_string_sys(name);
     let method_name = borrowed_string.to_string();
 
-    // TODO(v0.3,virtual-compat): remove local var
-    let hash = 0;
     T::__virtual_call(method_name.as_str(), hash)
 }
 
@@ -133,6 +130,7 @@ pub unsafe extern "C" fn get_virtual<T: cap::ImplementsGodotVirtual>(
     // This string is not ours, so we cannot call the destructor on it.
     let borrowed_string = StringName::borrow_string_sys(name);
     let method_name = borrowed_string.to_string();
+
     T::__virtual_call(method_name.as_str())
 }
 
@@ -140,15 +138,12 @@ pub unsafe extern "C" fn get_virtual<T: cap::ImplementsGodotVirtual>(
 pub unsafe extern "C" fn default_get_virtual<T: UserClass>(
     _class_user_data: *mut std::ffi::c_void,
     name: sys::GDExtensionConstStringNamePtr,
-    // TODO(v0.3,virtual-compat): re-enable parameter
-    // hash: u32,
+    hash: u32,
 ) -> sys::GDExtensionClassCallVirtual {
     // This string is not ours, so we cannot call the destructor on it.
     let borrowed_string = StringName::borrow_string_sys(name);
     let method_name = borrowed_string.to_string();
 
-    // TODO(v0.3,virtual-compat): remove local var
-    let hash = 0;
     T::__default_virtual_call(method_name.as_str(), hash)
 }
 

--- a/godot-core/src/registry/class.rs
+++ b/godot-core/src/registry/class.rs
@@ -86,11 +86,8 @@ type GodotCreationInfo = sys::GDExtensionClassCreationInfo4;
 
 #[cfg(before_api = "4.4")]
 pub(crate) type GodotGetVirtual = <sys::GDExtensionClassGetVirtual as sys::Inner>::FnPtr;
-// TODO(v0.3,virtual-compat): re-enable this to use GetVirtual2
-// #[cfg(since_api = "4.4")]
-// pub(crate) type GodotGetVirtual = <sys::GDExtensionClassGetVirtual2 as sys::Inner>::FnPtr;
 #[cfg(since_api = "4.4")]
-pub(crate) type GodotGetVirtual = <sys::GDExtensionClassGetVirtual as sys::Inner>::FnPtr;
+pub(crate) type GodotGetVirtual = <sys::GDExtensionClassGetVirtual2 as sys::Inner>::FnPtr;
 
 #[derive(Debug)]
 struct ClassRegistrationInfo {


### PR DESCRIPTION
Reverts #991's commit 60e48ff278d2ca488d4c64537907bcacf8bc78e5.
Makes godot-rust ready for GDExtension's compatibility feature (https://github.com/godotengine/godot/pull/100674).

CI will fail until upstream PR is merged.