### PR TITLE
`#[signal]`: validate that there is no function body

### DIFF
--- a/godot-macros/src/class/data_models/inherent_impl.rs
+++ b/godot-macros/src/class/data_models/inherent_impl.rs
@@ -282,7 +282,16 @@ fn process_godot_fns(
                     );
                 }
                 if function.return_ty.is_some() {
-                    return attr.bail("return types in #[signal] are not supported", function);
+                    return bail!(
+                        &function.return_ty,
+                        "return types in #[signal] are not supported"
+                    );
+                }
+                if function.body.is_some() {
+                    return bail!(
+                        &function.body,
+                        "#[signal] must not have a body; declare the function with a semicolon"
+                    );
                 }
 
                 let external_attributes = function.attributes.clone();


### PR DESCRIPTION
It was accidentally possible to provide a function body `#[signal]`, which caused some confusion with a user about that code never being executed.