### PR TITLE
Move `itest` default feature `codegen-full` into build script

### DIFF
--- a/godot-codegen/src/lib.rs
+++ b/godot-codegen/src/lib.rs
@@ -43,6 +43,13 @@ use std::path::{Path, PathBuf};
 
 pub type SubmitFn = dyn FnMut(PathBuf, TokenStream);
 
+#[cfg(not(feature = "codegen-full"))]
+pub const IS_CODEGEN_FULL: bool = false;
+
+/// Used by itest to determine true codegen status; see itest/build.rs.
+#[cfg(feature = "codegen-full")]
+pub const IS_CODEGEN_FULL: bool = true;
+
 fn write_file(path: &Path, contents: String) {
     let dir = path.parent().unwrap();
     let _ = std::fs::create_dir_all(dir);

--- a/itest/rust/Cargo.toml
+++ b/itest/rust/Cargo.toml
@@ -10,7 +10,8 @@ publish = false
 crate-type = ["cdylib"]
 
 [features]
-default = ["codegen-full"]
+# Default feature MUST be empty for workflow reasons, even if it differs from the default feature set in upstream `godot` crate.
+default = []
 codegen-full = ["godot/__codegen-full"]
 codegen-full-experimental = ["codegen-full", "godot/experimental-godot-api"]
 experimental-threads = ["godot/experimental-threads"]
@@ -28,6 +29,7 @@ serde_json = { version = "1.0", optional = true }
 [build-dependencies]
 godot-bindings = { path = "../../godot-bindings" } # emit_godot_version_cfg
 repo-tweak = { path = "../repo-tweak" }
+godot-codegen = { path = "../../godot-codegen" } # IS_CODEGEN_FULL
 
 # Minimum versions compatible with -Zminimal-versions
 proc-macro2 = "1.0.80" # Literal::c_string() added in 1.0.80.

--- a/itest/rust/build.rs
+++ b/itest/rust/build.rs
@@ -269,6 +269,15 @@ fn main() {
     rustfmt_if_needed(vec![rust_file]);
 
     godot_bindings::emit_godot_version_cfg();
+
+    // The godot crate has a __codegen-full default feature that enables the godot-codegen/codegen-full feature. When compiling the entire
+    // workspace itest also gets compiled with full codegen due to feature unification. This causes compiler errors since the
+    // itest/codegen-full feature does not automatically get enabled in such a situation.
+    //
+    // By conditionally emitting the feature config we can auto enable the feature for itest as well.
+    if godot_codegen::IS_CODEGEN_FULL {
+        println!("cargo::rustc-cfg=feature=\"codegen-full\"");
+    }
 }
 
 // TODO remove, or remove code duplication with codegen


### PR DESCRIPTION
Remove the `itest` default feature and conditionally enable `codegen-full` in `itest` via the build script, if it has been enabled in `godot-codegen`.

See https://github.com/godot-rust/gdext/pull/771#issuecomment-2752543562 for context.