### PR TITLE
Fix `DynGd<T,D>` export, implement proper export for `Array<DynGd<T,D>>`

### DIFF
--- a/godot-core/src/obj/dyn_gd.rs
+++ b/godot-core/src/obj/dyn_gd.rs
@@ -5,13 +5,13 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use crate::builtin::Variant;
+use crate::builtin::{GString, Variant};
 use crate::meta::error::ConvertError;
 use crate::meta::{ClassName, FromGodot, GodotConvert, PropertyHintInfo, ToGodot};
 use crate::obj::guards::DynGdRef;
 use crate::obj::{bounds, AsDyn, Bounds, DynGdMut, Gd, GodotClass, Inherits};
 use crate::registry::class::{get_dyn_property_hint_string, try_dynify_object};
-use crate::registry::property::{Export, Var};
+use crate::registry::property::{object_export_element_type_string, Export, Var};
 use crate::{meta, sys};
 use std::{fmt, ops};
 
@@ -478,6 +478,10 @@ where
     T: GodotClass,
     D: ?Sized + 'static,
 {
+    fn element_type_string() -> String {
+        let hint_string = get_dyn_property_hint_string::<T, D>();
+        object_export_element_type_string::<T>(hint_string)
+    }
 }
 
 impl<T, D> Var for DynGd<T, D>
@@ -502,7 +506,7 @@ where
 {
     fn export_hint() -> PropertyHintInfo {
         PropertyHintInfo {
-            hint_string: get_dyn_property_hint_string::<D>(),
+            hint_string: GString::from(get_dyn_property_hint_string::<T, D>()),
             ..<Gd<T> as Export>::export_hint()
         }
     }

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -9,7 +9,7 @@ use std::fmt::{Debug, Display, Formatter, Result as FmtResult};
 use std::ops::{Deref, DerefMut};
 
 use godot_ffi as sys;
-use sys::{static_assert_eq_size_align, SysPtr as _, VariantType};
+use sys::{static_assert_eq_size_align, SysPtr as _};
 
 use crate::builtin::{Callable, NodePath, StringName, Variant};
 use crate::global::PropertyHint;
@@ -19,11 +19,11 @@ use crate::meta::{
     ParamType, PropertyHintInfo, RefArg, ToGodot,
 };
 use crate::obj::{
-    bounds, cap, Bounds, DynGd, EngineEnum, GdDerefTarget, GdMut, GdRef, GodotClass, Inherits,
-    InstanceId, RawGd,
+    bounds, cap, Bounds, DynGd, GdDerefTarget, GdMut, GdRef, GodotClass, Inherits, InstanceId,
+    RawGd,
 };
 use crate::private::callbacks;
-use crate::registry::property::{Export, Var};
+use crate::registry::property::{object_export_element_type_string, Export, Var};
 use crate::{classes, out};
 
 /// Smart pointer to objects owned by the Godot engine.
@@ -795,27 +795,7 @@ impl<T: GodotClass> GodotType for Gd<T> {
 impl<T: GodotClass> ArrayElement for Gd<T> {
     fn element_type_string() -> String {
         // See also impl Export for Gd<T>.
-
-        let hint = if T::inherits::<classes::Resource>() {
-            Some(PropertyHint::RESOURCE_TYPE)
-        } else if T::inherits::<classes::Node>() {
-            Some(PropertyHint::NODE_TYPE)
-        } else {
-            None
-        };
-
-        // Exportable classes (Resource/Node based) include the {RESOURCE|NODE}_TYPE hint + the class name.
-        if let Some(export_hint) = hint {
-            format!(
-                "{variant}/{hint}:{class}",
-                variant = VariantType::OBJECT.ord(),
-                hint = export_hint.ord(),
-                class = T::class_name()
-            )
-        } else {
-            // Previous impl: format!("{variant}:", variant = VariantType::OBJECT.ord())
-            unreachable!("element_type_string() should only be invoked for exportable classes")
-        }
+        object_export_element_type_string::<T>(T::class_name())
     }
 }
 

--- a/godot-core/src/registry/plugin.rs
+++ b/godot-core/src/registry/plugin.rs
@@ -511,6 +511,16 @@ pub struct DynTraitImpl {
     /// The class that this `dyn Trait` implementation corresponds to.
     class_name: ClassName,
 
+    /// Base inherited class required for `DynGd<T, D>` exports (i.e. one specified in `#[class(base = ...)]`).
+    ///
+    /// Godot doesn't guarantee availability of all the GDExtension classes through the ClassDb while generating `PropertyHintInfo` for our exports.
+    /// Therefore, we rely on the built-in inherited base class in such cases.
+    /// Only [`class_name`][DynTraitImpl::class_name] is available at the time of adding given `DynTraitImpl` to plugin registry with `#[godot_dyn]`;
+    /// It is important to fill this information before registration.
+    ///
+    /// See also [`get_dyn_property_hint_string`][crate::registry::class::get_dyn_property_hint_string].
+    pub(crate) parent_class_name: Option<ClassName>,
+
     /// TypeId of the `dyn Trait` object.
     dyn_trait_typeid: any::TypeId,
 
@@ -533,6 +543,7 @@ impl DynTraitImpl {
     {
         Self {
             class_name: T::class_name(),
+            parent_class_name: None,
             dyn_trait_typeid: std::any::TypeId::of::<D>(),
             erased_dynify_fn: callbacks::dynify_fn::<T, D>,
         }

--- a/itest/rust/src/object_tests/dyn_gd_test.rs
+++ b/itest/rust/src/object_tests/dyn_gd_test.rs
@@ -514,6 +514,7 @@ impl InstanceIdProvider for foreign::NodeHealth {
 struct RefcDynGdExporter {
     #[var]
     first: Option<DynGd<Object, dyn Health>>,
+    // Using DynGd with concrete type foreign::NodeHealth doesn't give benefits over Gd, but is allowed in godot-rust 0.2.x.
     #[export]
     second: Option<DynGd<foreign::NodeHealth, dyn InstanceIdProvider<Id = InstanceId>>>,
 }


### PR DESCRIPTION
- Implement `element_type_string` for `DynGd<T, D>`.
- Extract `object_export_element_type_string` from `Gd<T>`'s ArrayElement` to share implementation between both.
- Include parent_class in DynTrait registration info 
- `#[export]` for `DynGd<T, D>` works as it would be `Gd<T>` for Node-based classes – Godot doesn't allow to export multiple node types via editor.
- `#[export]` for `DynGd<T, D>`  works the same for resource-based classes.
- Don't include non-resource based classes while creating hint_string for resources in debug mode.

Manual testing:

Given test library:

<details>

<summary> Test library </summary>

```rs
struct MyExtension;

#[gdextension]
unsafe impl ExtensionLibrary for MyExtension {}

trait ExampleTrait {
    fn dumb_method(&self) {
        godot_print!("Hello, I'm implementor of Example Trait");
    }
}

#[derive(GodotClass)]
#[class(init, base = Node)]
pub struct Collector {
    #[export]
    node: Option<DynGd<Node2D, dyn ExampleTrait>>,
    #[export]
    nodes: Array<DynGd<Node, dyn ExampleTrait>>,
    #[export]
    resources: Array<DynGd<Resource, dyn ExampleTrait>>,
}

#[godot_api]
impl INode for Collector {
    fn ready(&mut self) {
        godot_print!("{}", self.nodes);
        godot_print!("{}", self.resources);

        for n in self.nodes.iter_shared() {
            n.dyn_bind().dumb_method();
        }
        for r in self.resources.iter_shared() {
            r.dyn_bind().dumb_method();
        }
    }
}

#[derive(GodotClass)]
#[class(init, base = Node)]
pub struct A {}

#[godot_dyn]
impl ExampleTrait for A {}

#[derive(GodotClass)]
#[class(init, base = Resource)]
pub struct AR {}

#[godot_dyn]
impl ExampleTrait for AR {}

#[derive(GodotClass)]
#[class(init, base = Node)]
pub struct B {}

#[godot_dyn]
impl ExampleTrait for B {}

#[derive(GodotClass)]
#[class(init, base = Resource)]
pub struct BR {}

#[godot_dyn]
impl ExampleTrait for BR {}

#[derive(GodotClass)]
#[class(init, base = Node)]
pub struct C {}

#[godot_dyn]
impl ExampleTrait for C {}

#[derive(GodotClass)]
#[class(init, base = Resource)]
pub struct CR {}

#[godot_dyn]
impl ExampleTrait for CR {}


#[derive(GodotClass)]
#[class(init, base = Node2D)]
pub struct A2D {}

#[godot_dyn]
impl ExampleTrait for A2D {}
```

</details>

One is able to get desired results:

<details>

<summary> manual testing </summary>

![image](https://github.com/user-attachments/assets/9156f68c-851d-4031-8e25-9864a6698941)

![image](https://github.com/user-attachments/assets/05754255-ad2c-4f3d-90a2-6757da144bea)

![image](https://github.com/user-attachments/assets/6ee1298e-c190-4974-9459-095ea5f36e65)

![image](https://github.com/user-attachments/assets/37434d25-f308-4598-a17c-4d58d6d92362)

Exporting non-dynGd node yields proper error on runtime:

![image](https://github.com/user-attachments/assets/9c5cde62-acee-420f-996b-878b82f3db5c)

```bash
E 0:00:00:0344   godot_core::private::report_call_error: godot-rust function call failed: Collector::ready()
    Reason: [panic]  FromGodot::from_variant() failed -- none of the classes derived from `Node` have been linked to trait `dyn ExampleTrait` with #[godot_dyn]: Gd { id: 24998053138, class: Node }
  at /home/irwin/apps/godot/opensource-contr/missing_docs/gdext/godot-core/src/meta/godot_convert/mod.rs:106
  <C++ Source>   /home/irwin/apps/godot/opensource-contr/missing_docs/gdext/godot-core/src/private.rs:336 @ godot_core::private::report_call_error()
```

![image](https://github.com/user-attachments/assets/0849c832-e866-48b6-8319-f07fe757f66e)

```bash
[A:<A#24947721483>, B:<B#24964498700>, C:<C#24981275921>, A2D:<A2D#25014830355>]
[<AR#-9223372012007717619>, <AR#-9223372012058049266>]
Hello, I'm implementor of Example Trait
Hello, I'm implementor of Example Trait
Hello, I'm implementor of Example Trait
Hello, I'm implementor of Example Trait
Hello, I'm implementor of Example Trait
Hello, I'm implementor of Example Trait
```
</details>

~~For some reason~~ ClassDb might have not all the GDExtension classes loaded while generating `hint_string` for our exports – thus the fallback to registering parent_class while registering the class itself (built-in classes will always be accessible via ClassDb):

<details> 
<summary> ol'reliable godot_print! debugging </summary>

![image](https://github.com/user-attachments/assets/adb0f368-f5b7-4d07-8ac2-b5ed569aa553)

</details>

EDIT: It seems that given `PropertyHintInfo` is being generated before all the GDExtension classes are properly registered in Godot, I'm not sure if there is any sane way – outside of applied workaround – to deal with this issue :shrug: 