### PR TITLE
Add .uid files for GDScript + GDExtension resources; update script cache

### DIFF
--- a/.github/composite/godot-itest/action.yml
+++ b/.github/composite/godot-itest/action.yml
@@ -157,6 +157,7 @@ runs:
       # * tee:      still output logs while scanning for errors
       # * grep -q:  no output, use exit code 0 if found -> thus also &&
       # * pkill:    stop Godot execution (since it hangs in headless mode); simple 'head -1' did not work as expected
+      #             since it's not available on Windows, use taskkill in that case.
       # * exit:     the terminated process would return 143, but this is more explicit and future-proof
       #
       # --disallow-focus: fail if #[itest(focus)] is encountered, to prevent running only a few tests for full CI
@@ -166,10 +167,14 @@ runs:
         $GODOT4_BIN --headless -- --disallow-focus ${{ inputs.godot-args }} 2>&1 \
         | tee "${{ runner.temp }}/log.txt" \
         | tee >(grep -E "SCRIPT ERROR:|Can't open dynamic library" -q && {
-        	printf "\n::error::godot-itest: unrecoverable Godot error, abort...\n";
-        	pkill godot
-            echo "OUTCOME=godot-runtime" >> $GITHUB_ENV
-        	exit 2
+          printf "\n::error::godot-itest: unrecoverable Godot error, abort...\n";
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            taskkill -f -im godot*
+          else
+            pkill godot
+          fi
+          echo "OUTCOME=godot-runtime" >> $GITHUB_ENV
+          exit 2
         })
         
         echo "OUTCOME=success" >> $GITHUB_ENV
@@ -198,14 +203,14 @@ runs:
           "godot-runtime")
             echo "### :x: Godot runtime error" > $GITHUB_STEP_SUMMARY
             echo "$GODOT_BUILT_FROM" >> $GITHUB_STEP_SUMMARY
-        	echo "Aborted due to an error during Godot execution." >> $GITHUB_STEP_SUMMARY
+            echo "Aborted due to an error during Godot execution." >> $GITHUB_STEP_SUMMARY
             exit 2
             ;;
         
           "godot-leak")
             echo "### :x: Memory leak" > $GITHUB_STEP_SUMMARY
             echo "$GODOT_BUILT_FROM" >> $GITHUB_STEP_SUMMARY
-        	echo "Integration tests cause memory leaks." >> $GITHUB_STEP_SUMMARY
+            echo "Integration tests cause memory leaks." >> $GITHUB_STEP_SUMMARY
             exit 3
             ;;
         

--- a/examples/hot-reload/godot/rust.gdextension.uid
+++ b/examples/hot-reload/godot/rust.gdextension.uid
@@ -1,0 +1,1 @@
+uid://bm60he8dcrowk

--- a/examples/hot-reload/godot/test/ReloadOrchestrator.gd.uid
+++ b/examples/hot-reload/godot/test/ReloadOrchestrator.gd.uid
@@ -1,0 +1,1 @@
+uid://buwkqqupj5r3o

--- a/examples/hot-reload/godot/test/ReloadTest.gd.uid
+++ b/examples/hot-reload/godot/test/ReloadTest.gd.uid
@@ -1,0 +1,1 @@
+uid://bsfhdl1665yjl

--- a/itest/godot/.godot/global_script_class_cache.cfg
+++ b/itest/godot/.godot/global_script_class_cache.cfg
@@ -1,25 +1,25 @@
-list=Array[Dictionary]([{
+list=[{
 "base": &"Node",
 "class": &"GDScriptTestRunner",
 "icon": "",
+"is_abstract": false,
+"is_tool": true,
 "language": &"GDScript",
 "path": "res://TestRunner.gd"
 }, {
 "base": &"RefCounted",
-"class": &"TestStats",
-"icon": "",
-"language": &"GDScript",
-"path": "res://TestStats.gd"
-}, {
-"base": &"RefCounted",
 "class": &"TestSuite",
 "icon": "",
+"is_abstract": false,
+"is_tool": false,
 "language": &"GDScript",
 "path": "res://TestSuite.gd"
 }, {
 "base": &"TestSuite",
 "class": &"TestSuiteSpecial",
 "icon": "",
+"is_abstract": false,
+"is_tool": false,
 "language": &"GDScript",
 "path": "res://TestSuiteSpecial.gd"
-}])
+}]

--- a/itest/godot/InheritTests.gd.uid
+++ b/itest/godot/InheritTests.gd.uid
@@ -1,0 +1,1 @@
+uid://11yajm7pqhey

--- a/itest/godot/ManualFfiTests.gd.uid
+++ b/itest/godot/ManualFfiTests.gd.uid
@@ -1,0 +1,1 @@
+uid://c4r3oh2k4pfpe

--- a/itest/godot/ScriptInstanceTests.gd.uid
+++ b/itest/godot/ScriptInstanceTests.gd.uid
@@ -1,0 +1,1 @@
+uid://5xi1qa5btlen

--- a/itest/godot/SpecialTests.gd.uid
+++ b/itest/godot/SpecialTests.gd.uid
@@ -1,0 +1,1 @@
+uid://cj2c8t8bb8r5k

--- a/itest/godot/TestRunner.gd.uid
+++ b/itest/godot/TestRunner.gd.uid
@@ -1,0 +1,1 @@
+uid://dcsm6ho05dipr

--- a/itest/godot/TestSuite.gd.uid
+++ b/itest/godot/TestSuite.gd.uid
@@ -1,0 +1,1 @@
+uid://cjnex6snpwbsl

--- a/itest/godot/TestSuiteSpecial.gd.uid
+++ b/itest/godot/TestSuiteSpecial.gd.uid
@@ -1,0 +1,1 @@
+uid://cj4h847dxex0f

--- a/itest/godot/itest.gdextension.uid
+++ b/itest/godot/itest.gdextension.uid
@@ -1,0 +1,1 @@
+uid://c6fukwfyre1x5


### PR DESCRIPTION
Adds `.uid` files for the itest suite.

Removes an entry `TestStats` from the script cache, which caused problems on latest Godot 4.4-nightly. Also updates that file to the Godot 4.4 format.

Fixes the use of `pkill` on Windows runners, which isn't available, and uses `taskkill` instead.