### PR TITLE
Make CollisionShapes `...debug_color` methods available in release builds.

### DIFF
--- a/godot-codegen/src/special_cases/special_cases.rs
+++ b/godot-codegen/src/special_cases/special_cases.rs
@@ -65,16 +65,6 @@ pub fn is_class_method_deleted(class_name: &TyName, method: &JsonClassMethod, ct
         | ("VisualShaderNodeComment", "get_description")
         => true,
 
-        // Workaround for methods unexposed in Release mode, see https://github.com/godotengine/godot/pull/100317
-        // and https://github.com/godotengine/godot/pull/100328.
-        #[cfg(not(debug_assertions))]
-        | ("CollisionShape2D", "set_debug_color")
-        | ("CollisionShape2D", "get_debug_color")
-        | ("CollisionShape3D", "set_debug_color")
-        | ("CollisionShape3D", "get_debug_color")
-        | ("CollisionShape3D", "set_debug_fill_enabled")
-        | ("CollisionShape3D", "get_debug_fill_enabled") => true,
-
         // Thread APIs
         #[cfg(not(feature = "experimental-threads"))]
         | ("ResourceLoader", "load_threaded_get")


### PR DESCRIPTION
Removes workaround which prevented `CollisionShape`s `...debug_color` methods from being included in release. Such workaround is no longer needed after merging https://github.com/godotengine/godot/issues/100313 (thanks to @TCROC!)

-----------------

CollisionShape2D get_debug_color/set_debug_color has been not included in debug builds since https://github.com/godotengine/godot/commit/8bf2afd341bd5d4bd7a7467dea2949c42bf35f13#diff-b07f10570f29de9ab0e39e74828235039e69e0daf868c5c75df1ee08eebc51faR291 (after 4.3 but before 4.4)

CollisionShape3D get_debug_color/set_debug_color has been not included in debug builds since https://github.com/godotengine/godot/commit/0fc082e1ee3af5bb6a4b52f85756d24dc02b230f#diff-1478d3a16f2f88792c6319c04c5cf068e01bef1d4e4e66ab135c87d905ca93e6R183 (after 4.3 but before 4.4)

Both were exposed again for release builds after merging: https://github.com/godotengine/godot/pull/100317.

Aforementioned methods are available for CollisionShape2D in 4.4: https://github.com/godotengine/godot/blob/4.4/scene/2d/physics/collision_shape_2d.cpp#L277 and 4.3: https://github.com/godotengine/godot/blob/4.3/scene/2d/physics/collision_shape_2d.cpp#L277

as for CollisionShape3D – it is exposed for 4.4 https://github.com/godotengine/godot/blob/4.4/scene/3d/physics/collision_shape_3d.cpp#L176. Not present in 4.3 at all: https://github.com/godotengine/godot/blob/4.3/scene/3d/physics/collision_shape_3d.cpp#L161.



I tested it manually as well (with 4.3 and 4.4) and it seems to work