### PR TITLE
fix: parse doc strings with litrs

### DIFF
--- a/godot-macros/Cargo.toml
+++ b/godot-macros/Cargo.toml
@@ -12,7 +12,7 @@ homepage = "https://godot-rust.github.io"
 
 [features]
 api-custom = ["godot-bindings/api-custom"]
-register-docs = ["dep:markdown"]
+register-docs = ["dep:markdown", "dep:litrs"]
 codegen-full = ["godot/__codegen-full"]
 
 [lib]
@@ -24,6 +24,7 @@ proc-macro2 = "1.0.80" # Literal::c_string() added in 1.0.80.
 quote = "1.0.29"
 # Enabled by `docs`.
 markdown = { version = "=1.0.0-alpha.21", optional = true }
+litrs = { version = "0.4.1", optional = true }
 # Requires bugfixes from 0.6.1.
 venial = "0.6.1"
 

--- a/godot-macros/src/docs.rs
+++ b/godot-macros/src/docs.rs
@@ -113,14 +113,10 @@ fn siphon_docs_from_attributes(doc: &[Attribute]) -> impl Iterator<Item = String
             _ => None,
         })
         .flat_map(|doc| {
-            doc.iter().map(|x| {
-                x.to_string()
-                    .trim_start_matches('r')
-                    .trim_start_matches('#')
-                    .trim_start_matches('"')
-                    .trim_end_matches('#')
-                    .trim_end_matches('"')
-                    .to_string()
+            doc.iter().map(|token_tree| {
+                let str = token_tree.to_string();
+                litrs::StringLit::parse(str.clone())
+                    .map_or(str, |parsed| parsed.value().to_string())
             })
         })
 }

--- a/itest/rust/src/register_tests/res/registered_docs.xml
+++ b/itest/rust/src/register_tests/res/registered_docs.xml
@@ -2,12 +2,12 @@
 <class name="FairlyDocumented" inherits="Node" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 <brief_description>[i]documented[/i] ~ [b]documented[/b] ~ [AABB] &lt; [url=https://github.com/godot-rust/gdext/pull/748]pr[/url]</brief_description>
 <description>[i]documented[/i] ~ [b]documented[/b] ~ [AABB] &lt; [url=https://github.com/godot-rust/gdext/pull/748]pr[/url][br][br]This is a paragraph. It has some text in it. It&#39;s a paragraph. It&#39;s quite long, and wraps multiple lines. It is describing the struct [code]Player[/code]. Or maybe perhaps it&#39;s describing the module. It&#39;s hard to say, really. It even has some code in it: [code]let x = 5;[/code]. And some more code: [code]let y = 6;[/code]. And a bunch of [b]bold[/b] and [i]italic[/i] text with [i]different[/i] ways to do it. Don&#39;t forget about [url=https://example.com]links[/url].[br][br]a few tests:[br][br]headings:[br][br][b]Some heading[/b][br][br]lists:[br][br]• lists[br]• like this[br]    • with sublists[br]        that are multiline[br]        • and subsublists[br]• and list items[br][br]• maybe with [code]*[/code] as well[br][br][url=https://example.com]reference-style link[/url][br][br]links with back-references:[br][br]Blah blah¹ Also same reference¹[br][br]footnotes:[br][br]We cannot florbinate the glorb²[br][br]Third note in order of use³ and fourth ⁴[br][br]Fifth note in order of use. ⁶[br][br]Sixth footnote in order of use. ⁵[br][br]task lists:[br][br]We must ensure that we&#39;ve completed[br][br]• [ ] task 1[br]• [x] task 2[br][br]tables:[br][br]Header1 | Header2[br]abc | def[br][br]images:[br][br][url=https://godotengine.org/assets/press/logo_small_color_light.png]https://godotengine.org/assets/press/logo_small_color_light.png[/url][br][br][url=https://godotengine.org/assets/press/logo_small_color_dark.png]https://godotengine.org/assets/press/logo_small_color_dark.png[/url][br][br]blockquotes:[br][br]&gt; Some cool thing[br][br]ordered list:[br][br]1. thing one[br]2. thing two[br]    1. thing two point one[br]    2. thing two point two[br]    3. thing two point three[br][br][b]Something here &lt; this is technically header syntax[/b][br][br]And here[br][br]smart punctuation[br][br]codeblocks:[br][br][codeblock lang=rust]#![no_main]
-#[link_section=\&quot;.text\&quot;]
+#[link_section=&quot;.text&quot;]
 #[no_mangle]
 static main: u64 = 0x31c0678b10;[/codeblock][br][br][codeblock lang=gdscript]extends Node
 
 func _ready():
-   print(\&quot;Hello, world!\&quot;)[/codeblock][br][br][codeblock lang=csharp]using Godot;
+   print(&quot;Hello, world!&quot;)[/codeblock][br][br][codeblock lang=csharp]using Godot;
 
 public class Player : Node2D
 {


### PR DESCRIPTION
Fixes #885 

![Screenshot](https://github.com/user-attachments/assets/b478c2cf-8cb7-4a5d-aecd-c080c570d2c0)
