### PR TITLE
`Callable::from_local_static()` now requires Godot 4.4+

### DIFF
--- a/godot-core/src/builtin/variant/mod.rs
+++ b/godot-core/src/builtin/variant/mod.rs
@@ -8,7 +8,7 @@
 use crate::builtin::{
     GString, StringName, VariantArray, VariantDispatch, VariantOperator, VariantType,
 };
-use crate::meta::error::{ConvertError, ErrorKind, FromVariantError};
+use crate::meta::error::ConvertError;
 use crate::meta::{arg_into_ref, ArrayElement, AsArg, FromGodot, ToGodot};
 use godot_ffi as sys;
 use std::{fmt, ptr};
@@ -128,6 +128,7 @@ impl Variant {
 
         #[cfg(before_api = "4.4")]
         {
+            use crate::meta::error::{ErrorKind, FromVariantError};
             match self.try_to::<crate::obj::Gd<crate::classes::Object>>() {
                 Ok(obj) => Some(obj.instance_id_unchecked()),
                 Err(c)

--- a/godot-core/src/meta/error/convert_error.rs
+++ b/godot-core/src/meta/error/convert_error.rs
@@ -92,6 +92,7 @@ impl ConvertError {
         ErasedConvertError::from(self)
     }
 
+    #[cfg(before_api = "4.4")]
     pub(crate) fn kind(&self) -> &ErrorKind {
         &self.kind
     }

--- a/itest/rust/src/builtin_tests/containers/callable_test.rs
+++ b/itest/rust/src/builtin_tests/containers/callable_test.rs
@@ -136,6 +136,34 @@ fn callable_static() {
 
     #[cfg(since_api = "4.3")]
     assert_eq!(callable.get_argument_count(), 0); // Consistently doesn't work :)
+
+    // Test varying binds to static callables
+    // Last 3 of 4 arguments. Within Godot, bound arguments are used in-order AFTER call arguments
+    let bindv = callable.bindv(&varray![
+        "two",
+        array![&NodePath::from("three/four")],
+        &RefCounted::new_gd(),
+    ]);
+    assert!(!Variant::is_nil(&bindv.to_variant()));
+    // let bindv_result = bindv.callv(&varray![1]); // Call the binding, filling in the first argument
+    // assert!(!Variant::is_nil(&bindv_result)); // FIXME: Assertion fails
+    // let bind_result_data: VariantArray = bindv_result.to();
+    // assert_eq!(4, bind_result_data.len());
+
+    #[cfg(since_api = "4.2")]
+    {
+        // Same as above, with additional "bind" method
+        let bind = callable.bind(&[
+            "two".to_variant(),
+            array![&NodePath::from("three/four")].to_variant(),
+            RefCounted::new_gd().to_variant(),
+        ]);
+        assert!(!Variant::is_nil(&bind.to_variant()));
+        // let bind_result = bind.call(&[1.to_variant()]);
+        // assert!(!Variant::is_nil(&bind_result)); // FIXME: Assertion fails
+        // let bind_result_data: VariantArray = bind_result.to();
+        // assert_eq!(4, bind_result_data.len());
+    }
 }
 
 #[itest]

--- a/itest/rust/src/builtin_tests/containers/callable_test.rs
+++ b/itest/rust/src/builtin_tests/containers/callable_test.rs
@@ -98,27 +98,15 @@ fn callable_object_method() {
 }
 
 #[itest]
+#[cfg(since_api = "4.4")]
 fn callable_static() {
     let callable = Callable::from_local_static("CallableTestObj", "concat_array");
 
-    // Test current behavior in <4.4 and >=4.4. Although our API explicitly leaves it unspecified, we then notice change in implementation.
-    if cfg!(since_api = "4.4") {
-        assert_eq!(callable.object(), None);
-        assert_eq!(callable.object_id(), None);
-        assert_eq!(callable.method_name(), None);
-        assert!(callable.is_custom());
-        assert!(callable.is_valid());
-    } else {
-        assert!(callable.object().is_some());
-        assert!(callable.object_id().is_some());
-        assert_eq!(callable.method_name(), Some("concat_array".into()));
-        assert_eq!(callable.to_string(), "GDScriptNativeClass::concat_array");
-        assert!(!callable.is_custom());
-
-        // Surprisingly false, but call still works (see test below).
-        // What DOESN'T work is connecting 4.3 static methods to signals via this approach.
-        assert!(!callable.is_valid());
-    }
+    assert_eq!(callable.object(), None);
+    assert_eq!(callable.object_id(), None);
+    assert_eq!(callable.method_name(), None);
+    assert!(callable.is_custom());
+    assert!(callable.is_valid());
 
     assert!(!callable.is_null());
 
@@ -136,34 +124,32 @@ fn callable_static() {
 
     #[cfg(since_api = "4.3")]
     assert_eq!(callable.get_argument_count(), 0); // Consistently doesn't work :)
+}
 
-    // Test varying binds to static callables
-    // Last 3 of 4 arguments. Within Godot, bound arguments are used in-order AFTER call arguments
+// Regression test, see https://github.com/godot-rust/gdext/pull/1029.
+#[itest]
+#[cfg(since_api = "4.4")]
+fn callable_static_bind() {
+    let callable = Callable::from_local_static("CallableTestObj", "concat_array");
+    assert!(callable.is_valid());
+
+    // Test varying binds to static callables.
+    // Last 3 of 4 arguments. Within Godot, bound arguments are used in-order AFTER call arguments.
     let bindv = callable.bindv(&varray![
         "two",
         array![&NodePath::from("three/four")],
         &RefCounted::new_gd(),
     ]);
-    assert!(!Variant::is_nil(&bindv.to_variant()));
-    // let bindv_result = bindv.callv(&varray![1]); // Call the binding, filling in the first argument
-    // assert!(!Variant::is_nil(&bindv_result)); // FIXME: Assertion fails
-    // let bind_result_data: VariantArray = bindv_result.to();
-    // assert_eq!(4, bind_result_data.len());
+    assert!(bindv.is_valid());
 
-    #[cfg(since_api = "4.2")]
-    {
-        // Same as above, with additional "bind" method
-        let bind = callable.bind(&[
-            "two".to_variant(),
-            array![&NodePath::from("three/four")].to_variant(),
-            RefCounted::new_gd().to_variant(),
-        ]);
-        assert!(!Variant::is_nil(&bind.to_variant()));
-        // let bind_result = bind.call(&[1.to_variant()]);
-        // assert!(!Variant::is_nil(&bind_result)); // FIXME: Assertion fails
-        // let bind_result_data: VariantArray = bind_result.to();
-        // assert_eq!(4, bind_result_data.len());
-    }
+    assert!(!bindv.to_variant().is_nil());
+    let args = varray![1];
+    let bindv_result = bindv.callv(&args);
+
+    assert!(!bindv_result.is_nil());
+
+    let bind_result_data: VariantArray = bindv_result.to();
+    assert_eq!(4, bind_result_data.len());
 }
 
 #[itest]


### PR DESCRIPTION
I was having some issues with binding arguments to static method `Callable`s. @Bromeon suggested I make a PR to add some unit tests.

I'm new to contributing and I don't fully understand the Rust toolchain, so looking for feedback.
- Should I wrap this test in the `cfg!(since_api="4.4")` seeing as the callable API has changed a bit in that Godot version? How can I run this test with that API if so?
- ~~Test fails, indicating a bug. Should I just, comment it out to prevent interrupting workflows?~~ Commented it out for now