### PR TITLE
post `Rust 1.86` update: apply clippy lints

### DIFF
--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -104,7 +104,6 @@ jobs:
 
       # Note: could use `-- --no-deps` to not lint dependencies, however it doesn't really speed up and also skips deps in workspace.
       - name: "Check clippy"
-        # TODO(Rust 1.86): remove -A clippy::precedence; see https://github.com/godot-rust/gdext/pull/1055.
         run: |
           cargo clippy --all-targets $CLIPPY_FEATURES -- \
           -D clippy::suspicious \
@@ -114,8 +113,7 @@ jobs:
           -D clippy::dbg_macro \
           -D clippy::todo \
           -D clippy::unimplemented \
-          -D warnings \
-          -A clippy::precedence
+          -D warnings
 
   unit-test:
     name: unit-test (${{ matrix.name }}${{ matrix.rust-special }})

--- a/.github/workflows/minimal-ci.yml
+++ b/.github/workflows/minimal-ci.yml
@@ -96,7 +96,6 @@ jobs:
           components: clippy
 
       - name: "Check clippy"
-        # TODO(Rust 1.86): remove -A clippy::precedence; see https://github.com/godot-rust/gdext/pull/1055.
         run: |
           cargo clippy --all-targets $CLIPPY_FEATURES -- \
           -D clippy::suspicious \
@@ -106,8 +105,7 @@ jobs:
           -D clippy::dbg_macro \
           -D clippy::todo \
           -D clippy::unimplemented \
-          -D warnings \
-          -A clippy::precedence
+          -D warnings
           
 
   unit-test:

--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -133,8 +133,7 @@ jobs:
           -D clippy::dbg_macro \
           -D clippy::todo \
           -D clippy::unimplemented \
-          -D warnings \
-          -A clippy::precedence
+          -D warnings
 
   rustfmt:
     runs-on: ubuntu-latest

--- a/check.sh
+++ b/check.sh
@@ -146,12 +146,6 @@ function cmd_fmt() {
 }
 
 function cmd_clippy() {
-    # TODO(Rust 1.86): remove `-A clippy::precedence`.
-    # In Rust 1.85, `clippy::precedence` includes bitmasking and shift operations. Rigid adherence to this rule results in more noisy code, with
-    # little benefits (being aware of bit operator precedence is something we can expect + bit manipulations are common in Godot).
-    # This behavior will be reverted in 1.86 and moved into new lint `precedence_bits` included in `restriction` category.
-    # See https://github.com/godot-rust/gdext/pull/1055 and https://github.com/rust-lang/rust-clippy/pull/14115.
-
     run cargo clippy --all-targets "${extraCargoArgs[@]}" -- \
         -D clippy::suspicious \
         -D clippy::style \
@@ -160,13 +154,10 @@ function cmd_clippy() {
         -D clippy::dbg_macro \
         -D clippy::todo \
         -D clippy::unimplemented \
-        -D warnings \
-        -A clippy::precedence
+        -D warnings
 }
 
 function cmd_klippy() {
-    # TODO(Rust 1.86): remove `-A clippy::precedence`.
-
     run cargo clippy --fix --all-targets "${extraCargoArgs[@]}" -- \
         -D clippy::suspicious \
         -D clippy::style \
@@ -175,8 +166,7 @@ function cmd_klippy() {
         -D clippy::dbg_macro \
         -D clippy::todo \
         -D clippy::unimplemented \
-        -D warnings \
-        -A clippy::precedence
+        -D warnings
 }
 
 function cmd_test() {

--- a/godot-bindings/src/import.rs
+++ b/godot-bindings/src/import.rs
@@ -83,7 +83,6 @@ pub use gdextension_api::version_4_4 as prebuilt;
     feature = "api-custom",
 )))]
 // ]]
-
 // [version-sync] [[
 //  [include] current.minor
 //  [line] pub use gdextension_api::version_$snakeVersion as prebuilt;

--- a/godot-core/src/obj/on_ready.rs
+++ b/godot-core/src/obj/on_ready.rs
@@ -208,7 +208,7 @@ impl<T> OnReady<T> {
     /// - If this object was already provided with a closure during construction, in [`Self::new()`] or any other automatic constructor.
     pub fn init(&mut self, value: T) {
         match &self.state {
-            InitState::ManualUninitialized { .. } => {
+            InitState::ManualUninitialized => {
                 self.state = InitState::Initialized { value };
             }
             InitState::AutoPrepared { .. } => {
@@ -285,7 +285,7 @@ impl<T> std::ops::DerefMut for OnReady<T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         match &mut self.state {
             InitState::Initialized { value } => value,
-            InitState::ManualUninitialized { .. } | InitState::AutoPrepared { .. } => {
+            InitState::ManualUninitialized | InitState::AutoPrepared { .. } => {
                 panic!("value not yet initialized")
             }
             InitState::AutoInitializing => unreachable!(),

--- a/itest/repo-tweak/src/main.rs
+++ b/itest/repo-tweak/src/main.rs
@@ -76,7 +76,7 @@ fn sync_versions_recursive(parent_dir: &Path, top_level: bool) {
 
                 let mut file = File::create(path).expect("create file");
                 for m in ranges {
-                    file.write_all(content[last_pos..m.start].as_bytes())
+                    file.write_all(&content.as_bytes()[last_pos..m.start])
                         .expect("write file (before start)");
 
                     // Note: m.start..m.end is discarded and replaced with newly generated lines.
@@ -98,13 +98,13 @@ fn sync_versions_recursive(parent_dir: &Path, top_level: bool) {
                         file.write_all(post.as_bytes()).expect("write file (post)");
                     }
 
-                    file.write_all(content[m.end..m.after_end].as_bytes())
+                    file.write_all(&content.as_bytes()[m.end..m.after_end])
                         .expect("write file (after end)");
 
                     last_pos = m.after_end;
                 }
 
-                file.write_all(content[last_pos..].as_bytes())
+                file.write_all(&content.as_bytes()[last_pos..])
                     .expect("write to file (end)");
             }
         }

--- a/itest/rust/build.rs
+++ b/itest/rust/build.rs
@@ -572,7 +572,7 @@ fn write_gdscript_code(
 
     let ranges = repo_tweak::find_repeated_ranges(&template, "#(", "#)", &[], false);
     for m in ranges {
-        file.write_all(template[last..m.before_start].as_bytes())?;
+        file.write_all(&template.as_bytes()[last..m.before_start])?;
 
         replace_parts(&template[m.start..m.end], inputs, |replacement| {
             file.write_all(replacement.as_bytes())?;
@@ -581,7 +581,7 @@ fn write_gdscript_code(
 
         last = m.after_end;
     }
-    file.write_all(template[last..].as_bytes())?;
+    file.write_all(&template.as_bytes()[last..])?;
 
     Ok(())
 }


### PR DESCRIPTION
Remove `-A::clippy::precedence`.

Apply [`clippy::sliced-string-as-bytes`](https://rust-lang.github.io/rust-clippy/master/index.html#sliced_string_as_bytes) lint implied by `clippy::perf`. As far as I can tell pre and post lint versions are, functionally, the same; We don't rely on panic here and as far as I know we haven't spot any yet (+actually causing some seems ultra unlikely) 

Apply [`clippy::unneeded_struct_pattern`](https://rust-lang.github.io/rust-clippy/master/index.html#unneeded_struct_pattern) in `on_ready.rs`. InitState enum is not exposed outside this file, and we used both `InitState::ManualUninitialized` and `InitState::ManualUninitialized { .. }` – keeping these consistent won't hurt :thinking: . This is the only occurrence, if the need arises I would recommend to ignore this lint (mainly for future-proofing and whatnot).

Remove newline between templates in import.rs: https://rust-lang.github.io/rust-clippy/master/index.html#empty_line_after_outer_attr. This one is ultra stupid in this context; I thought about adding `#![allow(...)] on top of the file instead 