### PR TITLE
Add #[allow(...)] directives to macro-generated entries

### DIFF
--- a/godot-macros/src/class/derive_godot_class.rs
+++ b/godot-macros/src/class/derive_godot_class.rs
@@ -142,6 +142,7 @@ pub fn derive_godot_class(item: venial::Item) -> ParseResult<TokenStream> {
     let funcs_collection_struct_name = format_funcs_collection_struct(class_name);
     let funcs_collection_struct = quote! {
         #[doc(hidden)]
+        #[allow(non_camel_case_types)]
         pub struct #funcs_collection_struct_name {}
     };
 

--- a/godot-macros/src/derive/derive_from_godot.rs
+++ b/godot-macros/src/derive/derive_from_godot.rs
@@ -75,6 +75,7 @@ fn make_fromgodot_for_int_enum(
                 #(
                     // Interesting: using let instead of const would introduce a runtime bug. Its values cannot be used in match lhs (binding).
                     // However, bindings silently shadow variables, so the first match arm always runs; no warning in generated proc-macro code.
+                    #[allow(non_upper_case_globals)]
                     const #ord_variables: #int = #discriminants;
                 )*
 


### PR DESCRIPTION
This patch adds `#[allow(non_camel_case_types)]` and `#[allow(non_upper_case_globals)]` directives to generated `const`s and `struct`s.

While `cargo check` by default ignores naming style inconsistencies in macro-produced code, `rust-analyzer` seems to be using a more strict mode. `#[allow(...)]` annotations for generated entries allows to prevent the display of such warnings by the language server.

## Context

Without this patch, `rust-analyzer` produces the following type of stylistic warnings (tested in Neovim v0.10.4 / `rust-analyzer` v1.84.1):

When using `#[derive(GodotConvert)]` macro:
```
1. Constant `ORD_SharedInventory` should have UPPER_SNAKE_CASE name,
   e.g. `ORD_SHARED_INVENTORY` [non_upper_case_globals]
```
When using `#[derive(GodotClass)]` macro:
```
1. Structure `__gdext_CameraControl_Funcs` should have UpperCamelCase name,
   e.g. `GdextCameraControlFuncs` [non_camel_case_types]
```