### PR TITLE
Prevent signal_future_send_arg_no_panic test from panicing

### DIFF
--- a/itest/rust/src/engine_tests/async_test.rs
+++ b/itest/rust/src/engine_tests/async_test.rs
@@ -160,9 +160,8 @@ fn signal_future_non_send_arg_panic() -> TaskHandle {
     handle
 }
 
-// FIXME test is flaky and occasionally breaks CI job `linux-features-experimental`. Should become deterministic, then un-skip.
 #[cfg(feature = "experimental-threads")]
-#[itest(async, skip)]
+#[itest(async)]
 fn signal_future_send_arg_no_panic() -> TaskHandle {
     use crate::framework::ThreadCrosser;
 


### PR DESCRIPTION
The signal_future_send_arg_no_panic test has been flaky in some recent CI runs and caused a non-unwinding panic.

I spent a bunch of time figuring out what was going on with this test. In the end, I was able to narrow it down to the panic occurring inside the `Drop` implementation of the `FallibleSignalFuture`, specifically inside the call to `Signal::is_connected`. 

The `Future` is trying to perform some clean up when it's dropped, and in this test the cleanup overlaps with the cleanup of the thread that is emitting the signal. It sometimes occurred that the initial validity check in L266 passed, but when we checked if the callable is still connected in L280, the object was already freed. By checking the signal validity again, I was no longer able to encounter the panic. (I'm performing 100 repetitions of the `itest` run, and this was able to always trigger the panic before the fix https://github.com/godot-rust/gdext/actions/runs/14578392838/job/40889473417).

If we change the test to only drop the signal object once the async task has completed, we can prevent this panic from ever occurring. I would like to hold off on that change for now, though because this scenario could also come up in user code and hopefully, our Drop implementation is robust enough for the panic not to occur. 

Should the test remain flaky, we can change the way the signal object is handled.