### PR TITLE
`bind/bind_mut` borrow errors now print previous stacktrace

### DIFF
--- a/godot-core/src/meta/error/call_error.rs
+++ b/godot-core/src/meta/error/call_error.rs
@@ -301,7 +301,11 @@ impl CallError {
 
     #[doc(hidden)]
     pub fn failed_by_user_panic(call_ctx: &CallContext, reason: String) -> Self {
-        Self::new(call_ctx, reason, None)
+        // This can cause the panic message to be printed twice in some scenarios (e.g. bind_mut() borrow failure).
+        // But in other cases (e.g. itest `dynamic_call_with_panic`), it is only printed once.
+        // Would need some work to have a consistent experience.
+
+        Self::new(call_ctx, format!("function panicked: {reason}"), None)
     }
 
     fn new(

--- a/godot-core/src/private.rs
+++ b/godot-core/src/private.rs
@@ -296,11 +296,14 @@ where
 
         let message = format_panic_message(panic_info);
         if godot_print() {
+            // Also prints to stdout/stderr -- do not print twice.
             godot_error!("{message}");
+        } else {
+            eprintln!("{message}");
         }
 
         let backtrace = format_backtrace!("panic backtrace");
-        eprintln!("{message}{backtrace}");
+        eprintln!("{backtrace}");
         let _ignored_result = std::io::stderr().flush();
     }));
 }

--- a/godot-core/src/private.rs
+++ b/godot-core/src/private.rs
@@ -17,15 +17,17 @@ pub use sys::out;
 
 #[cfg(feature = "trace")]
 pub use crate::meta::trace;
+#[cfg(debug_assertions)]
+use std::cell::RefCell;
 
 use crate::global::godot_error;
 use crate::meta::error::CallError;
 use crate::meta::CallContext;
 use crate::sys;
-use std::cell::RefCell;
 use std::io::Write;
 use std::sync::atomic;
 use sys::Global;
+
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Global variables
 
@@ -249,6 +251,41 @@ pub fn format_panic_message(panic_info: &std::panic::PanicHookInfo) -> String {
     }
 }
 
+// Macro instead of function, to avoid 1 extra frame in backtrace.
+#[cfg(debug_assertions)]
+#[macro_export]
+macro_rules! format_backtrace {
+    ($prefix:expr, $backtrace:expr) => {{
+        use std::backtrace::BacktraceStatus;
+
+        let backtrace = $backtrace;
+
+        match backtrace.status() {
+            BacktraceStatus::Captured => format!("\n[{}]\n{}\n", $prefix, backtrace),
+            BacktraceStatus::Disabled => {
+                "(backtrace disabled, run application with `RUST_BACKTRACE=1` environment variable)"
+                    .to_string()
+            }
+            BacktraceStatus::Unsupported => {
+                "(backtrace unsupported for current platform)".to_string()
+            }
+            _ => "(backtrace status unknown)".to_string(),
+        }
+    }};
+
+    ($prefix:expr) => {
+        $crate::format_backtrace!($prefix, std::backtrace::Backtrace::capture())
+    };
+}
+
+#[cfg(not(debug_assertions))]
+#[macro_export]
+macro_rules! format_backtrace {
+    ($prefix:expr $(, $backtrace:expr)? ) => {
+        String::new()
+    };
+}
+
 pub fn set_gdext_hook<F>(godot_print: F)
 where
     F: Fn() -> bool + Send + Sync + 'static,
@@ -261,9 +298,9 @@ where
         if godot_print() {
             godot_error!("{message}");
         }
-        eprintln!("{message}");
-        #[cfg(debug_assertions)]
-        eprintln!("{}", std::backtrace::Backtrace::capture());
+
+        let backtrace = format_backtrace!("panic backtrace");
+        eprintln!("{message}{backtrace}");
         let _ignored_result = std::io::stderr().flush();
     }));
 }
@@ -322,6 +359,7 @@ thread_local! {
 pub fn get_gdext_panic_context() -> Option<String> {
     #[cfg(debug_assertions)]
     return ERROR_CONTEXT_STACK.with(|cell| cell.borrow().get_last());
+
     #[cfg(not(debug_assertions))]
     None
 }
@@ -337,13 +375,18 @@ where
     E: Fn() -> String,
     F: FnOnce() -> R + std::panic::UnwindSafe,
 {
+    #[cfg(not(debug_assertions))]
+    let _ = error_context; // Unused in Release.
+
     #[cfg(debug_assertions)]
     ERROR_CONTEXT_STACK.with(|cell| unsafe {
         // SAFETY: &error_context is valid for lifetime of function, and is removed from LAST_ERROR_CONTEXT before end of function.
         cell.borrow_mut().push_function(&error_context)
     });
+
     let result =
         std::panic::catch_unwind(code).map_err(|payload| extract_panic_message(payload.as_ref()));
+
     #[cfg(debug_assertions)]
     ERROR_CONTEXT_STACK.with(|cell| cell.borrow_mut().pop_function());
     result

--- a/godot-core/src/registry/class.rs
+++ b/godot-core/src/registry/class.rs
@@ -216,9 +216,13 @@ pub fn auto_register_classes(init_level: InitLevel) {
     // but it is much slower and doesn't guarantee that all the dependent classes will be already loaded in most cases.
     register_classes_and_dyn_traits(&mut map, init_level);
 
-    // actually register all the classes
+    // Actually register all the classes.
     for info in map.into_values() {
+        #[cfg(feature = "debug-log")]
+        let class_name = info.class_name;
+
         register_class_raw(info);
+
         out!("Class {class_name} loaded.");
     }
 

--- a/godot-core/src/storage/instance_storage.rs
+++ b/godot-core/src/storage/instance_storage.rs
@@ -4,6 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
+
 use godot_ffi as sys;
 use std::cell::Cell;
 use std::ptr;

--- a/godot-core/src/storage/mod.rs
+++ b/godot-core/src/storage/mod.rs
@@ -18,8 +18,11 @@ use std::any::type_name;
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Shared code for submodules
 
-fn bind_failed<T>(err: Box<dyn std::error::Error>) -> ! {
+fn bind_failed<T>(err: Box<dyn std::error::Error>, tracker: &DebugBorrowTracker) -> ! {
     let ty = type_name::<T>();
+
+    eprint!("{tracker}");
+
     panic!(
         "Gd<T>::bind() failed, already bound; T = {ty}.\n  \
         Make sure to use `self.base_mut()` or `self.base()` instead of `self.to_gd()` when possible.\n  \
@@ -27,8 +30,11 @@ fn bind_failed<T>(err: Box<dyn std::error::Error>) -> ! {
     )
 }
 
-fn bind_mut_failed<T>(err: Box<dyn std::error::Error>) -> ! {
+fn bind_mut_failed<T>(err: Box<dyn std::error::Error>, tracker: &DebugBorrowTracker) -> ! {
     let ty = type_name::<T>();
+
+    eprint!("{tracker}");
+
     panic!(
         "Gd<T>::bind_mut() failed, already bound; T = {ty}.\n  \
         Make sure to use `self.base_mut()` instead of `self.to_gd()` when possible.\n  \
@@ -37,9 +43,9 @@ fn bind_mut_failed<T>(err: Box<dyn std::error::Error>) -> ! {
 }
 
 fn bug_inaccessible<T>(err: Box<dyn std::error::Error>) -> ! {
-    // We should never hit this, except maybe in extreme cases like having more than
-    // `usize::MAX` borrows.
+    // We should never hit this, except maybe in extreme cases like having more than `usize::MAX` borrows.
     let ty = type_name::<T>();
+
     panic!(
         "`base_mut()` failed for type T = {ty}.\n  \
         This is most likely a bug, please report it.\n  \
@@ -78,4 +84,101 @@ fn log_drop<T: StorageRefCounted>(storage: &T) {
         rc = storage.godot_ref_count(),
         base = storage.base(),
     );
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// Tracking borrows in Debug mode
+
+#[cfg(debug_assertions)]
+use borrow_info::DebugBorrowTracker;
+
+#[cfg(not(debug_assertions))]
+use borrow_info_noop::DebugBorrowTracker;
+
+#[cfg(debug_assertions)]
+mod borrow_info {
+    use std::backtrace::Backtrace;
+    use std::fmt;
+    use std::sync::Mutex;
+
+    struct TrackedBorrow {
+        backtrace: Backtrace,
+        is_mut: bool,
+    }
+
+    /// Informational-only info about ongoing borrows.
+    pub(super) struct DebugBorrowTracker {
+        // Currently just tracks the last borrow. Could technically track 1 mut or N ref borrows, but would need destructor integration.
+        // Also never clears it when a guard drops, assuming that once a borrow fails, there must be at least one previous borrow conflicting.
+        // Is also not yet integrated with "inaccessible" borrows (reborrow through base_mut).
+        last_borrow: Mutex<Option<TrackedBorrow>>,
+    }
+
+    impl DebugBorrowTracker {
+        pub fn new() -> Self {
+            Self {
+                last_borrow: Mutex::new(None),
+            }
+        }
+
+        // Currently considers RUST_BACKTRACE due to performance reasons; force_capture() can be quite slow.
+        // User is expected to set the env var during debug sessions.
+
+        #[track_caller]
+        pub fn track_ref_borrow(&self) {
+            let mut guard = self.last_borrow.lock().unwrap();
+            *guard = Some(TrackedBorrow {
+                backtrace: Backtrace::capture(),
+                is_mut: false,
+            });
+        }
+
+        #[track_caller]
+        pub fn track_mut_borrow(&self) {
+            let mut guard = self.last_borrow.lock().unwrap();
+            *guard = Some(TrackedBorrow {
+                backtrace: Backtrace::capture(),
+                is_mut: true,
+            });
+        }
+    }
+
+    impl fmt::Display for DebugBorrowTracker {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            let guard = self.last_borrow.lock().unwrap();
+            if let Some(borrow) = &*guard {
+                let mutability = if borrow.is_mut { "bind_mut" } else { "bind" };
+
+                let prefix = format!("backtrace of previous `{mutability}` borrow");
+                let backtrace = crate::format_backtrace!(prefix, &borrow.backtrace);
+
+                writeln!(f, "{backtrace}")
+            } else {
+                writeln!(f, "no previous borrows tracked.")
+            }
+        }
+    }
+}
+
+#[cfg(not(debug_assertions))]
+mod borrow_info_noop {
+    use std::fmt;
+
+    pub(super) struct DebugBorrowTracker;
+
+    impl DebugBorrowTracker {
+        pub fn new() -> Self {
+            Self
+        }
+
+        pub fn track_ref_borrow(&self) {}
+
+        pub fn track_mut_borrow(&self) {}
+    }
+
+    impl fmt::Display for DebugBorrowTracker {
+        fn fmt(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result {
+            Ok(())
+        }
+    }
 }

--- a/godot-core/src/storage/mod.rs
+++ b/godot-core/src/storage/mod.rs
@@ -11,4 +11,71 @@ mod multi_threaded;
 #[cfg_attr(feature = "experimental-threads", allow(dead_code))]
 mod single_threaded;
 
+use godot_ffi::out;
 pub use instance_storage::*;
+use std::any::type_name;
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// Shared code for submodules
+
+fn bind_failed<T>(err: Box<dyn std::error::Error>) -> ! {
+    let ty = type_name::<T>();
+    panic!(
+        "Gd<T>::bind() failed, already bound; T = {ty}.\n  \
+        Make sure to use `self.base_mut()` or `self.base()` instead of `self.to_gd()` when possible.\n  \
+        Details: {err}."
+    )
+}
+
+fn bind_mut_failed<T>(err: Box<dyn std::error::Error>) -> ! {
+    let ty = type_name::<T>();
+    panic!(
+        "Gd<T>::bind_mut() failed, already bound; T = {ty}.\n  \
+        Make sure to use `self.base_mut()` instead of `self.to_gd()` when possible.\n  \
+        Details: {err}."
+    )
+}
+
+fn bug_inaccessible<T>(err: Box<dyn std::error::Error>) -> ! {
+    // We should never hit this, except maybe in extreme cases like having more than
+    // `usize::MAX` borrows.
+    let ty = type_name::<T>();
+    panic!(
+        "`base_mut()` failed for type T = {ty}.\n  \
+        This is most likely a bug, please report it.\n  \
+        Details: {err}."
+    )
+}
+
+fn log_construct<T>() {
+    out!(
+        "    Storage::construct             <{ty}>",
+        ty = type_name::<T>()
+    );
+}
+
+fn log_inc_ref<T: StorageRefCounted>(storage: &T) {
+    out!(
+        "    Storage::on_inc_ref (rc={rc})     <{ty}> -- {base:?}",
+        rc = T::godot_ref_count(storage),
+        base = storage.base(),
+        ty = type_name::<T>(),
+    );
+}
+
+fn log_dec_ref<T: StorageRefCounted>(storage: &T) {
+    out!(
+        "  | Storage::on_dec_ref (rc={rc})     <{ty}> -- {base:?}",
+        rc = T::godot_ref_count(storage),
+        base = storage.base(),
+        ty = type_name::<T>(),
+    );
+}
+
+fn log_drop<T: StorageRefCounted>(storage: &T) {
+    out!(
+        "    Storage::drop (rc={rc})           <{base:?}>",
+        rc = storage.godot_ref_count(),
+        base = storage.base(),
+    );
+}

--- a/godot-core/src/storage/multi_threaded.rs
+++ b/godot-core/src/storage/multi_threaded.rs
@@ -14,7 +14,7 @@ use godot_cell::panicking::{GdCell, InaccessibleGuard, MutGuard, RefGuard};
 use godot_cell::blocking::{GdCell, InaccessibleGuard, MutGuard, RefGuard};
 
 use crate::obj::{Base, GodotClass};
-use crate::storage::{AtomicLifecycle, Lifecycle, Storage, StorageRefCounted};
+use crate::storage::{AtomicLifecycle, DebugBorrowTracker, Lifecycle, Storage, StorageRefCounted};
 
 pub struct InstanceStorage<T: GodotClass> {
     user_instance: GdCell<T>,
@@ -23,6 +23,9 @@ pub struct InstanceStorage<T: GodotClass> {
     // Declared after `user_instance`, is dropped last
     pub(super) lifecycle: AtomicLifecycle,
     godot_ref_count: AtomicU32,
+
+    // No-op in Release mode.
+    borrow_tracker: DebugBorrowTracker,
 }
 
 // SAFETY:
@@ -47,6 +50,7 @@ unsafe impl<T: GodotClass> Storage for InstanceStorage<T> {
             base,
             lifecycle: AtomicLifecycle::new(Lifecycle::Alive),
             godot_ref_count: AtomicU32::new(1),
+            borrow_tracker: DebugBorrowTracker::new(),
         }
     }
 
@@ -58,16 +62,27 @@ unsafe impl<T: GodotClass> Storage for InstanceStorage<T> {
         &self.base
     }
 
+    // Multi-threaded binds are currently blocking. However, if they still report an error, we follow the single-threaded behavior
+    // of capturing the backtrace. This may be changed as the threading model (#18) evolves.
+
     fn get(&self) -> RefGuard<'_, T> {
-        self.user_instance
+        let guard = self
+            .user_instance
             .borrow()
-            .unwrap_or_else(|e| super::bind_failed::<T>(e))
+            .unwrap_or_else(|e| super::bind_failed::<T>(e, &self.borrow_tracker));
+
+        self.borrow_tracker.track_ref_borrow();
+        guard
     }
 
     fn get_mut(&self) -> MutGuard<'_, T> {
-        self.user_instance
+        let guard = self
+            .user_instance
             .borrow_mut()
-            .unwrap_or_else(|e| super::bind_mut_failed::<T>(e))
+            .unwrap_or_else(|e| super::bind_mut_failed::<T>(e, &self.borrow_tracker));
+
+        self.borrow_tracker.track_mut_borrow();
+        guard
     }
 
     fn get_inaccessible<'a: 'b, 'b>(

--- a/godot-core/src/storage/multi_threaded.rs
+++ b/godot-core/src/storage/multi_threaded.rs
@@ -5,7 +5,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::any::type_name;
 use std::sync::atomic::{AtomicU32, Ordering};
 
 #[cfg(not(feature = "experimental-threads"))]
@@ -15,7 +14,6 @@ use godot_cell::panicking::{GdCell, InaccessibleGuard, MutGuard, RefGuard};
 use godot_cell::blocking::{GdCell, InaccessibleGuard, MutGuard, RefGuard};
 
 use crate::obj::{Base, GodotClass};
-use crate::out;
 use crate::storage::{AtomicLifecycle, Lifecycle, Storage, StorageRefCounted};
 
 pub struct InstanceStorage<T: GodotClass> {
@@ -42,7 +40,8 @@ unsafe impl<T: GodotClass> Storage for InstanceStorage<T> {
         user_instance: Self::Instance,
         base: Base<<Self::Instance as GodotClass>::Base>,
     ) -> Self {
-        out!("    Storage::construct             <{}>", type_name::<T>());
+        super::log_construct::<T>();
+
         Self {
             user_instance: GdCell::new(user_instance),
             base,
@@ -60,29 +59,15 @@ unsafe impl<T: GodotClass> Storage for InstanceStorage<T> {
     }
 
     fn get(&self) -> RefGuard<'_, T> {
-        self.user_instance.borrow().unwrap_or_else(|err| {
-            panic!(
-                "\
-                    Gd<T>::bind() failed, already bound; T = {}.\n  \
-                    Make sure to use `self.base_mut()` or `self.base()` instead of `self.to_gd()` when possible.\n  \
-                    Details: {err}.\
-                ",
-                type_name::<T>()
-            )
-        })
+        self.user_instance
+            .borrow()
+            .unwrap_or_else(|e| super::bind_failed::<T>(e))
     }
 
     fn get_mut(&self) -> MutGuard<'_, T> {
-        self.user_instance.borrow_mut().unwrap_or_else(|err| {
-            panic!(
-                "\
-                    Gd<T>::bind_mut() failed, already bound; T = {}.\n  \
-                    Make sure to use `self.base_mut()` instead of `self.to_gd()` when possible.\n  \
-                    Details: {err}.\
-                ",
-                type_name::<T>()
-            )
-        })
+        self.user_instance
+            .borrow_mut()
+            .unwrap_or_else(|e| super::bind_mut_failed::<T>(e))
     }
 
     fn get_inaccessible<'a: 'b, 'b>(
@@ -91,18 +76,7 @@ unsafe impl<T: GodotClass> Storage for InstanceStorage<T> {
     ) -> InaccessibleGuard<'b, T> {
         self.user_instance
             .make_inaccessible(value)
-            .unwrap_or_else(|err| {
-                // We should never hit this, except maybe in extreme cases like having more than
-                // `usize::MAX` borrows.
-                panic!(
-                    "\
-                        `base_mut()` failed for type T = {}.\n  \
-                        This is most likely a bug, please report it.\n  \
-                        Details: {err}.\
-                    ",
-                    type_name::<T>()
-                )
-            })
+            .unwrap_or_else(|e| super::bug_inaccessible::<T>(e))
     }
 
     fn get_lifecycle(&self) -> Lifecycle {
@@ -121,29 +95,19 @@ impl<T: GodotClass> StorageRefCounted for InstanceStorage<T> {
 
     fn on_inc_ref(&self) {
         self.godot_ref_count.fetch_add(1, Ordering::Relaxed);
-        out!(
-            "    Storage::on_inc_ref (rc={})     <{:?}>",
-            self.godot_ref_count(),
-            self.base,
-        );
+
+        super::log_inc_ref(self);
     }
 
     fn on_dec_ref(&self) {
         self.godot_ref_count.fetch_sub(1, Ordering::Relaxed);
-        out!(
-            "  | Storage::on_dec_ref (rc={})     <{:?}>",
-            self.godot_ref_count(),
-            self.base,
-        );
+
+        super::log_dec_ref(self);
     }
 }
 
 impl<T: GodotClass> Drop for InstanceStorage<T> {
     fn drop(&mut self) {
-        out!(
-            "    Storage::drop (rc={})           <{:?}>",
-            self.godot_ref_count(),
-            self.base(),
-        );
+        super::log_drop(self);
     }
 }

--- a/itest/rust/src/object_tests/dynamic_call_test.rs
+++ b/itest/rust/src/object_tests/dynamic_call_test.rs
@@ -163,7 +163,7 @@ fn dynamic_call_with_panic() {
 
     let expected_error_message = "godot-rust function call failed: Object::call(&\"do_panic\")\
         \n  Source: ObjPayload::do_panic()\
-        \n    Reason: do_panic exploded"
+        \n    Reason: function panicked: do_panic exploded"
         .to_string();
 
     assert_eq!(call_error.to_string(), expected_error_message);


### PR DESCRIPTION
When `RUST_BACKTRACE` env var is set and Debug mode is active, each `Gd::bind/bind_mut` call (or the `DynGd::dyn_*` equivalent) captures a stack trace. If there is a borrow error later down the line, both the previous bind's trace and the panic trace will be printed. This should make it easier to locate conflicting borrows in code.

Reduces code duplication in single-/multi-threaded `Storage` impls.

Fixes panic messages being printed twice on the console, through both `godot_error!` and `eprintln!`.
There are still cases where panics are printed twice through `CallError`, but these are more complex to solve.