### PR TITLE
Fix `Variant` -> `Gd` conversions not taking into account dead objects

### DIFF
--- a/godot-core/src/builtin/variant/mod.rs
+++ b/godot-core/src/builtin/variant/mod.rs
@@ -8,10 +8,8 @@
 use crate::builtin::{
     GString, StringName, VariantArray, VariantDispatch, VariantOperator, VariantType,
 };
-use crate::classes;
 use crate::meta::error::ConvertError;
 use crate::meta::{arg_into_ref, ArrayElement, AsArg, FromGodot, ToGodot};
-use crate::obj::Gd;
 use godot_ffi as sys;
 use std::{fmt, ptr};
 use sys::{ffi_methods, interface_fn, GodotFfi};
@@ -491,16 +489,7 @@ impl fmt::Debug for Variant {
                 array.fmt(f)
             }
 
-            // Explicitly handle dead objects, because VariantDispatch::from_variant() will call Variant::to::<Gd<Object>>(),
-            // which panics if the object is dead. This can cause infinite panic loops, if errors (during conversions) print the value.
-            // TODO make VariantDispatch support this.
-            VariantType::OBJECT => {
-                match self.try_to::<Gd<classes::Object>>() {
-                    Ok(obj) => obj.fmt(f),
-                    Err(_e) => write!(f, "<Freed Object>"), // do NOT print error due to recursion.
-                }
-            }
-
+            // VariantDispatch also includes dead objects via `FreedObject` enumerator, which maps to "<Freed Object>".
             _ => VariantDispatch::from_variant(self).fmt(f),
         }
     }

--- a/godot-core/src/builtin/variant/mod.rs
+++ b/godot-core/src/builtin/variant/mod.rs
@@ -232,20 +232,17 @@ impl Variant {
         unsafe { interface_fn!(variant_booleanize)(self.var_sys()) != 0 }
     }
 
-    /* If we need to detect dead objects in the future, this is an alternative to try_to().
+    /// Assuming that this is of type `OBJECT`, checks whether the object is dead.
+    ///
+    /// Does not check again that the variant has type `OBJECT`.
+    pub(crate) fn is_object_alive(&self) -> bool {
+        debug_assert_eq!(self.get_type(), VariantType::OBJECT);
 
-    /// # Panics
-    /// In Debug mode, if this variant holds an object that has been freed.
-    fn ensure_alive_if_object(&self) {
-        // There is no dedicated API, however to_string() returns a magic variant for dead objects.
-        // This may of course fail if a string repr matches this exactly, but it's very unlikely.
-        debug_assert_ne!(
-            self.to_string(),
-            "<Freed Object>",
-            "Variant holds pointer to a dead object; all operations on it are invalid"
-        )
+        crate::gen::utilities::is_instance_valid(self)
+
+        // In case there are ever problems with this approach, alternative implementation:
+        // self.stringify() != "<Freed Object>".into()
     }
-    */
 
     // Conversions from/to Godot C++ `Variant*` pointers
     ffi_methods! {

--- a/godot-core/src/meta/error/convert_error.rs
+++ b/godot-core/src/meta/error/convert_error.rs
@@ -5,10 +5,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+use godot_ffi::VariantType;
 use std::error::Error;
 use std::fmt;
-
-use godot_ffi::VariantType;
 
 use crate::builtin::Variant;
 use crate::meta::{ArrayTypeInfo, ClassName, ToGodot};
@@ -34,6 +33,11 @@ impl ConvertError {
             ..Default::default()
         }
     }
+
+    // /// Create a new custom error for a conversion with the value that failed to convert.
+    // pub(crate) fn with_kind(kind: ErrorKind) -> Self {
+    //     Self { kind, value: None }
+    // }
 
     /// Create a new custom error for a conversion with the value that failed to convert.
     pub(crate) fn with_kind_value<V>(kind: ErrorKind, value: V) -> Self
@@ -323,6 +327,9 @@ pub(crate) enum FromVariantError {
     WrongClass {
         expected: ClassName,
     },
+
+    /// Variant holds an object which is no longer alive.
+    DeadObject,
 }
 
 impl FromVariantError {
@@ -345,6 +352,7 @@ impl fmt::Display for FromVariantError {
             Self::WrongClass { expected } => {
                 write!(f, "cannot convert to class {expected}")
             }
+            Self::DeadObject => write!(f, "variant holds object which is no longer alive"),
         }
     }
 }

--- a/godot-core/src/meta/godot_convert/mod.rs
+++ b/godot-core/src/meta/godot_convert/mod.rs
@@ -103,8 +103,7 @@ pub trait FromGodot: Sized + GodotConvert {
     /// If the conversion fails.
     fn from_variant(variant: &Variant) -> Self {
         Self::try_from_variant(variant).unwrap_or_else(|err| {
-            eprintln!("FromGodot::from_variant() failed: {err}");
-            panic!()
+            panic!("FromGodot::from_variant() failed -- {err}");
         })
     }
 }

--- a/itest/rust/src/builtin_tests/containers/variant_test.rs
+++ b/itest/rust/src/builtin_tests/containers/variant_test.rs
@@ -147,7 +147,7 @@ fn variant_dead_object_conversions() {
 
     // Variant::try_to().
     let result = variant.try_to::<Gd<Node>>();
-    let err = result.expect_err("Variant::to() with dead object should fail");
+    let err = result.expect_err("Variant::try_to::<Gd>() with dead object should fail");
     assert_eq!(
         err.to_string(),
         "variant holds object which is no longer alive: <Freed Object>"
@@ -157,6 +157,15 @@ fn variant_dead_object_conversions() {
     expect_panic("Variant::to() with dead object should panic", || {
         let _: Gd<Node> = variant.to();
     });
+
+    // Variant::try_to() -> Option<Gd>.
+    // This conversion does *not* return `None` for dead objects, but an error. `None` is reserved for NIL variants, see object_test.rs.
+    let result = variant.try_to::<Option<Gd<Node>>>();
+    let err = result.expect_err("Variant::try_to::<Option<Gd>>() with dead object should fail");
+    assert_eq!(
+        err.to_string(),
+        "variant holds object which is no longer alive: <Freed Object>"
+    );
 }
 
 #[itest]

--- a/itest/rust/src/builtin_tests/containers/variant_test.rs
+++ b/itest/rust/src/builtin_tests/containers/variant_test.rs
@@ -168,11 +168,10 @@ fn variant_bad_conversion_error_message() {
         .expect_err("i32 -> GString conversion should fail");
     assert_eq!(err.to_string(), "cannot convert from INT to STRING: 123");
 
-    // TODO this error isn't great, but unclear whether it can be improved. If not, document.
     let err = variant
         .try_to::<Gd<Node>>()
         .expect_err("i32 -> Gd<Node> conversion should fail");
-    assert_eq!(err.to_string(), "`Gd` cannot be null: null");
+    assert_eq!(err.to_string(), "cannot convert from INT to OBJECT: 123");
 }
 
 #[itest]

--- a/itest/rust/src/object_tests/object_test.rs
+++ b/itest/rust/src/object_tests/object_test.rs
@@ -536,6 +536,27 @@ fn object_engine_convert_variant_error() {
 }
 
 #[itest]
+fn object_convert_variant_option() {
+    let refc = RefCounted::new_gd();
+    let variant = refc.to_variant();
+
+    // Variant -> Option<Gd>.
+    let gd = Option::<Gd<RefCounted>>::from_variant(&variant);
+    assert_eq!(gd, Some(refc.clone()));
+
+    let nil = Variant::nil();
+    let gd = Option::<Gd<RefCounted>>::from_variant(&nil);
+    assert_eq!(gd, None);
+
+    // Option<Gd> -> Variant.
+    let back = Some(refc).to_variant();
+    assert_eq!(back, variant);
+
+    let back = None::<Gd<RefCounted>>.to_variant();
+    assert_eq!(back, Variant::nil());
+}
+
+#[itest]
 fn object_engine_returned_refcount() {
     let Some(file) = FileAccess::open("res://itest.gdextension", file_access::ModeFlags::READ)
     else {


### PR DESCRIPTION
`Variant::to()`, `Variant::try_to()` and `Gd::from_variant()` did not recognize when the object living inside the variant was dead. This sometimes caused a panic `"constructed RawGd weak pointer with instance ID 0"`, but generally caused UB, since the object pointer inside the variant was already dangling at that point.

---

Also improves error messages when converting variants of other types to object.
Old:

> `Gd` cannot be null: null

new:

> cannot convert from INT to OBJECT: 123

---

Furthermore, this fixes `Debug` impl hitting infinite recursion upon encountering a dead object.
Now prints `<Freed Object>` instead.