### PR TITLE
Type-safe signals for engine classes

### DIFF
--- a/godot-codegen/src/generator/classes.rs
+++ b/godot-codegen/src/generator/classes.rs
@@ -7,7 +7,9 @@
 use crate::context::{Context, NotificationEnum};
 use crate::generator::functions_common::{FnCode, FnDefinition, FnDefinitions};
 use crate::generator::method_tables::MethodTableKey;
-use crate::generator::{constants, docs, enums, functions_common, notifications, virtual_traits};
+use crate::generator::{
+    constants, docs, enums, functions_common, notifications, signals, virtual_traits,
+};
 use crate::models::domain::{
     ApiView, Class, ClassLike, ClassMethod, ExtensionApi, FnDirection, FnQualifier, Function,
     ModName, TyName,
@@ -120,6 +122,8 @@ fn make_class(class: &Class, ctx: &mut Context, view: &ApiView) -> GeneratedClas
         functions: methods,
         builders,
     } = make_class_methods(class, &class.methods, &cfg_attributes, ctx);
+
+    let signal_types = signals::make_class_signals(class, &class.signals, ctx);
 
     let enums = enums::make_enums(&class.enums, &cfg_attributes);
     let constants = constants::make_constants(&class.constants);
@@ -256,6 +260,7 @@ fn make_class(class: &Class, ctx: &mut Context, view: &ApiView) -> GeneratedClas
 
         #builders
         #enums
+        #signal_types
     };
     // note: TypePtr -> ObjectPtr conversion OK?
 

--- a/godot-codegen/src/generator/classes.rs
+++ b/godot-codegen/src/generator/classes.rs
@@ -137,14 +137,16 @@ fn make_class(class: &Class, ctx: &mut Context, view: &ApiView) -> GeneratedClas
     // Associated "sidecar" module is made public if there are other symbols related to the class, which are not
     // in top-level godot::classes module (notification enums are not in the sidecar, but in godot::classes::notify).
     // This checks if token streams (i.e. code) is empty.
-    let has_sidecar_module = !enums.is_empty() || !builders.is_empty();
+    let has_sidecar_module = !enums.is_empty() || !builders.is_empty() || signal_types.is_some();
 
     let class_doc = docs::make_class_doc(
         class_name,
         base_ident_opt,
         notification_enum.is_some(),
         has_sidecar_module,
+        signal_types.is_some(),
     );
+
     let module_doc = docs::make_module_doc(class_name);
 
     let virtual_trait = virtual_traits::make_virtual_methods_trait(

--- a/godot-codegen/src/generator/mod.rs
+++ b/godot-codegen/src/generator/mod.rs
@@ -25,6 +25,7 @@ pub mod lifecycle_builtins;
 pub mod method_tables;
 pub mod native_structures;
 pub mod notifications;
+pub mod signals;
 pub mod utility_functions;
 pub mod virtual_traits;
 

--- a/godot-codegen/src/generator/signals.rs
+++ b/godot-codegen/src/generator/signals.rs
@@ -1,0 +1,215 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+// Code duplication: while there is some overlap with godot-macros/signal.rs for #[signal] handling, this file here is quite a bit simpler,
+// as it only deals with predefined signal definitions (no user-defined #[cfg], visibility, etc). On the other hand, there is documentation
+// for these signals, and integration is slightly different due to lack of WithBaseField trait. Nonetheless, some parts could potentially
+// be extracted into a future crate shared by godot-codegen and godot-macros.
+
+use crate::context::Context;
+use crate::conv;
+use crate::models::domain::{Class, ClassLike, ClassSignal, FnParam, RustTy, TyName};
+use crate::util::{ident, safe_ident};
+use proc_macro2::{Ident, TokenStream};
+use quote::{format_ident, quote};
+
+pub fn make_class_signals(
+    class: &Class,
+    signals: &[ClassSignal],
+    _ctx: &mut Context,
+) -> TokenStream {
+    if signals.is_empty() {
+        return TokenStream::new();
+    }
+
+    let all_params: Vec<SignalParams> = signals
+        .iter()
+        .map(|s| SignalParams::new(&s.parameters))
+        .collect();
+
+    let signal_collection_struct = make_signal_collection(class, signals, &all_params);
+
+    let signal_types = signals
+        .iter()
+        .zip(all_params.iter())
+        .map(|(signal, params)| make_signal_individual_struct(signal, params));
+
+    quote! {
+        #signal_collection_struct
+        #( #signal_types )*
+    }
+}
+
+// Used outside, to document class with links to this type.
+pub fn make_collection_name(class_name: &TyName) -> Ident {
+    format_ident!("SignalsIn{}", class_name.rust_ty)
+}
+
+fn make_individual_struct_name(signal_name: &str) -> Ident {
+    let signal_pascal_name = conv::to_pascal_case(signal_name);
+    format_ident!("Sig{}", signal_pascal_name)
+}
+
+fn make_signal_collection(
+    class: &Class,
+    signals: &[ClassSignal],
+    params: &[SignalParams],
+) -> TokenStream {
+    let class_name = class.name();
+    let collection_struct_name = make_collection_name(class_name);
+
+    let provider_methods = signals.iter().zip(params).map(|(sig, params)| {
+        let signal_name_str = &sig.name;
+        let signal_name = ident(&sig.name);
+        let individual_struct_name = make_individual_struct_name(&sig.name);
+        let provider_docs = format!("Signature: `({})`", params.formatted_types);
+
+        quote! {
+            // Important to return lifetime 'c here, not '_.
+            #[doc = #provider_docs]
+            pub fn #signal_name(&mut self) -> #individual_struct_name<'c> {
+                #individual_struct_name {
+                    typed: crate::registry::signal::TypedSignal::new(self.__gd.clone(), #signal_name_str)
+                }
+            }
+        }
+    });
+
+    let collection_docs = format!(
+        "A collection of signals for the [`{c}`][crate::classes::{c}] class.",
+        c = class_name.rust_ty
+    );
+
+    quote! {
+        #[doc = #collection_docs]
+        #[cfg(since_api = "4.2")]
+        pub struct #collection_struct_name<'c> {
+            __gd: &'c mut Gd<re_export::#class_name>,
+        }
+
+        #[cfg(since_api = "4.2")]
+        impl<'c> #collection_struct_name<'c> {
+            #( #provider_methods )*
+        }
+
+        #[cfg(since_api = "4.2")]
+        impl crate::obj::WithSignals for re_export::#class_name {
+            type SignalCollection<'c> = #collection_struct_name<'c>;
+            #[doc(hidden)]
+            type __SignalObject<'c> = Gd<re_export::#class_name>;
+
+            #[doc(hidden)]
+            fn __signals_from_external(external: &mut Gd<Self>) -> Self::SignalCollection<'_> {
+                Self::SignalCollection {
+                    __gd: external,
+                }
+            }
+        }
+    }
+}
+
+fn make_signal_individual_struct(signal: &ClassSignal, params: &SignalParams) -> TokenStream {
+    let individual_struct_name = make_individual_struct_name(&signal.name);
+
+    let SignalParams {
+        param_list,
+        type_list,
+        name_list,
+        ..
+    } = params;
+
+    let class_name = &signal.surrounding_class;
+    let class_ty = quote! { re_export::#class_name };
+    let param_tuple = quote! { ( #type_list ) };
+
+    quote! {
+        #[cfg(since_api = "4.2")]
+        pub struct #individual_struct_name<'c> {
+           pub typed: crate::registry::signal::TypedSignal<'c, #class_ty, #param_tuple>,
+        }
+
+        #[cfg(since_api = "4.2")]
+        impl #individual_struct_name<'_> {
+            pub fn emit(&mut self, #param_list) {
+                self.typed.emit_tuple( (#name_list) );
+            }
+        }
+
+        #[cfg(since_api = "4.2")]
+        impl<'c> std::ops::Deref for #individual_struct_name<'c> {
+            type Target = crate::registry::signal::TypedSignal<'c, #class_ty, #param_tuple>;
+
+            fn deref(&self) -> &Self::Target {
+                &self.typed
+            }
+        }
+
+        #[cfg(since_api = "4.2")]
+        impl std::ops::DerefMut for #individual_struct_name<'_> {
+            fn deref_mut(&mut self) -> &mut Self::Target {
+                &mut self.typed
+            }
+        }
+    }
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+
+struct SignalParams {
+    /// `name: Type, ...`
+    param_list: TokenStream,
+
+    /// `Type, ...` -- for example inside a tuple type.
+    type_list: TokenStream,
+
+    /// `name, ...` -- for example inside a tuple value.
+    name_list: TokenStream,
+
+    /// `"name: Type, ..."` in nice format.
+    formatted_types: String,
+}
+
+impl SignalParams {
+    fn new(params: &[FnParam]) -> Self {
+        use std::fmt::Write;
+
+        let mut param_list = TokenStream::new();
+        let mut type_list = TokenStream::new();
+        let mut name_list = TokenStream::new();
+        let mut formatted_types = String::new();
+        let mut first = true;
+
+        for param in params.iter() {
+            let param_name = safe_ident(&param.name.to_string());
+            let param_ty = &param.type_;
+
+            param_list.extend(quote! { #param_name: #param_ty, });
+            type_list.extend(quote! { #param_ty, });
+            name_list.extend(quote! { #param_name, });
+
+            let formatted_ty = match param_ty {
+                RustTy::EngineClass { inner_class, .. } => format!("Gd<{inner_class}>"),
+                other => other.to_string(),
+            };
+
+            if first {
+                first = false;
+            } else {
+                write!(formatted_types, ", ").unwrap();
+            }
+
+            write!(formatted_types, "{}: {}", param_name, formatted_ty).unwrap();
+        }
+
+        Self {
+            param_list,
+            type_list,
+            name_list,
+            formatted_types,
+        }
+    }
+}

--- a/godot-codegen/src/models/domain.rs
+++ b/godot-codegen/src/models/domain.rs
@@ -12,7 +12,7 @@
 
 use crate::context::Context;
 use crate::conv;
-use crate::models::json::{JsonMethodArg, JsonMethodReturn, JsonSignal};
+use crate::models::json::{JsonMethodArg, JsonMethodReturn};
 use crate::util::{ident, option_as_slice, safe_ident};
 
 use proc_macro2::{Ident, Literal, TokenStream};

--- a/godot-codegen/src/models/domain.rs
+++ b/godot-codegen/src/models/domain.rs
@@ -12,7 +12,7 @@
 
 use crate::context::Context;
 use crate::conv;
-use crate::models::json::{JsonMethodArg, JsonMethodReturn};
+use crate::models::json::{JsonMethodArg, JsonMethodReturn, JsonSignal};
 use crate::util::{ident, option_as_slice, safe_ident};
 
 use proc_macro2::{Ident, Literal, TokenStream};
@@ -166,6 +166,7 @@ pub struct Class {
     pub constants: Vec<ClassConstant>,
     pub enums: Vec<Enum>,
     pub methods: Vec<ClassMethod>,
+    pub signals: Vec<ClassSignal>,
 }
 
 impl ClassLike for Class {
@@ -414,8 +415,6 @@ pub struct ClassMethod {
     pub surrounding_class: TyName,
 }
 
-impl ClassMethod {}
-
 impl Function for ClassMethod {
     fn common(&self) -> &FunctionCommon {
         &self.common
@@ -439,6 +438,14 @@ impl fmt::Display for ClassMethod {
             self.name(),
         )
     }
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+
+pub struct ClassSignal {
+    pub name: String,
+    pub parameters: Vec<FnParam>,
+    pub surrounding_class: TyName,
 }
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------

--- a/godot-codegen/src/models/domain_mapping.rs
+++ b/godot-codegen/src/models/domain_mapping.rs
@@ -13,7 +13,12 @@ use crate::models::domain::{
     FunctionCommon, GodotApiVersion, ModName, NativeStructure, Operator, Singleton, TyName,
     UtilityFunction,
 };
-use crate::models::json::{JsonBuiltinClass, JsonBuiltinMethod, JsonBuiltinSizes, JsonClass, JsonClassConstant, JsonClassMethod, JsonConstructor, JsonEnum, JsonEnumConstant, JsonExtensionApi, JsonHeader, JsonMethodReturn, JsonNativeStructure, JsonOperator, JsonSignal, JsonSingleton, JsonUtilityFunction};
+use crate::models::json::{
+    JsonBuiltinClass, JsonBuiltinMethod, JsonBuiltinSizes, JsonClass, JsonClassConstant,
+    JsonClassMethod, JsonConstructor, JsonEnum, JsonEnumConstant, JsonExtensionApi, JsonHeader,
+    JsonMethodReturn, JsonNativeStructure, JsonOperator, JsonSignal, JsonSingleton,
+    JsonUtilityFunction,
+};
 use crate::util::{get_api_level, ident, option_as_slice};
 use crate::{conv, special_cases};
 use proc_macro2::Ident;
@@ -112,7 +117,7 @@ impl Class {
 
         let signals = option_as_slice(&json.signals)
             .iter()
-            .map(|s| {
+            .filter_map(|s| {
                 let surrounding_class = &ty_name;
                 ClassSignal::from_json(s, surrounding_class, ctx)
             })
@@ -524,12 +529,16 @@ impl ClassSignal {
         json_signal: &JsonSignal,
         surrounding_class: &TyName,
         ctx: &mut Context,
-    ) -> Self {
-        Self {
+    ) -> Option<Self> {
+        if special_cases::is_signal_deleted(surrounding_class, json_signal) {
+            return None;
+        }
+
+        Some(Self {
             name: json_signal.name.clone(),
             parameters: FnParam::new_range(&json_signal.arguments, ctx),
             surrounding_class: surrounding_class.clone(),
-        }
+        })
     }
 }
 

--- a/godot-codegen/src/models/json.rs
+++ b/godot-codegen/src/models/json.rs
@@ -80,7 +80,7 @@ pub struct JsonClass {
     pub enums: Option<Vec<JsonEnum>>,
     pub methods: Option<Vec<JsonClassMethod>>,
     // pub properties: Option<Vec<Property>>,
-    // pub signals: Option<Vec<Signal>>,
+    pub signals: Option<Vec<JsonSignal>>,
 }
 
 #[derive(DeJson)]
@@ -179,10 +179,9 @@ pub struct JsonProperty {
 }
 
 #[derive(DeJson)]
-#[allow(dead_code)]
 pub struct JsonSignal {
-    name: String,
-    arguments: Option<Vec<JsonMethodArg>>,
+    pub name: String,
+    pub arguments: Option<Vec<JsonMethodArg>>,
 }
 
 #[derive(DeJson)]

--- a/godot-codegen/src/special_cases/special_cases.rs
+++ b/godot-codegen/src/special_cases/special_cases.rs
@@ -25,8 +25,9 @@
 
 use crate::conv::to_enum_type_uncached;
 use crate::models::domain::{Enum, RustTy, TyName};
-use crate::models::json::{JsonBuiltinMethod, JsonClassMethod, JsonUtilityFunction};
+use crate::models::json::{JsonBuiltinMethod, JsonClassMethod, JsonSignal, JsonUtilityFunction};
 use crate::special_cases::codegen_special_cases;
+use crate::util::option_as_slice;
 use crate::Context;
 use proc_macro2::Ident;
 // Deliberately private -- all checks must go through `special_cases`.
@@ -534,6 +535,14 @@ pub fn is_class_method_param_required(
 /// True if builtin method is excluded. Does NOT check for type exclusion; use [`is_builtin_type_deleted`] for that.
 pub fn is_builtin_method_deleted(_class_name: &TyName, method: &JsonBuiltinMethod) -> bool {
     codegen_special_cases::is_builtin_method_excluded(method)
+}
+
+/// True if signal is absent from codegen (only when surrounding class is excluded).
+pub fn is_signal_deleted(_class_name: &TyName, signal: &JsonSignal) -> bool {
+    // If any argument type (a class) is excluded.
+    option_as_slice(&signal.arguments)
+        .iter()
+        .any(|arg| codegen_special_cases::is_class_excluded(&arg.type_))
 }
 
 /// True if builtin type is excluded (`NIL` or scalars)

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -711,12 +711,17 @@ where
     /// Access user-defined signals of this object.
     ///
     /// For classes that have at least one `#[signal]` defined, returns a collection of signal names. Each returned signal has a specialized
-    /// API for connecting and emitting signals in a type-safe way. This method is the equivalent of [`WithSignals::signals()`], but when
-    /// called externally (not from `self`). If you are within the `impl` of a class, use `self.signals()` directly instead.
+    /// API for connecting and emitting signals in a type-safe way. This method is the equivalent of [`WithUserSignals::signals()`], but when
+    /// called externally (not from `self`). Furthermore, this is also available for engine classes, not just user-defined ones.
+    ///
+    /// When you are within the `impl` of a class, use `self.signals()` directly instead.
     ///
     /// If you haven't already, read the [book chapter about signals](https://godot-rust.github.io/book/register/signals.html) for a
     /// walkthrough.
-    pub fn signals(&self) -> T::SignalCollection<'_> {
+    ///
+    /// [`WithUserSignals::signals()`]: crate::obj::WithUserSignals::signals()
+    #[cfg(since_api = "4.2")]
+    pub fn signals(&mut self) -> T::SignalCollection<'_> {
         T::__signals_from_external(self)
     }
 }

--- a/godot-core/src/registry/signal/connect_builder.rs
+++ b/godot-core/src/registry/signal/connect_builder.rs
@@ -8,7 +8,7 @@
 use crate::builtin::{Callable, GString, Variant};
 use crate::classes::object::ConnectFlags;
 use crate::meta;
-use crate::obj::{bounds, Bounds, Gd, GodotClass, WithBaseField};
+use crate::obj::{bounds, Bounds, Gd, GodotClass, WithSignals};
 use crate::registry::signal::{SignalReceiver, TypedSignal};
 
 /// Type-state builder for customizing signal connections.
@@ -54,7 +54,7 @@ use crate::registry::signal::{SignalReceiver, TypedSignal};
 /// - [`done`][Self::done]: Finalize the connection. Consumes the builder and registers the signal with Godot.
 ///
 #[must_use]
-pub struct ConnectBuilder<'ts, 'c, CSig: GodotClass, CRcv, Ps, GodotFn> {
+pub struct ConnectBuilder<'ts, 'c, CSig: WithSignals, CRcv, Ps, GodotFn> {
     parent_sig: &'ts mut TypedSignal<'c, CSig, Ps>,
     data: BuilderData,
 
@@ -63,7 +63,7 @@ pub struct ConnectBuilder<'ts, 'c, CSig: GodotClass, CRcv, Ps, GodotFn> {
     godot_fn: GodotFn,
 }
 
-impl<'ts, 'c, CSig: WithBaseField, Ps: meta::ParamTuple> ConnectBuilder<'ts, 'c, CSig, (), Ps, ()> {
+impl<'ts, 'c, CSig: WithSignals, Ps: meta::ParamTuple> ConnectBuilder<'ts, 'c, CSig, (), Ps, ()> {
     pub(super) fn new(parent_sig: &'ts mut TypedSignal<'c, CSig, Ps>) -> Self {
         ConnectBuilder {
             parent_sig,
@@ -126,7 +126,7 @@ impl<'ts, 'c, CSig: WithBaseField, Ps: meta::ParamTuple> ConnectBuilder<'ts, 'c,
     }
 }
 
-impl<'ts, 'c, CSig: WithBaseField, CRcv: GodotClass, Ps: meta::ParamTuple>
+impl<'ts, 'c, CSig: WithSignals, CRcv: GodotClass, Ps: meta::ParamTuple>
     ConnectBuilder<'ts, 'c, CSig, Gd<CRcv>, Ps, ()>
 {
     /// **Stage 2:** method taking `&mut self`.
@@ -197,7 +197,7 @@ impl<'ts, 'c, CSig: WithBaseField, CRcv: GodotClass, Ps: meta::ParamTuple>
 #[allow(clippy::needless_lifetimes)] // 'ts + 'c are used conditionally.
 impl<'ts, 'c, CSig, CRcv, Ps, GodotFn> ConnectBuilder<'ts, 'c, CSig, CRcv, Ps, GodotFn>
 where
-    CSig: WithBaseField,
+    CSig: WithSignals,
     Ps: meta::ParamTuple,
     GodotFn: FnMut(&[&Variant]) -> Result<Variant, ()> + 'static,
 {

--- a/godot-core/src/task/futures.rs
+++ b/godot-core/src/task/futures.rs
@@ -17,7 +17,7 @@ use crate::builtin::{Callable, RustCallable, Signal, Variant};
 use crate::classes::object::ConnectFlags;
 use crate::meta::sealed::Sealed;
 use crate::meta::ParamTuple;
-use crate::obj::{EngineBitfield, Gd, GodotClass, WithBaseField};
+use crate::obj::{EngineBitfield, Gd, GodotClass, WithSignals};
 use crate::registry::signal::TypedSignal;
 
 pub(crate) use crate::impl_dynamic_send;
@@ -307,7 +307,7 @@ impl Signal {
     }
 }
 
-impl<C: WithBaseField, R: ParamTuple + IntoDynamicSend> TypedSignal<'_, C, R> {
+impl<C: WithSignals, R: ParamTuple + IntoDynamicSend> TypedSignal<'_, C, R> {
     /// Creates a fallible future for this signal.
     ///
     /// The future will resolve the next time the signal is emitted.
@@ -325,7 +325,7 @@ impl<C: WithBaseField, R: ParamTuple + IntoDynamicSend> TypedSignal<'_, C, R> {
     }
 }
 
-impl<C: WithBaseField, R: ParamTuple + IntoDynamicSend> IntoFuture for &TypedSignal<'_, C, R> {
+impl<C: WithSignals, R: ParamTuple + IntoDynamicSend> IntoFuture for &TypedSignal<'_, C, R> {
     type Output = R;
 
     type IntoFuture = SignalFuture<R>;

--- a/godot/src/prelude.rs
+++ b/godot/src/prelude.rs
@@ -36,4 +36,5 @@ pub use super::obj::EngineEnum as _;
 pub use super::obj::NewAlloc as _;
 pub use super::obj::NewGd as _;
 pub use super::obj::WithBaseField as _; // base(), base_mut(), to_gd()
-pub use super::obj::WithSignals as _; // signals()
+pub use super::obj::WithSignals as _; // Gd::signals()
+pub use super::obj::WithUserSignals as _; // self.signals()

--- a/itest/rust/src/engine_tests/async_test.rs
+++ b/itest/rust/src/engine_tests/async_test.rs
@@ -177,16 +177,16 @@ fn resolver_callabable_equality() {
 
 #[itest(async)]
 fn async_typed_signal() -> TaskHandle {
-    let object = AsyncRefCounted::new_gd();
-    let object_ref = object.clone();
+    let mut object = AsyncRefCounted::new_gd();
+    let mut copy = object.clone();
 
     let task_handle = task::spawn(async move {
-        let (result,) = object.signals().custom_signal().deref().await;
+        let (result,) = copy.signals().custom_signal().deref().await;
 
         assert_eq!(result, 66);
     });
 
-    object_ref.signals().custom_signal().emit(66);
+    object.signals().custom_signal().emit(66);
 
     task_handle
 }


### PR DESCRIPTION

Following up #1000, this pull request exposes all signals declared in Godot engine classes.
Closes #1108.

For example, [`Node` has the `child_entered_tree` signal](https://docs.godotengine.org/en/stable/classes/class_node.html#class-node-signal-child-entered-tree):

![image](https://github.com/user-attachments/assets/9cc0bcb4-d97a-455a-a17a-1cc48afad9a0)



To connect such a signal in Rust, we can simply do:


```rs
let mut node: Gd<Node> = /* some node in tree */;

node.signals()
    .child_entered_tree()
    .connect(|child_node| {
        println!("A child node entered the tree: {child_node}");
    });
```

In other words, it's the exact same API as before.

This PR also comes with other small changes:
1. `WithSignals` trait is split into `WithSignals` (all signal-enabled classes) and `WithUserSignals` (only `#[signal]` user-defined ones).
2. `Gd::signals()` now takes `&mut` instead of `&`. This is mostly for consistency with `self.signals()`, as well as Godot's own APIs `Object::connect`, `Object::emit` etc. all operating on `&mut self`. Technically it makes not much difference, but signal manipulation being linked to mutation has a higher chance of detecting unintended changes.






