### PR TITLE
Support `@export_file`, `@export_dir` etc. for `Array<GString>` and `PackedStringArray`

### DIFF
--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -20,6 +20,8 @@ env:
   # Crates to publish -- important, this doesn't work when there are spaces in any of the paths!
   # Keep in sync with update-version.sh
   GDEXT_CRATES: >
+    godot-bindings
+    godot-codegen
     godot-macros
     godot-ffi
     godot-cell

--- a/godot-bindings/src/lib.rs
+++ b/godot-bindings/src/lib.rs
@@ -217,20 +217,16 @@ pub fn remove_dir_all_reliable(path: &Path) {
     }
 }
 
-// Duplicates code from `make_gdext_build_struct` in `godot-codegen/generator/gdext_build_struct.rs`.
+/// Concrete check against an API level, not runtime level.
+///
+/// Necessary in `build.rs`, which doesn't itself have the cfgs.
 pub fn before_api(major_minor: &str) -> bool {
-    let mut parts = major_minor.split('.');
-    let queried_major = parts
-        .next()
-        .unwrap()
-        .parse::<u8>()
-        .expect("invalid major version");
-    let queried_minor = parts
-        .next()
-        .unwrap()
-        .parse::<u8>()
-        .expect("invalid minor version");
-    assert_eq!(queried_major, 4, "major version must be 4");
+    let queried_minor = major_minor
+        .strip_prefix("4.")
+        .expect("major version must be 4");
+
+    let queried_minor = queried_minor.parse::<u8>().expect("invalid minor version");
+
     let godot_version = get_godot_version();
     godot_version.minor < queried_minor
 }

--- a/godot-core/src/meta/traits.rs
+++ b/godot-core/src/meta/traits.rs
@@ -118,6 +118,12 @@ pub trait GodotType: GodotConvert<Via = Self> + sealed::Sealed + Sized + 'static
         ))
     }
 
+    /// Returns a string representation of the Godot type name, as it is used in several property hint contexts.
+    ///
+    /// Examples:
+    /// - `MyClass` for objects
+    /// - `StringName`, `AABB` or `int` for builtins
+    /// - `Array` for arrays
     #[doc(hidden)]
     fn godot_type_name() -> String;
 
@@ -165,7 +171,9 @@ pub trait ArrayElement: ToGodot + FromGodot + sealed::Sealed + meta::ParamType {
     // Note: several indirections in ArrayElement and the global `element_*` functions go through `GodotConvert::Via`,
     // to not require Self: GodotType. What matters is how array elements map to Godot on the FFI level (GodotType trait).
 
-    /// Returns the representation of this type as a type string.
+    /// Returns the representation of this type as a type string, e.g. `"4:"` for string, or `"24:34/MyClass"` for objects.
+    ///
+    /// (`4` and `24` are variant type ords; `34` is `PropertyHint::NODE_TYPE` ord).
     ///
     /// Used for elements in arrays (the latter despite `ArrayElement` not having a direct relation).
     ///

--- a/godot-core/src/registry/property.rs
+++ b/godot-core/src/registry/property.rs
@@ -226,8 +226,10 @@ where
 pub mod export_info_functions {
     use crate::builtin::GString;
     use crate::global::PropertyHint;
-    use crate::meta::PropertyHintInfo;
+    use crate::meta::{GodotType, PropertyHintInfo, PropertyInfo};
+    use crate::obj::EngineEnum;
     use crate::registry::property::Export;
+    use godot_ffi::VariantType;
 
     /// Turn a list of variables into a comma separated string containing only the identifiers corresponding
     /// to a true boolean variable.
@@ -416,9 +418,19 @@ pub mod export_info_functions {
         is_global: bool,
         filter: impl AsRef<str>,
     ) -> PropertyHintInfo {
+        let field_ty = T::Via::property_info("");
         let filter = filter.as_ref();
         debug_assert!(is_file || filter.is_empty()); // Dir never has filter.
 
+        export_file_or_dir_inner(&field_ty, is_file, is_global, filter)
+    }
+
+    pub fn export_file_or_dir_inner(
+        field_ty: &PropertyInfo,
+        is_file: bool,
+        is_global: bool,
+        filter: &str,
+    ) -> PropertyHintInfo {
         let hint = match (is_file, is_global) {
             (true, true) => PropertyHint::GLOBAL_FILE,
             (true, false) => PropertyHint::FILE,
@@ -426,9 +438,47 @@ pub mod export_info_functions {
             (false, false) => PropertyHint::DIR,
         };
 
+        // Returned value depends on field type.
+        match field_ty.variant_type {
+            // GString field:
+            // { "type": 4, "hint": 13, "hint_string": "*.png" }
+            VariantType::STRING => PropertyHintInfo {
+                hint,
+                hint_string: GString::from(filter),
+            },
+
+            // Array<GString> or PackedStringArray field:
+            // { "type": 28, "hint": 23, "hint_string": "4/13:*.png" }
+            VariantType::PACKED_STRING_ARRAY => to_string_array_hint(hint, filter),
+            VariantType::ARRAY if field_ty.is_array_of_elem::<GString>() => {
+                to_string_array_hint(hint, filter)
+            }
+
+            _ => {
+                // E.g. `global_file`.
+                let attribute_name = hint.as_str().to_lowercase();
+
+                // TODO nicer error handling.
+                // Compile time may be difficult (at least without extra traits... maybe const fn?). But at least more context info, field name etc.
+                panic!(
+                    "#[export({attribute_name})] only supports GString, Array<String> or PackedStringArray field types\n\
+                    encountered: {field_ty:?}"
+                );
+            }
+        }
+    }
+
+    /// For `Array<GString>` and `PackedStringArray` fields using one of the `@export[_global]_{file|dir}` annotations.
+    ///
+    /// Formats: `"4/13:"`, `"4/15:*.png"`, ...
+    fn to_string_array_hint(hint: PropertyHint, filter: &str) -> PropertyHintInfo {
+        let variant_ord = VariantType::STRING.ord(); // "4"
+        let hint_ord = hint.ord();
+        let hint_string = format!("{variant_ord}/{hint_ord}");
+
         PropertyHintInfo {
-            hint,
-            hint_string: GString::from(filter),
+            hint: PropertyHint::TYPE_STRING,
+            hint_string: format!("{hint_string}:{filter}").into(),
         }
     }
 
@@ -603,9 +653,9 @@ pub(crate) fn builtin_type_string<T: GodotType>() -> String {
 
     // Godot 4.3 changed representation for type hints, see https://github.com/godotengine/godot/pull/90716.
     if sys::GdextBuild::since_api("4.3") {
-        format!("{}:", variant_type.sys())
+        format!("{}:", variant_type.ord())
     } else {
-        format!("{}:{}", variant_type.sys(), T::godot_type_name())
+        format!("{}:{}", variant_type.ord(), T::godot_type_name())
     }
 }
 

--- a/godot-core/src/registry/property.rs
+++ b/godot-core/src/registry/property.rs
@@ -227,6 +227,7 @@ pub mod export_info_functions {
     use crate::builtin::GString;
     use crate::global::PropertyHint;
     use crate::meta::PropertyHintInfo;
+    use crate::registry::property::Export;
 
     /// Turn a list of variables into a comma separated string containing only the identifiers corresponding
     /// to a true boolean variable.
@@ -412,18 +413,39 @@ pub mod export_info_functions {
     /// Equivalent to `@export_file` in Godot.
     ///
     /// Pass an empty string to have no filter.
-    pub fn export_file<S: AsRef<str>>(filter: S) -> PropertyHintInfo {
-        export_file_inner(false, filter)
+    pub fn export_file<T: Export>(filter: impl AsRef<str>) -> PropertyHintInfo {
+        //T::var_hint()
+        export_file_inner::<T>(false, filter)
+    }
+
+    /// Equivalent to `@export_dir` in Godot.
+    ///
+    /// Pass an empty string to have no filter.
+    pub fn export_dir<T: Export>() -> PropertyHintInfo {
+        PropertyHintInfo {
+            hint: PropertyHint::DIR,
+            hint_string: GString::new(),
+        }
+    }
+
+    /// Equivalent to `@export_global_dir` in Godot.
+    ///
+    /// Pass an empty string to have no filter.
+    pub fn export_global_dir<T: Export>() -> PropertyHintInfo {
+        PropertyHintInfo {
+            hint: PropertyHint::GLOBAL_DIR,
+            hint_string: GString::new(),
+        }
     }
 
     /// Equivalent to `@export_global_file` in Godot.
     ///
     /// Pass an empty string to have no filter.
-    pub fn export_global_file<S: AsRef<str>>(filter: S) -> PropertyHintInfo {
-        export_file_inner(true, filter)
+    pub fn export_global_file<T: Export>(filter: impl AsRef<str>) -> PropertyHintInfo {
+        export_file_inner::<T>(true, filter)
     }
 
-    pub fn export_file_inner<S: AsRef<str>>(global: bool, filter: S) -> PropertyHintInfo {
+    pub fn export_file_inner<T: Export>(global: bool, filter: impl AsRef<str>) -> PropertyHintInfo {
         let hint = if global {
             PropertyHint::GLOBAL_FILE
         } else {
@@ -468,8 +490,6 @@ pub mod export_info_functions {
         export_flags_3d_physics => LAYERS_3D_PHYSICS,
         export_flags_3d_render => LAYERS_3D_RENDER,
         export_flags_3d_navigation => LAYERS_3D_NAVIGATION,
-        export_dir => DIR,
-        export_global_dir => GLOBAL_DIR,
         export_multiline => MULTILINE_TEXT,
         export_color_no_alpha => COLOR_NO_ALPHA,
     );

--- a/godot-core/src/registry/property.rs
+++ b/godot-core/src/registry/property.rs
@@ -410,58 +410,32 @@ pub mod export_info_functions {
         }
     }
 
-    /// Equivalent to `@export_file` in Godot.
-    ///
-    /// Pass an empty string to have no filter.
-    pub fn export_file<T: Export>(filter: impl AsRef<str>) -> PropertyHintInfo {
-        //T::var_hint()
-        export_file_inner::<T>(false, filter)
-    }
+    /// Handles `@export_file`, `@export_global_file`, `@export_dir` and `@export_global_dir`.
+    pub fn export_file_or_dir<T: Export>(
+        is_file: bool,
+        is_global: bool,
+        filter: impl AsRef<str>,
+    ) -> PropertyHintInfo {
+        let filter = filter.as_ref();
+        debug_assert!(is_file || filter.is_empty()); // Dir never has filter.
 
-    /// Equivalent to `@export_dir` in Godot.
-    ///
-    /// Pass an empty string to have no filter.
-    pub fn export_dir<T: Export>() -> PropertyHintInfo {
-        PropertyHintInfo {
-            hint: PropertyHint::DIR,
-            hint_string: GString::new(),
-        }
-    }
-
-    /// Equivalent to `@export_global_dir` in Godot.
-    ///
-    /// Pass an empty string to have no filter.
-    pub fn export_global_dir<T: Export>() -> PropertyHintInfo {
-        PropertyHintInfo {
-            hint: PropertyHint::GLOBAL_DIR,
-            hint_string: GString::new(),
-        }
-    }
-
-    /// Equivalent to `@export_global_file` in Godot.
-    ///
-    /// Pass an empty string to have no filter.
-    pub fn export_global_file<T: Export>(filter: impl AsRef<str>) -> PropertyHintInfo {
-        export_file_inner::<T>(true, filter)
-    }
-
-    pub fn export_file_inner<T: Export>(global: bool, filter: impl AsRef<str>) -> PropertyHintInfo {
-        let hint = if global {
-            PropertyHint::GLOBAL_FILE
-        } else {
-            PropertyHint::FILE
+        let hint = match (is_file, is_global) {
+            (true, true) => PropertyHint::GLOBAL_FILE,
+            (true, false) => PropertyHint::FILE,
+            (false, true) => PropertyHint::GLOBAL_DIR,
+            (false, false) => PropertyHint::DIR,
         };
 
         PropertyHintInfo {
             hint,
-            hint_string: filter.as_ref().into(),
+            hint_string: GString::from(filter),
         }
     }
 
     pub fn export_placeholder<S: AsRef<str>>(placeholder: S) -> PropertyHintInfo {
         PropertyHintInfo {
             hint: PropertyHint::PLACEHOLDER_TEXT,
-            hint_string: placeholder.as_ref().into(),
+            hint_string: GString::from(placeholder.as_ref()),
         }
     }
 

--- a/godot-core/src/registry/property.rs
+++ b/godot-core/src/registry/property.rs
@@ -449,7 +449,9 @@ pub mod export_info_functions {
 
             // Array<GString> or PackedStringArray field:
             // { "type": 28, "hint": 23, "hint_string": "4/13:*.png" }
+            #[cfg(since_api = "4.3")]
             VariantType::PACKED_STRING_ARRAY => to_string_array_hint(hint, filter),
+            #[cfg(since_api = "4.3")]
             VariantType::ARRAY if field_ty.is_array_of_elem::<GString>() => {
                 to_string_array_hint(hint, filter)
             }
@@ -460,8 +462,15 @@ pub mod export_info_functions {
 
                 // TODO nicer error handling.
                 // Compile time may be difficult (at least without extra traits... maybe const fn?). But at least more context info, field name etc.
+                #[cfg(since_api = "4.3")]
                 panic!(
                     "#[export({attribute_name})] only supports GString, Array<String> or PackedStringArray field types\n\
+                    encountered: {field_ty:?}"
+                );
+
+                #[cfg(before_api = "4.3")]
+                panic!(
+                    "#[export({attribute_name})] only supports GString type prior to Godot 4.3\n\
                     encountered: {field_ty:?}"
                 );
             }

--- a/godot-macros/src/class/data_models/field_export.rs
+++ b/godot-macros/src/class/data_models/field_export.rs
@@ -495,22 +495,19 @@ impl ExportType {
             } => quote_export_func! { export_flags_3d_navigation() },
 
             Self::File {
-                global: false,
+                global,
                 kind: FileKind::Dir,
-            } => quote_export_func! { export_dir<T>() },
-
-            Self::File {
-                global: true,
-                kind: FileKind::Dir,
-            } => quote_export_func! { export_global_dir<T>() },
+            } => {
+                let filter = quote! { "" };
+                quote_export_func! { export_file_or_dir<T>(false, #global, #filter) }
+            }
 
             Self::File {
                 global,
                 kind: FileKind::File { filter },
             } => {
                 let filter = filter.clone().unwrap_or(quote! { "" });
-
-                quote_export_func! { export_file_inner<T>(#global, #filter) }
+                quote_export_func! { export_file_or_dir<T>(true, #global, #filter) }
             }
 
             Self::Multiline => quote_export_func! { export_multiline() },
@@ -518,6 +515,7 @@ impl ExportType {
             Self::PlaceholderText { placeholder } => quote_export_func! {
                 export_placeholder(#placeholder)
             },
+
             Self::ColorNoAlpha => quote_export_func! { export_color_no_alpha() },
         }
     }

--- a/godot-macros/src/class/data_models/field_export.rs
+++ b/godot-macros/src/class/data_models/field_export.rs
@@ -388,7 +388,15 @@ macro_rules! quote_export_func {
         Some(quote! {
             ::godot::register::property::export_info_functions::$function_name($($tt)*)
         })
-    }
+    };
+
+    // Passes in a previously declared local `type FieldType = ...` as first generic argument.
+    // Doesn't work if function takes other generic arguments -- in that case it could be converted to a Type<...> parameter.
+    ($function_name:ident < T > ($($tt:tt)*)) => {
+        Some(quote! {
+            ::godot::register::property::export_info_functions::$function_name::<FieldType>($($tt)*)
+        })
+    };
 }
 
 impl ExportType {
@@ -489,12 +497,12 @@ impl ExportType {
             Self::File {
                 global: false,
                 kind: FileKind::Dir,
-            } => quote_export_func! { export_dir() },
+            } => quote_export_func! { export_dir<T>() },
 
             Self::File {
                 global: true,
                 kind: FileKind::Dir,
-            } => quote_export_func! { export_global_dir() },
+            } => quote_export_func! { export_global_dir<T>() },
 
             Self::File {
                 global,
@@ -502,7 +510,7 @@ impl ExportType {
             } => {
                 let filter = filter.clone().unwrap_or(quote! { "" });
 
-                quote_export_func! { export_file_inner(#global, #filter) }
+                quote_export_func! { export_file_inner<T>(#global, #filter) }
             }
 
             Self::Multiline => quote_export_func! { export_multiline() },

--- a/godot-macros/src/class/data_models/property.rs
+++ b/godot-macros/src/class/data_models/property.rs
@@ -154,7 +154,9 @@ pub fn make_property_impl(class_name: &Ident, fields: &Fields) -> TokenStream {
         );
 
         export_tokens.push(quote! {
-            ::godot::register::private::#registration_fn::<#class_name, #field_type>(
+            // This type may be reused in #hint, in case of generic functions.
+            type FieldType = #field_type;
+            ::godot::register::private::#registration_fn::<#class_name, FieldType>(
                 #field_name,
                 #getter_tokens,
                 #setter_tokens,

--- a/itest/rust/build.rs
+++ b/itest/rust/build.rs
@@ -471,18 +471,44 @@ fn generate_property_template(inputs: &[Input]) -> PropertyTests {
         pub struct PropertyTestsRust {
             #(#rust,)*
 
+            // All the @export_file/dir variants, with GString, Array<GString> and PackedStringArray.
             #[export(file)]
             export_file: GString,
+            #[export(file)]
+            export_file_array: Array<GString>,
+            #[export(file)]
+            export_file_parray: PackedStringArray,
             #[export(file = "*.txt")]
-            export_file_wildcard_txt: GString,
+            export_file_wildcard: GString,
+            #[export(file = "*.txt")]
+            export_file_wildcard_array: Array<GString>,
+            #[export(file = "*.txt")]
+            export_file_wildcard_parray: PackedStringArray,
             #[export(global_file)]
             export_global_file: GString,
+            #[export(global_file)]
+            export_global_file_array: Array<GString>,
+            #[export(global_file)]
+            export_global_file_parray: PackedStringArray,
             #[export(global_file = "*.png")]
-            export_global_file_wildcard_png: GString,
+            export_global_file_wildcard: GString,
+            #[export(global_file = "*.png")]
+            export_global_file_wildcard_array: Array<GString>,
+            #[export(global_file = "*.png")]
+            export_global_file_wildcard_parray: PackedStringArray,
             #[export(dir)]
             export_dir: GString,
+            #[export(dir)]
+            export_dir_array: Array<GString>,
+            #[export(dir)]
+            export_dir_parray: PackedStringArray,
             #[export(global_dir)]
             export_global_dir: GString,
+            #[export(global_dir)]
+            export_global_dir_array: Array<GString>,
+            #[export(global_dir)]
+            export_global_dir_parray: PackedStringArray,
+
             #[export(multiline)]
             export_multiline: GString,
             #[export(range = (0.0, 20.0))]
@@ -526,11 +552,24 @@ fn generate_property_template(inputs: &[Input]) -> PropertyTests {
         r#"
 {}
 @export_file var export_file: String
-@export_file("*.txt") var export_file_wildcard_txt: String
+@export_file var export_file_array: Array[String]
+@export_file var export_file_parray: PackedStringArray
+@export_file("*.txt") var export_file_wildcard: String
+@export_file("*.txt") var export_file_wildcard_array: Array[String]
+@export_file("*.txt") var export_file_wildcard_parray: PackedStringArray
 @export_global_file var export_global_file: String
-@export_global_file("*.png") var export_global_file_wildcard_png: String
+@export_global_file var export_global_file_array: Array[String]
+@export_global_file var export_global_file_parray: PackedStringArray
+@export_global_file("*.png") var export_global_file_wildcard: String
+@export_global_file("*.png") var export_global_file_wildcard_array: Array[String]
+@export_global_file("*.png") var export_global_file_wildcard_parray: PackedStringArray
 @export_dir var export_dir: String
+@export_dir var export_dir_array: Array[String]
+@export_dir var export_dir_parray: PackedStringArray
 @export_global_dir var export_global_dir: String
+@export_global_dir var export_global_dir_array: Array[String]
+@export_global_dir var export_global_dir_parray: PackedStringArray
+
 @export_multiline var export_multiline: String
 @export_range(0, 20) var export_range_float_0_20: float
 @export_range(-10, 20, 0.2) var export_range_float_neg10_20_02: float

--- a/itest/rust/src/object_tests/property_template_test.rs
+++ b/itest/rust/src/object_tests/property_template_test.rs
@@ -102,7 +102,12 @@ fn property_template_test(ctx: &TestContext) {
         "not all properties were matched, missing: {properties:?}"
     );
 
-    assert!(errors.is_empty(), "{}", errors.join("\n"));
+    assert!(
+        errors.is_empty(),
+        "Encountered {} mismatches between GDScript and Rust:\n{}",
+        errors.len(),
+        errors.join("\n")
+    );
 
     rust_properties.free();
 }

--- a/itest/rust/src/object_tests/property_template_test.rs
+++ b/itest/rust/src/object_tests/property_template_test.rs
@@ -21,7 +21,7 @@ use crate::framework::TestContext;
 
 use crate::register_tests::gen_ffi::PropertyTestsRust;
 
-#[itest]
+#[itest(focus)]
 fn property_template_test(ctx: &TestContext) {
     let rust_properties = PropertyTestsRust::new_alloc();
     let gdscript_properties = ctx.property_tests.clone();
@@ -92,6 +92,8 @@ fn property_template_test(ctx: &TestContext) {
             errors.push(format!(
                 "mismatch in property {name}:\n  GDScript: {gdscript_prop:?}\n  Rust:     {rust_prop:?}"
             ));
+        } else {
+            println!("matching property {name}\n  GDScript: {gdscript_prop:?}\n  Rust:     {rust_prop:?}");
         }
     }
 

--- a/itest/rust/src/object_tests/property_template_test.rs
+++ b/itest/rust/src/object_tests/property_template_test.rs
@@ -21,7 +21,7 @@ use crate::framework::TestContext;
 
 use crate::register_tests::gen_ffi::PropertyTestsRust;
 
-#[itest(focus)]
+#[itest]
 fn property_template_test(ctx: &TestContext) {
     let rust_properties = PropertyTestsRust::new_alloc();
     let gdscript_properties = ctx.property_tests.clone();
@@ -92,9 +92,9 @@ fn property_template_test(ctx: &TestContext) {
             errors.push(format!(
                 "mismatch in property {name}:\n  GDScript: {gdscript_prop:?}\n  Rust:     {rust_prop:?}"
             ));
-        } else {
-            println!("matching property {name}\n  GDScript: {gdscript_prop:?}\n  Rust:     {rust_prop:?}");
-        }
+        } /*else {
+              println!("matching property {name}\n  GDScript: {gdscript_prop:?}\n  Rust:     {rust_prop:?}");
+          }*/
     }
 
     assert!(

--- a/itest/rust/src/object_tests/property_template_test.rs
+++ b/itest/rust/src/object_tests/property_template_test.rs
@@ -44,6 +44,16 @@ fn property_template_test(ctx: &TestContext) {
             continue;
         }
 
+        // Skip @export_file and similar properties for Array<GString> and PackedStringArray (only supported in Godot 4.3+).
+        // Here, we use API and not runtime level, because inclusion/exclusion of GDScript code is determined at build time in godot-bindings.
+        //
+        // Name can start in `export_file`, `export_global_file`, `export_dir`, `export_global_dir`.
+        // Can end in either `_array` or `_parray`.
+        #[cfg(before_api = "4.3")]
+        if (name.contains("_file_") || name.contains("_dir_")) && name.ends_with("array") {
+            continue;
+        }
+
         if name.starts_with("var_") || name.starts_with("export_") {
             properties.insert(name, property);
         }


### PR DESCRIPTION
Supports the `#[export(file)]`, `#[export(file = "*.png")]` attributes and all their variants on two new types beside the existing `GString`:
- `Array<GString>`
- `PackedStringArray`

Also introduces very basic error handling for the case where `#[export(...)]` attributes are used on a type that doesn't support them. This is currently done via panic and can be improved in future versions, but would be out of scope for this PR.

Closes #772.