### PR TITLE
Add `rustc-args` to `package.metadata.docs.rs`

### DIFF
--- a/godot-bindings/Cargo.toml
+++ b/godot-bindings/Cargo.toml
@@ -51,6 +51,7 @@ regex = { workspace = true }
 [package.metadata.docs.rs]
 features = ["experimental-godot-api"]
 rustdoc-args = ["--cfg", "published_docs"]
+rustc-args = ["--cfg", "published_docs"]
 
 # Currently causes "unused manifest key" warnings. Maybe re-enable in the future, to make `published_docs` known.
 #[lints.rust]

--- a/godot-cell/Cargo.toml
+++ b/godot-cell/Cargo.toml
@@ -20,6 +20,7 @@ proptest = { workspace = true, optional = true }
 [package.metadata.docs.rs]
 features = ["experimental-godot-api"]
 rustdoc-args = ["--cfg", "published_docs"]
+rustc-args = ["--cfg", "published_docs"]
 
 # Currently causes "unused manifest key" warnings. Maybe re-enable in the future, to make `published_docs` known.
 #[lints.rust]

--- a/godot-codegen/Cargo.toml
+++ b/godot-codegen/Cargo.toml
@@ -36,6 +36,7 @@ godot-bindings = { path = "../godot-bindings", version = "=0.2.4" } # emit_godot
 [package.metadata.docs.rs]
 features = ["experimental-godot-api"]
 rustdoc-args = ["--cfg", "published_docs"]
+rustc-args = ["--cfg", "published_docs"]
 
 # Currently causes "unused manifest key" warnings. Maybe re-enable in the future, to make `published_docs` known.
 #[lints.rust]

--- a/godot-core/Cargo.toml
+++ b/godot-core/Cargo.toml
@@ -62,6 +62,7 @@ serde_json = { workspace = true }
 [package.metadata.docs.rs]
 features = ["experimental-godot-api"]
 rustdoc-args = ["--cfg", "published_docs"]
+rustc-args = ["--cfg", "published_docs"]
 
 # Currently causes "unused manifest key" warnings. Maybe re-enable in the future, to make `published_docs` known.
 #[lints.rust]

--- a/godot-ffi/Cargo.toml
+++ b/godot-ffi/Cargo.toml
@@ -50,6 +50,7 @@ godot-codegen = { path = "../godot-codegen", version = "=0.2.4" }
 [package.metadata.docs.rs]
 features = ["experimental-godot-api"]
 rustdoc-args = ["--cfg", "published_docs"]
+rustc-args = ["--cfg", "published_docs"]
 
 # Currently causes "unused manifest key" warnings. Maybe re-enable in the future, to make `published_docs` known.
 #[lints.rust]

--- a/godot-macros/Cargo.toml
+++ b/godot-macros/Cargo.toml
@@ -42,6 +42,7 @@ godot = { path = "../godot", default-features = false}
 [package.metadata.docs.rs]
 features = ["experimental-godot-api"]
 rustdoc-args = ["--cfg", "published_docs"]
+rustc-args = ["--cfg", "published_docs"]
 
 # Currently causes "unused manifest key" warnings. Maybe re-enable in the future, to make `published_docs` known.
 #[lints.rust]

--- a/godot/Cargo.toml
+++ b/godot/Cargo.toml
@@ -56,6 +56,7 @@ godot-macros = { path = "../godot-macros", version = "=0.2.4" }
 [package.metadata.docs.rs]
 features = ["experimental-godot-api"]
 rustdoc-args = ["--cfg", "published_docs"]
+rustc-args = ["--cfg", "published_docs"]
 
 # Currently causes "unused manifest key" warnings. Maybe re-enable in the future, to make `published_docs` known.
 #[lints.rust]


### PR DESCRIPTION
`rustc-args` (RUSTFLAGS) must be provided for docs.rs (this one: https://docs.rs/godot/latest/godot/) since `rustdoc-args` (RUSTDOCFLAGS) are propagated only to crate being built/documented and not to dependencies. 

Lack of this `cfg` prevents displaying information if given class is gated behind some feature.


related: https://github.com/godot-rust/gdext/issues/1163#issuecomment-2883380964
docs.rs metadata specification: https://docs.rs/about/metadata
fragment of code in which `docs.rs` extracts RUSTFLAGS and RUSTDOCFLAGS https://github.com/rust-lang/docs.rs/blob/b3b438839534526a276b01a215f325862f8c2025/crates/metadata/lib.rs#L270