### PR TITLE
Document runtime class in editor requirement

### DIFF
--- a/godot-core/src/classes/class_runtime.rs
+++ b/godot-core/src/classes/class_runtime.rs
@@ -102,6 +102,30 @@ pub(crate) fn ensure_object_inherits(derived: ClassName, base: ClassName, instan
     )
 }
 
+#[cfg(debug_assertions)]
+pub(crate) fn ensure_binding_not_null<T>(binding: sys::GDExtensionClassInstancePtr)
+where
+    T: GodotClass + Bounds<Declarer = bounds::DeclUser>,
+{
+    if !binding.is_null() {
+        return;
+    }
+
+    // Non-tool classes can't be instantiated in the editor.
+    if crate::classes::Engine::singleton().is_editor_hint() {
+        panic!(
+            "Class {} -- null instance; does the class have a Godot creator function? \
+            Ensure that the given class is a tool class with #[class(tool)], if it is being accessed in the editor.",
+            std::any::type_name::<T>()
+        )
+    } else {
+        panic!(
+            "Class {} -- null instance; does the class have a Godot creator function?",
+            std::any::type_name::<T>()
+        );
+    }
+}
+
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Implementation of this file
 

--- a/godot-macros/src/lib.rs
+++ b/godot-macros/src/lib.rs
@@ -325,7 +325,9 @@ use crate::util::{bail, ident, KvParser};
 /// See [`ExtensionLibrary::editor_run_behavior()`](../init/trait.ExtensionLibrary.html#method.editor_run_behavior)
 /// for more information and further customization.
 ///
-/// This is very similar to [GDScript's `@tool` feature](https://docs.godotengine.org/en/stable/tutorials/plugins/running_code_in_the_editor.html).
+/// This behaves similarly to [GDScript's `@tool` feature](https://docs.godotengine.org/en/stable/tutorials/plugins/running_code_in_the_editor.html).
+///
+/// **Note**: As in GDScript, the class must be marked as a `tool` to be accessible in the editor (e.g., for use by editor plugins and inspectors).
 ///
 /// ## Editor plugins
 ///


### PR DESCRIPTION
Closes: https://github.com/godot-rust/gdext/issues/755#issuecomment-2875951699

Document requirement of `#[class(tool)]`, the error will inform user about given requirement (identical to https://github.com/godotengine/godot/pull/94511/files)