### PR TITLE
Wasm threading fixes

### DIFF
--- a/godot-core/src/init/mod.rs
+++ b/godot-core/src/init/mod.rs
@@ -282,6 +282,48 @@ pub unsafe trait ExtensionLibrary {
         // Nothing by default.
     }
 
+    /// Whether to override the Wasm binary filename used by your GDExtension which the library should expect at runtime. Return `None`
+    /// to use the default where gdext expects either `{YourCrate}.wasm` (default binary name emitted by Rust) or
+    /// `{YourCrate}.threads.wasm` (for builds producing separate single-threaded and multi-threaded binaries).
+    ///
+    /// Upon exporting a game to the web, the library has to know at runtime the exact name of the `.wasm` binary file being used to load
+    /// each GDExtension. By default, Rust exports the binary as `cratename.wasm`, so that is the name checked by godot-rust by default.
+    ///
+    /// However, if you need to rename that binary, you can make the library aware of the new binary name by returning
+    /// `Some("newname.wasm")` (don't forget to **include the `.wasm` extension**).
+    ///
+    /// For example, to have two simultaneous versions, one supporting multi-threading and the other not, you could add a suffix to the
+    /// filename of the Wasm binary of the multi-threaded version in your build process. If you choose the suffix `.threads.wasm`,
+    /// you're in luck as godot-rust already accepts this suffix by default, but let's say you want to use a different suffix, such as
+    /// `-with-threads.wasm`. For this, you can have a `"nothreads"` feature which, when absent, should produce a suffixed binary,
+    /// which can be informed to gdext as follows:
+    ///
+    /// ```no_run
+    /// # use godot::init::*;
+    /// struct MyExtension;
+    ///
+    /// #[gdextension]
+    /// unsafe impl ExtensionLibrary for MyExtension {
+    ///     fn override_wasm_binary() -> Option<&'static str> {
+    ///         // Binary name unchanged ("mycrate.wasm") without thread support.
+    ///         #[cfg(feature = "nothreads")]
+    ///         return None;
+    ///
+    ///         // Tell gdext we add a custom suffix to the binary with thread support.
+    ///         // Please note that this is not needed if "mycrate.threads.wasm" is used.
+    ///         // (You could return `None` as well in that particular case.)
+    ///         #[cfg(not(feature = "nothreads"))]
+    ///         Some("mycrate-with-threads.wasm")
+    ///     }
+    /// }
+    /// ```
+    /// Note that simply overriding this method won't change the name of the Wasm binary produced by Rust automatically: you'll still
+    /// have to rename it by yourself in your build process, as well as specify the updated binary name in your `.gdextension` file.
+    /// This is just to ensure gdext is aware of the new name given to the binary, avoiding runtime errors.
+    fn override_wasm_binary() -> Option<&'static str> {
+        None
+    }
+
     /// Whether to enable hot reloading of this library. Return `None` to use the default behavior.
     ///
     /// Enabling this will ensure that the library can be hot reloaded. If this is disabled then hot reloading may still work, but there is no

--- a/godot-core/src/private.rs
+++ b/godot-core/src/private.rs
@@ -17,7 +17,7 @@ pub use sys::out;
 
 #[cfg(feature = "trace")]
 pub use crate::meta::trace;
-#[cfg(debug_assertions)]
+#[cfg(all(debug_assertions, not(wasm_nothreads)))]
 use std::cell::RefCell;
 
 use crate::global::godot_error;
@@ -321,12 +321,12 @@ pub(crate) fn has_error_print_level(level: u8) -> bool {
 /// Internal type used to store context information for debug purposes. Debug context is stored on the thread-local
 /// ERROR_CONTEXT_STACK, which can later be used to retrieve the current context in the event of a panic. This value
 /// probably shouldn't be used directly; use ['get_gdext_panic_context()'](get_gdext_panic_context) instead.
-#[cfg(debug_assertions)]
+#[cfg(all(debug_assertions, not(wasm_nothreads)))]
 struct ScopedFunctionStack {
     functions: Vec<*const dyn Fn() -> String>,
 }
 
-#[cfg(debug_assertions)]
+#[cfg(all(debug_assertions, not(wasm_nothreads)))]
 impl ScopedFunctionStack {
     /// # Safety
     /// Function must be removed (using [`pop_function()`](Self::pop_function)) before lifetime is invalidated.
@@ -351,7 +351,7 @@ impl ScopedFunctionStack {
     }
 }
 
-#[cfg(debug_assertions)]
+#[cfg(all(debug_assertions, not(wasm_nothreads)))]
 thread_local! {
     static ERROR_CONTEXT_STACK: RefCell<ScopedFunctionStack> = const {
         RefCell::new(ScopedFunctionStack { functions: Vec::new() })
@@ -360,10 +360,10 @@ thread_local! {
 
 // Value may return `None`, even from panic hook, if called from a non-Godot thread.
 pub fn get_gdext_panic_context() -> Option<String> {
-    #[cfg(debug_assertions)]
+    #[cfg(all(debug_assertions, not(wasm_nothreads)))]
     return ERROR_CONTEXT_STACK.with(|cell| cell.borrow().get_last());
 
-    #[cfg(not(debug_assertions))]
+    #[cfg(not(all(debug_assertions, not(wasm_nothreads))))]
     None
 }
 
@@ -378,10 +378,10 @@ where
     E: Fn() -> String,
     F: FnOnce() -> R + std::panic::UnwindSafe,
 {
-    #[cfg(not(debug_assertions))]
-    let _ = error_context; // Unused in Release.
+    #[cfg(not(all(debug_assertions, not(wasm_nothreads))))]
+    let _ = error_context; // Unused in Release or `wasm_nothreads` builds.
 
-    #[cfg(debug_assertions)]
+    #[cfg(all(debug_assertions, not(wasm_nothreads)))]
     ERROR_CONTEXT_STACK.with(|cell| unsafe {
         // SAFETY: &error_context is valid for lifetime of function, and is removed from LAST_ERROR_CONTEXT before end of function.
         cell.borrow_mut().push_function(&error_context)
@@ -390,7 +390,7 @@ where
     let result =
         std::panic::catch_unwind(code).map_err(|payload| extract_panic_message(payload.as_ref()));
 
-    #[cfg(debug_assertions)]
+    #[cfg(all(debug_assertions, not(wasm_nothreads)))]
     ERROR_CONTEXT_STACK.with(|cell| cell.borrow_mut().pop_function());
     result
 }

--- a/godot-core/src/task/async_runtime.rs
+++ b/godot-core/src/task/async_runtime.rs
@@ -55,6 +55,7 @@ pub fn spawn(future: impl Future<Output = ()> + 'static) -> TaskHandle {
     // By limiting async tasks to the main thread we can redirect all signal callbacks back to the main thread via `call_deferred`.
     //
     // Once thread-safe futures are possible the restriction can be lifted.
+    #[cfg(not(wasm_nothreads))]
     assert!(
         crate::init::is_main_thread(),
         "godot_task() can only be used on the main thread"


### PR DESCRIPTION
Currently implemented:

 - Adds custom wasm binary name support proposed in https://github.com/godot-rust/gdext/issues/438#issuecomment-2735355627, sample usage:

      ```rs
      struct MyExtension;
    
      #[cfg(feature = "nothreads")]
      #[gdextension]
      unsafe impl ExtensionLibrary for MyExtension {}
      
      #[cfg(not(feature = "nothreads"))]
      #[gdextension(wasm_binary = "mycrate.threads.wasm")]
      unsafe impl ExtensionLibrary for MyExtension {}
      ```
- Fixes `wasm_nothreads` compilation by not using compiled out function in `async_runtime.rs` (regression from https://github.com/godot-rust/gdext/pull/1043)
- Fixes `wasm_nothreads` runtime errors on init due to thread locals being used for panic handling (regression from https://github.com/godot-rust/gdext/pull/1037)

 ## TODO

Working on these, but feel free to review or merge what's already there.

- [x] ~~Potentially fix the rest of `async_runtime` to e.g. not use `std::thread::current` on nothreads builds (might need to be in a separate PR~~ Let's do that in a separate PR (edit: using that function is actually fine, let's keep an eye on it in case anything else could be a problem)
- [x] Automatically detect `.threads.wasm` when it still uses the crate name to avoid having to use the option introduced above outside atypical cases