### PR TITLE
Global main thread ID

### DIFF
--- a/godot-core/build.rs
+++ b/godot-core/build.rs
@@ -17,4 +17,5 @@ fn main() {
     println!("cargo:rerun-if-changed=build.rs");
 
     godot_bindings::emit_godot_version_cfg();
+    godot_bindings::emit_wasm_nothreads_cfg();
 }

--- a/godot-core/src/init/mod.rs
+++ b/godot-core/src/init/mod.rs
@@ -16,6 +16,9 @@ use crate::out;
 
 pub use sys::GdextBuild;
 
+#[cfg(not(wasm_nothreads))]
+pub use sys::{is_main_thread, main_thread_id};
+
 #[doc(hidden)]
 #[deny(unsafe_op_in_unsafe_fn)]
 pub unsafe fn __gdext_load_library<E: ExtensionLibrary>(


### PR DESCRIPTION
In #1043 I need to identify the main thread without accessing the related engine API. 

By storing the current thread ID during initialization, we can identify the main thread from that point on. I only found one other use of the main thread ID in `godot-ffi` but having access to the ThreadId of the main-thread could also be useful to user code.