### PR TITLE
Virtual dispatch: fix incorrect matching of renamed methods

### DIFF
--- a/godot-codegen/src/generator/virtual_definition_consts.rs
+++ b/godot-codegen/src/generator/virtual_definition_consts.rs
@@ -10,7 +10,7 @@ use crate::models::domain::{Class, ClassLike, ExtensionApi, FnDirection, Functio
 use proc_macro2::TokenStream;
 use quote::quote;
 
-pub fn make_virtual_hashes_file(api: &ExtensionApi, ctx: &mut Context) -> TokenStream {
+pub fn make_virtual_consts_file(api: &ExtensionApi, ctx: &mut Context) -> TokenStream {
     make_virtual_hashes_for_all_classes(&api.classes, ctx)
 }
 
@@ -39,14 +39,24 @@ fn make_virtual_hashes_for_class(class: &Class, ctx: &mut Context) -> TokenStrea
     };
 
     let constants = class.methods.iter().filter_map(|method| {
-        let FnDirection::Virtual { hash } = method.direction() else {
+        let FnDirection::Virtual {
+            #[cfg(since_api = "4.4")]
+            hash,
+        } = method.direction()
+        else {
             return None;
         };
 
         let rust_name = method.name_ident();
         let godot_name_str = method.godot_name();
+
+        #[cfg(since_api = "4.4")]
         let constant = quote! {
             pub const #rust_name: (&'static str, u32) = (#godot_name_str, #hash);
+        };
+        #[cfg(before_api = "4.4")]
+        let constant = quote! {
+            pub const #rust_name: &'static str = #godot_name_str;
         };
 
         Some(constant)

--- a/godot-ffi/src/lib.rs
+++ b/godot-ffi/src/lib.rs
@@ -82,8 +82,7 @@ pub use gen::table_editor_classes::*;
 pub use gen::table_scene_classes::*;
 pub use gen::table_servers_classes::*;
 pub use gen::table_utilities::*;
-#[cfg(since_api = "4.4")]
-pub use gen::virtual_hashes as known_virtual_hashes;
+pub use gen::virtual_consts as godot_virtual_consts;
 
 // Other
 pub use extras::*;

--- a/godot-macros/src/class/data_models/interface_trait_impl.rs
+++ b/godot-macros/src/class/data_models/interface_trait_impl.rs
@@ -107,9 +107,8 @@ pub fn transform_trait_impl(mut original_impl: venial::Impl) -> ParseResult<Toke
         let match_arm = OverriddenVirtualFn {
             cfg_attrs: vec![],
             rust_method_name: "_ready".to_string(),
-            // Can't use `hashes::ready` here, as the base class might not be `Node` (see above why such a branch is still added).
-            #[cfg(since_api = "4.4")]
-            godot_name_hash_constant: quote! { ::godot::sys::known_virtual_hashes::Node::ready },
+            // Can't use `virtuals::ready` here, as the base class might not be `Node` (see above why such a branch is still added).
+            godot_name_hash_constant: quote! { ::godot::sys::godot_virtual_consts::Node::ready },
             signature_info: SignatureInfo::fn_ready(),
             before_kind: BeforeKind::OnlyBefore,
             interface_trait: None,
@@ -136,16 +135,12 @@ pub fn transform_trait_impl(mut original_impl: venial::Impl) -> ParseResult<Toke
     };
 
     // See also __default_virtual_call() codegen.
-    let (hash_param, hashes_use, match_expr);
+    let (hash_param, match_expr);
     if cfg!(since_api = "4.4") {
         hash_param = quote! { hash: u32, };
-        hashes_use = quote! {
-            use ::godot::sys::known_virtual_hashes::#trait_base_class as hashes;
-        };
         match_expr = quote! { (name, hash) };
     } else {
         hash_param = TokenStream::new();
-        hashes_use = TokenStream::new();
         match_expr = quote! { name };
     };
 
@@ -164,9 +159,9 @@ pub fn transform_trait_impl(mut original_impl: venial::Impl) -> ParseResult<Toke
             fn __virtual_call(name: &str, #hash_param) -> ::godot::sys::GDExtensionClassCallVirtual {
                 //println!("virtual_call: {}.{}", std::any::type_name::<Self>(), name);
                 use ::godot::obj::UserClass as _;
+                use ::godot::sys::godot_virtual_consts::#trait_base_class as virtuals;
                 #tool_check
 
-                #hashes_use
                 match #match_expr {
                     #( #virtual_match_arms )*
                     _ => None,
@@ -459,7 +454,6 @@ fn handle_regular_virtual_fn<'a>(
     cfg_attrs: Vec<&'a venial::Attribute>,
     decls: &mut IDecls<'a>,
 ) -> Option<(venial::Punctuated<venial::FnParam>, Group)> {
-    #[cfg(since_api = "4.4")]
     let method_name_ident = original_method.name.clone();
     let method = util::reduce_to_signature(original_method);
 
@@ -520,10 +514,9 @@ fn handle_regular_virtual_fn<'a>(
         cfg_attrs,
         rust_method_name: virtual_method_name,
         // If ever the `I*` verbatim validation is relaxed (it won't work with use-renames or other weird edge cases), the approach
-        // with known_virtual_hashes module could be changed to something like the following (GodotBase = nearest Godot base class):
+        // with godot_virtual_consts module could be changed to something like the following (GodotBase = nearest Godot base class):
         // __get_virtual_hash::<Self::GodotBase>("method")
-        #[cfg(since_api = "4.4")]
-        godot_name_hash_constant: quote! { hashes::#method_name_ident },
+        godot_name_hash_constant: quote! { virtuals::#method_name_ident },
         signature_info,
         before_kind,
         interface_trait: Some(trait_path.clone()),
@@ -575,7 +568,8 @@ struct OverriddenVirtualFn<'a> {
     cfg_attrs: Vec<&'a venial::Attribute>,
     rust_method_name: String,
     /// Path to a pre-defined constant storing a `("_virtual_func", 123456789)` tuple with name and hash of the virtual function.
-    #[cfg(since_api = "4.4")]
+    ///
+    /// Before Godot 4.4, this just stores the name `"_virtual_func"`.
     godot_name_hash_constant: TokenStream,
     signature_info: SignatureInfo,
     before_kind: BeforeKind,
@@ -585,16 +579,7 @@ struct OverriddenVirtualFn<'a> {
 impl OverriddenVirtualFn<'_> {
     fn make_match_arm(&self, class_name: &Ident) -> TokenStream {
         let cfg_attrs = self.cfg_attrs.iter();
-
-        #[cfg(since_api = "4.4")]
-        let pattern = {
-            let godot_name_hash_constant = &self.godot_name_hash_constant;
-            quote! { #godot_name_hash_constant }
-        };
-
-        // Note: this is wrong before 4.4, as some methods are renamed in Rust.
-        #[cfg(before_api = "4.4")]
-        let pattern = self.rust_method_name.as_str();
+        let godot_name_hash_constant = &self.godot_name_hash_constant;
 
         // Lazily generate code for the actual work (calling user function).
         let method_callback = make_virtual_callback(
@@ -606,7 +591,7 @@ impl OverriddenVirtualFn<'_> {
 
         quote! {
             #(#cfg_attrs)*
-            #pattern => #method_callback,
+            #godot_name_hash_constant => #method_callback,
         }
     }
 }

--- a/godot-macros/src/class/derive_godot_class.rs
+++ b/godot-macros/src/class/derive_godot_class.rs
@@ -404,7 +404,7 @@ fn make_user_class_impl(
         if cfg!(since_api = "4.4") {
             hash_param = quote! { hash: u32, };
             matches_ready_hash = quote! {
-                (name, hash) == ::godot::sys::known_virtual_hashes::Node::ready
+                (name, hash) == ::godot::sys::godot_virtual_consts::Node::ready
             };
         } else {
             hash_param = TokenStream::new();


### PR DESCRIPTION
I discovered a bug that prevented some virtual methods from being dispatched correctly.

There are a few methods that are renamed during codegen (beyond just stripping the leading `_`), e.g. to avoid clashes. However, the `#[godot_api]` proc-macro always checks the incoming callback parameter (containing virtual function name) against _Rust_ names. This works in 99% of cases, which is why it wasn't discovered.

The solution is simple: extend the hash lookup mechanism to include the Godot function name. This now also introduces this lookup for versions < Godot 4.4, without hashes in that case.