### PR TITLE
Generated `emit()` functions now take `impl AsArg<T>`

### DIFF
--- a/godot-core/src/builtin/collections/array.rs
+++ b/godot-core/src/builtin/collections/array.rs
@@ -1137,6 +1137,10 @@ impl<T: ArrayElement> ParamType for Array<T> {
     fn arg_to_ref<'r>(arg: &'r Self::Arg<'_>) -> &'r Self {
         arg.cow_as_ref()
     }
+
+    fn arg_into_owned(arg: Self::Arg<'_>) -> Self {
+        arg.cow_into_owned()
+    }
 }
 
 impl<T: ArrayElement> GodotConvert for Array<T> {

--- a/godot-core/src/meta/mod.rs
+++ b/godot-core/src/meta/mod.rs
@@ -72,9 +72,10 @@ pub(crate) use traits::{
 use crate::registry::method::MethodParamOrReturnInfo;
 
 pub(crate) use crate::{
-    arg_into_owned, arg_into_ref, declare_arg_method, impl_asarg_by_ref, impl_asarg_by_value,
-    impl_godot_as_self,
+    arg_into_ref, declare_arg_method, impl_asarg_by_ref, impl_asarg_by_value, impl_godot_as_self,
 };
+// Public due to signals emit() needing it. Should be made pub(crate) again if that changes.
+pub use crate::arg_into_owned;
 
 #[doc(hidden)]
 pub use signature::*;

--- a/godot-core/src/obj/dyn_gd.rs
+++ b/godot-core/src/obj/dyn_gd.rs
@@ -543,6 +543,23 @@ where
     }
 }
 
+/*
+// See `impl AsArg for Gd<T>` for why this isn't yet implemented.
+impl<'r, T, TBase, D> meta::AsArg<DynGd<TBase, D>> for &'r DynGd<T, D>
+where
+    T: Inherits<TBase>,
+    TBase: GodotClass,
+    D: ?Sized + 'static,
+{
+    fn into_arg<'cow>(self) -> meta::CowArg<'cow, DynGd<TBase, D>>
+    where
+        'r: 'cow,
+    {
+        meta::CowArg::Owned(self.clone().upcast::<TBase>())
+    }
+}
+*/
+
 impl<T, D> meta::ParamType for DynGd<T, D>
 where
     T: GodotClass,

--- a/godot-core/src/obj/dyn_gd.rs
+++ b/godot-core/src/obj/dyn_gd.rs
@@ -557,6 +557,10 @@ where
     fn arg_to_ref<'r>(arg: &'r Self::Arg<'_>) -> &'r Self {
         arg.cow_as_ref()
     }
+
+    fn arg_into_owned(arg: Self::Arg<'_>) -> Self {
+        arg.cow_into_owned()
+    }
 }
 
 impl<T, D> meta::ArrayElement for DynGd<T, D>

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -862,6 +862,10 @@ impl<T: GodotClass> ParamType for Gd<T> {
     fn arg_to_ref<'r>(arg: &'r Self::Arg<'_>) -> &'r Self {
         arg.cow_as_ref()
     }
+
+    fn arg_into_owned(arg: Self::Arg<'_>) -> Self {
+        arg.cow_into_owned()
+    }
 }
 
 impl<T: GodotClass> AsArg<Option<Gd<T>>> for Option<&Gd<T>> {
@@ -883,6 +887,10 @@ impl<T: GodotClass> ParamType for Option<Gd<T>> {
 
     fn arg_to_ref<'r>(arg: &'r Self::Arg<'_>) -> &'r Self {
         arg.cow_as_ref()
+    }
+
+    fn arg_into_owned(arg: Self::Arg<'_>) -> Self {
+        arg.cow_into_owned()
     }
 }
 

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -852,6 +852,30 @@ impl<'r, T: GodotClass> AsArg<Gd<T>> for &'r Gd<T> {
     }
 }
 
+/*
+// TODO find a way to generalize AsArg to derived->base conversions without breaking type inference in array![].
+// Possibly we could use a "canonical type" with unambiguous mapping (&Gd<T> -> &Gd<T>, not &Gd<T> -> &Gd<TBase>).
+// See also regression test in array_test.rs.
+
+impl<'r, T, TBase> AsArg<Gd<TBase>> for &'r Gd<T>
+where
+    T: Inherits<TBase>,
+    TBase: GodotClass,
+{
+    #[doc(hidden)] // Repeated despite already hidden in trait; some IDEs suggest this otherwise.
+    fn into_arg<'cow>(self) -> CowArg<'cow, Gd<TBase>>
+    where
+        'r: 'cow, // Original reference must be valid for at least as long as the returned cow.
+    {
+        // Performance: clones unnecessarily, which has overhead for ref-counted objects.
+        // A result of being generic over base objects and allowing T: Inherits<Base> rather than just T == Base.
+        // Was previously `CowArg::Borrowed(self)`. Borrowed() can maybe be specialized for objects, or combined with AsObjectArg.
+
+        CowArg::Owned(self.clone().upcast::<TBase>())
+    }
+}
+*/
+
 impl<T: GodotClass> ParamType for Gd<T> {
     type Arg<'v> = CowArg<'v, Gd<T>>;
 

--- a/itest/rust/src/builtin_tests/containers/array_test.rs
+++ b/itest/rust/src/builtin_tests/containers/array_test.rs
@@ -570,6 +570,18 @@ fn array_resize() {
     assert_eq!(a, Array::new());
 }
 
+// Tests that arrays of objects can be declared without explicit type annotations. A similar test exists for DynGd in dyn_gd_test.rs.
+// This has deliberately been added to guard against regressions in case `AsArg` is extended (T: Inherits<Base> support broke this).
+fn __array_type_inference() {
+    let a = Node::new_alloc();
+    let b = Node::new_alloc();
+    let _array = array![&a, &b];
+
+    let c = ArrayTest::new_gd();
+    let d = ArrayTest::new_gd();
+    let _array = array![&c, &d];
+}
+
 #[derive(GodotClass, Debug)]
 #[class(init, base=RefCounted)]
 struct ArrayTest;

--- a/itest/rust/src/engine_tests/async_test.rs
+++ b/itest/rust/src/engine_tests/async_test.rs
@@ -229,7 +229,10 @@ fn async_typed_signal_with_array() -> TaskHandle {
         assert_eq!(result, array![1, 2, 3]);
     });
 
-    object.signals().custom_signal_array().emit(array![1, 2, 3]);
+    object
+        .signals()
+        .custom_signal_array()
+        .emit(&array![1, 2, 3]);
 
     task_handle
 }

--- a/itest/rust/src/object_tests/dyn_gd_test.rs
+++ b/itest/rust/src/object_tests/dyn_gd_test.rs
@@ -347,6 +347,7 @@ fn dyn_gd_store_in_godot_array() {
     let a = Gd::from_object(RefcHealth { hp: 33 }).into_dyn();
     let b = foreign::NodeHealth::new_alloc().into_dyn();
 
+    // Forward compat: .upcast() here becomes a breaking change if we generalize AsArg to include derived->base conversions.
     let array: Array<DynGd<Object, _>> = array![&a.upcast(), &b.upcast()];
 
     assert_eq!(array.at(0).dyn_bind().get_hitpoints(), 33);
@@ -355,8 +356,9 @@ fn dyn_gd_store_in_godot_array() {
     array.at(1).free();
 
     // Tests also type inference of array![]. Independent variable c.
-    let c = Gd::from_object(RefcHealth { hp: 33 }).into_dyn();
-    let array_inferred = array![&c];
+    let c: DynGd<RefcHealth, dyn Health> = Gd::from_object(RefcHealth { hp: 33 }).into_dyn();
+    let c = c.upcast::<RefCounted>();
+    let array_inferred /*: Array<DynGd<RefCounted, _>>*/ = array![&c];
     assert_eq!(array_inferred.at(0).dyn_bind().get_hitpoints(), 33);
 }
 

--- a/itest/rust/src/object_tests/dyn_gd_test.rs
+++ b/itest/rust/src/object_tests/dyn_gd_test.rs
@@ -4,6 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
+
 use crate::framework::{expect_panic, itest};
 // Test that all important dyn-related symbols are in the prelude.
 use godot::prelude::*;
@@ -352,6 +353,11 @@ fn dyn_gd_store_in_godot_array() {
     assert_eq!(array.at(1).dyn_bind().get_hitpoints(), 100);
 
     array.at(1).free();
+
+    // Tests also type inference of array![]. Independent variable c.
+    let c = Gd::from_object(RefcHealth { hp: 33 }).into_dyn();
+    let array_inferred = array![&c];
+    assert_eq!(array_inferred.at(0).dyn_bind().get_hitpoints(), 33);
 }
 
 #[itest]

--- a/itest/rust/src/object_tests/object_test.rs
+++ b/itest/rust/src/object_tests/object_test.rs
@@ -1040,6 +1040,7 @@ pub mod object_test_gd {
 
         #[func]
         fn return_nested_self() -> Array<Gd<<Self as GodotClass>::Base>> {
+            // Forward compat: .upcast() here becomes a breaking change if we generalize AsArg to include derived->base conversions.
             array![&Self::return_self().upcast()]
         }
     }


### PR DESCRIPTION

Another small signals QoL feature -- allows `emit()` arguments to be *mostly* passed like in other engine APIs, e.g.
- `i32`, `Vector2` and other `Copy` types by value
- `Gd`, `DynGd`, `Variant`, `Array`, `Dictionary` by reference
- Strings by reference or "string" literals

`AsArg` for objects isn't quite as flexible as `AsObjectArg`, which allows derived-to-base conversions. Generalizing `AsArg` the obvious way creates problems in other places, such as
```rs
let obj: Gd<...> = ...;
let a = array![&obj]; // type inference fails now
```
So we'd need to find a solution for `array!` to maybe not just call `push()` but do something with the types first.