### PR TITLE
Undo Wasm threading fix on panic context tracking

### DIFF
--- a/godot-core/src/private.rs
+++ b/godot-core/src/private.rs
@@ -17,7 +17,7 @@ pub use sys::out;
 
 #[cfg(feature = "trace")]
 pub use crate::meta::trace;
-#[cfg(all(debug_assertions, not(wasm_nothreads)))]
+#[cfg(debug_assertions)]
 use std::cell::RefCell;
 
 use crate::global::godot_error;
@@ -321,12 +321,12 @@ pub(crate) fn has_error_print_level(level: u8) -> bool {
 /// Internal type used to store context information for debug purposes. Debug context is stored on the thread-local
 /// ERROR_CONTEXT_STACK, which can later be used to retrieve the current context in the event of a panic. This value
 /// probably shouldn't be used directly; use ['get_gdext_panic_context()'](get_gdext_panic_context) instead.
-#[cfg(all(debug_assertions, not(wasm_nothreads)))]
+#[cfg(debug_assertions)]
 struct ScopedFunctionStack {
     functions: Vec<*const dyn Fn() -> String>,
 }
 
-#[cfg(all(debug_assertions, not(wasm_nothreads)))]
+#[cfg(debug_assertions)]
 impl ScopedFunctionStack {
     /// # Safety
     /// Function must be removed (using [`pop_function()`](Self::pop_function)) before lifetime is invalidated.
@@ -351,7 +351,7 @@ impl ScopedFunctionStack {
     }
 }
 
-#[cfg(all(debug_assertions, not(wasm_nothreads)))]
+#[cfg(debug_assertions)]
 thread_local! {
     static ERROR_CONTEXT_STACK: RefCell<ScopedFunctionStack> = const {
         RefCell::new(ScopedFunctionStack { functions: Vec::new() })
@@ -360,10 +360,10 @@ thread_local! {
 
 // Value may return `None`, even from panic hook, if called from a non-Godot thread.
 pub fn get_gdext_panic_context() -> Option<String> {
-    #[cfg(all(debug_assertions, not(wasm_nothreads)))]
+    #[cfg(debug_assertions)]
     return ERROR_CONTEXT_STACK.with(|cell| cell.borrow().get_last());
 
-    #[cfg(not(all(debug_assertions, not(wasm_nothreads))))]
+    #[cfg(not(debug_assertions))]
     None
 }
 
@@ -378,10 +378,10 @@ where
     E: Fn() -> String,
     F: FnOnce() -> R + std::panic::UnwindSafe,
 {
-    #[cfg(not(all(debug_assertions, not(wasm_nothreads))))]
-    let _ = error_context; // Unused in Release or `wasm_nothreads` builds.
+    #[cfg(not(debug_assertions))]
+    let _ = error_context; // Unused in Release.
 
-    #[cfg(all(debug_assertions, not(wasm_nothreads)))]
+    #[cfg(debug_assertions)]
     ERROR_CONTEXT_STACK.with(|cell| unsafe {
         // SAFETY: &error_context is valid for lifetime of function, and is removed from LAST_ERROR_CONTEXT before end of function.
         cell.borrow_mut().push_function(&error_context)
@@ -390,7 +390,7 @@ where
     let result =
         std::panic::catch_unwind(code).map_err(|payload| extract_panic_message(payload.as_ref()));
 
-    #[cfg(all(debug_assertions, not(wasm_nothreads)))]
+    #[cfg(debug_assertions)]
     ERROR_CONTEXT_STACK.with(|cell| cell.borrow_mut().pop_function());
     result
 }


### PR DESCRIPTION
Partially reverts #1093. The wasm binary name feature is still needed, and in principle we can keep the `#[cfg]` to not check for the main thread id as an optimization, though we can revise this in the future if the lack of the main thread id facilities ever becomes a hurdle for other parts of gdext.

As for thread locals, turns out we only need to ensure we don't pass `atomics`-related target feature flags when building for nothreads, and thread locals start working properly.

So, instead of trying to work around them in #1105, we should use thread locals like normal and instead change the book's instructions to suggest removing those flags _only for nothreads builds_ (threaded builds still need them).