### PR TITLE
itest runner must call on_finished deferred

### DIFF
--- a/itest/rust/src/framework/runner.rs
+++ b/itest/rust/src/framework/runner.rs
@@ -140,7 +140,7 @@ impl IntegrationTests {
                 );
 
                 // Calling deferred to break a potentially synchronous call stack and avoid re-entrancy.
-                on_finished.call(&[result.to_variant()]);
+                on_finished.call_deferred(&[result.to_variant()]);
             };
 
             Self::run_async_rust_tests(


### PR DESCRIPTION
The `itest` runner should call the `on_finished` callback deferred. The comment already mentions this but the call got accidentally changed in one of the revisions of #1043.