### PR TITLE
Add "validate_property" virtual func

### DIFF
--- a/godot-codegen/src/generator/virtual_traits.rs
+++ b/godot-codegen/src/generator/virtual_traits.rs
@@ -119,6 +119,18 @@ fn make_special_virtual_methods(notification_enum_name: &Ident) -> TokenStream {
             unimplemented!()
         }
 
+        /// Called whenever Godot retrieves value of property. Allows to customize existing properties.
+        /// Every property info goes through this method, except properties **added** with `get_property_list()`.
+        ///
+        /// Exposed `property` here is a shared mutable reference obtained (and returned to) from Godot.
+        ///
+        /// See also in the Godot docs:
+        /// * [`Object::_validate_property`](https://docs.godotengine.org/en/stable/classes/class_object.html#class-object-private-method-validate-property)
+        #[cfg(since_api = "4.2")]
+        fn validate_property(&self, property: &mut crate::meta::PropertyInfo) {
+            unimplemented!()
+        }
+
         /// Called by Godot to tell if a property has a custom revert or not.
         ///
         /// Return `None` for no custom revert, and return `Some(value)` to specify the custom revert.

--- a/godot-core/src/builtin/string/gstring.rs
+++ b/godot-core/src/builtin/string/gstring.rs
@@ -148,6 +148,17 @@ impl GString {
         *boxed
     }
 
+    /// Convert a `GString` sys pointer to a mutable reference with unbounded lifetime.
+    ///
+    /// # Safety
+    ///
+    /// - `ptr` must point to a live `GString` for the duration of `'a`.
+    /// - Must be exclusive - no other reference to given `GString` instance can exist for the duration of `'a`.
+    pub(crate) unsafe fn borrow_string_sys_mut<'a>(ptr: sys::GDExtensionStringPtr) -> &'a mut Self {
+        sys::static_assert_eq_size_align!(StringName, sys::types::OpaqueString);
+        &mut *(ptr.cast::<GString>())
+    }
+
     /// Moves this string into a string sys pointer. This is the same as using [`GodotFfi::move_return_ptr`].
     ///
     /// # Safety

--- a/godot-core/src/builtin/string/string_name.rs
+++ b/godot-core/src/builtin/string/string_name.rs
@@ -155,6 +155,19 @@ impl StringName {
         &*(ptr.cast::<StringName>())
     }
 
+    /// Convert a `StringName` sys pointer to a mutable reference with unbounded lifetime.
+    ///
+    /// # Safety
+    ///
+    /// - `ptr` must point to a live `StringName` for the duration of `'a`.
+    /// - Must be exclusive - no other reference to given `StringName` instance can exist for the duration of `'a`.
+    pub(crate) unsafe fn borrow_string_sys_mut<'a>(
+        ptr: sys::GDExtensionStringNamePtr,
+    ) -> &'a mut StringName {
+        sys::static_assert_eq_size_align!(StringName, sys::types::OpaqueStringName);
+        &mut *(ptr.cast::<StringName>())
+    }
+
     #[doc(hidden)]
     pub fn as_inner(&self) -> inner::InnerStringName {
         inner::InnerStringName::from_outer(self)

--- a/godot-core/src/obj/traits.rs
+++ b/godot-core/src/obj/traits.rs
@@ -472,6 +472,7 @@ where
 pub mod cap {
     use super::*;
     use crate::builtin::{StringName, Variant};
+    use crate::meta::PropertyInfo;
     use crate::obj::{Base, Bounds, Gd};
     use std::any::Any;
 
@@ -569,6 +570,13 @@ pub mod cap {
     pub trait GodotPropertyGetRevert: GodotClass {
         #[doc(hidden)]
         fn __godot_property_get_revert(&self, property: StringName) -> Option<Variant>;
+    }
+
+    #[doc(hidden)]
+    #[cfg(since_api = "4.2")]
+    pub trait GodotValidateProperty: GodotClass {
+        #[doc(hidden)]
+        fn __godot_validate_property(&self, property: &mut PropertyInfo);
     }
 
     /// Auto-implemented for `#[godot_api] impl MyClass` blocks

--- a/godot-core/src/registry/class.rs
+++ b/godot-core/src/registry/class.rs
@@ -452,6 +452,8 @@ fn fill_class_info(item: PluginItem, c: &mut ClassRegistrationInfo) {
             user_property_get_revert_fn,
             #[cfg(all(since_api = "4.3", feature = "register-docs"))]
                 virtual_method_docs: _,
+            #[cfg(since_api = "4.2")]
+            validate_property_fn,
         }) => {
             c.user_register_fn = user_register_fn;
 
@@ -477,6 +479,10 @@ fn fill_class_info(item: PluginItem, c: &mut ClassRegistrationInfo) {
             c.godot_params.property_can_revert_func = user_property_can_revert_fn;
             c.godot_params.property_get_revert_func = user_property_get_revert_fn;
             c.user_virtual_fn = get_virtual_fn;
+            #[cfg(since_api = "4.2")]
+            {
+                c.godot_params.validate_property_func = validate_property_fn;
+            }
         }
         PluginItem::DynTraitImpl(dyn_trait_impl) => {
             let type_id = dyn_trait_impl.dyn_trait_typeid();

--- a/godot-core/src/registry/plugin.rs
+++ b/godot-core/src/registry/plugin.rs
@@ -404,6 +404,13 @@ pub struct ITraitImpl {
             r_ret: sys::GDExtensionVariantPtr,
         ) -> sys::GDExtensionBool,
     >,
+    #[cfg(since_api = "4.2")]
+    pub(crate) validate_property_fn: Option<
+        unsafe extern "C" fn(
+            p_instance: sys::GDExtensionClassInstancePtr,
+            p_property: *mut sys::GDExtensionPropertyInfo,
+        ) -> sys::GDExtensionBool,
+    >,
 }
 
 impl ITraitImpl {
@@ -482,6 +489,15 @@ impl ITraitImpl {
         set(
             &mut self.user_property_can_revert_fn,
             callbacks::property_can_revert::<T>,
+        );
+        self
+    }
+
+    #[cfg(since_api = "4.2")]
+    pub fn with_validate_property<T: GodotClass + cap::GodotValidateProperty>(mut self) -> Self {
+        set(
+            &mut self.validate_property_fn,
+            callbacks::validate_property::<T>,
         );
         self
     }

--- a/itest/rust/src/object_tests/mod.rs
+++ b/itest/rust/src/object_tests/mod.rs
@@ -23,6 +23,9 @@ mod property_template_test;
 mod property_test;
 mod reentrant_test;
 mod singleton_test;
+// `validate_property` is only supported in Godot 4.2+.
+#[cfg(since_api = "4.2")]
+mod validate_property_test;
 mod virtual_methods_test;
 
 // Need to test this in the init level method.

--- a/itest/rust/src/object_tests/object_test.rs
+++ b/itest/rust/src/object_tests/object_test.rs
@@ -26,7 +26,7 @@ use godot::sys::{self, interface_fn, GodotFfi};
 use crate::framework::{expect_panic, itest, TestContext};
 
 // TODO:
-// * make sure that ptrcalls are used when possible (ie. when type info available; maybe GDScript integration test)
+// * make sure that ptrcalls are used when possible (i.e. when type info available; maybe GDScript integration test)
 // * Deref impl for user-defined types
 
 #[itest]

--- a/itest/rust/src/object_tests/validate_property_test.rs
+++ b/itest/rust/src/object_tests/validate_property_test.rs
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use godot::builtin::{Array, Dictionary, GString, StringName};
+use godot::classes::IObject;
+use godot::global::{PropertyHint, PropertyUsageFlags};
+use godot::meta::PropertyInfo;
+use godot::obj::NewAlloc;
+use godot::register::{godot_api, GodotClass};
+use godot::test::itest;
+
+#[derive(GodotClass)]
+#[class(base = Object, init)]
+pub struct ValidatePropertyTest {
+    #[var(hint = NONE, hint_string = "initial")]
+    #[export]
+    my_var: i64,
+}
+
+#[godot_api]
+impl IObject for ValidatePropertyTest {
+    fn validate_property(&self, property: &mut PropertyInfo) {
+        if property.property_name.to_string() == "my_var" {
+            property.usage = PropertyUsageFlags::NO_EDITOR;
+            property.property_name = StringName::from("SuperNewTestPropertyName");
+            property.hint_info.hint_string = GString::from("SomePropertyHint");
+            property.hint_info.hint = PropertyHint::TYPE_STRING;
+
+            // Makes no sense, but allows to check if given ClassName can be properly moved to GDExtensionPropertyInfo.
+            property.class_name = <ValidatePropertyTest as godot::obj::GodotClass>::class_name();
+        }
+    }
+}
+
+#[itest]
+fn validate_property_test() {
+    let obj = ValidatePropertyTest::new_alloc();
+    let properties: Array<Dictionary> = obj.get_property_list();
+
+    let property = properties
+        .iter_shared()
+        .find(|dict| {
+            dict.get("name")
+                .is_some_and(|v| v.to_string() == "SuperNewTestPropertyName")
+        })
+        .expect("Test failed – unable to find validated property.");
+
+    let hint_string = property
+        .get("hint_string")
+        .expect("validated property dict should contain a `hint_string` entry.")
+        .to::<GString>();
+    assert_eq!(hint_string, GString::from("SomePropertyHint"));
+
+    let class = property
+        .get("class_name")
+        .expect("Validated property dict should contain a class_name entry.")
+        .to::<StringName>();
+    assert_eq!(class, StringName::from("ValidatePropertyTest"));
+
+    let usage = property
+        .get("usage")
+        .expect("Validated property dict should contain an usage entry.")
+        .to::<PropertyUsageFlags>();
+    assert_eq!(usage, PropertyUsageFlags::NO_EDITOR);
+
+    let hint = property
+        .get("hint")
+        .expect("Validated property dict should contain a hint entry.")
+        .to::<PropertyHint>();
+    assert_eq!(hint, PropertyHint::TYPE_STRING);
+
+    obj.free();
+}


### PR DESCRIPTION
Adds "validate property" virtual func, modeled after godot-cpp implementation: https://github.com/godotengine/godot/pull/81515 with proper test (can be moved to` property_test.rs`? :thinking:).


The procedure looks as follows:
* Receive **shared** `*mut sys::GDExtensionPropertyInfo` from Godot
* Create `PropertyInfo` out of it and expose it to user from modification 
* Move constructed&modified `PropertyInfo` back to `*mut sys::GDExtensionPropertyInfo`.

