### PR TITLE
Regression test for checking if `RustCallable` is connected to signal.

### DIFF
--- a/godot-core/src/builtin/callable.rs
+++ b/godot-core/src/builtin/callable.rs
@@ -540,7 +540,9 @@ mod custom_callable {
     ///
     /// Since callables can be invoked from anywhere, they must be self-contained (`'static`) and thread-safe (`Send + Sync`).
     /// They also should implement `Display` for the Godot string representation.
-    /// Furthermore, `PartialEq` and `Hash` are required for equality checks and usage as a key in a `Dictionary`.
+    /// Furthermore, `Hash` is required for usage as a key in a `Dictionary` and for checking signal connections –
+    /// Godot considers a custom callable to be connected to a signal if a callable with the same hash is already connected to that signal.
+    /// Finally, `PartialEq` is necessary for equality checks.
     pub trait RustCallable: 'static + PartialEq + Hash + fmt::Display + Send + Sync {
         /// Invokes the callable with the given arguments as `Variant` references.
         ///

--- a/itest/rust/src/builtin_tests/containers/callable_test.rs
+++ b/itest/rust/src/builtin_tests/containers/callable_test.rs
@@ -384,6 +384,7 @@ pub mod custom_callable {
     use super::*;
     use crate::framework::{assert_eq_self, quick_thread, ThreadCrosser};
     use godot::builtin::{Dictionary, RustCallable};
+    use godot::prelude::Signal;
     use godot::sys;
     use godot::sys::GdextBuild;
     use std::fmt;
@@ -611,6 +612,41 @@ pub mod custom_callable {
         assert_eq!(Variant::nil(), callable.callv(&varray![]));
 
         assert_eq!(1, received.load(Ordering::SeqCst));
+    }
+
+    #[itest]
+    fn callable_is_connected() {
+        let tracker = Tracker::new();
+        let tracker2 = Tracker::new();
+
+        // Adder hash depends on its sum.
+        let some_callable = Callable::from_custom(Adder::new_tracked(3, tracker));
+        let identical_callable = Callable::from_custom(Adder::new_tracked(3, tracker2));
+
+        let obj = RefCounted::new_gd();
+        let signal = Signal::from_object_signal(&obj, "script_changed");
+        signal.connect(&some_callable, 0);
+
+        // Given Custom Callable is connected to signal
+        // if callable with the very same hash is already connected.
+        assert!(signal.is_connected(&some_callable));
+        assert!(signal.is_connected(&identical_callable));
+
+        let change = [2.to_variant()];
+
+        // Change the hash.
+        signal.emit(&change);
+
+        // The hash, dependent on `Adder.sum` has been changed.
+        // `identical_callable` is considered NOT connected.
+        assert!(signal.is_connected(&some_callable));
+        assert!(!signal.is_connected(&identical_callable));
+
+        identical_callable.call(&change);
+
+        // The hashes are, once again, identical.
+        assert!(signal.is_connected(&some_callable));
+        assert!(signal.is_connected(&identical_callable));
     }
 
     // ------------------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
# What this PR is aiming to solve?

Since [Async Signals](https://github.com/godot-rust/gdext/pull/1043) is making use of checking if a given RustCallable is connected to a signal, it is worth to add some regression testing & documenting when Godot considers custom callable to be connected.

Personally I had no idea before I checked the source code :sweat_smile: 