### PR TITLE
Bump MSRV from 1.80 to 1.85

### DIFF
--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -147,7 +147,7 @@ jobs:
 
           - name: linux
             os: ubuntu-22.04
-            rust-toolchain: "1.80"
+            rust-toolchain: "1.85"
             rust-special: -msrv
 
     steps:

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -19,7 +19,7 @@ on:
 
 env:
   # Keep this a variable for easy search&replace.
-  MSRV: 1.80
+  MSRV: 1.85
 
 jobs:
   notify-docs:

--- a/examples/dodge-the-creeps/rust/Cargo.toml
+++ b/examples/dodge-the-creeps/rust/Cargo.toml
@@ -2,7 +2,7 @@
 name = "dodge-the-creeps"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.80"
+rust-version = "1.85"
 license = "MPL-2.0"
 publish = false
 

--- a/examples/hot-reload/rust/Cargo.toml
+++ b/examples/hot-reload/rust/Cargo.toml
@@ -2,7 +2,7 @@
 name = "hot-reload"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.85"
 license = "MPL-2.0"
 publish = false
 

--- a/godot-bindings/Cargo.toml
+++ b/godot-bindings/Cargo.toml
@@ -2,7 +2,7 @@
 name = "godot-bindings"
 version = "0.2.4"
 edition = "2021"
-rust-version = "1.80"
+rust-version = "1.85"
 license = "MPL-2.0"
 keywords = ["gamedev", "godot", "engine", "ffi", "sys"]
 categories = ["game-engines", "graphics"]

--- a/godot-cell/Cargo.toml
+++ b/godot-cell/Cargo.toml
@@ -2,7 +2,7 @@
 name = "godot-cell"
 version = "0.2.4"
 edition = "2021"
-rust-version = "1.80"
+rust-version = "1.85"
 license = "MPL-2.0"
 keywords = ["gamedev", "godot", "engine", "ffi"]
 categories = ["game-engines", "graphics"]

--- a/godot-codegen/Cargo.toml
+++ b/godot-codegen/Cargo.toml
@@ -2,7 +2,7 @@
 name = "godot-codegen"
 version = "0.2.4"
 edition = "2021"
-rust-version = "1.80"
+rust-version = "1.85"
 license = "MPL-2.0"
 keywords = ["gamedev", "godot", "engine", "codegen"]
 categories = ["game-engines", "graphics"]

--- a/godot-core/Cargo.toml
+++ b/godot-core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "godot-core"
 version = "0.2.4"
 edition = "2021"
-rust-version = "1.80"
+rust-version = "1.85"
 license = "MPL-2.0"
 keywords = ["gamedev", "godot", "engine", "2d", "3d"] # possibly: "ffi"
 categories = ["game-engines", "graphics"]

--- a/godot-core/src/meta/args/ref_arg.rs
+++ b/godot-core/src/meta/args/ref_arg.rs
@@ -193,6 +193,6 @@ where
     }
 
     fn is_null(&self) -> bool {
-        self.shared_ref.map_or(true, T::is_null)
+        self.shared_ref.is_none_or(T::is_null)
     }
 }

--- a/godot-core/src/obj/script.rs
+++ b/godot-core/src/obj/script.rs
@@ -362,7 +362,7 @@ where
 
     if object_script_variant
         .object_id()
-        .map_or(true, |instance_id| instance_id != script.instance_id())
+        .is_none_or(|instance_id| instance_id != script.instance_id())
     {
         return false;
     }

--- a/godot-ffi/Cargo.toml
+++ b/godot-ffi/Cargo.toml
@@ -2,7 +2,7 @@
 name = "godot-ffi"
 version = "0.2.4"
 edition = "2021"
-rust-version = "1.80"
+rust-version = "1.85"
 license = "MPL-2.0"
 keywords = ["gamedev", "godot", "engine", "ffi"]
 categories = ["game-engines", "graphics"]

--- a/godot-macros/Cargo.toml
+++ b/godot-macros/Cargo.toml
@@ -2,7 +2,7 @@
 name = "godot-macros"
 version = "0.2.4"
 edition = "2021"
-rust-version = "1.80"
+rust-version = "1.85"
 license = "MPL-2.0"
 keywords = ["gamedev", "godot", "engine", "derive", "macro"]
 categories = ["game-engines", "graphics"]

--- a/godot-macros/src/itest.rs
+++ b/godot-macros/src/itest.rs
@@ -67,7 +67,7 @@ pub fn attribute_itest(input_item: venial::Item) -> ParseResult<TokenStream> {
             .return_ty
             .as_ref()
             .and_then(extract_typename)
-            .map_or(true, |segment| segment.ident != "TaskHandle")
+            .is_none_or(|segment| segment.ident != "TaskHandle")
     {
         return bad_async_signature(&func);
     }

--- a/godot/Cargo.toml
+++ b/godot/Cargo.toml
@@ -2,7 +2,7 @@
 name = "godot"
 version = "0.2.4"
 edition = "2021"
-rust-version = "1.80"
+rust-version = "1.85"
 license = "MPL-2.0"
 keywords = ["gamedev", "godot", "engine", "2d", "3d"] # possibly: "ffi"
 categories = ["game-engines", "graphics"]

--- a/itest/repo-tweak/Cargo.toml
+++ b/itest/repo-tweak/Cargo.toml
@@ -2,7 +2,7 @@
 name = "repo-tweak"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.80"
+rust-version = "1.85"
 license = "MPL-2.0"
 publish = false
 

--- a/itest/rust/Cargo.toml
+++ b/itest/rust/Cargo.toml
@@ -2,7 +2,7 @@
 name = "itest"
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.80"
+rust-version = "1.85"
 license = "MPL-2.0"
 publish = false
 


### PR DESCRIPTION
Unblocks #1037 depending on [`PanicHookInfo`](https://doc.rust-lang.org/nightly/std/panic/struct.PanicHookInfo.html), among others.

Follow clippy to use [`is_none_or(...)`](https://doc.rust-lang.org/std/option/enum.Option.html#method.is_none_or) instead of `map_or(true, ...)`. 
This function is available as of Rust 1.82.