### PR TITLE
Follow clippy 1.84; limit `NodePath::subpath()` polyfill again

### DIFF
--- a/godot-codegen/src/special_cases/codegen_special_cases.rs
+++ b/godot-codegen/src/special_cases/codegen_special_cases.rs
@@ -74,14 +74,16 @@ pub(crate) fn is_class_method_excluded(method: &JsonClassMethod, ctx: &mut Conte
     };
 
     // Exclude if return type contains an excluded type.
-    if method.return_value.as_ref().map_or(false, |ret| {
-        is_arg_or_return_excluded(ret.type_.as_str(), ctx)
-    }) {
+    if method
+        .return_value
+        .as_ref()
+        .is_some_and(|ret| is_arg_or_return_excluded(ret.type_.as_str(), ctx))
+    {
         return true;
     }
 
     // Exclude if any argument contains an excluded type.
-    if method.arguments.as_ref().map_or(false, |args| {
+    if method.arguments.as_ref().is_some_and(|args| {
         args.iter()
             .any(|arg| is_arg_or_return_excluded(arg.type_.as_str(), ctx))
     }) {
@@ -107,8 +109,8 @@ pub(crate) fn is_utility_function_excluded(
     function
         .return_type
         .as_ref()
-        .map_or(false, |ret| is_type_excluded(ret.as_str(), ctx))
-        || function.arguments.as_ref().map_or(false, |args| {
+        .is_some_and(|ret| is_type_excluded(ret.as_str(), ctx))
+        || function.arguments.as_ref().is_some_and(|args| {
             args.iter()
                 .any(|arg| is_type_excluded(arg.type_.as_str(), ctx))
         })

--- a/godot-core/src/builtin/string/node_path.rs
+++ b/godot-core/src/builtin/string/node_path.rs
@@ -8,7 +8,7 @@
 use std::fmt;
 
 use godot_ffi as sys;
-use godot_ffi::{ffi_methods, GodotFfi};
+use godot_ffi::{ffi_methods, GdextBuild, GodotFfi};
 
 use crate::builtin::inner;
 
@@ -142,19 +142,23 @@ impl NodePath {
     #[cfg(since_api = "4.3")]
     #[doc(alias = "slice")]
     pub fn subpath(&self, begin: i32, exclusive_end: i32) -> NodePath {
-        // Polyfill for bug https://github.com/godotengine/godot/pull/100954.
-        // TODO(v0.3) make polyfill (everything but last line) conditional if PR is merged in 4.4.
-        let name_count = self.get_name_count() as i32;
-        let subname_count = self.get_subname_count() as i32;
-        let total_count = name_count + subname_count;
+        // Polyfill for bug https://github.com/godotengine/godot/pull/100954, fixed in 4.4.
+        let begin = if GdextBuild::since_api("4.4") {
+            begin
+        } else {
+            let name_count = self.get_name_count() as i32;
+            let subname_count = self.get_subname_count() as i32;
+            let total_count = name_count + subname_count;
 
-        let mut begin = begin.clamp(-total_count, total_count);
-        if begin < 0 {
-            begin += total_count;
-        }
-        if begin > name_count {
-            begin += 1;
-        }
+            let mut begin = begin.clamp(-total_count, total_count);
+            if begin < 0 {
+                begin += total_count;
+            }
+            if begin > name_count {
+                begin += 1;
+            }
+            begin
+        };
 
         self.as_inner().slice(begin as i64, exclusive_end as i64)
     }

--- a/godot-core/src/builtin/variant/mod.rs
+++ b/godot-core/src/builtin/variant/mod.rs
@@ -453,9 +453,9 @@ impl Drop for Variant {
 // Variant is not Eq because it can contain floats and other types composed of floats.
 impl PartialEq for Variant {
     fn eq(&self, other: &Self) -> bool {
-        Self::evaluate(self, other, VariantOperator::EQUAL)
-            .map(|v| v.to::<bool>())
-            .unwrap_or(false) // if there is no defined conversion, then they are non-equal
+        Self::evaluate(self, other, VariantOperator::EQUAL) //.
+            .is_some_and(|v| v.to::<bool>())
+        // If there is no defined conversion (-> None), then they are non-equal.
     }
 }
 

--- a/godot-core/src/meta/args/ref_arg.rs
+++ b/godot-core/src/meta/args/ref_arg.rs
@@ -193,6 +193,6 @@ where
     }
 
     fn is_null(&self) -> bool {
-        self.shared_ref.map(|r| r.is_null()).unwrap_or(true)
+        self.shared_ref.map_or(true, T::is_null)
     }
 }

--- a/godot-core/src/obj/bounds.rs
+++ b/godot-core/src/obj/bounds.rs
@@ -272,8 +272,7 @@ impl MemDynamic {
     /// Check whether dynamic type is ref-counted.
     fn inherits_refcounted<T: GodotClass>(obj: &RawGd<T>) -> bool {
         obj.instance_id_unchecked()
-            .map(|id| id.is_ref_counted())
-            .unwrap_or(false)
+            .is_some_and(|id| id.is_ref_counted())
     }
 }
 impl Sealed for MemDynamic {}
@@ -301,8 +300,7 @@ impl DynMemory for MemDynamic {
         out!("  MemDyn::dec   <{}>", std::any::type_name::<T>());
         if obj
             .instance_id_unchecked()
-            .map(|id| id.is_ref_counted())
-            .unwrap_or(false)
+            .is_some_and(|id| id.is_ref_counted())
         {
             // Will call `RefCounted::unreference()` which checks for liveness.
             MemRefCounted::maybe_dec_ref(obj)

--- a/godot-core/src/obj/raw_gd.rs
+++ b/godot-core/src/obj/raw_gd.rs
@@ -103,8 +103,7 @@ impl<T: GodotClass> RawGd<T> {
     pub(crate) fn is_instance_valid(&self) -> bool {
         self.cached_rtti
             .as_ref()
-            .map(|rtti| rtti.instance_id().lookup_validity())
-            .unwrap_or(false)
+            .is_some_and(|rtti| rtti.instance_id().lookup_validity())
     }
 
     // See use-site for explanation.

--- a/godot-ffi/src/toolbox.rs
+++ b/godot-ffi/src/toolbox.rs
@@ -227,7 +227,7 @@ fn strip_module_paths(full_name: &str) -> String {
                 result.push(c);
 
                 // Handle spaces after commas for readability.
-                if c == ',' && chars.peek().map_or(false, |&next_c| next_c != ' ') {
+                if c == ',' && chars.peek().is_some_and(|&next_c| next_c != ' ') {
                     result.push(' ');
                 }
             }

--- a/godot-macros/src/util/mod.rs
+++ b/godot-macros/src/util/mod.rs
@@ -141,7 +141,7 @@ fn delimiter_opening_char(delimiter: Delimiter) -> char {
 /// declaration of the form `impl MyTrait for SomeType`. The type `SomeType` is irrelevant in this example.
 pub(crate) fn is_impl_named(original_impl: &venial::Impl, name: &str) -> bool {
     let trait_name = original_impl.trait_ty.as_ref().unwrap(); // unwrap: already checked outside
-    extract_typename(trait_name).map_or(false, |seg| seg.ident == name)
+    extract_typename(trait_name).is_some_and(|seg| seg.ident == name)
 }
 
 /// Validates either:
@@ -238,7 +238,7 @@ pub(crate) fn path_ends_with_complex(path: &venial::TypeExpr, expected: &str) ->
         .map(|path| {
             path.segments
                 .last()
-                .map_or(false, |seg| seg.ident == expected)
+                .is_some_and(|seg| seg.ident == expected)
         })
         .unwrap_or(false)
 }
@@ -248,7 +248,7 @@ pub(crate) fn extract_cfg_attrs(
 ) -> impl IntoIterator<Item = &venial::Attribute> {
     attrs.iter().filter(|attr| {
         attr.get_single_path_segment()
-            .map_or(false, |name| name == "cfg")
+            .is_some_and(|name| name == "cfg")
     })
 }
 

--- a/godot-macros/src/util/mod.rs
+++ b/godot-macros/src/util/mod.rs
@@ -228,19 +228,15 @@ pub(crate) fn path_is_single(path: &[TokenTree], expected: &str) -> bool {
 
 pub(crate) fn path_ends_with(path: &[TokenTree], expected: &str) -> bool {
     // Could also use TypeExpr::as_path(), or fn below this one.
-    path.last()
-        .map(|last| last.to_string() == expected)
-        .unwrap_or(false)
+    path.last().is_some_and(|last| last.to_string() == expected)
 }
 
 pub(crate) fn path_ends_with_complex(path: &venial::TypeExpr, expected: &str) -> bool {
-    path.as_path()
-        .map(|path| {
-            path.segments
-                .last()
-                .is_some_and(|seg| seg.ident == expected)
-        })
-        .unwrap_or(false)
+    path.as_path().is_some_and(|path| {
+        path.segments
+            .last()
+            .is_some_and(|seg| seg.ident == expected)
+    })
 }
 
 pub(crate) fn extract_cfg_attrs(

--- a/itest/rust/src/framework/runner.rs
+++ b/itest/rust/src/framework/runner.rs
@@ -333,9 +333,7 @@ fn print_test_pre(test_case: &str, test_file: String, last_file: &mut Option<Str
 
 fn print_file_header(file: String, last_file: &mut Option<String>) {
     // Check if we need to open a new category for a file.
-    let print_file = last_file
-        .as_ref()
-        .map_or(true, |last_file| last_file != &file);
+    let print_file = last_file.as_ref() != Some(&file);
 
     if print_file {
         println!("\n   {}:", extract_file_subtitle(&file));


### PR DESCRIPTION
Original `NodePath` PR #982 added a workaround for a Godot bug, which interpreted indices wrong. 
Now that upstream https://github.com/godotengine/godot/pull/100954 has been merged, we can limit that polyfill to Godot version 4.3.

Also follows suit with new clippy lints from Rust 1.84.