### PR TITLE
Allow `Gd<T>` to be passed as a parameter in async signals

### DIFF
--- a/godot-core/src/meta/mod.rs
+++ b/godot-core/src/meta/mod.rs
@@ -49,9 +49,10 @@ mod class_name;
 mod godot_convert;
 mod method_info;
 mod property_info;
-mod sealed;
 mod signature;
 mod traits;
+
+pub(crate) mod sealed;
 
 pub mod error;
 

--- a/godot-core/src/meta/sealed.rs
+++ b/godot-core/src/meta/sealed.rs
@@ -23,6 +23,9 @@ impl Sealed for Vector4 {}
 impl Sealed for Vector2i {}
 impl Sealed for Vector3i {}
 impl Sealed for Vector4i {}
+impl Sealed for Vector2Axis {}
+impl Sealed for Vector3Axis {}
+impl Sealed for Vector4Axis {}
 impl Sealed for Quaternion {}
 impl Sealed for Color {}
 impl Sealed for GString {}
@@ -72,3 +75,12 @@ where
     T::Ffi: GodotNullableFfi,
 {
 }
+impl<T1> Sealed for (T1,) {}
+impl<T1, T2> Sealed for (T1, T2) {}
+impl<T1, T2, T3> Sealed for (T1, T2, T3) {}
+impl<T1, T2, T3, T4> Sealed for (T1, T2, T3, T4) {}
+impl<T1, T2, T3, T4, T5> Sealed for (T1, T2, T3, T4, T5) {}
+impl<T1, T2, T3, T4, T5, T6> Sealed for (T1, T2, T3, T4, T5, T6) {}
+impl<T1, T2, T3, T4, T5, T6, T7> Sealed for (T1, T2, T3, T4, T5, T6, T7) {}
+impl<T1, T2, T3, T4, T5, T6, T7, T8> Sealed for (T1, T2, T3, T4, T5, T6, T7, T8) {}
+impl<T1, T2, T3, T4, T5, T6, T7, T8, T9> Sealed for (T1, T2, T3, T4, T5, T6, T7, T8, T9) {}

--- a/godot-core/src/task/mod.rs
+++ b/godot-core/src/task/mod.rs
@@ -15,12 +15,15 @@ mod async_runtime;
 mod futures;
 
 pub(crate) use async_runtime::cleanup;
+pub(crate) use futures::{impl_dynamic_send, ThreadConfined};
 
 pub use async_runtime::{spawn, TaskHandle};
-pub use futures::{FallibleSignalFuture, FallibleSignalFutureError, SignalFuture};
+pub use futures::{
+    DynamicSend, FallibleSignalFuture, FallibleSignalFutureError, IntoDynamicSend, SignalFuture,
+};
 
 // Only exported for itest.
 #[cfg(feature = "trace")]
 pub use async_runtime::has_godot_task_panicked;
 #[cfg(feature = "trace")]
-pub use futures::SignalFutureResolver;
+pub use futures::{create_test_signal_future_resolver, SignalFutureResolver};

--- a/itest/rust/Cargo.toml
+++ b/itest/rust/Cargo.toml
@@ -24,6 +24,7 @@ serde = ["dep:serde", "dep:serde_json", "godot/serde"]
 godot = { path = "../../godot", default-features = false, features = ["__trace"] }
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1.0", optional = true }
+pin-project-lite = { version = "0.2" }
 
 [build-dependencies]
 godot-bindings = { path = "../../godot-bindings" } # emit_godot_version_cfg


### PR DESCRIPTION
Introduce a runtime check if the passed signal argument was actually sent between threads while being `!Send`.

This allows `Gd<T>` to be used when awaiting signals, as long as the signal is not emitted on a different thread than the main-thread. Should the user await a signal with a non `!Send` argument from a different thread, a panic will occur.

Resolves #1074.

Depends on #1090.