### PR TITLE
Rename: OnEditor `invalid` to `sentinel` 

### DIFF
--- a/godot-core/src/obj/oneditor.rs
+++ b/godot-core/src/obj/oneditor.rs
@@ -114,7 +114,7 @@ use crate::registry::property::{BuiltinExport, Export, Var};
 /// `OnEditor<T>` can be used with other built-ins to provide extra validation logic and making sure that given properties has been set.
 /// Example usage might be checking if entities has been granted properly generated id.
 ///
-/// In such cases the value which will be deemed invalid **must** be specified with `#[init(uninit = val)]`.
+/// In such cases the value which will be deemed invalid **must** be specified with `#[init(sentinel = val)]`.
 /// Given `val` will be used to represent uninitialized `OnEditor<T>` in the Godot editor.
 /// Accessing uninitialized value will cause the panic.
 ///
@@ -129,7 +129,7 @@ use crate::registry::property::{BuiltinExport, Export, Var};
 ///     // Uninitialized value will be represented by `42` in the editor.
 ///     // Will cause panic if not set via the editor or code before use.
 ///     #[export]
-///     #[init(invalid = 42)]
+///     #[init(sentinel = 42)]
 ///     some_primitive: OnEditor<i64>,
 /// }
 ///
@@ -190,7 +190,7 @@ impl<T: Var + FromGodot + PartialEq> OnEditor<T> {
     /// Creates new `OnEditor<T>` with a value that is considered invalid.
     ///
     /// If this value is not changed in the editor, accessing it from Rust will cause a panic.
-    pub fn new_invalid(val: T) -> Self
+    pub fn from_sentinel(val: T) -> Self
     where
         T::Via: BuiltinExport,
     {

--- a/godot-macros/src/class/derive_godot_class.rs
+++ b/godot-macros/src/class/derive_godot_class.rs
@@ -592,14 +592,14 @@ fn parse_fields(
                 });
             }
 
-            // #[init(invalid = val)]
-            if let Some(invalid_representation) = parser.handle_expr("invalid")? {
+            // #[init(sentinel = val)]
+            if let Some(sentinel_representation) = parser.handle_expr("sentinel")? {
                 let mut is_well_formed = true;
                 if !field.is_oneditor {
                     is_well_formed = false;
                     errors.push(error!(
                         parser.span(),
-                        "The key `invalid` in attribute #[init] requires field of type `OnEditor<T>`"
+                        "The key `sentinel` in attribute #[init] requires field of type `OnEditor<T>`"
                     ));
                 }
 
@@ -607,12 +607,12 @@ fn parse_fields(
                     is_well_formed = false;
                     errors.push(error!(
 				        parser.span(),
-				        "The key `invalid` in attribute #[init] is mutually exclusive with the keys `default` and `val`"
+				        "The key `sentinel` in attribute #[init] is mutually exclusive with the keys `default` and `val`"
 			        ));
                 }
 
                 let default_val = if is_well_formed {
-                    quote! { OnEditor::new_invalid( #invalid_representation ) }
+                    quote! { OnEditor::from_sentinel( #sentinel_representation ) }
                 } else {
                     quote! { todo!() }
                 };

--- a/itest/rust/src/object_tests/oneditor_test.rs
+++ b/itest/rust/src/object_tests/oneditor_test.rs
@@ -14,7 +14,7 @@ use godot::obj::{Gd, NewAlloc, OnEditor};
 
 #[itest]
 fn oneditor_deref() {
-    let mut on_editor = OnEditor::new_invalid(0);
+    let mut on_editor = OnEditor::from_sentinel(0);
     on_editor.init(42);
     assert_eq!(*on_editor, 42);
 
@@ -25,7 +25,7 @@ fn oneditor_deref() {
 #[itest]
 fn oneditor_no_value_panic_on_deref_primitive() {
     expect_panic("Deref on null fails for primitive", || {
-        let on_editor_panic: OnEditor<i64> = OnEditor::new_invalid(0);
+        let on_editor_panic: OnEditor<i64> = OnEditor::from_sentinel(0);
         let _ref: &i64 = &on_editor_panic;
     });
     expect_panic("Deref on null fails for Gd class", || {
@@ -34,7 +34,7 @@ fn oneditor_no_value_panic_on_deref_primitive() {
     });
 
     expect_panic("DerefMut on null fails for primitive", || {
-        let mut on_editor_panic: OnEditor<i64> = OnEditor::new_invalid(0);
+        let mut on_editor_panic: OnEditor<i64> = OnEditor::from_sentinel(0);
         let _ref: &mut i64 = &mut on_editor_panic;
     });
     expect_panic("DerefMut on null fails for Gd class", || {
@@ -68,7 +68,7 @@ fn oneditor_no_panic_on_ready() {
 #[class(init, base=Node)]
 struct OnEditorNoDefault {
     #[export]
-    #[init(invalid = 0)]
+    #[init(sentinel = 0)]
     some_primitive: OnEditor<i64>,
     #[export]
     node_field: OnEditor<Gd<Node>>,


### PR DESCRIPTION
`#[init(invalid= val)]` -> `#[init(sentinel = val)]`
`OnEditor::new_invalid(val)` -> `OnEditor::from_sentinel(val)`