### PR TITLE
Add support for `@experimental` and `@deprecated` attributes for user-generated docs.

### DIFF
--- a/godot-core/src/docs.rs
+++ b/godot-core/src/docs.rs
@@ -23,6 +23,8 @@ use std::collections::HashMap;
 pub struct StructDocs {
     pub base: &'static str,
     pub description: &'static str,
+    pub experimental: &'static str,
+    pub deprecated: &'static str,
     pub members: &'static str,
 }
 
@@ -98,6 +100,8 @@ pub fn gather_xml_docs() -> impl Iterator<Item = String> {
             let StructDocs {
                 base,
                 description,
+                experimental,
+                deprecated,
                 members,
             } = pieces.definition;
 
@@ -112,15 +116,14 @@ pub fn gather_xml_docs() -> impl Iterator<Item = String> {
                 .then(String::new)
                 .unwrap_or_else(|| format!("<methods>{methods}{virtual_methods}</methods>"));
 
-            let (brief, mut description) = match description
+            let (brief, description) = match description
                 .split_once("[br]") {
-                    Some((brief, description)) => (brief, description),
+                    Some((brief, description)) => (brief, description.trim_start_matches("[br]")),
                     None => (description, ""),
                 };
-            description = description.trim_start_matches("[br]");
 
             format!(r#"<?xml version="1.0" encoding="UTF-8"?>
-<class name="{class}" inherits="{base}" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+<class name="{class}" inherits="{base}"{deprecated}{experimental} xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 <brief_description>{brief}</brief_description>
 <description>{description}</description>
 {methods_block}

--- a/godot-macros/src/lib.rs
+++ b/godot-macros/src/lib.rs
@@ -441,6 +441,11 @@ use crate::util::{bail, ident, KvParser};
 /// struct DocumentedStruct {
 ///     /// This is a class member.
 ///     /// You can use markdown formatting such as _italics_.
+///     ///
+///     /// @experimental `@experimental` and `@deprecated` attributes are supported.
+///     /// The description for such attribute spans for the whole annotated paragraph.
+///     ///
+///     /// This is the rest of a doc description.
 ///     #[var]
 ///     item: f32,
 /// }

--- a/itest/rust/src/register_tests/register_docs_test.rs
+++ b/itest/rust/src/register_tests/register_docs_test.rs
@@ -12,6 +12,8 @@ use godot::prelude::*;
 
 /// *documented* ~ **documented** ~ [AABB] < [pr](https://github.com/godot-rust/gdext/pull/748)
 ///
+/// @deprecated we will use normal integration tests with editor in the future.
+///
 /// This is a paragraph. It has some text in it. It's a paragraph. It's quite
 /// long, and wraps multiple lines. It is describing the struct `Player`. Or
 /// maybe perhaps it's describing the module. It's hard to say, really. It even
@@ -22,6 +24,12 @@ use godot::prelude::*;
 /// a few tests:
 ///
 /// headings:
+///
+/// @experimental both experimental
+/// and
+/// deprecated
+/// tags
+/// are **experimental**.
 ///
 /// # Some heading
 ///
@@ -149,6 +157,15 @@ pub struct FairlyDocumented {
     #[doc = r#"this is very documented"#]
     #[var]
     item: f32,
+    #[doc = "@deprecated use on your own risk!!"]
+    #[doc = ""]
+    #[doc = "not to be confused with B!"]
+    #[export]
+    a: i32,
+    /// Some docs…
+    /// @experimental idk.
+    #[export]
+    b: i64,
     /// is it documented?
     #[var]
     item_2: i64,
@@ -167,6 +184,8 @@ impl INode for FairlyDocumented {
     fn init(base: Base<Node>) -> Self {
         Self {
             base,
+            a: 22,
+            b: 44,
             item: 883.0,
             item_2: 25,
             item_xml: "".into(),
@@ -183,6 +202,16 @@ impl FairlyDocumented {
 
     #[constant]
     const PURPOSE: i64 = 42;
+
+    /// Hmmmm
+    /// @deprecated Did you know that constants can be deprecated?
+    #[constant]
+    const A: i64 = 128;
+
+    /// Who would know that!
+    /// @experimental Did you know that constants can be experimental?
+    #[constant]
+    const B: i64 = 128;
 
     /// this docstring has < a special character
     #[constant]
@@ -228,6 +257,24 @@ impl FairlyDocumented {
         panic!()
     }
 
+    /// This is a method.
+    /// @experimental might explode on use
+    /// …maybe?
+    ///
+    /// Who knows
+    #[func]
+    fn experimental_method() {}
+
+    /// @deprecated EXPLODES ON USE
+    /// DO NOT USE
+    ///
+    /// ?????
+    /// @experimental somebody probably uses it??
+    ///
+    /// probably
+    #[func]
+    fn deprecated_method() {}
+
     #[signal]
     fn undocumented_signal(p: Vector3, w: f64);
 
@@ -238,6 +285,23 @@ impl FairlyDocumented {
     /// The `Gd<Node>` param should be properly escaped
     #[signal]
     fn documented_signal(p: Vector3, w: f64, node: Gd<Node>);
+
+    /// My signal
+    ///
+    /// @deprecated – use other_signal instead.
+    ///
+    /// huh?!
+    #[signal]
+    fn deprecated(x: i64);
+
+    /// New signal
+    ///
+    /// @experimental this is new signal
+    /// use it at your own risk
+    ///
+    /// fr.
+    #[signal]
+    fn other_signal(x: i64);
 }
 
 #[itest]

--- a/itest/rust/src/register_tests/res/registered_docs.xml
+++ b/itest/rust/src/register_tests/res/registered_docs.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<class name="FairlyDocumented" inherits="Node" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+<class name="FairlyDocumented" inherits="Node" deprecated="we will use normal integration tests with editor in the future." experimental="both experimental and deprecated tags are [b]experimental[/b]." xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 <brief_description>[i]documented[/i] ~ [b]documented[/b] ~ [AABB] &lt; [url=https://github.com/godot-rust/gdext/pull/748]pr[/url]</brief_description>
 <description>This is a paragraph. It has some text in it. It&#39;s a paragraph. It&#39;s quite long, and wraps multiple lines. It is describing the struct [code]Player[/code]. Or maybe perhaps it&#39;s describing the module. It&#39;s hard to say, really. It even has some code in it: [code]let x = 5;[/code]. And some more code: [code]let y = 6;[/code]. And a bunch of [b]bold[/b] and [i]italic[/i] text with [i]different[/i] ways to do it. Don&#39;t forget about [url=https://example.com]links[/url].[br][br]a few tests:[br][br]headings:[br][br][b]Some heading[/b][br][br]lists:[br][br]• lists[br]• like this[br]    • with sublists[br]        that are multiline[br]        • and subsublists[br]• and list items[br][br]• maybe with [code]*[/code] as well[br][br][url=https://example.com]reference-style link[/url][br][br]links with back-references:[br][br]Blah blah¹ Also same reference¹[br][br]footnotes:[br][br]We cannot florbinate the glorb²[br][br]Third note in order of use³ and fourth ⁴[br][br]Fifth note in order of use. ⁶[br][br]Sixth footnote in order of use. ⁵[br][br]task lists:[br][br]We must ensure that we&#39;ve completed[br][br]• [ ] task 1[br]• [x] task 2[br][br]tables:[br][br]Header1 | Header2[br]abc | def[br][br]images:[br][br][url=https://godotengine.org/assets/press/logo_small_color_light.png]https://godotengine.org/assets/press/logo_small_color_light.png[/url][br][br][url=https://godotengine.org/assets/press/logo_small_color_dark.png]https://godotengine.org/assets/press/logo_small_color_dark.png[/url][br][br]blockquotes:[br][br]&gt; Some cool thing[br][br]ordered list:[br][br]1. thing one[br]2. thing two[br]    1. thing two point one[br]    2. thing two point two[br]    3. thing two point three[br][br][b]Something here &lt; this is technically header syntax[/b][br][br]And here[br][br]smart punctuation[br][br]codeblocks:[br][br][codeblock lang=rust]#![no_main]
 #[link_section=&quot;.text&quot;]
@@ -49,6 +49,22 @@ public class Player : Node2D
   </description>
 </method>
 
+<method name="experimental_method" experimental="might explode on use …maybe?">
+  <return type="()" />
+  
+  <description>
+  This is a method. Who knows
+  </description>
+</method>
+
+<method name="deprecated_method" deprecated="EXPLODES ON USE DO NOT USE" experimental="somebody probably uses it??">
+  <return type="()" />
+  
+  <description>
+  ????? probably
+  </description>
+</method>
+
 <method name="_init">
   <return type="Self" />
   <param index="0" name="base" type="Base &lt; Node &gt;" />
@@ -57,7 +73,7 @@ public class Player : Node2D
   </description>
 </method>
 </methods>
-<constants><constant name="RANDOM" value="4">Documentation.</constant><constant name="XML" value="1">this docstring has &lt; a special character</constant></constants>
+<constants><constant name="RANDOM" value="4">Documentation.</constant><constant name="A" value="128" deprecated="Did you know that constants can be deprecated?">Hmmmm</constant><constant name="B" value="128" experimental="Did you know that constants can be experimental?">Who would know that!</constant><constant name="XML" value="1">this docstring has &lt; a special character</constant></constants>
 <signals>
 <signal name="documented_signal">
   <param index="0" name="p" type="Vector3" /><param index="1" name="w" type="f64" /><param index="2" name="node" type="Gd &lt; Node &gt;" />
@@ -65,6 +81,20 @@ public class Player : Node2D
   some user signal[br][br]some multiline doc[br][br]The [code]Gd&lt;Node&gt;[/code] param should be properly escaped
   </description>
 </signal>
+
+<signal name="deprecated" deprecated="– use other_signal instead.">
+  <param index="0" name="x" type="i64" />
+  <description>
+  My signal[br][br]huh?!
+  </description>
+</signal>
+
+<signal name="other_signal" experimental="this is new signal use it at your own risk">
+  <param index="0" name="x" type="i64" />
+  <description>
+  New signal[br][br]fr.
+  </description>
+</signal>
 </signals>
-<members><member name="item" type="f32" default="">this is very documented</member><member name="item_2" type="i64" default="">is it documented?</member><member name="item_xml" type="GString" default="">this docstring has &lt; a special character</member></members>
+<members><member name="item" type="f32" default="">this is very documented</member><member name="a" type="i32" default="" deprecated="use on your own risk!!">not to be confused with B!</member><member name="b" type="i64" default="" experimental="idk.">Some docs…</member><member name="item_2" type="i64" default="">is it documented?</member><member name="item_xml" type="GString" default="">this docstring has &lt; a special character</member></members>
 </class>


### PR DESCRIPTION
Adds support for `@experimental` and `@deprecated` for user-generated docs.
closes #1088 

----

Manual testing:

<details>

<summary> Manual test case </summary>

```rs
/// I'm documenting my class here.
///
/// @deprecated huh?!
///
/// And here as well.
///
/// @experimental are you sure about that??????
/// this is still experimental…
///
/// ...Or maybe not???
#[derive(GodotClass)]
#[class(init, base=Node)]
struct MyTestNode {
    #[doc="@experimental use on your own risk!!"]
    #[doc=""]
    #[doc="not to be confused with B!"]
    #[export]
    a: i32,
    /// Some docs…
    /// @experimental idk.
    #[export]
    #[init(sentinel = SomeEnum::Invalid)]
    b: OnEditor<SomeEnum>,
    #[var]
    #[init(sentinel = SomeEnum::Invalid)]
    c: OnEditor<SomeEnum>,
    base: Base<Node>,
}


#[godot_api]
impl MyTestNode {
    /// Hmmmm
    /// @deprecated Did you know that constants can be deprecated?
    #[constant]
    const A: i64 = 128;

    /// Who would know that!
    /// @experimental Did you know that constants can be experimental?
    #[constant]
    const B: i64 = 128;

    /// My signal
    ///
    /// @deprecated – use other_signal instead.
    ///
    /// huh?!
    #[signal]
    fn deprecated(x: i64);

    /// New signal
    ///
    /// @experimental this is new signal
    /// use it at your own risk
    ///
    /// fr.
    #[signal]
    fn other_signal(x: i64);

    /// This is a method.
    /// @experimental might explode on use
    /// …maybe?
    ///
    /// Who knows
    #[func]
    fn experimental_method() {}

    /// @deprecated EXPLODES ON USE
    /// DO NOT USE
    ///
    /// ?????
    /// @experimental somebody probably uses it??
    ///
    /// probably
    #[func]
    fn deprecated_method() {}
}
```

</details>

Results:
<details>
<summary> Manual testing in editor </summary>

![image](https://github.com/user-attachments/assets/e969f73a-fe44-45af-8500-67f9dc569df8)

![image](https://github.com/user-attachments/assets/ea5d4325-3cb3-4108-bd10-c0ee4d2ba168)

![image](https://github.com/user-attachments/assets/b7c0f608-e30c-439d-aa71-70051068e29b)

![image](https://github.com/user-attachments/assets/820b762e-6ddc-4213-9265-34aa453499d1)

</details>