### PR TITLE
`emit()` now available on inherited symbols + smaller cleanups

### DIFF
--- a/godot-codegen/src/generator/signals.rs
+++ b/godot-codegen/src/generator/signals.rs
@@ -174,8 +174,7 @@ fn make_signal_collection(
     let code = quote! {
         #[doc = #collection_docs]
         // C is needed for signals of derived classes that are upcast via Deref; C in that class is the derived class.
-        pub struct #collection_struct_name<'c, C: WithSignals = #class_name>
-        {
+        pub struct #collection_struct_name<'c, C: WithSignals /* = #class_name */> {
             #[doc(hidden)]
             pub(crate) __internal_obj: Option<C::__SignalObj<'c>>,
         }
@@ -228,8 +227,8 @@ fn make_signal_individual_struct(signal: &ClassSignal, params: &SignalParams) ->
         ..
     } = params;
 
-    let class_name = &signal.surrounding_class;
-    let class_ty = quote! { #class_name };
+    // let class_name = &signal.surrounding_class;
+    // let class_ty = quote! { #class_name };
     let param_tuple = quote! { ( #type_list ) };
     let typed_name = format_ident!("Typed{}", individual_struct_name);
 
@@ -238,11 +237,11 @@ fn make_signal_individual_struct(signal: &ClassSignal, params: &SignalParams) ->
         // Reduce tokens to parse by reusing this type definitions.
         type #typed_name<'c, C> = TypedSignal<'c, C, #param_tuple>;
 
-        pub struct #individual_struct_name<'c, C: WithSignals = #class_ty> {
+        pub struct #individual_struct_name<'c, C: WithSignals /* = #class_ty */> {
            typed: #typed_name<'c, C>,
         }
 
-        impl<'c> #individual_struct_name<'c> {
+        impl<'c, C: WithSignals> #individual_struct_name<'c, C> {
             pub fn emit(&mut self, #param_list) {
                 self.typed.emit_tuple( (#name_list) );
             }

--- a/godot-core/src/registry/signal/typed_signal.rs
+++ b/godot-core/src/registry/signal/typed_signal.rs
@@ -84,13 +84,6 @@ impl<'c, C: WithSignals, Ps: meta::ParamTuple> TypedSignal<'c, C, Ps> {
         Self::new(obj, signal_name)
     }
 
-    // pub fn extract_user<Ps: meta::ParamTuple>(
-    //     this: &mut Option<UserSignalObject<'c, C>>,
-    //     signal_name: &'static str,
-    // ) -> TypedSignal<'c, C, Ps> {
-    //     TypedSignal::extract(this, signal_name)
-    // }
-
     // Currently only invoked from godot-core classes, or from UserSignalObject::into_typed_signal.
     // When making public, make also #[doc(hidden)].
     fn new(object: C::__SignalObj<'c>, name: &'static str) -> Self {

--- a/godot-macros/src/class/data_models/signal.rs
+++ b/godot-macros/src/class/data_models/signal.rs
@@ -302,13 +302,7 @@ impl SignalCollection {
             // visibility that exceeds the class visibility). So, we can as well declare the visibility here.
             #vis_marker fn #signal_name(&mut self) -> #individual_struct_name<'c, C> {
                 #individual_struct_name {
-                    // __typed: ::godot::register::TypedSignal::new(self.__internal_obj, #signal_name_str)
-                    // __typed: ::godot::register::TypedSignal::<'c, C, _>::new(self.__internal_obj, #signal_name_str)
-                    // __typed: todo!()
-
-                    // __typed: self.__internal_obj.into_typed_signal(#signal_name_str)
                     __typed: ::godot::register::TypedSignal::<'c, C, _>::extract(&mut self.__internal_obj, #signal_name_str)
-
                 }
             }
         });


### PR DESCRIPTION
Small follow-up to #1134, allowing to also call `emit()` on base class functions. This was disabled because of generic parameters `<'c>` instead of `<'c, C>`, thus defaulting to `C = Self`.

Adds tests for "internal" (`self`) connecting + emitting of signals declared in the base class.

Also cleans up some dead code.