### PR TITLE
Properly set GDExtensionBool is_valid to true in `to_string` function.

### DIFF
--- a/.github/composite/godot-install/action.yml
+++ b/.github/composite/godot-install/action.yml
@@ -41,13 +41,11 @@ runs:
       env:
         ARTIFACT_NAME: ${{ inputs.artifact-name }}
 #      if: steps.cache-godot.outputs.cache-hit != 'true'
-      # If a specific Godot revision should be used, rather than latest, use this:
-      # curl https://nightly.link/Bromeon/godot4-nightly/actions/runs/4910907653/$ARTIFACT_NAME.zip \
       run: |
         if [[ $ARTIFACT_NAME == *"nightly"* ]]; then
           url="https://nightly.link/Bromeon/godot4-nightly/workflows/compile-godot-nightly/master/$ARTIFACT_NAME.zip"
-          # FIXME: re-enable latest as soon as https://github.com/godotengine/godot/issues/105834 is resolved.
-          url="https://nightly.link/Bromeon/godot4-nightly/actions/runs/14632778165/$ARTIFACT_NAME.zip"
+          # If a specific Godot revision should be used, rather than latest, use this:
+          # url="https://nightly.link/Bromeon/godot4-nightly/actions/runs/<WORKFLOW_RUN_ID>/$ARTIFACT_NAME.zip"
         else
           url="https://nightly.link/Bromeon/godot4-nightly/workflows/compile-godot-stable/master/$ARTIFACT_NAME.zip"
         fi

--- a/godot-core/src/registry/callbacks.rs
+++ b/godot-core/src/registry/callbacks.rs
@@ -188,7 +188,7 @@ pub unsafe extern "C" fn default_get_virtual<T: UserClass>(
 
 pub unsafe extern "C" fn to_string<T: cap::GodotToString>(
     instance: sys::GDExtensionClassInstancePtr,
-    _is_valid: *mut sys::GDExtensionBool,
+    is_valid: *mut sys::GDExtensionBool,
     out_string: sys::GDExtensionStringPtr,
 ) {
     // Note: to_string currently always succeeds, as it is only provided for classes that have a working implementation.
@@ -200,6 +200,7 @@ pub unsafe extern "C" fn to_string<T: cap::GodotToString>(
 
     // Transfer ownership to Godot
     string.move_into_string_ptr(out_string);
+    *is_valid = sys::conv::SYS_TRUE;
 }
 
 #[cfg(before_api = "4.2")]


### PR DESCRIPTION
it does what it says on the tin, duh.

GDExtension never checked this bool before: https://github.com/godotengine/godot/pull/105546. It was never initialized by either side (UB: https://doc.rust-lang.org/reference/behavior-considered-undefined.html#r-undefined.validity.undef)