### PR TITLE
Add diagnostic hints for missing `ToGodot`/`FromGodot` traits

### DIFF
--- a/godot-core/src/meta/args/as_arg.rs
+++ b/godot-core/src/meta/args/as_arg.rs
@@ -49,9 +49,9 @@ use std::ffi::CStr;
 /// custom types. Classes are already supported through upcasting and [`AsObjectArg`][crate::meta::AsObjectArg].
 #[diagnostic::on_unimplemented(
     message = "Argument of type `{Self}` cannot be passed to an `impl AsArg<{T}>` parameter",
-    note = "If you pass by value, consider borrowing instead.",
+    note = "if you pass by value, consider borrowing instead.",
     note = "GString/StringName/NodePath aren't implicitly convertible for performance reasons; use their `arg()` method.",
-    note = "See also `AsArg` docs: https://godot-rust.github.io/docs/gdext/master/godot/meta/trait.AsArg.html"
+    note = "see also `AsArg` docs: https://godot-rust.github.io/docs/gdext/master/godot/meta/trait.AsArg.html"
 )]
 pub trait AsArg<T: ParamType>
 where

--- a/godot-core/src/meta/args/object_arg.rs
+++ b/godot-core/src/meta/args/object_arg.rs
@@ -46,8 +46,8 @@ use std::ptr;
 /// | (null literal)    |                       | `Gd::null_arg()` |
 #[diagnostic::on_unimplemented(
     message = "Argument of type `{Self}` cannot be passed to an `impl AsObjectArg<{T}>` parameter",
-    note = "If you pass by value, consider borrowing instead.",
-    note = "See also `AsObjectArg` docs: https://godot-rust.github.io/docs/gdext/master/godot/meta/trait.AsObjectArg.html"
+    note = "if you pass by value, consider borrowing instead.",
+    note = "see also `AsObjectArg` docs: https://godot-rust.github.io/docs/gdext/master/godot/meta/trait.AsObjectArg.html"
 )]
 pub trait AsObjectArg<T>
 where

--- a/godot-core/src/meta/godot_convert/mod.rs
+++ b/godot-core/src/meta/godot_convert/mod.rs
@@ -42,6 +42,12 @@ pub trait GodotConvert {
 /// Please read the [`godot::meta` module docs][crate::meta] for further information about conversions.
 ///
 /// This trait can be derived using the [`#[derive(GodotConvert)]`](../register/derive.GodotConvert.html) macro.
+#[diagnostic::on_unimplemented(
+    message = "passing type `{Self}` to Godot requires `ToGodot` trait, which is usually provided by the library",
+    note = "ToGodot is implemented for built-in types (i32, Vector2, GString, …). For objects, use Gd<T> instead of T.",
+    note = "if you really need a custom representation (for non-class types), implement ToGodot manually or use #[derive(GodotConvert)].",
+    note = "see also: https://godot-rust.github.io/docs/gdext/master/godot/meta"
+)]
 pub trait ToGodot: Sized + GodotConvert {
     /// Target type of [`to_godot()`](ToGodot::to_godot), which can differ from [`Via`][GodotConvert::Via] for pass-by-reference types.
     ///
@@ -76,6 +82,12 @@ pub trait ToGodot: Sized + GodotConvert {
 /// Please read the [`godot::meta` module docs][crate::meta] for further information about conversions.
 ///
 /// This trait can be derived using the [`#[derive(GodotConvert)]`](../register/derive.GodotConvert.html) macro.
+#[diagnostic::on_unimplemented(
+    message = "receiving type `{Self}` from Godot requires `FromGodot` trait, which is usually provided by the library",
+    note = "FromGodot is implemented for built-in types (i32, Vector2, GString, …). For objects, use Gd<T> instead of T.",
+    note = "if you really need a custom representation (for non-class types), implement FromGodot manually or use #[derive(GodotConvert)]",
+    note = "see also: https://godot-rust.github.io/docs/gdext/master/godot/meta"
+)]
 pub trait FromGodot: Sized + GodotConvert {
     /// Converts the Godot representation to this type, returning `Err` on failure.
     fn try_from_godot(via: Self::Via) -> Result<Self, ConvertError>;

--- a/godot-core/src/obj/traits.rs
+++ b/godot-core/src/obj/traits.rs
@@ -21,7 +21,7 @@ use godot_ffi as sys;
 /// Normally, you don't need to implement this trait yourself; use [`#[derive(GodotClass)]`](../register/derive.GodotClass.html) instead.
 // Above intra-doc link to the derive-macro only works as HTML, not as symbol link.
 #[diagnostic::on_unimplemented(
-    message = "Only classes registered with Godot are allowed in this context",
+    message = "only classes registered with Godot are allowed in this context",
     note = "you can use `#[derive(GodotClass)]` to register your own structs with Godot",
     note = "see also: https://godot-rust.github.io/book/register/classes.html"
 )]
@@ -262,7 +262,7 @@ pub trait IndexEnum: EngineEnum {
 #[diagnostic::on_unimplemented(
     message = "Class `{Self}` requires a `Base<T>` field",
     label = "missing field `_base: Base<...>` in struct declaration",
-    note = "A base field is required to access the base from within `self`, as well as for #[signal], #[rpc] and #[func(virtual)]",
+    note = "a base field is required to access the base from within `self`, as well as for #[signal], #[rpc] and #[func(virtual)]",
     note = "see also: https://godot-rust.github.io/book/register/classes.html#the-base-field"
 )]
 pub trait WithBaseField: GodotClass + Bounds<Declarer = bounds::DeclUser> {
@@ -527,8 +527,8 @@ pub mod cap {
     #[diagnostic::on_unimplemented(
         message = "Class `{Self}` requires either an `init` constructor, or explicit opt-out",
         label = "needs `init`",
-        note = "To provide a default constructor, use `#[class(init)]` or implement an `init` method",
-        note = "To opt out, use `#[class(no_init)]`",
+        note = "to provide a default constructor, use `#[class(init)]` or implement an `init` method",
+        note = "to opt out, use `#[class(no_init)]`",
         note = "see also: https://godot-rust.github.io/book/register/constructors.html"
     )]
     pub trait GodotDefault: GodotClass {


### PR DESCRIPTION
Most useful when `T` is accidentally used in place of `Gd<T>`.