### PR TITLE
Document `DynGd<_, D>` type inference.

### DIFF
--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -482,7 +482,7 @@ impl<T: GodotClass> Gd<T> {
     pub fn into_dyn<D>(self) -> DynGd<T, D>
     where
         T: crate::obj::AsDyn<D> + Bounds<Declarer = bounds::DeclUser>,
-        D: ?Sized,
+        D: ?Sized + 'static,
     {
         DynGd::<T, D>::from_gd(self)
     }

--- a/godot-core/src/obj/guards.rs
+++ b/godot-core/src/obj/guards.rs
@@ -104,7 +104,10 @@ pub struct DynGdRef<'a, D: ?Sized> {
     cached_ptr: *const D,
 }
 
-impl<'a, D: ?Sized> DynGdRef<'a, D> {
+impl<'a, D> DynGdRef<'a, D>
+where
+    D: ?Sized + 'static,
+{
     #[doc(hidden)]
     pub fn from_guard<T: AsDyn<D>>(guard: GdRef<'a, T>) -> Self {
         let obj = &*guard;
@@ -147,7 +150,10 @@ pub struct DynGdMut<'a, D: ?Sized> {
     cached_ptr: *mut D,
 }
 
-impl<'a, D: ?Sized> DynGdMut<'a, D> {
+impl<'a, D> DynGdMut<'a, D>
+where
+    D: ?Sized + 'static,
+{
     #[doc(hidden)]
     pub fn from_guard<T: AsDyn<D>>(mut guard: GdMut<'a, T>) -> Self {
         let obj = &mut *guard;

--- a/godot-core/src/obj/traits.rs
+++ b/godot-core/src/obj/traits.rs
@@ -148,7 +148,10 @@ unsafe impl<T: GodotClass> Inherits<T> for T {}
 // Note: technically, `Trait` doesn't _have to_ implement `Self`. The Rust type system provides no way to verify that a) D is a trait object,
 // and b) that the trait behind it is implemented for the class. Thus, users could any another reference type, such as `&str` pointing to a field.
 // This should be safe, since lifetimes are checked throughout and the class instance remains in place (pinned) inside a DynGd.
-pub trait AsDyn<Trait: ?Sized>: GodotClass {
+pub trait AsDyn<Trait>: GodotClass
+where
+    Trait: ?Sized + 'static,
+{
     fn dyn_upcast(&self) -> &Trait;
     fn dyn_upcast_mut(&mut self) -> &mut Trait;
 }

--- a/godot-core/src/registry/callbacks.rs
+++ b/godot-core/src/registry/callbacks.rs
@@ -192,7 +192,6 @@ pub unsafe extern "C" fn to_string<T: cap::GodotToString>(
     out_string: sys::GDExtensionStringPtr,
 ) {
     // Note: to_string currently always succeeds, as it is only provided for classes that have a working implementation.
-    // is_valid output parameter thus not needed.
 
     let storage = as_storage::<T>(instance);
     let instance = storage.get();
@@ -200,6 +199,8 @@ pub unsafe extern "C" fn to_string<T: cap::GodotToString>(
 
     // Transfer ownership to Godot
     string.move_into_string_ptr(out_string);
+
+    // Note: is_valid comes uninitialized and must be set.
     *is_valid = sys::conv::SYS_TRUE;
 }
 


### PR DESCRIPTION
Closes: #1026 

- Document when type inference works and when it doesn't.
- Going with lilizoey [suggestion](https://github.com/godot-rust/gdext/issues/1026#issuecomment-2645925679) – Explicitly enforce `Trait: 'static` for `DynGd<T, Trait>` and `AsDyn<Trait>`  (we have no means to track lifetimes of given object either way which means it might be invalidated at any point – albeit creating such `DynGd` is hard, since `GodotClass` must be `'static` either way).

----------------------

Despite messing with it for some time I couldn't force compiler to properly infer given types – thus I limited myself to merely documenting it :unamused:.