### PR TITLE
Add `OnReady::from_loaded()` + `#[init(load = "PATH")]`

### DIFF
--- a/godot-core/src/obj/mod.rs
+++ b/godot-core/src/obj/mod.rs
@@ -16,8 +16,8 @@ mod dyn_gd;
 mod gd;
 mod guards;
 mod instance_id;
-mod oneditor;
-mod onready;
+mod on_editor;
+mod on_ready;
 mod raw_gd;
 mod traits;
 
@@ -28,8 +28,8 @@ pub use dyn_gd::DynGd;
 pub use gd::*;
 pub use guards::{BaseMut, BaseRef, DynGdMut, DynGdRef, GdMut, GdRef};
 pub use instance_id::*;
-pub use oneditor::*;
-pub use onready::*;
+pub use on_editor::*;
+pub use on_ready::*;
 pub use raw_gd::*;
 pub use traits::*;
 

--- a/godot-core/src/obj/on_editor.rs
+++ b/godot-core/src/obj/on_editor.rs
@@ -21,7 +21,7 @@ use crate::registry::property::{BuiltinExport, Export, Var};
 /// `OnEditor<T>` should always be used as a property, preferably in tandem with an `#[export]` or `#[var]`.
 /// Initializing `OnEditor` values via code before the first use is supported but should be limited to use cases involving builder or factory patterns.
 ///
-/// [`Option<Gd<T>>`](std::option) and [`OnReady<Gd<T>>`](crate::obj::onready::OnReady) should be used for any other late initialization logic.
+/// [`Option<Gd<T>>`](std::option) and [`OnReady<Gd<T>>`](crate::obj::on_ready::OnReady) should be used for any other late initialization logic.
 ///
 /// # Using `OnEditor<T>` with `Gd<T>` and `DynGd<T, D>`
 ///

--- a/godot-core/src/obj/on_ready.rs
+++ b/godot-core/src/obj/on_ready.rs
@@ -5,10 +5,10 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use crate::builtin::NodePath;
-use crate::classes::Node;
+use crate::builtin::{GString, NodePath};
+use crate::classes::{Node, Resource};
 use crate::meta::{arg_into_owned, AsArg, GodotConvert};
-use crate::obj::{Gd, GodotClass, Inherits};
+use crate::obj::{Gd, Inherits};
 use crate::registry::property::Var;
 use std::fmt::{self, Debug, Formatter};
 use std::mem;
@@ -21,10 +21,10 @@ use std::mem;
 ///
 /// `OnReady<T>` should always be used as a field. There are two modes to use it:
 ///
-/// 1. **Automatic mode, using [`new()`](OnReady::new), [`from_base_fn()`](OnReady::from_base_fn) or
-///    [`node()`](OnReady::<Gd<T>>::from_node).**<br>
+/// 1. **Automatic mode, using [`new()`](OnReady::new), [`from_base_fn()`](OnReady::from_base_fn),
+///    [`from_node()`][Self::from_node] or [`from_loaded()`][Self::from_loaded].**<br>
 ///    Before `ready()` is called, all `OnReady` fields constructed with the above methods are automatically initialized,
-///    in the order of declaration. This means that you can safely access them in `ready()`.<br><br>
+///    in the order of declaration. This means that you can safely access them in `ready()`.<br>
 /// 2. **Manual mode, using [`manual()`](Self::manual).**<br>
 ///    These fields are left uninitialized until you call [`init()`][Self::init] on them. This is useful if you need more complex
 ///    initialization scenarios than a closure allows. If you forget initialization, a panic will occur on first access.
@@ -111,16 +111,18 @@ pub struct OnReady<T> {
     state: InitState<T>,
 }
 
-impl<T: GodotClass + Inherits<Node>> OnReady<Gd<T>> {
+impl<T: Inherits<Node>> OnReady<Gd<T>> {
     /// Variant of [`OnReady::new()`], fetching the node located at `path` before `ready()`.
     ///
-    /// This is the functional equivalent of the GDScript pattern `@onready var node = $NodePath`.
+    /// This is the functional equivalent of the GDScript pattern `@onready var node = $NODE_PATH`.
     ///
-    /// # Panics
-    /// - If `path` does not point to a valid node.
+    /// When used with `#[class(init)]`, the field can be annotated with `#[init(node = "NODE_PATH")]` to call this constructor.
+    ///
+    /// # Panics (deferred)
+    /// - If `path` does not point to a valid node, or its type is not a `T` or a subclass.
     ///
     /// Note that the panic will only happen if and when the node enters the SceneTree for the first time
-    ///  (i.e.: it receives the `READY` notification).
+    /// (i.e. it receives the `READY` notification).
     pub fn from_node(path: impl AsArg<NodePath>) -> Self {
         arg_into_owned!(path);
 
@@ -130,6 +132,25 @@ impl<T: GodotClass + Inherits<Node>> OnReady<Gd<T>> {
     #[deprecated = "Renamed to `from_node`."]
     pub fn node(path: impl AsArg<NodePath>) -> Self {
         Self::from_node(path)
+    }
+}
+
+impl<T: Inherits<Resource>> OnReady<Gd<T>> {
+    /// Variant of [`OnReady::new()`], loading the resource stored at `path` before `ready()`.
+    ///
+    /// This is the functional equivalent of the GDScript pattern `@onready var res = load(...)`.
+    ///
+    /// When used with `#[class(init)]`, the field can be annotated with `#[init(load = "FILE_PATH")]` to call this constructor.
+    ///
+    /// # Panics (deferred)
+    /// - If the resource does not exist at `path`, cannot be loaded or is not compatible with type `T`.
+    ///
+    /// Note that the panic will only happen if and when the node enters the SceneTree for the first time
+    /// (i.e. it receives the `READY` notification).
+    pub fn from_loaded(path: impl AsArg<GString>) -> Self {
+        arg_into_owned!(path);
+
+        Self::new(move || crate::tools::load(&path))
     }
 }
 
@@ -175,7 +196,7 @@ impl<T> OnReady<T> {
     ///
     /// # Panics
     /// - If `init()` was called before.
-    /// - If this object was already provided with a closure during construction, in [`Self::new()`].
+    /// - If this object was already provided with a closure during construction, in [`Self::new()`] or any other automatic constructor.
     pub fn init(&mut self, value: T) {
         match &self.state {
             InitState::ManualUninitialized { .. } => {

--- a/godot-core/src/obj/on_ready.rs
+++ b/godot-core/src/obj/on_ready.rs
@@ -22,7 +22,7 @@ use std::mem;
 /// `OnReady<T>` should always be used as a field. There are two modes to use it:
 ///
 /// 1. **Automatic mode, using [`new()`](OnReady::new), [`from_base_fn()`](OnReady::from_base_fn) or
-///    [`node()`](OnReady::<Gd<T>>::node).**<br>
+///    [`node()`](OnReady::<Gd<T>>::from_node).**<br>
 ///    Before `ready()` is called, all `OnReady` fields constructed with the above methods are automatically initialized,
 ///    in the order of declaration. This means that you can safely access them in `ready()`.<br><br>
 /// 2. **Manual mode, using [`manual()`](Self::manual).**<br>
@@ -86,8 +86,10 @@ use std::mem;
 /// #[class(init, base = Node)]
 /// struct MyClass {
 ///    base: Base<Node>,
+///
 ///    #[init(node = "ChildPath")]
 ///    auto: OnReady<Gd<Node2D>>,
+///
 ///    #[init(val = OnReady::manual())]
 ///    manual: OnReady<i32>,
 /// }
@@ -119,10 +121,15 @@ impl<T: GodotClass + Inherits<Node>> OnReady<Gd<T>> {
     ///
     /// Note that the panic will only happen if and when the node enters the SceneTree for the first time
     ///  (i.e.: it receives the `READY` notification).
-    pub fn node(path: impl AsArg<NodePath>) -> Self {
+    pub fn from_node(path: impl AsArg<NodePath>) -> Self {
         arg_into_owned!(path);
 
         Self::from_base_fn(move |base| base.get_node_as(&path))
+    }
+
+    #[deprecated = "Renamed to `from_node`."]
+    pub fn node(path: impl AsArg<NodePath>) -> Self {
+        Self::from_node(path)
     }
 }
 

--- a/godot-core/src/obj/on_ready.rs
+++ b/godot-core/src/obj/on_ready.rs
@@ -19,7 +19,12 @@ use std::mem;
 /// Godot in particular encourages initialization inside `ready()`, e.g. to access the scene tree after a node is inserted into it.
 /// The alternative to using this pattern is [`Option<T>`][option], which needs to be explicitly unwrapped with `unwrap()` or `expect()` each time.
 ///
-/// `OnReady<T>` should always be used as a field. There are two modes to use it:
+/// If you have a value that you expect to be initialized in the Godot editor, use [`OnEditor<T>`][crate::obj::OnEditor] instead.
+/// As a general "maybe initialized" type, `Option<Gd<T>>` is always available, even if more verbose.
+///
+/// # Late-init semantics
+///
+/// `OnReady<T>` should always be used as a struct field. There are two modes to use it:
 ///
 /// 1. **Automatic mode, using [`new()`](OnReady::new), [`from_base_fn()`](OnReady::from_base_fn),
 ///    [`from_node()`][Self::from_node] or [`from_loaded()`][Self::from_loaded].**<br>
@@ -114,7 +119,9 @@ pub struct OnReady<T> {
 impl<T: Inherits<Node>> OnReady<Gd<T>> {
     /// Variant of [`OnReady::new()`], fetching the node located at `path` before `ready()`.
     ///
-    /// This is the functional equivalent of the GDScript pattern `@onready var node = $NODE_PATH`.
+    /// This is the functional equivalent of:
+    /// - the GDScript pattern `@onready var node = $NODE_PATH`.
+    /// - the Rust method [`Node::get_node_as()`].
     ///
     /// When used with `#[class(init)]`, the field can be annotated with `#[init(node = "NODE_PATH")]` to call this constructor.
     ///
@@ -138,7 +145,9 @@ impl<T: Inherits<Node>> OnReady<Gd<T>> {
 impl<T: Inherits<Resource>> OnReady<Gd<T>> {
     /// Variant of [`OnReady::new()`], loading the resource stored at `path` before `ready()`.
     ///
-    /// This is the functional equivalent of the GDScript pattern `@onready var res = load(...)`.
+    /// This is the functional equivalent of:
+    /// - the GDScript pattern `@onready var res = load(...)`.
+    /// - the Rust function [`tools::load()`][crate::tools::load].
     ///
     /// When used with `#[class(init)]`, the field can be annotated with `#[init(load = "FILE_PATH")]` to call this constructor.
     ///

--- a/godot-macros/src/class/derive_godot_class.rs
+++ b/godot-macros/src/class/derive_godot_class.rs
@@ -9,8 +9,8 @@ use proc_macro2::{Ident, Punct, TokenStream};
 use quote::{format_ident, quote, quote_spanned};
 
 use crate::class::{
-    make_property_impl, make_virtual_callback, BeforeKind, Field, FieldDefault, FieldExport,
-    FieldVar, Fields, SignatureInfo,
+    make_property_impl, make_virtual_callback, BeforeKind, Field, FieldCond, FieldDefault,
+    FieldExport, FieldVar, Fields, SignatureInfo,
 };
 use crate::util::{
     bail, error, format_funcs_collection_struct, ident, path_ends_with_complex,
@@ -530,7 +530,7 @@ fn parse_fields(
                 );
             }
 
-            // #[init(val = expr)]
+            // #[init(val = EXPR)]
             if let Some(default) = parser.handle_expr("val")? {
                 field.default_val = Some(FieldDefault {
                     default_val: default,
@@ -555,30 +555,13 @@ fn parse_fields(
                 })
             }
 
-            // #[init(node = "NodePath")]
+            // #[init(node = "PATH")]
             if let Some(node_path) = parser.handle_expr("node")? {
-                let mut is_well_formed = true;
-                if !field.is_onready {
-                    is_well_formed = false;
-                    errors.push(error!(
-                        parser.span(),
-                        "The key `node` in attribute #[init] requires field of type `OnReady<T>`\n\
-				         Hint: the syntax #[init(node = \"NodePath\")] is equivalent to \
-				         #[init(val = OnReady::from_node(\"NodePath\"))], \
-				         which can only be assigned to fields of type `OnReady<T>`"
-                    ));
-                }
-
-                if field.default_val.is_some() {
-                    is_well_formed = false;
-                    errors.push(error!(
-				        parser.span(),
-				        "The key `node` in attribute #[init] is mutually exclusive with the keys `default` and `val`\n\
-				         Hint: the syntax #[init(node = \"NodePath\")] is equivalent to \
-				         #[init(val = OnReady::from_node(\"NodePath\"))], \
-				         both aren't allowed since they would override each other"
-			        ));
-                }
+                let is_well_formed = field.ensure_preconditions(
+                    Some(FieldCond::IsOnReady),
+                    parser.span(),
+                    &mut errors,
+                );
 
                 let default_val = if is_well_formed {
                     quote! { OnReady::from_node(#node_path) }
@@ -592,27 +575,36 @@ fn parse_fields(
                 });
             }
 
-            // #[init(sentinel = val)]
-            if let Some(sentinel_representation) = parser.handle_expr("sentinel")? {
-                let mut is_well_formed = true;
-                if !field.is_oneditor {
-                    is_well_formed = false;
-                    errors.push(error!(
-                        parser.span(),
-                        "The key `sentinel` in attribute #[init] requires field of type `OnEditor<T>`"
-                    ));
-                }
-
-                if field.default_val.is_some() {
-                    is_well_formed = false;
-                    errors.push(error!(
-				        parser.span(),
-				        "The key `sentinel` in attribute #[init] is mutually exclusive with the key `val`"
-			        ));
-                }
+            // #[init(load = "PATH")]
+            if let Some(resource_path) = parser.handle_expr("load")? {
+                let is_well_formed = field.ensure_preconditions(
+                    Some(FieldCond::IsOnReady),
+                    parser.span(),
+                    &mut errors,
+                );
 
                 let default_val = if is_well_formed {
-                    quote! { OnEditor::from_sentinel( #sentinel_representation ) }
+                    quote! { OnReady::from_loaded(#resource_path) }
+                } else {
+                    quote! { todo!() }
+                };
+
+                field.default_val = Some(FieldDefault {
+                    default_val,
+                    span: parser.span(),
+                });
+            }
+
+            // #[init(sentinel = EXPR)]
+            if let Some(sentinel_value) = parser.handle_expr("sentinel")? {
+                let is_well_formed = field.ensure_preconditions(
+                    Some(FieldCond::IsOnEditor),
+                    parser.span(),
+                    &mut errors,
+                );
+
+                let default_val = if is_well_formed {
+                    quote! { OnEditor::from_sentinel(#sentinel_value) }
                 } else {
                     quote! { todo!() }
                 };
@@ -649,6 +641,9 @@ fn parse_fields(
             if let Some(override_onready) = handle_opposite_keys(&mut parser, "onready", "hint")? {
                 field.is_onready = override_onready;
             }
+
+            // Not yet implemented for OnEditor.
+
             parser.finish()?;
         }
 

--- a/godot-macros/src/class/derive_godot_class.rs
+++ b/godot-macros/src/class/derive_godot_class.rs
@@ -557,62 +557,32 @@ fn parse_fields(
 
             // #[init(node = "PATH")]
             if let Some(node_path) = parser.handle_expr("node")? {
-                let is_well_formed = field.ensure_preconditions(
-                    Some(FieldCond::IsOnReady),
-                    parser.span(),
+                field.set_default_val_if(
+                    || quote! { OnReady::from_node(#node_path) },
+                    FieldCond::IsOnReady,
+                    &parser,
                     &mut errors,
                 );
-
-                let default_val = if is_well_formed {
-                    quote! { OnReady::from_node(#node_path) }
-                } else {
-                    quote! { todo!() }
-                };
-
-                field.default_val = Some(FieldDefault {
-                    default_val,
-                    span: parser.span(),
-                });
             }
 
             // #[init(load = "PATH")]
             if let Some(resource_path) = parser.handle_expr("load")? {
-                let is_well_formed = field.ensure_preconditions(
-                    Some(FieldCond::IsOnReady),
-                    parser.span(),
+                field.set_default_val_if(
+                    || quote! { OnReady::from_loaded(#resource_path) },
+                    FieldCond::IsOnReady,
+                    &parser,
                     &mut errors,
                 );
-
-                let default_val = if is_well_formed {
-                    quote! { OnReady::from_loaded(#resource_path) }
-                } else {
-                    quote! { todo!() }
-                };
-
-                field.default_val = Some(FieldDefault {
-                    default_val,
-                    span: parser.span(),
-                });
             }
 
             // #[init(sentinel = EXPR)]
             if let Some(sentinel_value) = parser.handle_expr("sentinel")? {
-                let is_well_formed = field.ensure_preconditions(
-                    Some(FieldCond::IsOnEditor),
-                    parser.span(),
+                field.set_default_val_if(
+                    || quote! { OnEditor::from_sentinel(#sentinel_value) },
+                    FieldCond::IsOnEditor,
+                    &parser,
                     &mut errors,
                 );
-
-                let default_val = if is_well_formed {
-                    quote! { OnEditor::from_sentinel(#sentinel_value) }
-                } else {
-                    quote! { todo!() }
-                };
-
-                field.default_val = Some(FieldDefault {
-                    default_val,
-                    span: parser.span(),
-                });
             }
 
             parser.finish()?;

--- a/godot-macros/src/class/derive_godot_class.rs
+++ b/godot-macros/src/class/derive_godot_class.rs
@@ -563,8 +563,8 @@ fn parse_fields(
                     errors.push(error!(
                         parser.span(),
                         "The key `node` in attribute #[init] requires field of type `OnReady<T>`\n\
-				         Help: The syntax #[init(node = \"NodePath\")] is equivalent to \
-				         #[init(val = OnReady::node(\"NodePath\"))], \
+				         Hint: the syntax #[init(node = \"NodePath\")] is equivalent to \
+				         #[init(val = OnReady::from_node(\"NodePath\"))], \
 				         which can only be assigned to fields of type `OnReady<T>`"
                     ));
                 }
@@ -574,14 +574,14 @@ fn parse_fields(
                     errors.push(error!(
 				        parser.span(),
 				        "The key `node` in attribute #[init] is mutually exclusive with the keys `default` and `val`\n\
-				         Help: The syntax #[init(node = \"NodePath\")] is equivalent to \
-				         #[init(val = OnReady::node(\"NodePath\"))], \
+				         Hint: the syntax #[init(node = \"NodePath\")] is equivalent to \
+				         #[init(val = OnReady::from_node(\"NodePath\"))], \
 				         both aren't allowed since they would override each other"
 			        ));
                 }
 
                 let default_val = if is_well_formed {
-                    quote! { OnReady::node(#node_path) }
+                    quote! { OnReady::from_node(#node_path) }
                 } else {
                     quote! { todo!() }
                 };
@@ -607,7 +607,7 @@ fn parse_fields(
                     is_well_formed = false;
                     errors.push(error!(
 				        parser.span(),
-				        "The key `sentinel` in attribute #[init] is mutually exclusive with the keys `default` and `val`"
+				        "The key `sentinel` in attribute #[init] is mutually exclusive with the key `val`"
 			        ));
                 }
 

--- a/itest/rust/src/engine_tests/save_load_test.rs
+++ b/itest/rust/src/engine_tests/save_load_test.rs
@@ -5,7 +5,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use godot::obj::NewGd;
+use godot::classes;
+use godot::classes::notify::NodeNotification;
+use godot::obj::{Base, Gd, NewAlloc, NewGd, OnReady};
 use godot::register::GodotClass;
 use godot::tools::{load, save, try_load, try_save};
 
@@ -23,6 +25,17 @@ fn remove_test_file(file_name: &str) {
 struct SavedGame {
     #[export]
     level: u32,
+}
+
+// Needed to test OnReady integration of load.
+#[derive(GodotClass)]
+#[class(base=Node, init)]
+struct GameLoader {
+    // Test also more complex expressions.
+    #[init(load = &format!("res://{}", RESOURCE_NAME))]
+    game: OnReady<Gd<SavedGame>>,
+
+    _base: Base<classes::Node>,
 }
 
 const RESOURCE_NAME: &str = "test_resource.tres";
@@ -66,6 +79,23 @@ fn load_test() {
 
     let loaded = load::<SavedGame>(&res_path);
     assert_eq!(loaded.bind().get_level(), level);
+
+    remove_test_file(RESOURCE_NAME);
+}
+
+#[itest]
+fn load_with_onready() {
+    let res_path = format!("res://{}", RESOURCE_NAME);
+
+    let mut resource = SavedGame::new_gd();
+    resource.bind_mut().set_level(555);
+
+    save(&resource, &res_path);
+
+    let mut loader = GameLoader::new_alloc();
+    loader.notify(NodeNotification::READY);
+    assert_eq!(loader.bind().game.bind().get_level(), 555);
+    loader.free();
 
     remove_test_file(RESOURCE_NAME);
 }

--- a/itest/rust/src/object_tests/onready_test.rs
+++ b/itest/rust/src/object_tests/onready_test.rs
@@ -5,6 +5,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+// Integration of OnReady with #[init(load = "PATH")] is tested in save_load_test.rs.
+
 use crate::framework::{expect_panic, itest};
 use godot::classes::notify::NodeNotification;
 use godot::classes::{INode, Node};


### PR DESCRIPTION
The new syntax can be used to load resources, just like with [`tools::load()`](https://godot-rust.github.io/docs/gdext/master/godot/tools/fn.load.html):
```rs
#[derive(GodotClass)]
#[class(init, base=Node)]
struct MyClass {

    #[init(load = "res://path/to/scene.tscn"))]
    scene: OnReady<Gd<PackedScene>>,
    ...
}

// Equivalent to OnReady::from_loaded("res://path/to/scene.tscn") inside init().
```


Furthermore:
- renames `OnReady::node()` -> `from_node()`
- refactors proc-macro internals related to `#[init(...)]`
- improves `OnEditor` + `OnReady` docs