### PR TITLE
Inherited typed signals

### DIFF
--- a/godot-codegen/src/generator/signals.rs
+++ b/godot-codegen/src/generator/signals.rs
@@ -122,7 +122,7 @@ fn make_with_signals_impl(
             #[doc(hidden)]
             fn __signals_from_external(gd_mut: &mut Gd<Self>) -> Self::SignalCollection<'_, Self> {
                 Self::SignalCollection {
-                    __internal_obj: gd_mut.clone(),
+                    __internal_obj: Some(gd_mut.clone()),
                 }
             }
         }
@@ -158,9 +158,9 @@ fn make_signal_collection(
         quote! {
             // Important to return lifetime 'c here, not '_.
             #[doc = #provider_docs]
-            pub fn #signal_name(self) -> #individual_struct_name<'c, C> {
+            pub fn #signal_name(&mut self) -> #individual_struct_name<'c, C> {
                 #individual_struct_name {
-                    typed: TypedSignal::new(self.__internal_obj, #signal_name_str)
+                    typed: TypedSignal::extract(&mut self.__internal_obj, #signal_name_str)
                 }
             }
         }
@@ -177,7 +177,7 @@ fn make_signal_collection(
         pub struct #collection_struct_name<'c, C: WithSignals = #class_name>
         {
             #[doc(hidden)]
-            pub(crate) __internal_obj: C::__SignalObj<'c>,
+            pub(crate) __internal_obj: Option<C::__SignalObj<'c>>,
         }
 
         impl<'c, C: WithSignals> #collection_struct_name<'c, C> {

--- a/godot-codegen/src/generator/signals.rs
+++ b/godot-codegen/src/generator/signals.rs
@@ -71,7 +71,7 @@ pub fn make_class_signals(
 
         #[cfg(since_api = "4.2")]
         mod signals {
-            use crate::obj::Gd;
+            use crate::obj::{Gd, GodotClass};
             use super::re_export::#class_name;
             use crate::registry::signal::TypedSignal;
             use super::*;
@@ -204,13 +204,19 @@ fn make_upcast_deref_impl(class_name: &TyName, collection_struct_name: &Ident) -
             >::SignalCollection<'c, C>;
 
             fn deref(&self) -> &Self::Target {
-                todo!()
+                type Derived = #class_name;
+                type Base = <#class_name as GodotClass>::Base;
+
+                crate::private::upcast_signal_collection::<C, Derived, Base>(self)
             }
         }
 
         impl<'c, C: WithSignals> std::ops::DerefMut for #collection_struct_name<'c, C> {
             fn deref_mut(&mut self) -> &mut Self::Target {
-                todo!()
+                type Derived = #class_name;
+                type Base = <#class_name as GodotClass>::Base;
+
+                crate::private::upcast_signal_collection_mut::<C, Derived, Base>(self)
             }
         }
     }

--- a/godot-codegen/src/generator/signals.rs
+++ b/godot-codegen/src/generator/signals.rs
@@ -205,18 +205,14 @@ fn make_upcast_deref_impl(class_name: &TyName, collection_struct_name: &Ident) -
 
             fn deref(&self) -> &Self::Target {
                 type Derived = #class_name;
-                type Base = <#class_name as GodotClass>::Base;
-
-                crate::private::upcast_signal_collection::<C, Derived, Base>(self)
+                crate::private::signal_collection_to_base::<C, Derived>(self)
             }
         }
 
         impl<'c, C: WithSignals> std::ops::DerefMut for #collection_struct_name<'c, C> {
             fn deref_mut(&mut self) -> &mut Self::Target {
                 type Derived = #class_name;
-                type Base = <#class_name as GodotClass>::Base;
-
-                crate::private::upcast_signal_collection_mut::<C, Derived, Base>(self)
+                crate::private::signal_collection_to_base_mut::<C, Derived>(self)
             }
         }
     }

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -721,7 +721,7 @@ where
     ///
     /// [`WithUserSignals::signals()`]: crate::obj::WithUserSignals::signals()
     #[cfg(since_api = "4.2")]
-    pub fn signals(&mut self) -> T::SignalCollection<'_> {
+    pub fn signals(&mut self) -> T::SignalCollection<'_, T> {
         T::__signals_from_external(self)
     }
 }

--- a/godot-core/src/obj/traits.rs
+++ b/godot-core/src/obj/traits.rs
@@ -10,6 +10,7 @@ use crate::builtin::GString;
 use crate::init::InitLevel;
 use crate::meta::ClassName;
 use crate::obj::{bounds, Base, BaseMut, BaseRef, Bounds, Gd};
+#[cfg(since_api = "4.2")]
 use crate::registry::signal::SignalObject;
 use crate::storage::Storage;
 use godot_ffi as sys;

--- a/godot-core/src/obj/traits.rs
+++ b/godot-core/src/obj/traits.rs
@@ -452,7 +452,7 @@ pub trait WithSignals: GodotClass + Inherits<crate::classes::Object> {
     ///   (e.g. a user-defined node) connecting/emitting signals of a base class (e.g. `Node`).
     type SignalCollection<'c, C>
     where
-        C: WithSignals + 'c;
+        C: WithSignals;
 
     /// Whether the representation needs to be able to hold just `Gd` (for engine classes) or `UserSignalObject` (for user classes).
     // Note: this cannot be in Declarer (Engine/UserDecl) as associated type `type SignalObjectType<'c, T: WithSignals>`,

--- a/godot-core/src/private.rs
+++ b/godot-core/src/private.rs
@@ -12,9 +12,8 @@ pub use crate::registry::plugin::{
     ClassPlugin, DynTraitImpl, ErasedDynGd, ErasedRegisterFn, ITraitImpl, InherentImpl, PluginItem,
     Struct,
 };
-pub use crate::registry::signal::{
-    signal_collection_to_base, signal_collection_to_base_mut, UserSignalObject,
-};
+#[cfg(since_api = "4.2")]
+pub use crate::registry::signal::priv_re_export::*;
 pub use crate::storage::{as_storage, Storage};
 pub use sys::out;
 

--- a/godot-core/src/private.rs
+++ b/godot-core/src/private.rs
@@ -474,14 +474,14 @@ pub fn rebuild_gd(object_ref: &classes::Object) -> Gd<classes::Object> {
 }
 
 pub fn upcast_signal_collection<'r, 'c, Derived, Base>(
-    derived: &'r Derived::SignalCollection<'c>,
-) -> &'r Base::SignalCollection<'c>
+    derived: &'r Derived::SignalCollection<'c, Derived>,
+) -> &'r Base::SignalCollection<'c, Derived>
 where
     Derived: WithSignals + Inherits<Base>,
     Base: WithSignals,
 {
     let derived_collection_ptr = std::ptr::from_ref(derived);
-    let base_collection_ptr = derived_collection_ptr.cast::<Base::SignalCollection<'c>>();
+    let base_collection_ptr = derived_collection_ptr.cast::<Base::SignalCollection<'c, Derived>>();
 
     // SAFETY:
     // - Signal collections have the same memory layout, independent of their enclosing class. (While they may differ depending on
@@ -493,14 +493,14 @@ where
 }
 
 pub fn upcast_signal_collection_mut<'r, 'c, Derived, Base>(
-    derived: &'r mut Derived::SignalCollection<'c>,
-) -> &'r mut Base::SignalCollection<'c>
+    derived: &'r mut Derived::SignalCollection<'c, Derived>,
+) -> &'r mut Base::SignalCollection<'c, Derived>
 where
     Derived: WithSignals + Inherits<Base>,
     Base: WithSignals,
 {
     let derived_collection_ptr = std::ptr::from_mut(derived);
-    let base_collection_ptr = derived_collection_ptr.cast::<Base::SignalCollection<'c>>();
+    let base_collection_ptr = derived_collection_ptr.cast::<Base::SignalCollection<'c, Derived>>();
 
     // SAFETY: see upcast_signal_collection.
     unsafe { &mut *base_collection_ptr }

--- a/godot-core/src/private.rs
+++ b/godot-core/src/private.rs
@@ -466,10 +466,10 @@ fn report_call_error(call_error: CallError, track_globally: bool) -> i32 {
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Signal helpers
 
-pub fn rebuild_gd<T>(object_ref: &classes::Object) -> Gd<T> {
+pub fn rebuild_gd(object_ref: &classes::Object) -> Gd<classes::Object> {
     let ptr = object_ref.__object_ptr();
 
-    // SAFETY: ptr comes from valid internal API.
+    // SAFETY: ptr comes from valid internal API (and is non-null, so unwrap in from_obj_sys won't fail).
     unsafe { Gd::from_obj_sys(ptr) }
 }
 
@@ -484,7 +484,8 @@ where
     let base_collection_ptr = derived_collection_ptr.cast::<Base::SignalCollection<'c>>();
 
     // SAFETY:
-    // - Signal collections have all the same memory layout, independent of their enclosing class.
+    // - Signal collections have the same memory layout, independent of their enclosing class. (While they may differ depending on
+    //   internal/external usage, upcasts
     // - The `Inherits` bound additionally ensures that all signals present in Base are also present in Derived, i.e.
     //   reducing the collection to a smaller subset of signals is safe.
     // - The lifetimes remain unchanged.
@@ -501,11 +502,7 @@ where
     let derived_collection_ptr = std::ptr::from_mut(derived);
     let base_collection_ptr = derived_collection_ptr.cast::<Base::SignalCollection<'c>>();
 
-    // SAFETY:
-    // - Signal collections have all the same memory layout, independent of their enclosing class.
-    // - The `Inherits` bound additionally ensures that all signals present in Base are also present in Derived, i.e.
-    //   reducing the collection to a smaller subset of signals is safe.
-    // - The lifetimes remain unchanged.
+    // SAFETY: see upcast_signal_collection.
     unsafe { &mut *base_collection_ptr }
 }
 

--- a/godot-core/src/private.rs
+++ b/godot-core/src/private.rs
@@ -473,15 +473,38 @@ pub fn rebuild_gd(object_ref: &classes::Object) -> Gd<classes::Object> {
     unsafe { Gd::from_obj_sys(ptr) }
 }
 
-pub fn upcast_signal_collection<'r, 'c, Derived, Base>(
-    derived: &'r Derived::SignalCollection<'c, Derived>,
-) -> &'r Base::SignalCollection<'c, Derived>
+
+// pub fn signal_collection_to_base<'r, 'c, C, Derived, Base>(
+//     derived: &'r Derived::SignalCollection<'c, C>,
+// ) -> &'r Base::SignalCollection<'c, C>
+// where
+//     C: WithSignals,
+//     Derived: WithSignals + Inherits<Base>,
+//     Base: WithSignals,
+// {
+//     let derived_collection_ptr = std::ptr::from_ref(derived);
+//     let base_collection_ptr = derived_collection_ptr.cast::<Base::SignalCollection<'c, C>>();
+//
+//     // SAFETY:
+//     // - Signal collections have the same memory layout, independent of their enclosing class. (While they may differ depending on
+//     //   internal/external usage, upcasts
+//     // - The `Inherits` bound additionally ensures that all signals present in Base are also present in Derived, i.e.
+//     //   reducing the collection to a smaller subset of signals is safe.
+//     // - The lifetimes remain unchanged.
+//     unsafe { &*base_collection_ptr }
+// }
+
+
+pub fn upcast_signal_collection<'r, 'c, C, Derived, Base>(
+    derived: &'r Derived::SignalCollection<'c, C>,
+) -> &'r Base::SignalCollection<'c, C>
 where
+    C: WithSignals,
     Derived: WithSignals + Inherits<Base>,
     Base: WithSignals,
 {
     let derived_collection_ptr = std::ptr::from_ref(derived);
-    let base_collection_ptr = derived_collection_ptr.cast::<Base::SignalCollection<'c, Derived>>();
+    let base_collection_ptr = derived_collection_ptr.cast::<Base::SignalCollection<'c, C>>();
 
     // SAFETY:
     // - Signal collections have the same memory layout, independent of their enclosing class. (While they may differ depending on
@@ -492,19 +515,21 @@ where
     unsafe { &*base_collection_ptr }
 }
 
-pub fn upcast_signal_collection_mut<'r, 'c, Derived, Base>(
-    derived: &'r mut Derived::SignalCollection<'c, Derived>,
-) -> &'r mut Base::SignalCollection<'c, Derived>
+pub fn upcast_signal_collection_mut<'r, 'c, C, Derived, Base>(
+    derived: &'r mut Derived::SignalCollection<'c, C>,
+) -> &'r mut Base::SignalCollection<'c, C>
 where
+    C: WithSignals,
     Derived: WithSignals + Inherits<Base>,
     Base: WithSignals,
 {
     let derived_collection_ptr = std::ptr::from_mut(derived);
-    let base_collection_ptr = derived_collection_ptr.cast::<Base::SignalCollection<'c, Derived>>();
+    let base_collection_ptr = derived_collection_ptr.cast::<Base::SignalCollection<'c, C>>();
 
     // SAFETY: see upcast_signal_collection.
     unsafe { &mut *base_collection_ptr }
 }
+
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/godot-core/src/registry/mod.rs
+++ b/godot-core/src/registry/mod.rs
@@ -20,7 +20,9 @@ pub mod signal;
 
 // Contents re-exported in `godot` crate; just keep empty.
 #[cfg(before_api = "4.2")]
-pub mod signal {}
+pub mod signal {
+    pub mod re_export {}
+}
 
 // RpcConfig uses MultiplayerPeer::TransferMode and MultiplayerApi::RpcMode, which are only enabled in `codegen-full` feature.
 #[cfg(feature = "codegen-full")]

--- a/godot-core/src/registry/signal/mod.rs
+++ b/godot-core/src/registry/signal/mod.rs
@@ -11,7 +11,8 @@ mod typed_signal;
 pub(crate) mod variadic;
 
 pub use connect_builder::*;
-pub use signal_object::{SignalObject, UserSignalObject};
+//pub use signal_object::{SignalObject, UserSignalObject};
+pub use signal_object::*;
 pub use typed_signal::*;
 pub use variadic::SignalReceiver;
 

--- a/godot-core/src/registry/signal/mod.rs
+++ b/godot-core/src/registry/signal/mod.rs
@@ -6,10 +6,13 @@
  */
 
 mod connect_builder;
+mod signal_object;
 mod typed_signal;
 pub(crate) mod variadic;
 
 pub use connect_builder::*;
+pub use signal_object::{SignalObject, UserSignalObject};
 pub use typed_signal::*;
 pub use variadic::SignalReceiver;
+
 // ParamTuple re-exported in crate::meta.

--- a/godot-core/src/registry/signal/mod.rs
+++ b/godot-core/src/registry/signal/mod.rs
@@ -5,15 +5,30 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+// Whole module only available in Godot 4.2+.
+
 mod connect_builder;
 mod signal_object;
 mod typed_signal;
-pub(crate) mod variadic;
 
-pub use connect_builder::*;
-//pub use signal_object::{SignalObject, UserSignalObject};
-pub use signal_object::*;
-pub use typed_signal::*;
-pub use variadic::SignalReceiver;
+pub(crate) mod variadic;
+pub(crate) use connect_builder::*;
+pub(crate) use signal_object::*;
+pub(crate) use typed_signal::*;
+pub(crate) use variadic::SignalReceiver;
+
+// Used in `godot` crate.
+pub mod re_export {
+    pub use super::connect_builder::ConnectBuilder;
+    pub use super::typed_signal::TypedSignal;
+    pub use super::variadic::SignalReceiver;
+}
+
+// Used in `godot::private` module.
+pub mod priv_re_export {
+    pub use super::signal_object::{
+        signal_collection_to_base, signal_collection_to_base_mut, UserSignalObject,
+    };
+}
 
 // ParamTuple re-exported in crate::meta.

--- a/godot-core/src/registry/signal/signal_object.rs
+++ b/godot-core/src/registry/signal/signal_object.rs
@@ -38,7 +38,11 @@ pub enum UserSignalObject<'c, C> {
     External { gd: Gd<Object> },
 }
 
-impl<'c, C: WithUserSignals> UserSignalObject<'c, C> {
+impl<'c, C> UserSignalObject<'c, C>
+where
+    // 2nd bound necessary, so generics match for TypedSignal construction.
+    C: WithUserSignals + WithSignals<__SignalObj<'c> = UserSignalObject<'c, C>>,
+{
     #[inline]
     pub fn from_external(object: Gd<C>) -> Self {
         Self::External {

--- a/godot-core/src/registry/signal/signal_object.rs
+++ b/godot-core/src/registry/signal/signal_object.rs
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+// Implementation note:
+// If this codes too much code bloat / compilation time due to excessive monomorphization of C, it's possible to type-erase this, as
+// the internal representation just needs Object. This would allow that all signal collections look the same. It would however make
+//
+
+use crate::classes::Object;
+use crate::obj::{Gd, WithBaseField, WithSignals, WithUserSignals};
+
+/// Indirection from [`TypedSignal`] to the actual Godot object.
+#[doc(hidden)]
+pub trait SignalObject<'c> {
+    fn with_object_mut(&mut self, f: impl FnOnce(&mut Object));
+    fn to_owned_object(&self) -> Gd<Object>;
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// Impl for signals() on user classes.
+
+/// Links to a Godot object, either via reference (for `&mut self` uses) or via `Gd`.
+///
+/// Needs to differentiate the two cases:
+/// - `C` is a user object implementing `WithBaseField`, possibly having access from within the class.
+/// - `C` is an engine object, so only accessible through `Gd<C>`.
+#[doc(hidden)]
+pub enum UserSignalObject<'c, C> {
+    /// Helpful for emit: reuse `&mut self` from within the `impl` block, goes through `base_mut()` re-borrowing and thus allows re-entrant calls
+    /// through Godot.
+    Internal { self_mut: &'c mut C },
+    //Internal { obj_mut: &'c mut classes::Object },
+    /// From outside, based on `Gd` pointer.
+    External { gd: Gd<Object> },
+}
+
+impl<'c, C: WithUserSignals> UserSignalObject<'c, C> {
+    #[inline]
+    pub fn from_external(object: Gd<C>) -> Self {
+        Self::External {
+            gd: object.upcast(),
+        }
+    }
+
+    #[inline]
+    pub fn from_internal(self_mut: &'c mut C) -> Self {
+        Self::Internal { self_mut }
+    }
+}
+
+impl<'c, C: WithUserSignals> SignalObject<'c> for UserSignalObject<'c, C> {
+    #[inline]
+    fn with_object_mut(&mut self, f: impl FnOnce(&mut Object)) {
+        match self {
+            Self::Internal { self_mut } => {
+                let mut guard = <C as WithBaseField>::base_mut(*self_mut);
+                f(guard.upcast_object_mut())
+            }
+            Self::External { gd } => f(gd.upcast_object_mut()),
+        }
+    }
+
+    #[inline]
+    fn to_owned_object(&self) -> Gd<Object> {
+        match self {
+            // SignalObject::Internal { obj_mut } => crate::private::rebuild_gd(*obj_mut),
+            Self::Internal { self_mut } => <C as WithBaseField>::to_gd(self_mut).upcast_object(),
+            Self::External { gd } => gd.clone(),
+        }
+    }
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// Impl for signals() on engine classes.
+
+impl<'c, C: WithSignals> SignalObject<'c> for Gd<C> {
+    #[inline]
+    fn with_object_mut(&mut self, f: impl FnOnce(&mut Object)) {
+        f(self.upcast_object_mut())
+    }
+
+    #[inline]
+    fn to_owned_object(&self) -> Gd<Object> {
+        self.clone().upcast_object()
+    }
+}

--- a/godot-core/src/registry/signal/typed_signal.rs
+++ b/godot-core/src/registry/signal/typed_signal.rs
@@ -14,11 +14,10 @@ use crate::registry::signal::{
 };
 use std::borrow::Cow;
 use std::marker::PhantomData;
-// ----------------------------------------------------------------------------------------------------------------------------------------------
 
 /// Object part of the signal receiver (handler).
 ///
-/// Functionality overlaps partly with [`super::AsObjectArg`] and [`super::AsArg<ObjectArg>`]. Can however not directly be replaced
+/// Functionality overlaps partly with [`meta::AsObjectArg`] and [`meta::AsArg<ObjectArg>`]. Can however not directly be replaced
 /// with `AsObjectArg`, since that allows nullability and doesn't require `&mut T`. Maybe there's a way to reuse them though.
 pub trait ToSignalObj<C: GodotClass> {
     fn to_signal_obj(&self) -> Gd<C>;
@@ -148,7 +147,7 @@ impl<'c, C: WithSignals, Ps: meta::ParamTuple> TypedSignal<'c, C, Ps> {
     ///
     /// To connect to methods on the same object that declares the `#[signal]`, use [`connect_self()`][Self::connect_self].  \
     /// If you need cross-thread signals or connect flags, use [`connect_builder()`][Self::connect_builder].
-    pub fn connect_obj<'a, F, OtherC>(&mut self, object: &impl ToSignalObj<OtherC>, mut method: F)
+    pub fn connect_obj<F, OtherC>(&mut self, object: &impl ToSignalObj<OtherC>, mut method: F)
     where
         OtherC: GodotClass + Bounds<Declarer = bounds::DeclUser>,
         for<'c_rcv> F: SignalReceiver<&'c_rcv mut OtherC, Ps>,

--- a/godot-core/src/registry/signal/typed_signal.rs
+++ b/godot-core/src/registry/signal/typed_signal.rs
@@ -66,18 +66,18 @@ impl<C: GodotClass> SignalObj<C> for Gd<C> {
 ///
 /// Functionality overlaps partly with [`super::AsObjectArg`] and [`super::AsArg<ObjectArg>`]. Can however not directly be replaced
 /// with `AsObjectArg`, since that allows nullability and doesn't require `&mut T`. Maybe there's a way to reuse them though.
-pub trait IntoSignalObj<C: GodotClass> {
-    fn into_signal_obj(self) -> Gd<C>;
+pub trait ToSignalObj<C: GodotClass> {
+    fn to_signal_obj(&self) -> Gd<C>;
 }
 
-impl<C: GodotClass> IntoSignalObj<C> for &Gd<C> {
-    fn into_signal_obj(self) -> Gd<C> {
+impl<C: GodotClass> ToSignalObj<C> for Gd<C> {
+    fn to_signal_obj(&self) -> Gd<C> {
         self.clone()
     }
 }
 
-impl<C: WithBaseField> IntoSignalObj<C> for &mut C {
-    fn into_signal_obj(self) -> Gd<C> {
+impl<C: WithBaseField> ToSignalObj<C> for C {
+    fn to_signal_obj(&self) -> Gd<C> {
         WithBaseField::to_gd(self)
     }
 }
@@ -167,12 +167,12 @@ impl<'c, C: WithSignals, Ps: meta::ParamTuple> TypedSignal<'c, C, Ps> {
     ///
     /// To connect to methods on the same object that declares the `#[signal]`, use [`connect_self()`][Self::connect_self].  \
     /// If you need cross-thread signals or connect flags, use [`connect_builder()`][Self::connect_builder].
-    pub fn connect_obj<F, OtherC>(&mut self, object: impl IntoSignalObj<OtherC>, mut method: F)
+    pub fn connect_obj<'a, F, OtherC>(&mut self, object: &impl ToSignalObj<OtherC>, mut method: F)
     where
         OtherC: GodotClass + Bounds<Declarer = bounds::DeclUser>,
         for<'c_rcv> F: SignalReceiver<&'c_rcv mut OtherC, Ps>,
     {
-        let mut gd = object.into_signal_obj();
+        let mut gd = object.to_signal_obj();
         // let mut gd = gd.to_owned_object();
         let godot_fn = make_godot_fn(move |args| {
             let mut instance = gd.bind_mut();

--- a/godot-core/src/registry/signal/typed_signal.rs
+++ b/godot-core/src/registry/signal/typed_signal.rs
@@ -71,7 +71,30 @@ pub struct TypedSignal<'c, C: WithSignals, Ps> {
 
 impl<'c, C: WithSignals, Ps: meta::ParamTuple> TypedSignal<'c, C, Ps> {
     #[doc(hidden)]
-    pub fn new(object: C::__SignalObj<'c>, name: &'static str) -> Self {
+    pub fn extract(
+        obj: &mut Option<C::__SignalObj<'c>>,
+        signal_name: &'static str,
+    ) -> TypedSignal<'c, C, Ps> {
+        let obj = obj.take().unwrap_or_else(|| {
+            panic!(
+                "signals().{signal_name}() call failed; signals() allows only one signal configuration at a time \n\
+                see https://godot-rust.github.io/book/register/signals.html#one-signal-at-a-time"
+            )
+        });
+
+        Self::new(obj, signal_name)
+    }
+
+    // pub fn extract_user<Ps: meta::ParamTuple>(
+    //     this: &mut Option<UserSignalObject<'c, C>>,
+    //     signal_name: &'static str,
+    // ) -> TypedSignal<'c, C, Ps> {
+    //     TypedSignal::extract(this, signal_name)
+    // }
+
+    // Currently only invoked from godot-core classes, or from UserSignalObject::into_typed_signal.
+    // When making public, make also #[doc(hidden)].
+    fn new(object: C::__SignalObj<'c>, name: &'static str) -> Self {
         Self {
             object,
             name: Cow::Borrowed(name),

--- a/godot-core/src/registry/signal/typed_signal.rs
+++ b/godot-core/src/registry/signal/typed_signal.rs
@@ -62,6 +62,28 @@ impl<C: GodotClass> SignalObj<C> for Gd<C> {
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 
+/// Object part of the signal receiver (handler).
+///
+/// Functionality overlaps partly with [`super::AsObjectArg`] and [`super::AsArg<ObjectArg>`]. Can however not directly be replaced
+/// with `AsObjectArg`, since that allows nullability and doesn't require `&mut T`. Maybe there's a way to reuse them though.
+pub trait IntoSignalObj<C: GodotClass> {
+    fn into_signal_obj(self) -> Gd<C>;
+}
+
+impl<C: GodotClass> IntoSignalObj<C> for &Gd<C> {
+    fn into_signal_obj(self) -> Gd<C> {
+        self.clone()
+    }
+}
+
+impl<C: WithBaseField> IntoSignalObj<C> for &mut C {
+    fn into_signal_obj(self) -> Gd<C> {
+        WithBaseField::to_gd(self)
+    }
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+
 /// Type-safe version of a Godot signal.
 ///
 /// Short-lived type, only valid in the scope of its surrounding object type `C`, for lifetime `'c`. The generic argument `Ps` represents
@@ -145,16 +167,17 @@ impl<'c, C: WithSignals, Ps: meta::ParamTuple> TypedSignal<'c, C, Ps> {
     ///
     /// To connect to methods on the same object that declares the `#[signal]`, use [`connect_self()`][Self::connect_self].  \
     /// If you need cross-thread signals or connect flags, use [`connect_builder()`][Self::connect_builder].
-    pub fn connect_obj<F, OtherC>(&mut self, object: &Gd<OtherC>, mut function: F)
+    pub fn connect_obj<F, OtherC>(&mut self, object: impl IntoSignalObj<OtherC>, mut method: F)
     where
         OtherC: GodotClass + Bounds<Declarer = bounds::DeclUser>,
         for<'c_rcv> F: SignalReceiver<&'c_rcv mut OtherC, Ps>,
     {
-        let mut gd = object.clone();
+        let mut gd = object.into_signal_obj();
+        // let mut gd = gd.to_owned_object();
         let godot_fn = make_godot_fn(move |args| {
             let mut instance = gd.bind_mut();
             let instance = &mut *instance;
-            function.call(instance, args);
+            method.call(instance, args);
         });
 
         self.inner_connect_godot_fn::<F>(godot_fn);

--- a/godot-macros/src/class/data_models/inherent_impl.rs
+++ b/godot-macros/src/class/data_models/inherent_impl.rs
@@ -107,7 +107,7 @@ pub fn transform_inherent_impl(
 
     // For each #[func] in this impl block, create one constant.
     let func_name_constants = make_funcs_collection_constants(&funcs, &class_name);
-    let (signal_registrations, signals_collection_struct) =
+    let (signal_registrations, signal_symbol_types) =
         make_signal_registrations(&signals, &class_name, &class_name_obj)?;
 
     #[cfg(feature = "codegen-full")]
@@ -186,7 +186,7 @@ pub fn transform_inherent_impl(
             impl #funcs_collection {
                 #( #func_name_constants )*
             }
-            #signals_collection_struct
+            #signal_symbol_types
         };
 
         Ok(result)

--- a/godot-macros/src/class/data_models/signal.rs
+++ b/godot-macros/src/class/data_models/signal.rs
@@ -309,9 +309,8 @@ fn make_signal_collection(class_name: &Ident, collection: SignalCollection) -> O
         pub struct #collection_struct_name<'c, C = #class_name>
         where C: ::godot::obj::GodotClass
         {
-            // To allow external call in the future (given Gd<T>, not self), this could be an enum with either BaseMut or &mut Gd<T>/&mut T.
             #[doc(hidden)] // Necessary because it's in the same scope as the user-defined class, so appearing in IDE completion.
-            __internal_obj: ::godot::register::UserSignalObj<'c, C>
+            __internal_obj: ::godot::register::UserSignalObject<'c, C>
         }
 
         impl<'c> #collection_struct_name<'c> {
@@ -331,12 +330,14 @@ fn make_with_signals_impl(class_name: &Ident, collection_struct_name: &Ident) ->
         impl ::godot::obj::WithSignals for #class_name {
             type SignalCollection<'c> = #collection_struct_name<'c, Self>;
             #[doc(hidden)]
-            type __SignalObject<'c> = ::godot::register::UserSignalObj<'c, Self>;
+            type __SignalObj<'c> = ::godot::register::UserSignalObject<'c, Self>;
 
             #[doc(hidden)]
             fn __signals_from_external(external: &mut Gd<Self>) -> Self::SignalCollection<'_> {
                 Self::SignalCollection {
-                    __internal_obj: ::godot::register::UserSignalObj::External { gd: external.clone() }
+                    __internal_obj: ::godot::register::UserSignalObject::External {
+                        gd: external.clone().upcast::<Object>()
+                    }
                 }
             }
         }
@@ -344,7 +345,7 @@ fn make_with_signals_impl(class_name: &Ident, collection_struct_name: &Ident) ->
         impl ::godot::obj::WithUserSignals for #class_name {
             fn signals(&mut self) -> Self::SignalCollection<'_> {
                 Self::SignalCollection {
-                    __internal_obj: ::godot::register::UserSignalObj::Internal { obj_mut: self }
+                    __internal_obj: ::godot::register::UserSignalObject::Internal { self_mut: self }
                 }
             }
         }

--- a/godot-macros/src/class/data_models/signal.rs
+++ b/godot-macros/src/class/data_models/signal.rs
@@ -463,8 +463,7 @@ fn make_upcast_deref_impl(class_name: &Ident, collection_struct_name: &Ident) ->
                 type Derived = #class_name;
                 type Base = <#class_name as ::godot::obj::GodotClass>::Base;
 
-                // ::godot::private::upcast_signal_collection::<Derived, Base>(self)
-                todo!()
+                ::godot::private::upcast_signal_collection::<C, Derived, Base>(self)
             }
         }
 
@@ -473,8 +472,7 @@ fn make_upcast_deref_impl(class_name: &Ident, collection_struct_name: &Ident) ->
                 type Derived = #class_name;
                 type Base = <#class_name as ::godot::obj::GodotClass>::Base;
 
-                // ::godot::private::upcast_signal_collection_mut::<Derived, Base>(self)
-                todo!()
+                ::godot::private::upcast_signal_collection_mut::<C, Derived, Base>(self)
             }
         }
     }

--- a/godot-macros/src/class/derive_godot_class.rs
+++ b/godot-macros/src/class/derive_godot_class.rs
@@ -265,7 +265,7 @@ fn make_onready_init(all_fields: &[Field]) -> TokenStream {
     if !onready_fields.is_empty() {
         quote! {
             {
-                let base = <Self as godot::obj::WithBaseField>::to_gd(self).upcast();
+                let base = <Self as ::godot::obj::WithBaseField>::to_gd(self).upcast();
                 #( #onready_fields )*
             }
         }

--- a/godot-macros/src/util/mod.rs
+++ b/godot-macros/src/util/mod.rs
@@ -407,3 +407,8 @@ pub fn format_funcs_collection_constant(_class_name: &Ident, func_name: &Ident) 
 pub fn format_funcs_collection_struct(class_name: &Ident) -> Ident {
     format_ident!("__godot_{class_name}_Funcs")
 }
+
+/// Returns the name of the macro used to communicate the `struct` (class) visibility to other symbols.
+pub fn format_class_visibility_macro(class_name: &Ident) -> Ident {
+    format_ident!("__godot_{class_name}_vis_macro")
+}

--- a/godot/src/lib.rs
+++ b/godot/src/lib.rs
@@ -184,7 +184,7 @@ pub mod init {
 /// Register/export Rust symbols to Godot: classes, methods, enums...
 pub mod register {
     pub use godot_core::registry::property;
-    pub use godot_core::registry::signal::{ConnectBuilder, SignalReceiver, TypedSignal};
+    pub use godot_core::registry::signal::re_export::*;
     pub use godot_macros::{godot_api, godot_dyn, Export, GodotClass, GodotConvert, Var};
 
     #[cfg(feature = "__codegen-full")]

--- a/godot/src/lib.rs
+++ b/godot/src/lib.rs
@@ -184,7 +184,7 @@ pub mod init {
 /// Register/export Rust symbols to Godot: classes, methods, enums...
 pub mod register {
     pub use godot_core::registry::property;
-    pub use godot_core::registry::signal::*;
+    pub use godot_core::registry::signal::{ConnectBuilder, SignalReceiver, TypedSignal};
     pub use godot_macros::{godot_api, godot_dyn, Export, GodotClass, GodotConvert, Var};
 
     #[cfg(feature = "__codegen-full")]

--- a/itest/rust/src/builtin_tests/containers/signal_test.rs
+++ b/itest/rust/src/builtin_tests/containers/signal_test.rs
@@ -269,6 +269,20 @@ fn signal_symbols_engine(ctx: &crate::framework::TestContext) {
     node.free();
 }
 
+// Test that Node signals are accessible from a derived class.
+// #[cfg(since_api = "4.2")]
+// #[itest]
+// fn signal_symbols_engine_inherited(ctx: &crate::framework::TestContext) {
+//     let mut receiver = Receiver::new_alloc();
+//
+//     let sig = receiver.signals().rename_node("new name");
+//
+//     //node.signals().renamed()
+//
+//     // Remove from tree for other tests.
+//     // node.free();
+// }
+
 #[itest]
 fn signal_construction_and_id() {
     let mut object = RefCounted::new_gd();

--- a/itest/rust/src/builtin_tests/containers/signal_test.rs
+++ b/itest/rust/src/builtin_tests/containers/signal_test.rs
@@ -270,18 +270,21 @@ fn signal_symbols_engine(ctx: &crate::framework::TestContext) {
 }
 
 // Test that Node signals are accessible from a derived class.
-// #[cfg(since_api = "4.2")]
-// #[itest]
-// fn signal_symbols_engine_inherited(ctx: &crate::framework::TestContext) {
-//     let mut receiver = Receiver::new_alloc();
-//
-//     let sig = receiver.signals().rename_node("new name");
-//
-//     //node.signals().renamed()
-//
-//     // Remove from tree for other tests.
-//     // node.free();
-// }
+#[cfg(since_api = "4.2")]
+#[itest(focus)]
+fn signal_symbols_engine_inherited(ctx: &crate::framework::TestContext) {
+    let mut node = Emitter::new_alloc();
+
+    // Add to tree, so signals are propagated.
+    ctx.scene_tree.clone().add_child(&node);
+
+    //node.signals().renamed().connect()
+
+    node.set_name("new name");
+
+    // Remove from tree for other tests.
+    node.free();
+}
 
 #[itest]
 fn signal_construction_and_id() {
@@ -317,9 +320,9 @@ mod emitter {
     use godot::obj::WithUserSignals;
 
     #[derive(GodotClass)]
-    #[class(init, base=Object)]
+    #[class(init, base=Node)] // Node instead of Object to test some signals defined in superclasses.
     pub struct Emitter {
-        _base: Base<Object>,
+        _base: Base<Node>,
         #[cfg(since_api = "4.2")]
         pub last_received_int: i64,
     }

--- a/itest/rust/src/builtin_tests/containers/signal_test.rs
+++ b/itest/rust/src/builtin_tests/containers/signal_test.rs
@@ -447,6 +447,22 @@ impl Receiver {
 }
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
+
+// Class which is deliberately `pub` but has only private `#[signal]` declaration.
+// Regression test, as this caused "leaked private types" in the past.
+#[derive(GodotClass)]
+#[class(init, base=Object)]
+pub struct PubClassPrivSignal {
+    _base: Base<Object>,
+}
+
+#[godot_api]
+impl PubClassPrivSignal {
+    #[signal]
+    fn private_signal();
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
 // 4.2+ custom callables
 
 #[cfg(since_api = "4.2")]


### PR DESCRIPTION
Following previous work on typed signals in #1000 and #1111.
Closes #1112.

## Features

It is now possible to use signals from the base class without the `.clone().upcast().signals()` workaround:
```rs
let mut node: Gd<MyClass> = ...;

node.signals()
    .renamed()
    .connect(|| println!("renamed"));
```
or from `self`:
```rs
self.signals()
    .renamed()
    .connect_self(Self::handler);
```

You can also trivially emit base signals:
```rs
self.signals().renamed().emit();
```
<br>

## Alternatives and trade-offs

This took me forever since I kept running into a wall with inheritance and trait hell. I had many ideas, which I implemented to varying degrees. Writing them down in case the question comes up why the current approach was chosen and not X, or to better understand what exactly led to this design.
1. Make `TypedSignal` completely "unlinked" without lifetime `'c`, letting it only store a `Gd<T>`.
    - Works well for connecting (which just calls Godot APIs), however `emit` can easily cause double-borrow errors when invoked from `self`.
    - This means we have to keep `&mut self` borrowed (precisely: `BaseMut` guard), which then requires a lifetime.
    
1. Back and forth between the "signal collection" (struct returned by `signals()`) being able to call one or multiple signals.
    - Allowing `let s = obj.signals(); s.first_sig(); s.second_sig();` is possible, but requires 2nd lifetime `TypedSignal<'a, 'c, ...>`.
    - 2nd lifetime `'a` renders temporary calls `obj.signals.first_sig()` impossible, which is a big downgrade.
1. Signal collection methods taking `self` or `&mut self`:
   - Owned: seems logical if only 1 signal can be called anyway.
   - However, this doesn't work with `Deref`-enabled methods, so can't work for base classes.
   - So, I settled for `&mut self` with runtime checks to be invoked only once. Will be documented.
1. Generic argument `C` (the static class on which `signals()` is invoked)
   - Previously, `TypedSignal` was just typed with the class that _declared_ the signals (e.g. `Node`). Now `C` can be `MyClass` even if a `Node` signal is manipulated.
   - `C` is necessary for only one thing: `connect_self()` type safety
   - This requires passing `C` through all signal collections and all individual signal structs.
1. Instead of fluent API, use something like `Signals::connect(self, Self::renamed, Self::handler)`
   - Flatter -- wouldn't need to duct `C` and `'c` deeply through multiple layers.
   - Constants `Self::renamed` cannot be `Deref`-inherited... so we'd still need `Signals::connect(self.signals().renamed(), Self::handler)`
   - For emit, we need to pass in `&mut self` but can only do so once; `Signals::emit(self.signals().damage_taken(), 123)` would then still need to deep-borrow `self` through `self.signals()`.
1. A macro `connect! { Node::renamed => Self::handler }`
   - Sounds good for simple cases, but would need fancy DSL for more complex ones.
   - Can still be added later, probably good to have a typed API as foundation anyway.
1. Explicitly selecting signals through `self.signals_of::<Node>().renamed()`
   - My 2nd favorite approach and the one I would have gone with, had the current one not worked out (I was considering giving up a few times :grimacing: ).
   - It makes people aware where signals are declared and doesn't mix the scopes.
   - On the other hand, GDScript throws all signals together with all other symbols (`func`, `var`, `const`, global API, class names, ...) and it's not really a point of complaint. Often people don't actually care (e.g. button handlers are in `BaseButton`, not `Button`). We at least have a dedicated `signals()` namespace, and usually the number of total signals in a class is manageable.
   - Something like might still be interesting for generic programming based on `Inherits<Base>` bound, similar to the `upcast_ref` pattern.
1. Duplicate signals in each derived class
   - Alternative to `Deref`, but generates a ton of symbols in both Godot and user APIs.
   - However, would work with far less generic code and wouldn't be subject to the "`&mut self` despite once" issue.

The current approach adds quite a bit of internal complexity and extra generic code. Hopefully the monomorphization is bearable; if it becomes a problem, we might look for simpler alternatives, e.g. splitting connect/emit APIs or duplicating signals in each class rather than `Deref`.

Either way, the signals API is completely new, and this PR is just another addition in the chain of many before it. I'd like to settle for an initial version, but **future API changes** are still possible. We'll likely see more of the practical impact once more users start working with typed signals.