### PR TITLE
Explicit signal visibility

### DIFF
--- a/godot-macros/src/class/data_models/func.rs
+++ b/godot-macros/src/class/data_models/func.rs
@@ -188,7 +188,7 @@ pub struct SignatureInfo {
     pub receiver_type: ReceiverType,
     pub param_idents: Vec<Ident>,
     pub param_types: Vec<venial::TypeExpr>,
-    pub ret_type: TokenStream,
+    pub return_type: TokenStream,
 }
 
 impl SignatureInfo {
@@ -198,7 +198,7 @@ impl SignatureInfo {
             receiver_type: ReceiverType::Mut,
             param_idents: vec![],
             param_types: vec![],
-            ret_type: quote! { () },
+            return_type: quote! { () },
         }
     }
 
@@ -207,7 +207,7 @@ impl SignatureInfo {
 
     pub fn tuple_type(&self) -> TokenStream {
         // Note: for GdSelf receivers, first parameter is not even part of SignatureInfo anymore.
-        util::make_signature_tuple_type(&self.ret_type, &self.param_types)
+        util::make_signature_tuple_type(&self.return_type, &self.param_types)
     }
 }
 
@@ -392,7 +392,7 @@ pub(crate) fn into_signature_info(
         receiver_type,
         param_idents,
         param_types,
-        ret_type,
+        return_type: ret_type,
     }
 }
 

--- a/godot-macros/src/class/data_models/inherent_impl.rs
+++ b/godot-macros/src/class/data_models/inherent_impl.rs
@@ -319,18 +319,14 @@ fn process_godot_fns(
                         "#[signal] must not have a body; declare the function with a semicolon"
                     );
                 }
-                if function.vis_marker.is_some() {
-                    return bail!(
-                        &function.vis_marker,
-                        "#[signal] must not have a visibility specifier; signals are always public"
-                    );
-                }
 
                 let external_attributes = function.attributes.clone();
-                let sig = util::reduce_to_signature(function);
+
+                let mut fn_signature = util::reduce_to_signature(function);
+                fn_signature.vis_marker = function.vis_marker.clone();
 
                 signal_definitions.push(SignalDefinition {
-                    signature: sig,
+                    fn_signature,
                     external_attributes,
                     has_builder: !signal.no_builder,
                 });

--- a/godot-macros/src/docs.rs
+++ b/godot-macros/src/docs.rs
@@ -154,11 +154,17 @@ fn make_docs_from_attributes(doc: &[Attribute]) -> Option<String> {
 }
 
 fn make_signal_docs(signal: &SignalDefinition) -> Option<String> {
-    let name = &signal.signature.name;
-    let params = params(signal.signature.params.iter().filter_map(|(x, _)| match x {
-        FnParam::Receiver(_) => None,
-        FnParam::Typed(y) => Some((&y.name, &y.ty)),
-    }));
+    let name = &signal.fn_signature.name;
+    let params = params(
+        signal
+            .fn_signature
+            .params
+            .iter()
+            .filter_map(|(x, _)| match x {
+                FnParam::Receiver(_) => None,
+                FnParam::Typed(y) => Some((&y.name, &y.ty)),
+            }),
+    );
     let desc = make_docs_from_attributes(&signal.external_attributes)?;
     Some(format!(
         r#"
@@ -251,7 +257,11 @@ pub fn make_method_docs(method: &FuncDefinition) -> Option<String> {
         .registered_name
         .clone()
         .unwrap_or_else(|| method.rust_ident().to_string());
-    let ret = method.signature_info.ret_type.to_token_stream().to_string();
+    let ret = method
+        .signature_info
+        .return_type
+        .to_token_stream()
+        .to_string();
     let params = params(
         method
             .signature_info

--- a/godot-macros/src/lib.rs
+++ b/godot-macros/src/lib.rs
@@ -774,6 +774,9 @@ pub fn derive_godot_class(input: TokenStream) -> TokenStream {
 /// method, you can access all declared signals in `self.signals().some_signal()` or `gd.signals().some_signal()`. The returned object is
 /// of type [`TypedSignal`], which provides further APIs for emitting and connecting, among others.
 ///
+/// Visibility of signals **must not exceed class visibility**. If your class is private (as above) and you declare your signal as `pub fn`,
+/// you will get a compile error "can't leak private type".
+///
 /// A detailed explanation with examples is available in the [book chapter _Registering signals_](https://godot-rust.github.io/book/register/signals.html).
 ///
 /// [`WithSignals`]: ../obj/trait.WithSignals.html

--- a/godot-macros/src/util/mod.rs
+++ b/godot-macros/src/util/mod.rs
@@ -83,7 +83,7 @@ pub(crate) use require_api_version;
 
 pub fn reduce_to_signature(function: &venial::Function) -> venial::Function {
     let mut reduced = function.clone();
-    reduced.vis_marker = None; // TODO needed?
+    reduced.vis_marker = None; // retained outside in the case of #[signal].
     reduced.attributes.clear();
     reduced.tk_semicolon = None;
     reduced.body = None;

--- a/itest/rust/src/builtin_tests/containers/signal_test.rs
+++ b/itest/rust/src/builtin_tests/containers/signal_test.rs
@@ -264,8 +264,9 @@ mod emitter {
         #[signal]
         fn signal_unit();
 
+        // Public to demonstrate usage inside module.
         #[signal]
-        fn signal_int(arg1: i64);
+        pub fn signal_int(arg1: i64);
 
         #[signal]
         fn signal_obj(arg1: Gd<Object>, arg2: GString);

--- a/itest/rust/src/builtin_tests/containers/signal_test.rs
+++ b/itest/rust/src/builtin_tests/containers/signal_test.rs
@@ -245,51 +245,58 @@ fn signal_construction_and_id() {
 /// Global sets the value of the received argument and whether it was a static function.
 static LAST_STATIC_FUNCTION_ARG: Global<i64> = Global::default();
 
-#[derive(GodotClass)]
-#[class(init, base=Object)]
-struct Emitter {
-    _base: Base<Object>,
-    #[cfg(since_api = "4.2")]
-    last_received_int: i64,
-}
+// Separate module to test signal visibility.
+use emitter::Emitter;
 
-#[godot_api]
-impl Emitter {
-    #[signal]
-    fn signal_unit();
+mod emitter {
+    use super::*;
 
-    #[signal]
-    fn signal_int(arg1: i64);
-
-    #[signal]
-    fn signal_obj(arg1: Gd<Object>, arg2: GString);
-
-    #[func]
-    fn self_receive(&mut self, arg1: i64) {
+    #[derive(GodotClass)]
+    #[class(init, base=Object)]
+    pub struct Emitter {
+        _base: Base<Object>,
         #[cfg(since_api = "4.2")]
-        {
-            self.last_received_int = arg1;
+        pub last_received_int: i64,
+    }
+
+    #[godot_api]
+    impl Emitter {
+        #[signal]
+        fn signal_unit();
+
+        #[signal]
+        fn signal_int(arg1: i64);
+
+        #[signal]
+        fn signal_obj(arg1: Gd<Object>, arg2: GString);
+
+        #[func]
+        pub fn self_receive(&mut self, arg1: i64) {
+            #[cfg(since_api = "4.2")]
+            {
+                self.last_received_int = arg1;
+            }
         }
-    }
 
-    #[func]
-    fn self_receive_static(arg1: i64) {
-        *LAST_STATIC_FUNCTION_ARG.lock() = arg1;
-    }
+        #[func]
+        fn self_receive_static(arg1: i64) {
+            *LAST_STATIC_FUNCTION_ARG.lock() = arg1;
+        }
 
-    // "Internal" means connect/emit happens from within the class (via &mut self).
+        // "Internal" means connect/emit happens from within the class (via &mut self).
 
-    #[cfg(since_api = "4.2")]
-    fn connect_signals_internal(&mut self, tracker: Rc<Cell<i64>>) {
-        let mut sig = self.signals().signal_int();
-        sig.connect_self(Self::self_receive);
-        sig.connect(Self::self_receive_static);
-        sig.connect(move |i| tracker.set(i));
-    }
+        #[cfg(since_api = "4.2")]
+        pub fn connect_signals_internal(&mut self, tracker: Rc<Cell<i64>>) {
+            let mut sig = self.signals().signal_int();
+            sig.connect_self(Self::self_receive);
+            sig.connect(Self::self_receive_static);
+            sig.connect(move |i| tracker.set(i));
+        }
 
-    #[cfg(since_api = "4.2")]
-    fn emit_signals_internal(&mut self) {
-        self.signals().signal_int().emit(1234);
+        #[cfg(since_api = "4.2")]
+        pub fn emit_signals_internal(&mut self) {
+            self.signals().signal_int().emit(1234);
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #1073.

New semantics:
1. `#[signal]` declarations can now have a visibility specifier: `pub`, `pub(crate)`, etc.
2. Both the generated signal struct and the `signals().my_sig()` accessor method inherit this visibility.

---

> [!warning]
> `#[signal]` visibility **must not exceed** class visibility.

---

Otherwise it will lead to an error message:

> can't leak private type

pointing to the class macro (not the signal). I'm aware this is not the best UX, but I don't know of any better approach. Suggestions welcome.

The core problem is that the generated signal struct has a `Deref` impl to `TypedSignal<C, ...>`, where `C` is the declaring class. So if the signal struct had wider visibility than `C`, it would implicitly make the other type public, which rustc doesn't like. Maybe there's a trick here... See also https://github.com/godot-rust/gdext/pull/1061#issuecomment-2692164492.