### PR TITLE
Implement GString concatenation operator

### DIFF
--- a/godot-core/src/global/mod.rs
+++ b/godot-core/src/global/mod.rs
@@ -24,7 +24,9 @@
 
 mod print;
 
-pub use crate::{godot_error, godot_print, godot_print_rich, godot_script_error, godot_warn};
+pub use crate::{
+    godot_error, godot_print, godot_print_rich, godot_script_error, godot_str, godot_warn,
+};
 
 // Some enums are directly re-exported from crate::builtin.
 pub use crate::gen::central::global_enums::*;

--- a/godot-core/src/global/print.rs
+++ b/godot-core/src/global/print.rs
@@ -105,3 +105,15 @@ macro_rules! godot_print_rich {
         ])
     };
 }
+
+/// Concatenates format-style into a `GString`.
+#[macro_export]
+macro_rules! godot_str {
+    ($fmt:literal $(, $args:expr)* $(,)?) => {
+        $crate::global::str(&[
+            $crate::builtin::Variant::from(
+                format!($fmt $(, $args)*)
+            )
+        ])
+    };
+}

--- a/itest/rust/src/engine_tests/utilities_test.rs
+++ b/itest/rust/src/engine_tests/utilities_test.rs
@@ -33,17 +33,22 @@ fn utilities_sign() {
 
 #[itest]
 fn utilities_str() {
+    let a = 12;
+    let b = " is a ";
+    let c = true;
+    let d = " number";
     let concat = str(&[
-        Variant::from(12),
-        Variant::from(" is a "),
-        Variant::from(true),
-        Variant::from(" number"),
+        Variant::from(a),
+        Variant::from(b),
+        Variant::from(c),
+        Variant::from(d),
     ]);
 
     let empty = str(&[]);
 
     // TODO: implement GString==&str operator. Then look for "...".into() patterns and replace them.
     assert_eq!(concat, "12 is a true number".into());
+    assert_eq!(concat, godot_str!("{a}{b}{c}{d}"));
     assert_eq!(empty, GString::new());
 }
 


### PR DESCRIPTION
This will allow for users to add together their GString references with plus sign notation from within the Rust runtime of a gdextension, like so:

```
let concat = &GString::from("12") + &GString::from(" is a ") + &GString::from("true") + &GString::from(" number");
```
