### PR TITLE
Masked enums can now be constructed from integers

### DIFF
--- a/godot-codegen/src/special_cases/special_cases.rs
+++ b/godot-codegen/src/special_cases/special_cases.rs
@@ -884,6 +884,11 @@ pub fn is_enum_bitfield(class_name: Option<&TyName>, enum_name: &str) -> Option<
 ///
 /// If a mapping is found, returns the corresponding `RustTy`.
 pub fn as_enum_bitmaskable(enum_: &Enum) -> Option<RustTy> {
+    if enum_.is_bitfield {
+        // Only enums need this treatment.
+        return None;
+    }
+
     let class_name = enum_.surrounding_class.as_ref();
     let class_name_str = class_name.map(|ty| ty.godot_ty.as_str());
     let enum_name = enum_.godot_name.as_str();

--- a/itest/rust/src/engine_tests/engine_enum_test.rs
+++ b/itest/rust/src/engine_tests/engine_enum_test.rs
@@ -11,7 +11,7 @@ use godot::global::{Key, KeyModifierMask};
 use godot::obj::{EngineBitfield, EngineEnum};
 
 #[itest]
-fn enum_with_masked_bitfield() {
+fn enum_with_masked_bitfield_ord() {
     let key = Key::A;
     let mask = KeyModifierMask::SHIFT;
 
@@ -27,4 +27,22 @@ fn enum_with_masked_bitfield() {
     let mut key = Key::A;
     key |= KeyModifierMask::SHIFT;
     assert_eq!(key.ord(), 65 | (1 << 25));
+}
+
+#[itest]
+fn enum_with_masked_bitfield_from_ord() {
+    let shifted_key = Key::A | KeyModifierMask::SHIFT;
+    let ord = shifted_key.ord();
+    assert_eq!(ord, 65 | (1 << 25));
+
+    let back = Key::try_from_ord(ord);
+    assert_eq!(back, Some(shifted_key), "deserialize bitmasked enum");
+
+    let back = Key::from_ord(ord);
+    assert_eq!(back, shifted_key, "deserialize bitmasked enum");
+
+    // For random values that are *not* a valid enum|mask combination, try_from_ord() should fail.
+    // Not implemented, as it's hard to achieve this without breaking forward compatibility; see make_enum_engine_trait_impl().
+    // let back = Key::try_from_ord(31);
+    // assert_eq!(back, None, "don't deserialize invalid bitmasked enum");
 }


### PR DESCRIPTION
Implements a more lenient `EngineEnum::try_from_ord()` in cases where an enum can be "masked", as defined in #857.

Fixes #350.

---

Originally, I added a new trait `MaskedEnum` that would implement an `unmask()` function to separate enum and flags, see b8de0fcfc7fc890397951e9ee11c8d4abaaf3860. However, it turned out it's not applicable for `MouseButton/MouseButtonMask` since their values overlap. If we find a generic solution, we'd need to address this first. 

But the value of that trait is anyway limited, because for the `Key`/`KeyModifierMask` case (the only other implementor of `MaskedEnum`), there is already `KeyModifierMask::CODE_MASK` and `KeyModifierMask::MODIFIER_MASK` which allow efficient masking/unmasking.