### PR TITLE
Fix: add `pub` to the test struct `GdSelfObj`

### DIFF
--- a/itest/rust/src/register_tests/func_test.rs
+++ b/itest/rust/src/register_tests/func_test.rs
@@ -70,7 +70,7 @@ impl FuncObj {
 
 #[derive(GodotClass)]
 #[class(base=RefCounted)]
-struct GdSelfObj {
+pub struct GdSelfObj {
     internal_value: i32,
 
     base: Base<RefCounted>,


### PR DESCRIPTION
Private `GdSelfObj` cause signal test failed