### PR TITLE
fix clippy warnings: this looks like a formatting argument but it is not part of a formatting macro

### DIFF
--- a/itest/rust/src/builtin_tests/geometry/quaternion_test.rs
+++ b/itest/rust/src/builtin_tests/geometry/quaternion_test.rs
@@ -41,11 +41,11 @@ fn quaternion_from_axis_angle() {
     assert_eq_approx!(quat.w, 0.877583);
 
     // 2. Should panic if axis is not normalized.
-    expect_panic("Quaternion axis {axis:?} is not normalized.", || {
+    expect_panic("Quaternion axis (0, 0, 0) is not normalized.", || {
         Quaternion::from_axis_angle(Vector3::ZERO, 1.0);
     });
 
-    expect_panic("Quaternion axis {axis:?} is not normalized.", || {
+    expect_panic("Quaternion axis (0, 0.7, 0) is not normalized.", || {
         Quaternion::from_axis_angle(Vector3::UP * 0.7, 1.0);
     });
 }


### PR DESCRIPTION
With my version of clippy ``clippy 0.1.86 (99768c80a1 2025-01-23)`` (probably newer than CI build?) I'm getting two warnings on current master:

```
warning: this looks like a formatting argument but it is not part of a formatting macro
  --> itest/rust/src/builtin_tests/geometry/quaternion_test.rs:44:35
   |
44 |     expect_panic("Quaternion axis {axis:?} is not normalized.", || {
   |                                   ^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#literal_string_with_formatting_args
   = note: `#[warn(clippy::literal_string_with_formatting_args)]` on by default

warning: this looks like a formatting argument but it is not part of a formatting macro
  --> itest/rust/src/builtin_tests/geometry/quaternion_test.rs:48:35
   |
48 |     expect_panic("Quaternion axis {axis:?} is not normalized.", || {
   |                                   ^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#literal_string_with_formatting_args
```

The warnings are correct, expect_panic is a function (not a macro) that takes a string argument:

<img width="634" alt="image" src="https://github.com/user-attachments/assets/c7116648-a25f-4e4d-b0c4-6c089a63b363" />

Edit:

yep the warning was added with v1.85: https://rust-lang.github.io/rust-clippy/master/index.html#literal_string_with_formatting_args

Edit2: hmm it's part of the "nursery" group so should be disabled by default, do feel free to just close this PR if it's not applicable.