### PR TITLE
Add godot 4.3 to minimal CI

### DIFF
--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -344,7 +344,7 @@ jobs:
             os: ubuntu-22.04
             artifact-name: linux-4.3
             godot-binary: godot.linuxbsd.editor.dev.x86_64
-            #godot-prebuilt-patch: '4.3.x'
+            godot-prebuilt-patch: '4.3'
 
           - name: linux-4.2
             os: ubuntu-22.04

--- a/.github/workflows/minimal-ci.yml
+++ b/.github/workflows/minimal-ci.yml
@@ -181,6 +181,12 @@ jobs:
             godot-binary: godot.linuxbsd.editor.dev.x86_64
             godot-prebuilt-patch: '4.2.2'
 
+          - name: linux-4.3
+            os: ubuntu-22.04
+            artifact-name: linux-4.3
+            godot-binary: godot.linuxbsd.editor.dev.x86_64
+            godot-prebuilt-patch: '4.3'
+
           # Memory checkers
 
           - name: linux-memcheck


### PR DESCRIPTION
Adds Godot 4.3 to minimal CI and makes sure that feature api-4-3 is being included for a job in full CI workflow as well.

[Allegedly the last Godot 4.4 beta will be released next week](https://godotengine.org/article/dev-snapshot-godot-4-4-beta-3/)  – afterwards we will be few ReleaseCandidates away from stable release (it took 3 weeks for Godot 4.3).