### PR TITLE
Create nothreads-compatible thread local

### DIFF
--- a/godot-core/src/meta/signature.rs
+++ b/godot-core/src/meta/signature.rs
@@ -739,7 +739,7 @@ pub mod trace {
         TRACE.set(Some(report));
     }
 
-    thread_local! {
+    crate::private::godot_thread_local! {
         static TRACE: Cell<Option<CallReport>> = Cell::default();
     }
 }


### PR DESCRIPTION
This implements a custom `thread_local` impl which just defaults to a global variable on `wasm_nothreads`, which otherwise wouldn't support thread locals due to an apparent lack of support in Rust's `std`[^1], allowing for an alternative fix to the thread local stuff from #1093. **This is inherently unsafe** so we trust the user to only use `experimental-wasm-nothreads` if they have indeed disabled threading. (I wonder if there's some way we could detect bad usage at runtime.)

I've tested and this makes the panic context tracker work. Next up, I'd like to test async signals before undrafting, though comments are welcome as the implementation won't change.

## Questions

- [ ] Should we expose `godot_thread_local!` to all gdext users? I think it'd be a nice utility to have once we add more polyfills to it.. wonder if there are any downsides to that.

[^1]: I guess it just doesn't have a way to check if threads are available or not, unlike our flag...