### PR TITLE
GodotFfi::variant_type can be const

### DIFF
--- a/godot-core/src/builtin/aabb.rs
+++ b/godot-core/src/builtin/aabb.rs
@@ -466,9 +466,7 @@ impl std::fmt::Display for Aabb {
 // SAFETY:
 // This type is represented as `Self` in Godot, so `*mut Self` is sound.
 unsafe impl GodotFfi for Aabb {
-    fn variant_type() -> sys::VariantType {
-        sys::VariantType::AABB
-    }
+    const VARIANT_TYPE: sys::VariantType = sys::VariantType::AABB;
 
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Self; .. }
 }

--- a/godot-core/src/builtin/basis.rs
+++ b/godot-core/src/builtin/basis.rs
@@ -632,9 +632,7 @@ impl Mul<Vector3> for Basis {
 // SAFETY:
 // This type is represented as `Self` in Godot, so `*mut Self` is sound.
 unsafe impl GodotFfi for Basis {
-    fn variant_type() -> sys::VariantType {
-        sys::VariantType::BASIS
-    }
+    const VARIANT_TYPE: sys::VariantType = sys::VariantType::BASIS;
 
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Self; .. }
 }

--- a/godot-core/src/builtin/callable.rs
+++ b/godot-core/src/builtin/callable.rs
@@ -456,9 +456,7 @@ impl_builtin_traits! {
 // The `opaque` in `Callable` is just a pair of pointers, and requires no special initialization or cleanup
 // beyond what is done in `from_opaque` and `drop`. So using `*mut Opaque` is safe.
 unsafe impl GodotFfi for Callable {
-    fn variant_type() -> sys::VariantType {
-        sys::VariantType::CALLABLE
-    }
+    const VARIANT_TYPE: sys::VariantType = sys::VariantType::CALLABLE;
 
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Opaque;
         fn new_from_sys;

--- a/godot-core/src/builtin/collections/array.rs
+++ b/godot-core/src/builtin/collections/array.rs
@@ -1032,9 +1032,7 @@ impl VariantArray {
 //   Arrays are properly initialized through a `from_sys` call, but the ref-count should be incremented
 //   as that is the callee's responsibility. Which we do by calling `std::mem::forget(array.clone())`.
 unsafe impl<T: ArrayElement> GodotFfi for Array<T> {
-    fn variant_type() -> VariantType {
-        VariantType::ARRAY
-    }
+    const VARIANT_TYPE: VariantType = VariantType::ARRAY;
 
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Opaque; .. }
 }
@@ -1257,9 +1255,9 @@ impl<T: ArrayElement> GodotFfiVariant for Array<T> {
 
     fn ffi_from_variant(variant: &Variant) -> Result<Self, ConvertError> {
         // First check if the variant is an array. The array conversion shouldn't be called otherwise.
-        if variant.get_type() != Self::variant_type() {
+        if variant.get_type() != Self::VARIANT_TYPE {
             return Err(FromVariantError::BadType {
-                expected: Self::variant_type(),
+                expected: Self::VARIANT_TYPE,
                 actual: variant.get_type(),
             }
             .into_error(variant.clone()));

--- a/godot-core/src/builtin/collections/dictionary.rs
+++ b/godot-core/src/builtin/collections/dictionary.rs
@@ -342,9 +342,7 @@ impl Dictionary {
 //   incremented as that is the callee's responsibility. Which we do by calling
 //   `std::mem::forget(dictionary.clone())`.
 unsafe impl GodotFfi for Dictionary {
-    fn variant_type() -> sys::VariantType {
-        sys::VariantType::DICTIONARY
-    }
+    const VARIANT_TYPE: sys::VariantType = sys::VariantType::DICTIONARY;
 
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Opaque; .. }
 }

--- a/godot-core/src/builtin/collections/packed_array.rs
+++ b/godot-core/src/builtin/collections/packed_array.rs
@@ -626,9 +626,7 @@ macro_rules! impl_packed_array {
         }
 
         unsafe impl GodotFfi for $PackedArray {
-            fn variant_type() -> sys::VariantType {
-                sys::VariantType::$VariantType
-            }
+            const VARIANT_TYPE: sys::VariantType = sys::VariantType::$VariantType;
 
             ffi_methods! { type sys::GDExtensionTypePtr = *mut Opaque; .. }
         }

--- a/godot-core/src/builtin/color.rs
+++ b/godot-core/src/builtin/color.rs
@@ -355,9 +355,7 @@ impl Color {
 // SAFETY:
 // This type is represented as `Self` in Godot, so `*mut Self` is sound.
 unsafe impl GodotFfi for Color {
-    fn variant_type() -> sys::VariantType {
-        sys::VariantType::COLOR
-    }
+    const VARIANT_TYPE: sys::VariantType = sys::VariantType::COLOR;
 
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Self; .. }
 }

--- a/godot-core/src/builtin/plane.rs
+++ b/godot-core/src/builtin/plane.rs
@@ -265,9 +265,7 @@ impl Neg for Plane {
 // SAFETY:
 // This type is represented as `Self` in Godot, so `*mut Self` is sound.
 unsafe impl GodotFfi for Plane {
-    fn variant_type() -> sys::VariantType {
-        sys::VariantType::PLANE
-    }
+    const VARIANT_TYPE: sys::VariantType = sys::VariantType::PLANE;
 
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Self;
         fn new_from_sys;

--- a/godot-core/src/builtin/projection.rs
+++ b/godot-core/src/builtin/projection.rs
@@ -557,9 +557,7 @@ impl GlamConv for Projection {
 
 // SAFETY: This type is represented as `Self` in Godot, so `*mut Self` is sound.
 unsafe impl GodotFfi for Projection {
-    fn variant_type() -> sys::VariantType {
-        sys::VariantType::PROJECTION
-    }
+    const VARIANT_TYPE: sys::VariantType = sys::VariantType::PROJECTION;
 
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Self; .. }
 }

--- a/godot-core/src/builtin/quaternion.rs
+++ b/godot-core/src/builtin/quaternion.rs
@@ -347,9 +347,7 @@ impl Mul<Vector3> for Quaternion {
 // SAFETY:
 // This type is represented as `Self` in Godot, so `*mut Self` is sound.
 unsafe impl GodotFfi for Quaternion {
-    fn variant_type() -> sys::VariantType {
-        sys::VariantType::QUATERNION
-    }
+    const VARIANT_TYPE: sys::VariantType = sys::VariantType::QUATERNION;
 
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Self; .. }
 }

--- a/godot-core/src/builtin/rect2.rs
+++ b/godot-core/src/builtin/rect2.rs
@@ -286,9 +286,7 @@ impl Rect2 {
 // SAFETY:
 // This type is represented as `Self` in Godot, so `*mut Self` is sound.
 unsafe impl GodotFfi for Rect2 {
-    fn variant_type() -> sys::VariantType {
-        sys::VariantType::RECT2
-    }
+    const VARIANT_TYPE: sys::VariantType = sys::VariantType::RECT2;
 
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Self; .. }
 }

--- a/godot-core/src/builtin/rect2i.rs
+++ b/godot-core/src/builtin/rect2i.rs
@@ -293,9 +293,7 @@ impl Rect2i {
 // SAFETY:
 // This type is represented as `Self` in Godot, so `*mut Self` is sound.
 unsafe impl GodotFfi for Rect2i {
-    fn variant_type() -> sys::VariantType {
-        sys::VariantType::RECT2I
-    }
+    const VARIANT_TYPE: sys::VariantType = sys::VariantType::RECT2I;
 
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Self; .. }
 }

--- a/godot-core/src/builtin/rid.rs
+++ b/godot-core/src/builtin/rid.rs
@@ -121,9 +121,7 @@ impl std::fmt::Display for Rid {
 // SAFETY:
 // This type is represented as `Self` in Godot, so `*mut Self` is sound.
 unsafe impl GodotFfi for Rid {
-    fn variant_type() -> sys::VariantType {
-        sys::VariantType::RID
-    }
+    const VARIANT_TYPE: sys::VariantType = sys::VariantType::RID;
 
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Self;
         fn new_from_sys;

--- a/godot-core/src/builtin/signal.rs
+++ b/godot-core/src/builtin/signal.rs
@@ -166,9 +166,7 @@ impl Signal {
 // The `opaque` in `Signal` is just a pair of pointers, and requires no special initialization or cleanup
 // beyond what is done in `from_opaque` and `drop`. So using `*mut Opaque` is safe.
 unsafe impl GodotFfi for Signal {
-    fn variant_type() -> sys::VariantType {
-        sys::VariantType::SIGNAL
-    }
+    const VARIANT_TYPE: sys::VariantType = sys::VariantType::SIGNAL;
 
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Opaque;
         fn new_from_sys;

--- a/godot-core/src/builtin/string/gstring.rs
+++ b/godot-core/src/builtin/string/gstring.rs
@@ -272,9 +272,7 @@ impl GString {
 //   incremented as that is the callee's responsibility. Which we do by calling
 //   `std::mem::forget(string.clone())`.
 unsafe impl GodotFfi for GString {
-    fn variant_type() -> sys::VariantType {
-        sys::VariantType::STRING
-    }
+    const VARIANT_TYPE: sys::VariantType = sys::VariantType::STRING;
 
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Self; .. }
 }

--- a/godot-core/src/builtin/string/node_path.rs
+++ b/godot-core/src/builtin/string/node_path.rs
@@ -195,9 +195,7 @@ impl NodePath {
 //   incremented as that is the callee's responsibility. Which we do by calling
 //   `std::mem::forget(node_path.clone())`.
 unsafe impl GodotFfi for NodePath {
-    fn variant_type() -> sys::VariantType {
-        sys::VariantType::NODE_PATH
-    }
+    const VARIANT_TYPE: sys::VariantType = sys::VariantType::NODE_PATH;
 
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Opaque; .. }
 }

--- a/godot-core/src/builtin/string/string_name.rs
+++ b/godot-core/src/builtin/string/string_name.rs
@@ -268,9 +268,7 @@ impl StringName {
 //   incremented as that is the callee's responsibility. Which we do by calling
 //   `std::mem::forget(string_name.clone())`.
 unsafe impl GodotFfi for StringName {
-    fn variant_type() -> sys::VariantType {
-        sys::VariantType::STRING_NAME
-    }
+    const VARIANT_TYPE: sys::VariantType = sys::VariantType::STRING_NAME;
 
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Opaque; .. }
 }

--- a/godot-core/src/builtin/transform2d.rs
+++ b/godot-core/src/builtin/transform2d.rs
@@ -408,9 +408,7 @@ impl GlamConv for Transform2D {
 // SAFETY:
 // This type is represented as `Self` in Godot, so `*mut Self` is sound.
 unsafe impl GodotFfi for Transform2D {
-    fn variant_type() -> sys::VariantType {
-        sys::VariantType::TRANSFORM2D
-    }
+    const VARIANT_TYPE: sys::VariantType = sys::VariantType::TRANSFORM2D;
 
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Self; .. }
 }

--- a/godot-core/src/builtin/transform3d.rs
+++ b/godot-core/src/builtin/transform3d.rs
@@ -387,9 +387,7 @@ impl GlamConv for Transform3D {
 // SAFETY:
 // This type is represented as `Self` in Godot, so `*mut Self` is sound.
 unsafe impl GodotFfi for Transform3D {
-    fn variant_type() -> sys::VariantType {
-        sys::VariantType::TRANSFORM3D
-    }
+    const VARIANT_TYPE: sys::VariantType = sys::VariantType::TRANSFORM3D;
 
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Self; .. }
 }

--- a/godot-core/src/builtin/variant/impls.rs
+++ b/godot-core/src/builtin/variant/impls.rs
@@ -47,9 +47,9 @@ macro_rules! impl_ffi_variant {
 
             fn ffi_from_variant(variant: &Variant) -> Result<Self, ConvertError> {
                 // Type check -- at the moment, a strict match is required.
-                if variant.get_type() != Self::variant_type() {
+                if variant.get_type() != Self::VARIANT_TYPE {
                     return Err(FromVariantError::BadType {
-                        expected: Self::variant_type(),
+                        expected: Self::VARIANT_TYPE,
                         actual: variant.get_type(),
                     }
                     .into_error(variant.clone()));
@@ -244,7 +244,7 @@ impl GodotType for Variant {
 
     fn property_info(property_name: &str) -> PropertyInfo {
         PropertyInfo {
-            variant_type: Self::variant_type(),
+            variant_type: Self::VARIANT_TYPE,
             class_name: Self::class_name(),
             property_name: StringName::from(property_name),
             hint_info: PropertyHintInfo::none(),

--- a/godot-core/src/builtin/variant/mod.rs
+++ b/godot-core/src/builtin/variant/mod.rs
@@ -462,9 +462,7 @@ crate::meta::impl_asarg_by_ref!(Variant);
 // `from_opaque` properly initializes a dereferenced pointer to an `OpaqueVariant`.
 // `std::mem::swap` is sufficient for returning a value.
 unsafe impl GodotFfi for Variant {
-    fn variant_type() -> VariantType {
-        VariantType::NIL
-    }
+    const VARIANT_TYPE: VariantType = VariantType::NIL;
 
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Self; .. }
 }

--- a/godot-core/src/builtin/vectors/vector2.rs
+++ b/godot-core/src/builtin/vectors/vector2.rs
@@ -187,9 +187,7 @@ impl fmt::Display for Vector2 {
 // SAFETY:
 // This type is represented as `Self` in Godot, so `*mut Self` is sound.
 unsafe impl GodotFfi for Vector2 {
-    fn variant_type() -> sys::VariantType {
-        sys::VariantType::VECTOR2
-    }
+    const VARIANT_TYPE: sys::VariantType = sys::VariantType::VECTOR2;
 
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Self; .. }
 }

--- a/godot-core/src/builtin/vectors/vector2i.rs
+++ b/godot-core/src/builtin/vectors/vector2i.rs
@@ -104,9 +104,7 @@ impl fmt::Display for Vector2i {
 // SAFETY:
 // This type is represented as `Self` in Godot, so `*mut Self` is sound.
 unsafe impl GodotFfi for Vector2i {
-    fn variant_type() -> sys::VariantType {
-        sys::VariantType::VECTOR2I
-    }
+    const VARIANT_TYPE: sys::VariantType = sys::VariantType::VECTOR2I;
 
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Self; .. }
 }

--- a/godot-core/src/builtin/vectors/vector3.rs
+++ b/godot-core/src/builtin/vectors/vector3.rs
@@ -258,9 +258,7 @@ impl fmt::Display for Vector3 {
 // SAFETY:
 // This type is represented as `Self` in Godot, so `*mut Self` is sound.
 unsafe impl GodotFfi for Vector3 {
-    fn variant_type() -> sys::VariantType {
-        sys::VariantType::VECTOR3
-    }
+    const VARIANT_TYPE: sys::VariantType = sys::VariantType::VECTOR3;
 
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Self; .. }
 }

--- a/godot-core/src/builtin/vectors/vector3i.rs
+++ b/godot-core/src/builtin/vectors/vector3i.rs
@@ -108,9 +108,7 @@ impl fmt::Display for Vector3i {
 // SAFETY:
 // This type is represented as `Self` in Godot, so `*mut Self` is sound.
 unsafe impl GodotFfi for Vector3i {
-    fn variant_type() -> sys::VariantType {
-        sys::VariantType::VECTOR3I
-    }
+    const VARIANT_TYPE: sys::VariantType = sys::VariantType::VECTOR3I;
 
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Self; .. }
 }

--- a/godot-core/src/builtin/vectors/vector4.rs
+++ b/godot-core/src/builtin/vectors/vector4.rs
@@ -100,9 +100,7 @@ impl fmt::Display for Vector4 {
 // SAFETY:
 // This type is represented as `Self` in Godot, so `*mut Self` is sound.
 unsafe impl GodotFfi for Vector4 {
-    fn variant_type() -> sys::VariantType {
-        sys::VariantType::VECTOR4
-    }
+    const VARIANT_TYPE: sys::VariantType = sys::VariantType::VECTOR4;
 
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Self; .. }
 }

--- a/godot-core/src/builtin/vectors/vector4i.rs
+++ b/godot-core/src/builtin/vectors/vector4i.rs
@@ -111,9 +111,7 @@ impl fmt::Display for Vector4i {
 // SAFETY:
 // This type is represented as `Self` in Godot, so `*mut Self` is sound.
 unsafe impl GodotFfi for Vector4i {
-    fn variant_type() -> sys::VariantType {
-        sys::VariantType::VECTOR4I
-    }
+    const VARIANT_TYPE: sys::VariantType = sys::VariantType::VECTOR4I;
 
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Self; .. }
 }

--- a/godot-core/src/meta/args/cow_arg.rs
+++ b/godot-core/src/meta/args/cow_arg.rs
@@ -119,9 +119,7 @@ unsafe impl<T> GodotFfi for CowArg<'_, T>
 where
     T: GodotFfi,
 {
-    fn variant_type() -> sys::VariantType {
-        T::variant_type()
-    }
+    const VARIANT_TYPE: sys::VariantType = T::VARIANT_TYPE;
 
     unsafe fn new_from_sys(_ptr: sys::GDExtensionConstTypePtr) -> Self {
         wrong_direction!(new_from_sys)

--- a/godot-core/src/meta/args/object_arg.rs
+++ b/godot-core/src/meta/args/object_arg.rs
@@ -274,9 +274,7 @@ where
 {
     // If anything changes here, keep in sync with RawGd impl.
 
-    fn variant_type() -> sys::VariantType {
-        sys::VariantType::OBJECT
-    }
+    const VARIANT_TYPE: sys::VariantType = sys::VariantType::OBJECT;
 
     unsafe fn new_from_sys(_ptr: sys::GDExtensionConstTypePtr) -> Self {
         unreachable!("ObjectArg should only be passed *to* Godot, not *from*.")

--- a/godot-core/src/meta/args/ref_arg.rs
+++ b/godot-core/src/meta/args/ref_arg.rs
@@ -122,9 +122,7 @@ unsafe impl<T> GodotFfi for RefArg<'_, T>
 where
     T: GodotFfi,
 {
-    fn variant_type() -> sys::VariantType {
-        T::variant_type()
-    }
+    const VARIANT_TYPE: sys::VariantType = T::VARIANT_TYPE;
 
     unsafe fn new_from_sys(_ptr: sys::GDExtensionConstTypePtr) -> Self {
         wrong_direction!(new_from_sys)

--- a/godot-core/src/meta/traits.rs
+++ b/godot-core/src/meta/traits.rs
@@ -89,7 +89,7 @@ pub trait GodotType: GodotConvert<Via = Self> + sealed::Sealed + Sized + 'static
     #[doc(hidden)]
     fn property_info(property_name: &str) -> PropertyInfo {
         PropertyInfo {
-            variant_type: Self::Ffi::variant_type(),
+            variant_type: Self::Ffi::VARIANT_TYPE,
             class_name: Self::class_name(),
             property_name: builtin::StringName::from(property_name),
             hint_info: Self::property_hint_info(),
@@ -188,7 +188,7 @@ pub trait ArrayElement: ToGodot + FromGodot + sealed::Sealed + meta::ParamType {
 
 #[doc(hidden)]
 pub(crate) fn element_variant_type<T: ArrayElement>() -> VariantType {
-    <T::Via as GodotType>::Ffi::variant_type()
+    <T::Via as GodotType>::Ffi::VARIANT_TYPE
 }
 
 #[doc(hidden)]

--- a/godot-core/src/obj/raw_gd.rs
+++ b/godot-core/src/obj/raw_gd.rs
@@ -466,9 +466,7 @@ where
 {
     // If anything changes here, keep in sync with ObjectArg impl.
 
-    fn variant_type() -> sys::VariantType {
-        sys::VariantType::OBJECT
-    }
+    const VARIANT_TYPE: sys::VariantType = sys::VariantType::OBJECT;
 
     unsafe fn new_from_sys(ptr: sys::GDExtensionConstTypePtr) -> Self {
         Self::from_obj_sys_weak(ptr as sys::GDExtensionObjectPtr)

--- a/godot-core/src/registry/godot_register_wrappers.rs
+++ b/godot-core/src/registry/godot_register_wrappers.rs
@@ -46,7 +46,7 @@ pub fn register_var<C: GodotClass, T: Var>(
     usage: PropertyUsageFlags,
 ) {
     let info = PropertyInfo {
-        variant_type: <<T as GodotConvert>::Via as GodotType>::Ffi::variant_type(),
+        variant_type: <<T as GodotConvert>::Via as GodotType>::Ffi::VARIANT_TYPE,
         class_name: <T as GodotConvert>::Via::class_name(),
         property_name: StringName::from(property_name),
         hint_info,

--- a/godot-core/src/registry/property.rs
+++ b/godot-core/src/registry/property.rs
@@ -545,7 +545,7 @@ mod export_impls {
 pub(crate) fn builtin_type_string<T: GodotType>() -> String {
     use sys::GodotFfi as _;
 
-    let variant_type = T::Ffi::variant_type();
+    let variant_type = T::Ffi::VARIANT_TYPE;
 
     // Godot 4.3 changed representation for type hints, see https://github.com/godotengine/godot/pull/90716.
     if sys::GdextBuild::since_api("4.3") {

--- a/godot-ffi/src/godot_ffi.rs
+++ b/godot-ffi/src/godot_ffi.rs
@@ -25,7 +25,7 @@ use std::marker::PhantomData;
 #[doc(hidden)] // shows up in implementors otherwise
 pub unsafe trait GodotFfi {
     #[doc(hidden)]
-    fn variant_type() -> sys::VariantType;
+    const VARIANT_TYPE: sys::VariantType;
 
     #[doc(hidden)]
     fn default_param_metadata() -> sys::GDExtensionClassMethodArgumentMetadata {
@@ -427,17 +427,13 @@ mod scalars {
     }
     */
     unsafe impl GodotFfi for bool {
-        fn variant_type() -> sys::VariantType {
-            sys::VariantType::BOOL
-        }
+        const VARIANT_TYPE: sys::VariantType = sys::VariantType::BOOL;
 
         ffi_methods! { type sys::GDExtensionTypePtr = *mut Self; .. }
     }
 
     unsafe impl GodotFfi for i64 {
-        fn variant_type() -> sys::VariantType {
-            sys::VariantType::INT
-        }
+        const VARIANT_TYPE: sys::VariantType = sys::VariantType::INT;
 
         fn default_param_metadata() -> sys::GDExtensionClassMethodArgumentMetadata {
             sys::GDEXTENSION_METHOD_ARGUMENT_METADATA_INT_IS_INT64
@@ -447,9 +443,7 @@ mod scalars {
     }
 
     unsafe impl GodotFfi for f64 {
-        fn variant_type() -> sys::VariantType {
-            sys::VariantType::FLOAT
-        }
+        const VARIANT_TYPE: sys::VariantType = sys::VariantType::FLOAT;
 
         fn default_param_metadata() -> sys::GDExtensionClassMethodArgumentMetadata {
             sys::GDEXTENSION_METHOD_ARGUMENT_METADATA_REAL_IS_DOUBLE
@@ -459,9 +453,7 @@ mod scalars {
     }
 
     unsafe impl GodotFfi for () {
-        fn variant_type() -> sys::VariantType {
-            sys::VariantType::NIL
-        }
+        const VARIANT_TYPE: sys::VariantType = sys::VariantType::NIL;
 
         unsafe fn new_from_sys(_ptr: sys::GDExtensionConstTypePtr) -> Self {
             // Do nothing


### PR DESCRIPTION
We can turn `GodotFfi::variant_type` into a `const VARIANT_TYPE`.