### PR TITLE
Work around `OpenXR*` APIs wrongly exposed in release; wider release checks in CI

### DIFF
--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -338,7 +338,9 @@ jobs:
             os: ubuntu-22.04
             artifact-name: linux-release-nightly
             godot-binary: godot.linuxbsd.template_release.x86_64
-            rust-extra-args: --release
+            # Use `codegen-full-experimental` to make sure that all function tables can be loaded in Godot release builds.
+            # If the experimental part causes problems, downgrade to `codegen-full`.
+            rust-extra-args: --release --features itest/codegen-full-experimental
             rust-cache-key: release
 
           # Linux compat (4.1 disabled, already covered by memcheck)

--- a/godot-codegen/src/special_cases/special_cases.rs
+++ b/godot-codegen/src/special_cases/special_cases.rs
@@ -141,12 +141,15 @@ pub fn is_godot_type_deleted(godot_ty: &str) -> bool {
         | "MovieWriterPNGWAV"
         | "ResourceFormatImporterSaver"
         => true,
-        // Previously loaded lazily; in 4.2 it loads at the Scene level. See: https://github.com/godotengine/godot/pull/81305
+
+        // Previously loaded lazily; in 4.2 it loads at the Scene level: https://github.com/godotengine/godot/pull/81305
         | "ThemeDB"
         => cfg!(before_api = "4.2"),
-        // reintroduced in 4.3. See: https://github.com/godotengine/godot/pull/80214
+
+        // Reintroduced in 4.3: https://github.com/godotengine/godot/pull/80214
         | "UniformSetCacheRD"
         => cfg!(before_api = "4.3"),
+
         _ => false
     }
 }

--- a/godot-codegen/src/util.rs
+++ b/godot-codegen/src/util.rs
@@ -60,11 +60,17 @@ pub fn make_sname_ptr(identifier: &str) -> TokenStream {
 pub fn get_api_level(class: &JsonClass) -> ClassCodegenLevel {
     // Work around wrong classification in https://github.com/godotengine/godot/issues/86206.
     fn override_editor(class_name: &str) -> bool {
-        cfg!(before_api = "4.3")
-            && matches!(
-                class_name,
-                "ResourceImporterOggVorbis" | "ResourceImporterMP3"
-            )
+        match class_name {
+            // https://github.com/godotengine/godot/issues/103867
+            "OpenXRInteractionProfileEditorBase"
+            | "OpenXRInteractionProfileEditor"
+            | "OpenXRBindingModifierEditor" => cfg!(before_api = "4.5"),
+
+            // https://github.com/godotengine/godot/issues/86206
+            "ResourceImporterOggVorbis" | "ResourceImporterMP3" => cfg!(before_api = "4.3"),
+
+            _ => false,
+        }
     }
 
     if special_cases::is_class_level_server(&class.name) {

--- a/godot-ffi/src/toolbox.rs
+++ b/godot-ffi/src/toolbox.rs
@@ -350,11 +350,8 @@ pub(crate) fn load_class_method(
 
     if method.is_null() {
         panic!(
-            "Failed to load class method {}::{} (hash {}).\n\
-            Make sure gdext and Godot are compatible: https://godot-rust.github.io/book/gdext/advanced/compatibility.html",
-            class_name,
-            method_name,
-            hash
+            "Failed to load class method {}::{} (hash {}).{INFO}",
+            class_name, method_name, hash
         )
     }
 
@@ -421,7 +418,7 @@ pub(crate) fn read_version_string(version_ptr: &sys::GDExtensionGodotVersion) ->
         .to_string()
 }
 
-const INFO: &str = "\nMake sure gdext and Godot are compatible: https://godot-rust.github.io/book/gdext/advanced/compatibility.html";
+const INFO: &str = "\nMake sure gdext and Godot are compatible: https://godot-rust.github.io/book/toolchain/compatibility.html";
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Private abstractions


### PR DESCRIPTION
Fixes #1067.

Workaround for upstream issue https://github.com/godotengine/godot/issues/103867.
This PR is written in a way that the workaround is hopefully no longer needed in Godot 4.5 :slightly_smiling_face: 