### PR TITLE
Fix `#[derive(Var)]` generating incorrect `hint_string` for enums

### DIFF
--- a/godot-macros/src/derive/derive_var.rs
+++ b/godot-macros/src/derive/derive_var.rs
@@ -61,7 +61,7 @@ fn create_property_hint_impl(convert: &GodotConvert) -> TokenStream {
             quote! {
                 ::godot::meta::PropertyHintInfo {
                     hint: ::godot::global::PropertyHint::ENUM,
-                    hint_string: #hint_string.into(),
+                    hint_string: ::godot::builtin::GString::from(#hint_string),
                 }
             }
         }


### PR DESCRIPTION
Fixes #1009.