### PR TITLE
Allow virtual methods to be GdSelf in special cases

### DIFF
--- a/godot-codegen/src/generator/default_parameters.rs
+++ b/godot-codegen/src/generator/default_parameters.rs
@@ -211,8 +211,8 @@ fn make_extender_receiver(sig: &dyn Function) -> ExtenderReceiver {
     let builder_mut = match sig.qualifier() {
         FnQualifier::Const | FnQualifier::Static => quote! {},
         FnQualifier::Mut => quote! { mut },
-        FnQualifier::Global => {
-            unreachable!("default parameters not supported for global methods; {sig}")
+        FnQualifier::Global | FnQualifier::GdSelf => {
+            unreachable!("default parameters not supported for global or gdself methods; {sig}")
         }
     };
 

--- a/godot-codegen/src/generator/functions_common.rs
+++ b/godot-codegen/src/generator/functions_common.rs
@@ -308,6 +308,7 @@ pub fn make_receiver(qualifier: FnQualifier, ffi_arg_in: TokenStream) -> FnRecei
     let (param, param_lifetime_a) = match qualifier {
         FnQualifier::Const => (quote! { &self, }, quote! { &'a self, }),
         FnQualifier::Mut => (quote! { &mut self, }, quote! { &'a mut self, }),
+        FnQualifier::GdSelf => (quote! { this: Gd<Self>, }, quote! { this: Gd<Self>, }),
         FnQualifier::Static => (quote! {}, quote! {}),
         FnQualifier::Global => (quote! {}, quote! {}),
     };
@@ -316,6 +317,9 @@ pub fn make_receiver(qualifier: FnQualifier, ffi_arg_in: TokenStream) -> FnRecei
     if matches!(qualifier, FnQualifier::Static) {
         ffi_arg = quote! { std::ptr::null_mut() };
         self_prefix = quote! { Self:: };
+    } else if matches!(qualifier, FnQualifier::Static) {
+        ffi_arg = ffi_arg_in;
+        self_prefix = quote! { this. };
     } else {
         ffi_arg = ffi_arg_in;
         self_prefix = quote! { self. };

--- a/godot-codegen/src/generator/virtual_traits.rs
+++ b/godot-codegen/src/generator/virtual_traits.rs
@@ -145,7 +145,10 @@ fn make_virtual_method(method: &ClassMethod) -> Option<TokenStream> {
 
     // Virtual methods are never static.
     let qualifier = method.qualifier();
-    assert!(matches!(qualifier, FnQualifier::Mut | FnQualifier::Const));
+    assert!(matches!(
+        qualifier,
+        FnQualifier::Mut | FnQualifier::Const | FnQualifier::GdSelf
+    ));
 
     let definition = functions_common::make_function_definition(
         method,

--- a/godot-codegen/src/models/domain.rs
+++ b/godot-codegen/src/models/domain.rs
@@ -462,6 +462,7 @@ pub enum FnDirection {
 pub enum FnQualifier {
     Mut,    // &mut self
     Const,  // &self
+    GdSelf, // Gd<Self>
     Static, // Self
     Global, // (nothing) // TODO remove?
 }

--- a/godot-codegen/src/models/domain_mapping.rs
+++ b/godot-codegen/src/models/domain_mapping.rs
@@ -458,6 +458,7 @@ impl ClassMethod {
         }
 
         let is_private = special_cases::is_method_private(class_name, &method.name);
+        let is_gdself = special_cases::is_virtual_method_gdself(class_name, rust_method_name);
 
         let godot_method_name = method.name.clone();
 
@@ -468,7 +469,11 @@ impl ClassMethod {
                 is_actually_const = override_const;
             }
 
-            FnQualifier::from_const_static(is_actually_const, method.is_static)
+            if is_gdself {
+                FnQualifier::GdSelf
+            } else {
+                FnQualifier::from_const_static(is_actually_const, method.is_static)
+            }
         };
 
         // Since Godot 4.4, GDExtension advertises whether virtual methods have a default implementation or are required to be overridden.

--- a/godot-codegen/src/special_cases/special_cases.rs
+++ b/godot-codegen/src/special_cases/special_cases.rs
@@ -855,6 +855,19 @@ pub fn is_enum_exhaustive(class_name: Option<&TyName>, enum_name: &str) -> bool 
     }
 }
 
+/// Certain virtual methods can make it very difficult to avoid double bind issues
+/// if they take &self or &mut self.
+///
+/// These methods take Gd<Self> as a receiver so the implementer can decide when to bind
+/// and unbind them.
+pub fn is_virtual_method_gdself(class_name: &TyName, method: &str) -> bool {
+    match (class_name.godot_ty.as_str(), method) {
+        ("MultiplayerAPIExtension", "poll") => true,
+
+        _ => false,
+    }
+}
+
 /// Whether an enum can be combined with another enum (return value) for bitmasking purposes.
 ///
 /// If multiple masks are ever necessary, this can be extended to return a slice instead of Option.


### PR DESCRIPTION
So, this allows virtual methods take `Gd<Self>` as a receiver. It also implements this as a special case for exactly one method, that being `MultiplayerApiExtension::poll`. This is useful because we want to call rpc functions out of poll and if that function calls back to any multiplayer function (which most rpc functions do, even if it's just `is_server` or to get the remote peer) then we get double bind exceptions. This way, the implementer can unbind, call, rebind to avoid that.

Not sure if this is a sensible way to allow this or if there are any other places it would be useful. It's a pretty breaking change for a pretty niche problem but it's working well for me.
