### PR TITLE
User classes expose typed-signal API even without `#[signal]`

### DIFF
--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -326,7 +326,8 @@ impl<T: GodotClass> Gd<T> {
 
     /// Equivalent to [`upcast::<Object>()`][Self::upcast], but without bounds.
     // Not yet public because it might need _mut/_ref overloads, and 6 upcast methods are a bit much...
-    pub(crate) fn upcast_object(self) -> Gd<classes::Object> {
+    #[doc(hidden)] // no public API, but used by #[signal].
+    pub fn upcast_object(self) -> Gd<classes::Object> {
         self.owned_cast()
             .expect("Upcast to Object failed. This is a bug; please report it.")
     }

--- a/godot-macros/src/class/godot_api.rs
+++ b/godot-macros/src/class/godot_api.rs
@@ -17,9 +17,20 @@ fn parse_inherent_impl_attr(meta: TokenStream) -> Result<super::InherentImplAttr
     let item = venial_parse_meta(&meta, format_ident!("godot_api"), &quote! { fn func(); })?;
     let mut attr = KvParser::parse_required(item.attributes(), "godot_api", &meta)?;
     let secondary = attr.handle_alone("secondary")?;
+    let no_typed_signals = attr.handle_alone("no_typed_signals")?;
     attr.finish()?;
 
-    Ok(super::InherentImplAttr { secondary })
+    if no_typed_signals && secondary {
+        return bail!(
+            meta,
+            "#[godot_api]: keys `secondary` and `no_typed_signals` are mutually exclusive; secondary blocks allow no signals anyway"
+        )?;
+    }
+
+    Ok(super::InherentImplAttr {
+        secondary,
+        no_typed_signals,
+    })
 }
 
 pub fn attribute_godot_api(

--- a/godot-macros/src/util/kv_parser.rs
+++ b/godot-macros/src/util/kv_parser.rs
@@ -64,6 +64,7 @@ impl KvParser {
     /// Like `parse()`, but removes the attribute from the list.
     ///
     /// Useful for `#[proc_macro_attributes]`, where handled attributes must not show up in resulting code.
+    // Currently unused.
     pub fn parse_remove(
         attributes: &mut Vec<venial::Attribute>,
         expected: &str,

--- a/godot-macros/src/util/kv_parser.rs
+++ b/godot-macros/src/util/kv_parser.rs
@@ -38,6 +38,8 @@ impl KvParser {
     }
 
     /// Create a new parser which checks for presence of an `#[expected]` attribute.
+    ///
+    /// Returns `Ok(None)` if the attribute is not present.
     pub fn parse(attributes: &[venial::Attribute], expected: &str) -> ParseResult<Option<Self>> {
         let mut found_attr: Option<Self> = None;
 
@@ -45,7 +47,7 @@ impl KvParser {
             let path = &attr.path;
             if path_is_single(path, expected) {
                 if found_attr.is_some() {
-                    return bail!(attr, "only a single #[{expected}] attribute allowed",);
+                    return bail!(attr, "only a single #[{expected}] attribute allowed");
                 }
 
                 let attr_name = expected.to_string();
@@ -54,6 +56,39 @@ impl KvParser {
                     map: ParserState::parse(attr_name, &attr.value)?,
                 });
             }
+        }
+
+        Ok(found_attr)
+    }
+
+    /// Like `parse()`, but removes the attribute from the list.
+    ///
+    /// Useful for `#[proc_macro_attributes]`, where handled attributes must not show up in resulting code.
+    pub fn parse_remove(
+        attributes: &mut Vec<venial::Attribute>,
+        expected: &str,
+    ) -> ParseResult<Option<Self>> {
+        let mut found_attr: Option<Self> = None;
+        let mut found_index: Option<usize> = None;
+
+        for (i, attr) in attributes.iter().enumerate() {
+            let path = &attr.path;
+            if path_is_single(path, expected) {
+                if found_attr.is_some() {
+                    return bail!(attr, "only a single #[{expected}] attribute allowed");
+                }
+
+                let attr_name = expected.to_string();
+                found_index = Some(i);
+                found_attr = Some(Self {
+                    span: attr.tk_brackets.span,
+                    map: ParserState::parse(attr_name, &attr.value)?,
+                });
+            }
+        }
+
+        if let Some(index) = found_index {
+            attributes.remove(index);
         }
 
         Ok(found_attr)

--- a/godot-macros/src/util/mod.rs
+++ b/godot-macros/src/util/mod.rs
@@ -409,3 +409,8 @@ pub fn format_funcs_collection_struct(class_name: &Ident) -> Ident {
 pub fn format_class_visibility_macro(class_name: &Ident) -> Ident {
     format_ident!("__godot_{class_name}_vis_macro")
 }
+
+/// Returns the name of the macro used to communicate whether the `struct` (class) contains a base field.
+pub fn format_class_base_field_macro(class_name: &Ident) -> Ident {
+    format_ident!("__godot_{class_name}_has_base_field_macro")
+}

--- a/itest/rust/src/builtin_tests/containers/signal_test.rs
+++ b/itest/rust/src/builtin_tests/containers/signal_test.rs
@@ -336,40 +336,13 @@ fn signal_symbols_engine_inherited_no_own_signals() {
 
     let mut sig = obj.signals().property_list_changed();
     sig.connect_self(|this: &mut Receiver| {
-        this.receive_int_mut(941);
+        this.receive_int(941);
     });
 
     obj.notify_property_list_changed();
     assert_eq!(obj.bind().last_received.get(), LastReceived::Int(941));
 
     obj.free();
-}
-
-// Test that trait is implemented even without own #[signal] declarations (to access base signals).
-#[cfg(since_api = "4.2")]
-const fn __type_check<'c>() {
-    use godot::classes::Object;
-    use godot::obj::WithSignals;
-
-    // Needs WithUserSignals, not just WithSignals, to allow self.signals().
-    const fn has_with_user_signals<T: godot::obj::WithUserSignals>() {}
-
-    trait SameType {}
-    impl<T> SameType for (T, T) {}
-    const fn is_same_type<T, U>()
-    where
-        (T, U): SameType,
-    {
-    }
-
-    has_with_user_signals::<Receiver>();
-
-    // Checks whether there is no new collection defined, but instead the base collection is reused.
-    // This reduces the amount of proc-macro generated code.
-    is_same_type::<
-        <Receiver as WithSignals>::SignalCollection<'c, Receiver>,
-        <Object as WithSignals>::SignalCollection<'c, Receiver>, //.
-    >();
 }
 
 #[itest]

--- a/itest/rust/src/object_tests/object_test.rs
+++ b/itest/rust/src/object_tests/object_test.rs
@@ -997,8 +997,9 @@ pub mod object_test_gd {
     }
     use nested::ObjectTest;
 
-    #[godot_api]
-    #[hint(typed_signals = false)] // Allows nested::ObjectTest, which would fail otherwise due to generated decl-macro being out-of-scope.
+    // Disabling signals allows nested::ObjectTest, which would fail otherwise due to generated decl-macro being out-of-scope.
+    #[godot_api(no_typed_signals)]
+    // #[hint(has_base_field = false)] // if we allow more fine-grained control in the future
     impl nested::ObjectTest {
         #[func]
         fn pass_object(&self, object: Gd<Object>) -> i64 {

--- a/itest/rust/src/object_tests/object_test.rs
+++ b/itest/rust/src/object_tests/object_test.rs
@@ -998,6 +998,7 @@ pub mod object_test_gd {
     use nested::ObjectTest;
 
     #[godot_api]
+    #[hint(typed_signals = false)] // Allows nested::ObjectTest, which would fail otherwise due to generated decl-macro being out-of-scope.
     impl nested::ObjectTest {
         #[func]
         fn pass_object(&self, object: Gd<Object>) -> i64 {


### PR DESCRIPTION
Previously, you needed at least one `#[signal]` to make your `GodotClass` eligible for the `WithUserSignals` trait, meaning otherwise you couldn't access `self.signals()` or `Gd::signals()` methods. This made sense while at the time, but with implicit access to base signals, this can now be relaxed.

The new rule is: typed signals are enabled **if your class has a `Base<T>` field**. This still allows to use lightweight data classes without base fields.

This PR also provides a blanked opt-out for typed signals:
```rs
#[godot_api(no_typed_signals)]
impl MyClass {
    ...
}
```
This should be rarely needed, but can be helpful in situations where proc-macro API causes problems (e.g. `impl nested::MyClass`) or excessive code generation. If enabled, `#[signal]` can still be used and will register the signal, but not generate any typed APIs -- just like in v0.2.