### PR TITLE
Release job in minimal CI; temporarily work around Godot blocker

### DIFF
--- a/.github/composite/godot-install/action.yml
+++ b/.github/composite/godot-install/action.yml
@@ -42,10 +42,12 @@ runs:
         ARTIFACT_NAME: ${{ inputs.artifact-name }}
 #      if: steps.cache-godot.outputs.cache-hit != 'true'
       # If a specific Godot revision should be used, rather than latest, use this:
-      # curl https://nightly.link/Bromeon/godot4-nightly/actions/runs/4910907653/${{ inputs.artifact-name }}.zip \
+      # curl https://nightly.link/Bromeon/godot4-nightly/actions/runs/4910907653/$ARTIFACT_NAME.zip \
       run: |
         if [[ $ARTIFACT_NAME == *"nightly"* ]]; then
           url="https://nightly.link/Bromeon/godot4-nightly/workflows/compile-godot-nightly/master/$ARTIFACT_NAME.zip"
+          # FIXME: re-enable latest as soon as https://github.com/godotengine/godot/issues/105834 is resolved.
+          url="https://nightly.link/Bromeon/godot4-nightly/actions/runs/14632778165/$ARTIFACT_NAME.zip"
         else
           url="https://nightly.link/Bromeon/godot4-nightly/workflows/compile-godot-stable/master/$ARTIFACT_NAME.zip"
         fi

--- a/.github/workflows/minimal-ci.yml
+++ b/.github/workflows/minimal-ci.yml
@@ -167,6 +167,15 @@ jobs:
             godot-binary: godot.linuxbsd.editor.dev.x86_64
             rust-extra-args: --features itest/experimental-threads,itest/codegen-full-experimental,godot/api-custom,godot/serde,itest/register-docs
 
+          - name: linux-release
+            os: ubuntu-22.04
+            artifact-name: linux-release-nightly
+            godot-binary: godot.linuxbsd.template_release.x86_64
+            # Use `codegen-full-experimental` to make sure that all function tables can be loaded in Godot release builds.
+            # If the experimental part causes problems, downgrade to `codegen-full`.
+            rust-extra-args: --release --features itest/codegen-full-experimental
+            rust-cache-key: release
+
           # Linux compat
 
           - name: linux-4.4


### PR DESCRIPTION
Release builds have recently caused occasional problems, which then only showed up upon merge, causing unexpected blocked pipelines. This makes them recognizable much earlier.

Also pins the nightly Godot version, until there's more clarity about https://github.com/godotengine/godot/issues/105834 which currently blocks Release pipelines due to memory leaks.