### PR TITLE
Implement `XformInv<...>` for `Transform2D`, `Transform3D`, `Basis`.

### DIFF
--- a/godot-core/src/builtin/basis.rs
+++ b/godot-core/src/builtin/basis.rs
@@ -633,7 +633,13 @@ impl XformInv<Vector3> for Basis {
     /// Inversely transforms given [`Vector3`] by this basis,
     /// under the assumption that the basis is orthonormal (i.e. rotation/reflection is fine, scaling/skew is not).
     ///
-    /// `basis.xform_inv(vector)` is equivalent to `basis.transposed() * vector`. See [`Basis::transposed()`].
+    /// Since given basis is assumed to be orthonormal (i.e. it is both orthogonal – with all axis perpendicular to each other – and all the axis are normalized),
+    /// `basis.transposed()` (matrix flipped over its diagonal) is equal to `basis.inverse()`
+    /// (i.e. `basis * basis.transposed() == basis * basis.inverse() == Basis::Identity`),
+    /// thus `basis.xform_inv(vector)` is equivalent both to `basis.transposed() * vector` and `basis.inverse() * vector`.
+    ///
+    /// See [`Basis::transposed()`] and [Godot docs (stable) for `Basis`](https://docs.godotengine.org/en/stable/classes/class_basis.html)
+    /// with following [Matrices and Transform tutorial](https://docs.godotengine.org/en/stable/tutorials/math/matrices_and_transforms.html).
     ///
     /// For transforming by inverse of a non-orthonormal basis (e.g. with scaling) `basis.inverse() * vector` can be used instead. See [`Basis::inverse()`].
     ///

--- a/godot-core/src/builtin/basis.rs
+++ b/godot-core/src/builtin/basis.rs
@@ -8,7 +8,7 @@
 use godot_ffi as sys;
 use sys::{ffi_methods, GodotFfi};
 
-use crate::builtin::math::{ApproxEq, FloatExt, GlamConv, GlamType};
+use crate::builtin::math::{ApproxEq, FloatExt, GlamConv, GlamType, XformInv};
 use crate::builtin::real_consts::FRAC_PI_2;
 use crate::builtin::{real, EulerOrder, Quaternion, RMat3, RQuat, RVec2, RVec3, Vector3};
 use std::cmp::Ordering;
@@ -626,6 +626,24 @@ impl Mul<Vector3> for Basis {
 
     fn mul(self, rhs: Vector3) -> Self::Output {
         self.glam2(&rhs, |a, b| a * b)
+    }
+}
+
+impl XformInv<Vector3> for Basis {
+    /// Inversely transforms given [`Vector3`] by this basis,
+    /// under the assumption that the basis is orthonormal (i.e. rotation/reflection is fine, scaling/skew is not).
+    ///
+    /// `basis.xform_inv(vector)` is equivalent to `basis.transposed() * vector`. See [`Basis::transposed()`].
+    ///
+    /// For transforming by inverse of a non-orthonormal basis (e.g. with scaling) `basis.inverse() * vector` can be used instead. See [`Basis::inverse()`].
+    ///
+    /// _Godot equivalent: `vector * basis`_
+    fn xform_inv(&self, rhs: Vector3) -> Vector3 {
+        Vector3::new(
+            self.col_a().dot(rhs),
+            self.col_b().dot(rhs),
+            self.col_c().dot(rhs),
+        )
     }
 }
 

--- a/godot-core/src/builtin/math/mod.rs
+++ b/godot-core/src/builtin/math/mod.rs
@@ -8,10 +8,12 @@
 mod approx_eq;
 mod float;
 mod glam_helpers;
+mod xform;
 
 pub use crate::{assert_eq_approx, assert_ne_approx};
 pub use approx_eq::ApproxEq;
 pub use float::FloatExt;
+pub use xform::XformInv;
 
 // Internal glam re-exports
 pub(crate) use glam_helpers::*;

--- a/godot-core/src/builtin/math/xform.rs
+++ b/godot-core/src/builtin/math/xform.rs
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+/// Applying inverse transforms.
+///
+/// See also: [`Transform2D`](crate::builtin::Transform2D), [`Transform3D`](crate::builtin::Transform3D), [`Basis`](crate::builtin::Basis).
+///
+/// _Godot equivalent: `rhs * mat`_
+pub trait XformInv<T> {
+    fn xform_inv(&self, rhs: T) -> T;
+}

--- a/godot-core/src/builtin/math/xform.rs
+++ b/godot-core/src/builtin/math/xform.rs
@@ -10,6 +10,6 @@
 /// See also: [`Transform2D`](crate::builtin::Transform2D), [`Transform3D`](crate::builtin::Transform3D), [`Basis`](crate::builtin::Basis).
 ///
 /// _Godot equivalent: `rhs * mat`_
-pub trait XformInv<T> {
+pub trait XformInv<T>: std::ops::Mul<T> {
     fn xform_inv(&self, rhs: T) -> T;
 }

--- a/godot-core/src/builtin/mod.rs
+++ b/godot-core/src/builtin/mod.rs
@@ -26,6 +26,7 @@ pub use crate::sys::VariantType;
 pub mod __prelude_reexport {
     use super::*;
 
+    pub use super::math::XformInv;
     pub use aabb::*;
     pub use basis::*;
     pub use callable::*;

--- a/godot-core/src/builtin/transform2d.rs
+++ b/godot-core/src/builtin/transform2d.rs
@@ -39,12 +39,12 @@ use std::ops::{Mul, MulAssign};
 ///
 /// # Transform operations
 ///
-/// | Operation                      | Transform2D                    | Notes                               |
-/// |--------------------------------|--------------------------------|-------------------------------------|
-/// | Apply                          | transform * v                  | Supports [`Rect2`] and [`Vector2`]. |
-/// | Apply inverse                  | transform.xform_inv(v)         | Supports [`Rect2`] and [`Vector2`]. |
-/// | Apply, no translate            | transform.basis_xform(v)       | Supports [`Vector2`].               |
-/// | Apply inverse, no translate    | transform.basis_xform_inv(v)   | Supports [`Vector2`].               |
+/// | Operation                      | Transform2D                      | Notes                               |
+/// |--------------------------------|----------------------------------|-------------------------------------|
+/// | Apply                          | `transform * v`                  | Supports [`Rect2`] and [`Vector2`]. |
+/// | Apply inverse                  | `transform.xform_inv(v)`         | Supports [`Rect2`] and [`Vector2`]. |
+/// | Apply, no translate            | `transform.basis_xform(v)`       | Supports [`Vector2`].               |
+/// | Apply inverse, no translate    | `transform.basis_xform_inv(v)`   | Supports [`Vector2`].               |
 ///
 /// # Godot docs
 ///

--- a/godot-core/src/builtin/transform2d.rs
+++ b/godot-core/src/builtin/transform2d.rs
@@ -8,7 +8,7 @@
 use godot_ffi as sys;
 use sys::{ffi_methods, GodotFfi};
 
-use crate::builtin::math::{assert_ne_approx, ApproxEq, FloatExt, GlamConv, GlamType};
+use crate::builtin::math::{assert_ne_approx, ApproxEq, FloatExt, GlamConv, GlamType, XformInv};
 use crate::builtin::real_consts::PI;
 use crate::builtin::{real, RAffine2, RMat2, Rect2, Vector2};
 
@@ -36,6 +36,15 @@ use std::ops::{Mul, MulAssign};
 /// [`Basis`]: crate::builtin::Basis
 /// [`Transform3D`]: crate::builtin::Transform3D
 /// [`Projection`]: crate::builtin::Projection
+///
+/// # Transform operations
+///
+/// | Operation                      | Transform2D                    | Notes                               |
+/// |--------------------------------|--------------------------------|-------------------------------------|
+/// | Apply                          | transform * v                  | Supports [`Rect2`] and [`Vector2`]. |
+/// | Apply inverse                  | transform.xform_inv(v)         | Supports [`Rect2`] and [`Vector2`]. |
+/// | Apply, no translate            | transform.basis_xform(v)       | Supports [`Vector2`].               |
+/// | Apply inverse, no translate    | transform.basis_xform_inv(v)   | Supports [`Vector2`].               |
 ///
 /// # Godot docs
 ///
@@ -349,6 +358,19 @@ impl Mul<Vector2> for Transform2D {
     }
 }
 
+impl XformInv<Vector2> for Transform2D {
+    /// Inversely transforms (multiplies) the given [`Vector2`] by this transformation matrix,
+    /// under the assumption that the transformation basis is orthonormal (i.e. rotation/reflection is fine, scaling/skew is not).
+    ///
+    /// For transforming by inverse of an affine transformation (e.g. with scaling) `transform.affine_inverse() * vector` can be used instead. See: [`Transform2D::affine_inverse()`].
+    ///
+    /// _Godot equivalent: `vector * transform` or `transform.inverse() * vector`_
+    fn xform_inv(&self, rhs: Vector2) -> Vector2 {
+        let v = rhs - self.origin;
+        self.basis_xform_inv(v)
+    }
+}
+
 impl Mul<real> for Transform2D {
     type Output = Self;
 
@@ -370,9 +392,41 @@ impl Mul<Rect2> for Transform2D {
         let ya = self.b * rhs.position.y;
         let yb = self.b * rhs.end().y;
 
-        let position = Vector2::coord_min(xa, xb) + Vector2::coord_min(ya, yb) + self.origin;
-        let end = Vector2::coord_max(xa, xb) + Vector2::coord_max(ya, yb) + self.origin;
-        Rect2::new(position, end - position)
+        let position = Vector2::coord_min(xa, xb) + Vector2::coord_min(ya, yb);
+        let end = Vector2::coord_max(xa, xb) + Vector2::coord_max(ya, yb);
+        Rect2::new(position + self.origin, end - position)
+    }
+}
+
+impl XformInv<Rect2> for Transform2D {
+    /// Inversely transforms (multiplies) the given [`Rect2`] by this [`Transform2D`] transformation matrix, under the assumption that the transformation basis is orthonormal (i.e. rotation/reflection is fine, scaling/skew is not).
+    ///
+    /// For transforming by inverse of an affine transformation (e.g. with scaling) `transform.affine_inverse() * vector` can be used instead. See: [`Transform2D::affine_inverse()`].
+    ///
+    /// _Godot equivalent: `rect2 * transform` or `transform.inverse() * rect2`_
+    fn xform_inv(&self, rhs: Rect2) -> Rect2 {
+        // https://web.archive.org/web/20220317024830/https://dev.theomader.com/transform-bounding-boxes/
+        // Same as Godot's `Transform2D::xform_inv` but omits unnecessary `Rect2::expand_to`.
+        // There is probably some more clever way to do that.
+
+        // Use the first point initialize our min/max.
+        let start = self.xform_inv(rhs.position);
+        // `min` is position of our aabb, `max` is the farthest vertex.
+        let (mut min, mut max) = (start, start);
+
+        let vertices = [
+            Vector2::new(rhs.position.x, rhs.position.y + rhs.size.y),
+            rhs.end(),
+            Vector2::new(rhs.position.x + rhs.size.x, rhs.position.y),
+        ];
+
+        for v in vertices {
+            let transformed = self.xform_inv(v);
+            min = Vector2::coord_min(min, transformed);
+            max = Vector2::coord_max(max, transformed);
+        }
+
+        Rect2::new(min, max - min)
     }
 }
 

--- a/itest/rust/src/builtin_tests/common.rs
+++ b/itest/rust/src/builtin_tests/common.rs
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+//! Functions shared between various built-in tests.
+
+use godot::builtin::VariantOperator;
+use godot::meta::{FromGodot, ToGodot};
+use godot::private::class_macros::assert_eq_approx;
+
+/// Asserts that result of evaluated operation via variants and expected one are approximately equal.
+///
+/// Used to check if operations performed in Godot Rust yield the same result as ones performed via Godot runtime.
+pub(crate) fn assert_evaluate_approx_eq<T, U, E>(
+    left: T,
+    right: U,
+    op: VariantOperator,
+    expected: E,
+) where
+    T: ToGodot,
+    U: ToGodot,
+    E: FromGodot + std::fmt::Debug + godot::builtin::math::ApproxEq + Copy,
+{
+    let lhs = left
+        .to_variant()
+        .evaluate(&right.to_variant(), op)
+        .expect("Result of evaluation can't be null!")
+        .to::<E>();
+
+    assert_eq_approx!(lhs, expected);
+}

--- a/itest/rust/src/builtin_tests/geometry/transform2d_test.rs
+++ b/itest/rust/src/builtin_tests/geometry/transform2d_test.rs
@@ -8,13 +8,19 @@
 use crate::framework::itest;
 
 use godot::builtin::inner::InnerTransform2D;
-use godot::builtin::{real, RealConv, Rect2, Transform2D, VariantOperator, Vector2};
+use godot::builtin::{real, RealConv, Rect2, Transform2D, VariantOperator, Vector2, XformInv};
 use godot::meta::ToGodot;
 use godot::private::class_macros::assert_eq_approx;
 
 const TEST_TRANSFORM: Transform2D = Transform2D::from_cols(
     Vector2::new(1.0, 2.0),
     Vector2::new(3.0, 4.0),
+    Vector2::new(5.0, 6.0),
+);
+
+const TEST_TRANSFORM_ORTHONORMAL: Transform2D = Transform2D::from_cols(
+    Vector2::new(1.0, 0.0),
+    Vector2::new(0.0, 1.0),
     Vector2::new(5.0, 6.0),
 );
 
@@ -101,6 +107,51 @@ fn transform2d_xform_equiv() {
             .rotated(0.8)
             .to_variant()
             .evaluate(&rect_2.to_variant(), VariantOperator::MULTIPLY)
+            .unwrap()
+            .to::<Rect2>(),
+        "operator: Transform2D * Rect2 (2)"
+    );
+}
+
+#[itest]
+fn transform2d_xform_inv_equiv() {
+    let vec = Vector2::new(1.0, 2.0);
+
+    assert_eq_approx!(
+        TEST_TRANSFORM_ORTHONORMAL.xform_inv(vec),
+        vec.to_variant()
+            .evaluate(
+                &TEST_TRANSFORM_ORTHONORMAL.to_variant(),
+                VariantOperator::MULTIPLY
+            )
+            .unwrap()
+            .to::<Vector2>(),
+        "operator: Transform2D * Vector2"
+    );
+
+    let rect_2 = Rect2::new(Vector2::new(1.0, 2.0), Vector2::new(3.0, 4.0));
+
+    assert_eq_approx!(
+        TEST_TRANSFORM_ORTHONORMAL.xform_inv(rect_2),
+        rect_2
+            .to_variant()
+            .evaluate(
+                &TEST_TRANSFORM_ORTHONORMAL.to_variant(),
+                VariantOperator::MULTIPLY
+            )
+            .unwrap()
+            .to::<Rect2>(),
+        "operator: Transform2D * Rect2 (1)"
+    );
+
+    assert_eq_approx!(
+        TEST_TRANSFORM_ORTHONORMAL.rotated(0.8).xform_inv(rect_2),
+        rect_2
+            .to_variant()
+            .evaluate(
+                &TEST_TRANSFORM_ORTHONORMAL.rotated(0.8).to_variant(),
+                VariantOperator::MULTIPLY
+            )
             .unwrap()
             .to::<Rect2>(),
         "operator: Transform2D * Rect2 (2)"

--- a/itest/rust/src/builtin_tests/geometry/transform2d_test.rs
+++ b/itest/rust/src/builtin_tests/geometry/transform2d_test.rs
@@ -7,9 +7,9 @@
 
 use crate::framework::itest;
 
+use crate::builtin_tests::common::assert_evaluate_approx_eq;
 use godot::builtin::inner::InnerTransform2D;
 use godot::builtin::{real, RealConv, Rect2, Transform2D, VariantOperator, Vector2, XformInv};
-use godot::meta::ToGodot;
 use godot::private::class_macros::assert_eq_approx;
 
 const TEST_TRANSFORM: Transform2D = Transform2D::from_cols(
@@ -79,37 +79,31 @@ fn transform2d_determinant() {
 fn transform2d_xform_equiv() {
     let vec = Vector2::new(1.0, 2.0);
 
-    assert_eq_approx!(
+    // operator: Transform2D * Vector2
+    assert_evaluate_approx_eq(
+        TEST_TRANSFORM,
+        vec,
+        VariantOperator::MULTIPLY,
         TEST_TRANSFORM * vec,
-        TEST_TRANSFORM
-            .to_variant()
-            .evaluate(&vec.to_variant(), VariantOperator::MULTIPLY)
-            .unwrap()
-            .to::<Vector2>(),
-        "operator: Transform2D * Vector2"
     );
 
     let rect_2 = Rect2::new(Vector2::new(1.0, 2.0), Vector2::new(3.0, 4.0));
 
-    assert_eq_approx!(
+    // operator: Transform2D * Rect2 (1)
+    assert_evaluate_approx_eq(
+        TEST_TRANSFORM,
+        rect_2,
+        VariantOperator::MULTIPLY,
         TEST_TRANSFORM * rect_2,
-        TEST_TRANSFORM
-            .to_variant()
-            .evaluate(&rect_2.to_variant(), VariantOperator::MULTIPLY)
-            .unwrap()
-            .to::<Rect2>(),
-        "operator: Transform2D * Rect2 (1)"
     );
 
-    assert_eq_approx!(
-        TEST_TRANSFORM.rotated(0.8) * rect_2,
-        TEST_TRANSFORM
-            .rotated(0.8)
-            .to_variant()
-            .evaluate(&rect_2.to_variant(), VariantOperator::MULTIPLY)
-            .unwrap()
-            .to::<Rect2>(),
-        "operator: Transform2D * Rect2 (2)"
+    // "operator: Transform2D * Rect2 (2)"
+    let transform_rotated = TEST_TRANSFORM_ORTHONORMAL.rotated(0.8);
+    assert_evaluate_approx_eq(
+        transform_rotated,
+        rect_2,
+        VariantOperator::MULTIPLY,
+        transform_rotated * rect_2,
     );
 }
 
@@ -117,43 +111,30 @@ fn transform2d_xform_equiv() {
 fn transform2d_xform_inv_equiv() {
     let vec = Vector2::new(1.0, 2.0);
 
-    assert_eq_approx!(
+    // operator: Vector2 * Transform2D
+    assert_evaluate_approx_eq(
+        vec,
+        TEST_TRANSFORM_ORTHONORMAL,
+        VariantOperator::MULTIPLY,
         TEST_TRANSFORM_ORTHONORMAL.xform_inv(vec),
-        vec.to_variant()
-            .evaluate(
-                &TEST_TRANSFORM_ORTHONORMAL.to_variant(),
-                VariantOperator::MULTIPLY
-            )
-            .unwrap()
-            .to::<Vector2>(),
-        "operator: Transform2D * Vector2"
     );
 
     let rect_2 = Rect2::new(Vector2::new(1.0, 2.0), Vector2::new(3.0, 4.0));
 
-    assert_eq_approx!(
+    // operator: Rect2 * Transform2D (1)
+    assert_evaluate_approx_eq(
+        rect_2,
+        TEST_TRANSFORM_ORTHONORMAL,
+        VariantOperator::MULTIPLY,
         TEST_TRANSFORM_ORTHONORMAL.xform_inv(rect_2),
-        rect_2
-            .to_variant()
-            .evaluate(
-                &TEST_TRANSFORM_ORTHONORMAL.to_variant(),
-                VariantOperator::MULTIPLY
-            )
-            .unwrap()
-            .to::<Rect2>(),
-        "operator: Transform2D * Rect2 (1)"
     );
 
-    assert_eq_approx!(
-        TEST_TRANSFORM_ORTHONORMAL.rotated(0.8).xform_inv(rect_2),
-        rect_2
-            .to_variant()
-            .evaluate(
-                &TEST_TRANSFORM_ORTHONORMAL.rotated(0.8).to_variant(),
-                VariantOperator::MULTIPLY
-            )
-            .unwrap()
-            .to::<Rect2>(),
-        "operator: Transform2D * Rect2 (2)"
+    // operator: Rect2 * Transform2D (2)
+    let transform_rotated = TEST_TRANSFORM_ORTHONORMAL.rotated(0.8);
+    assert_evaluate_approx_eq(
+        rect_2,
+        transform_rotated,
+        VariantOperator::MULTIPLY,
+        transform_rotated.xform_inv(rect_2),
     );
 }

--- a/itest/rust/src/builtin_tests/geometry/transform3d_test.rs
+++ b/itest/rust/src/builtin_tests/geometry/transform3d_test.rs
@@ -7,9 +7,9 @@
 
 use crate::framework::itest;
 
+use crate::builtin_tests::common::assert_evaluate_approx_eq;
 use godot::builtin::inner::InnerTransform3D;
 use godot::builtin::{Aabb, Basis, Plane, Transform3D, VariantOperator, Vector3, XformInv};
-use godot::meta::ToGodot;
 use godot::private::class_macros::assert_eq_approx;
 
 const TEST_TRANSFORM: Transform3D = Transform3D::new(
@@ -51,38 +51,32 @@ fn transform3d_equiv() {
 fn transform3d_xform_equiv() {
     let vec = Vector3::new(1.0, 2.0, 3.0);
 
-    assert_eq_approx!(
+    // operator: Transform3D * Vector3
+    assert_evaluate_approx_eq(
+        TEST_TRANSFORM,
+        vec,
+        VariantOperator::MULTIPLY,
         TEST_TRANSFORM * vec,
-        TEST_TRANSFORM
-            .to_variant()
-            .evaluate(&vec.to_variant(), VariantOperator::MULTIPLY)
-            .unwrap()
-            .to::<Vector3>(),
-        "operator: Transform3D * Vector3"
     );
 
     let aabb = Aabb::new(Vector3::new(1.0, 2.0, 3.0), Vector3::new(4.0, 5.0, 6.0));
 
-    assert_eq_approx!(
+    // operator: Transform3D * Aabb
+    assert_evaluate_approx_eq(
+        TEST_TRANSFORM,
+        aabb,
+        VariantOperator::MULTIPLY,
         TEST_TRANSFORM * aabb,
-        TEST_TRANSFORM
-            .to_variant()
-            .evaluate(&aabb.to_variant(), VariantOperator::MULTIPLY)
-            .unwrap()
-            .to::<Aabb>(),
-        "operator: Transform3D * Aabb"
     );
 
     let plane = Plane::new(Vector3::new(1.0, 2.0, 3.0).normalized(), 5.0);
 
-    assert_eq_approx!(
+    // operator: Transform3D * Plane
+    assert_evaluate_approx_eq(
+        TEST_TRANSFORM,
+        plane,
+        VariantOperator::MULTIPLY,
         TEST_TRANSFORM * plane,
-        TEST_TRANSFORM
-            .to_variant()
-            .evaluate(&plane.to_variant(), VariantOperator::MULTIPLY)
-            .unwrap()
-            .to::<Plane>(),
-        "operator: Transform3D * Plane"
     );
 }
 
@@ -90,60 +84,42 @@ fn transform3d_xform_equiv() {
 fn transform3d_xform_inv_equiv() {
     let vec = Vector3::new(1.0, 2.0, 3.0);
 
-    assert_eq_approx!(
+    // operator: Vector3 * Transform3D
+    assert_evaluate_approx_eq(
+        vec,
+        TEST_TRANSFORM_ORTHONORMAL,
+        VariantOperator::MULTIPLY,
         TEST_TRANSFORM_ORTHONORMAL.xform_inv(vec),
-        vec.to_variant()
-            .evaluate(
-                &TEST_TRANSFORM_ORTHONORMAL.to_variant(),
-                VariantOperator::MULTIPLY
-            )
-            .unwrap()
-            .to::<Vector3>(),
-        "operator: Vector3 * Transform3D"
     );
 
     let aabb = Aabb::new(Vector3::new(1.0, 2.0, 3.0), Vector3::new(4.0, 5.0, 6.0));
 
-    assert_eq_approx!(
+    // operator: Aabb * Transform3D  (1)
+    assert_evaluate_approx_eq(
+        aabb,
+        TEST_TRANSFORM_ORTHONORMAL,
+        VariantOperator::MULTIPLY,
         TEST_TRANSFORM_ORTHONORMAL.xform_inv(aabb),
-        aabb.to_variant()
-            .evaluate(
-                &TEST_TRANSFORM_ORTHONORMAL.to_variant(),
-                VariantOperator::MULTIPLY
-            )
-            .unwrap()
-            .to::<Aabb>(),
-        "operator: Transform3D * Aabb"
     );
 
-    assert_eq_approx!(
-        TEST_TRANSFORM_ORTHONORMAL
-            .rotated(Vector3::new(0.2, 0.4, 1.0).normalized(), 0.8)
-            .xform_inv(aabb),
-        aabb.to_variant()
-            .evaluate(
-                &TEST_TRANSFORM_ORTHONORMAL
-                    .rotated(Vector3::new(0.2, 0.4, 1.0).normalized(), 0.8)
-                    .to_variant(),
-                VariantOperator::MULTIPLY
-            )
-            .unwrap()
-            .to::<Aabb>(),
-        "operator: Transform3D * Aabb"
+    let transform_rotated =
+        TEST_TRANSFORM_ORTHONORMAL.rotated(Vector3::new(0.2, 0.4, 1.0).normalized(), 0.8);
+
+    // operator: Aabb * Transform3D (2)
+    assert_evaluate_approx_eq(
+        aabb,
+        transform_rotated,
+        VariantOperator::MULTIPLY,
+        transform_rotated.xform_inv(aabb),
     );
 
     let plane = Plane::new(Vector3::new(1.0, 2.0, 3.0).normalized(), 5.0);
 
-    assert_eq_approx!(
+    // operator: Plane * Transform3D
+    assert_evaluate_approx_eq(
+        plane,
+        TEST_TRANSFORM_ORTHONORMAL,
+        VariantOperator::MULTIPLY,
         TEST_TRANSFORM_ORTHONORMAL.xform_inv(plane),
-        plane
-            .to_variant()
-            .evaluate(
-                &TEST_TRANSFORM_ORTHONORMAL.to_variant(),
-                VariantOperator::MULTIPLY
-            )
-            .unwrap()
-            .to::<Plane>(),
-        "operator: Transform3D * Plane"
     );
 }

--- a/itest/rust/src/builtin_tests/geometry/transform3d_test.rs
+++ b/itest/rust/src/builtin_tests/geometry/transform3d_test.rs
@@ -91,9 +91,12 @@ fn transform3d_xform_inv_equiv() {
     let vec = Vector3::new(1.0, 2.0, 3.0);
 
     assert_eq_approx!(
-        TEST_TRANSFORM.xform_inv(vec),
+        TEST_TRANSFORM_ORTHONORMAL.xform_inv(vec),
         vec.to_variant()
-            .evaluate(&TEST_TRANSFORM.to_variant(), VariantOperator::MULTIPLY)
+            .evaluate(
+                &TEST_TRANSFORM_ORTHONORMAL.to_variant(),
+                VariantOperator::MULTIPLY
+            )
             .unwrap()
             .to::<Vector3>(),
         "operator: Vector3 * Transform3D"

--- a/itest/rust/src/builtin_tests/mod.rs
+++ b/itest/rust/src/builtin_tests/mod.rs
@@ -49,5 +49,7 @@ mod color_test;
 
 mod convert_test;
 
+mod common;
+
 #[cfg(feature = "serde")]
 mod serde_test;


### PR DESCRIPTION
Implements `Mul<Transform...>` for `Vector2`, `Vector3`.

We already support `Transform * Vector` so the reverse should be supported as well. Tests are translated 1:1 from Godot (the implementation haven't really changed for 12 years and I don't expect to see any changes here anytime soon).

<details>

<summary> Godot Impl </summary>

Multiplying Godot [Vector x Transform](https://github.com/godotengine/godot/blob/54278a48e7030b25f5dfe1ddc950effac076f3dc/core/variant/variant_op.cpp#L355C78-L355C89) results in performing [XFormInv](https://github.com/godotengine/godot/blob/54278a48e7030b25f5dfe1ddc950effac076f3dc/core/math/transform_3d.h#L140).

</details>

Initially I did it with macro, but it is not worth it.