### PR TITLE
Adjust test to account for `Node::set_name()` change (`String` -> `StringName`)

### DIFF
--- a/itest/rust/src/object_tests/object_test.rs
+++ b/itest/rust/src/object_tests/object_test.rs
@@ -708,7 +708,11 @@ fn object_engine_accept_polymorphic() {
     let expected_name = StringName::from("Node name");
     let expected_class = GString::from("Node3D");
 
+    // Node::set_name() changed to accept StringName, in https://github.com/godotengine/godot/pull/76560.
+    #[cfg(before_api = "4.5")]
     node.set_name(expected_name.arg());
+    #[cfg(since_api = "4.5")]
+    node.set_name(&expected_name);
 
     let actual_name = accept_node(node.clone());
     assert_eq!(actual_name, expected_name);


### PR DESCRIPTION
Following upstream change in https://github.com/godotengine/godot/pull/76560.
Fixes CI which assumed that `Node::set_name()` would always take a `GString` argument.

This now needs case differentiation when passing Godot strings to `Node::set_name()`:
- API level 4.4 can pass `set_name(&gstring)`, `set_name(string_name.arg())`
- API level 4.5 can pass `set_name(gstring.arg())`, `set_name(&string_name)`

Some thoughts:
- We could of course implement `AsArg` for both `String`/`StringName` interchangeably, but I didn't do this so far as it would be easy to miss perf-relevant conversions. An API change like this could introduce quite a bit different runtime behavior, which would be very hard to find. 
- Another option would be to provide `.arg()` even for the same type, to handle explicit "I take potential conversion into account" scenarios.
- To avoid case differentiations, `&str` and `&String` can still be provided as arguments.