### PR TITLE
Replace macro approach with `IndirectSignalReceiver` to force type inference to work when connecting closures to the signals

### DIFF
--- a/godot-core/src/registry/signal/mod.rs
+++ b/godot-core/src/registry/signal/mod.rs
@@ -9,6 +9,7 @@
 
 mod connect_builder;
 mod signal_object;
+mod signal_receiver;
 mod typed_signal;
 
 use crate::builtin::{GString, Variant};
@@ -20,6 +21,8 @@ pub(crate) use typed_signal::*;
 // Used in `godot` crate.
 pub mod re_export {
     pub use super::connect_builder::ConnectBuilder;
+    pub use super::signal_receiver::IndirectSignalReceiver;
+    pub use super::signal_receiver::SignalReceiver;
     pub use super::typed_signal::TypedSignal;
 }
 

--- a/godot-core/src/registry/signal/signal_receiver.rs
+++ b/godot-core/src/registry/signal/signal_receiver.rs
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+//! Emulates variadic argument lists (via tuples), related to functions and signals.
+// https://geo-ant.github.io/blog/2021/rust-traits-and-variadic-functions
+//
+// Could be generalized with R return type, and not special-casing `self`. But keep simple until actually needed.
+
+use crate::meta::FromGodot;
+use crate::meta::InParamTuple;
+use crate::obj::{Gd, GodotClass};
+use std::marker::PhantomData;
+
+/// Trait that is implemented for functions that can be connected to signals.
+///
+/// This is used in [`ConnectBuilder`](crate::registry::signal::connect_builder::ConnectBuilder).
+/// There are three variations of the `C` (class instance) parameter:
+/// - `()` for global and associated ("static") functions.
+/// - `&C` for `&self` methods.
+/// - `&mut C` for `&mut self` methods.
+///
+/// See also [Signals](https://godot-rust.github.io/book/register/signals.html) in the book.
+pub trait SignalReceiver<C, Ps>: 'static {
+    /// Invoke the receiver on the given instance (possibly `()`) with `params`.
+    fn call(&mut self, maybe_instance: C, params: Ps);
+}
+
+// Next-gen trait solver should allow for type inference in closures, when function traits are involved, without using identity struct
+// and other hacks. Since `IndirectSignalReceiver` is just a view, it should be drop-in replacement.
+/// A special "identity struct" which allows to use type inference while specifying various closures for connections.
+///
+/// rustc can't infer types in closures when dealing with `Fn/FnMut/FnOnce` traits abstracted behind another trait (in our case
+/// [`SignalReceiver`]). To make type inference work in such cases, we need to specify concrete type – such as `FnMut(...) -> R`
+/// or `<&mut F as Into<IndirectSignalReceiver<'_, Instance, Params, Func>>>`.
+///
+/// In other words, `IndirectSignalReceiver` allows us to "smuggle" in a `Fn*` trait, forcing rustc to deal with type inference while resolving
+/// its inner type.
+///
+/// # Example usage
+///
+/// ```no_run
+/// # use godot::register::{IndirectSignalReceiver, SignalReceiver};
+/// # let mut function = || {};
+/// # let args = ();
+/// IndirectSignalReceiver::from(&mut function)
+///     .function()
+///     .call((), args);
+///```
+///
+/// # Further reading
+/// - [rustc issue #63702](https://github.com/rust-lang/rust/issues/63702)
+/// - [identity function trick](https://users.rust-lang.org/t/type-inference-in-closures/78399/3)
+/// - [rustc comments around closure type-check](https://github.com/rust-lang/rust/blob/5ad7454f7503b6af2800bf4a7c875962cb03f913/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs#L306-L317)
+pub struct IndirectSignalReceiver<'view, I, Ps, F>
+where
+    Ps: InParamTuple,
+    F: SignalReceiver<I, Ps> + 'static,
+{
+    inner: &'view mut F,
+    _phantoms: PhantomData<(I, Ps)>,
+}
+
+impl<'view, I, Ps, F> IndirectSignalReceiver<'view, I, Ps, F>
+where
+    Ps: InParamTuple,
+    F: SignalReceiver<I, Ps> + 'static,
+{
+    /// Retrieves inner `&mut F` function ready to be used as [`SignalReceiver`].
+    pub fn function(&'view mut self) -> &'view mut F {
+        self.inner
+    }
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// Generated impls
+
+macro_rules! impl_signal_recipient {
+    ($( $args:ident : $Ps:ident ),*) => {
+        // --------------------------------------------------------------------------------------------------------------------------------------
+        // SignalReceiver
+
+        // Global and associated functions.
+        impl<F, R, $($Ps: std::fmt::Debug + FromGodot + 'static),*> SignalReceiver<(), ( $($Ps,)* )> for F
+            where F: FnMut( $($Ps,)* ) -> R + 'static
+        {
+            fn call(&mut self, _no_instance: (), ($($args,)*): ( $($Ps,)* )) {
+                self($($args,)*);
+            }
+        }
+
+        // Methods with mutable receiver - &mut self.
+        impl<F, R, C, $($Ps: std::fmt::Debug + FromGodot + 'static),*> SignalReceiver<&mut C, ( $($Ps,)* )> for F
+            where F: FnMut( &mut C, $($Ps,)* ) -> R + 'static
+        {
+            fn call(&mut self, instance: &mut C, ($($args,)*): ( $($Ps,)* )) {
+                self(instance, $($args,)*);
+            }
+        }
+
+        // Methods with immutable receiver - &self.
+        impl<F, R, C, $($Ps: std::fmt::Debug + FromGodot + 'static),*> SignalReceiver<&C, ( $($Ps,)* )> for F
+            where F: FnMut( &C, $($Ps,)* ) -> R + 'static
+        {
+            fn call(&mut self, instance: &C, ($($args,)*): ( $($Ps,)* )) {
+                self(instance, $($args,)*);
+            }
+        }
+
+        // Methods with gd receiver - Gd<Self>.
+        impl<F, R, C, $($Ps: std::fmt::Debug + FromGodot + 'static),*> SignalReceiver<Gd<C>, ( $($Ps,)* )> for F
+            where F: FnMut( Gd<C>, $($Ps,)* ) -> R + 'static, C: GodotClass
+        {
+            fn call(&mut self, instance: Gd<C>, ($($args,)*): ( $($Ps,)* )) {
+                self(instance, $($args,)*);
+            }
+        }
+
+                // --------------------------------------------------------------------------------------------------------------------------------------
+        // FnMut -> IndirectSignalReceiver
+
+        impl<'c_view, F, R, $($Ps: std::fmt::Debug + FromGodot + 'static),*> From<&'c_view mut F> for IndirectSignalReceiver<'c_view, (), ($($Ps,)*), F>
+            where F: FnMut( $($Ps,)* ) -> R + 'static
+        {
+            fn from(value: &'c_view mut F) -> Self {
+                IndirectSignalReceiver {
+                    inner: value,
+                    _phantoms: PhantomData,
+                }
+            }
+        }
+
+        impl<'c_view, F, R, C, $($Ps: std::fmt::Debug + FromGodot + 'static),*> From<&'c_view mut F> for IndirectSignalReceiver<'c_view, &mut C, ($($Ps,)*), F>
+            where F: FnMut( &mut C, $($Ps,)* ) -> R + 'static
+        {
+            fn from(value: &'c_view mut F) -> Self {
+                IndirectSignalReceiver {
+                    inner: value,
+                    _phantoms: PhantomData,
+                }
+            }
+        }
+
+        impl<'c_view, F, R, C, $($Ps: std::fmt::Debug + FromGodot + 'static),*> From<&'c_view mut F> for IndirectSignalReceiver<'c_view, &C, ($($Ps,)*), F>
+            where F: FnMut( &C, $($Ps,)* ) -> R + 'static
+        {
+            fn from(value: &'c_view mut F) -> Self {
+                IndirectSignalReceiver {
+                    inner: value,
+                    _phantoms: PhantomData,
+                }
+            }
+        }
+
+        impl<'c_view, F, R, C, $($Ps: std::fmt::Debug + FromGodot + 'static),*> From<&'c_view mut F> for IndirectSignalReceiver<'c_view, Gd<C>, ($($Ps,)*), F>
+            where F: FnMut( Gd<C>, $($Ps,)* ) -> R + 'static, C: GodotClass
+        {
+            fn from(value: &'c_view mut F) -> Self {
+                IndirectSignalReceiver {
+                    inner: value,
+                    _phantoms: PhantomData,
+                }
+            }
+        }
+    };
+}
+
+impl_signal_recipient!();
+impl_signal_recipient!(arg0: P0);
+impl_signal_recipient!(arg0: P0, arg1: P1);
+impl_signal_recipient!(arg0: P0, arg1: P1, arg2: P2);
+impl_signal_recipient!(arg0: P0, arg1: P1, arg2: P2, arg3: P3);
+impl_signal_recipient!(arg0: P0, arg1: P1, arg2: P2, arg3: P3, arg4: P4);
+impl_signal_recipient!(arg0: P0, arg1: P1, arg2: P2, arg3: P3, arg4: P4, arg5: P5);
+impl_signal_recipient!(arg0: P0, arg1: P1, arg2: P2, arg3: P3, arg4: P4, arg5: P5, arg6: P6);
+impl_signal_recipient!(arg0: P0, arg1: P1, arg2: P2, arg3: P3, arg4: P4, arg5: P5, arg6: P6, arg7: P7);
+impl_signal_recipient!(arg0: P0, arg1: P1, arg2: P2, arg3: P3, arg4: P4, arg5: P5, arg6: P6, arg7: P7, arg8: P8);
+impl_signal_recipient!(arg0: P0, arg1: P1, arg2: P2, arg3: P3, arg4: P4, arg5: P5, arg6: P6, arg7: P7, arg8: P8, arg9: P9);


### PR DESCRIPTION
# What does this PR solve?

Allows us to use `FnTraits` for signal connections instead of generating signature for every single possible function. This approach makes creating signal extensions and whatnot much easier (since we can work with `FnTrait` instead of doing hoops to change Fn signature into `ParamTuple` and back again).

This PR does not introduce any changes in user-facing API (unless we missed something in itest :sweat_smile:)


# WHAT ????

Alright, let's start from scratch.

Crab is behaving very silly when it comes to type inference for closures, especially when Fn Traits are anyhow involved – which is ultra annoying and forces users to sprinkle their code with unhealthy amount of noise. To make it worse, type inference is, on first glance, inconsistent – qualified calls in qualified context are fine (ok, in layman terms – doing Trait stuff, like display and whatnot), while invoking methods on individual types doesn't work.

```rs
trait Bar {}

impl<F> Bar for F
where 
    F: FnMut(i32) -> i32
{
    
}

fn baz(x: impl Bar) {
    
}


fn main() {
    // + is syntax sugar for std::ops::Add::add(...) so there is a qualified call in qualified context…
    baz(|i| { i + 1 });

    // BUT this won't compile!
    // error[E0282]: type annotations needed
    // let closure = baz(|i| { i.abs() });
    //                    ^    - type must be known at this point

    // Changing it to i32::abs(i) makes it working again.
    baz(|i| { i32::abs(i) });
}
```
See: <https://github.com/rust-lang/rust/issues/63702>.

Part of this weirdness can be addressed by using so-called "identity function". It is well known and established hack, mentioned, for example, here: <https://users.rust-lang.org/t/type-inference-in-closures/78399>.

```rs
trait Bar {}

impl<F> Bar for F
where 
    F: FnMut(i32) -> i32
{
    
}

fn identity_function(i: impl FnMut(i32) -> i32) -> impl Bar {
    i
}

fn baz(x: impl Bar) {
    
}


fn main() {
    baz(|i| { i + 1 });

    // Compiles again
    baz(identity_function(|i| { i.abs() }));
}
```

Why does it work? Well, the answer can be found in this apologetic comment in the compiler:

https://github.com/rust-lang/rust/blob/5ad7454f7503b6af2800bf4a7c875962cb03f913/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs#L306-L317

```rs
        // Check the arguments.
        // We do this in a pretty awful way: first we type-check any arguments
        // that are not closures, then we type-check the closures. This is so
        // that we have more information about the types of arguments when we
        // type-check the functions. This isn't really the right way to do this.
        for check_closures in [false, true] {
            // More awful hacks: before we check argument types, try to do
            // an "opportunistic" trait resolution of any trait bounds on
            // the call. This helps coercions.
            if check_closures {
                self.select_obligations_where_possible(|_| {})
            }
```

Don't worry if you haven't understand anything, we are in the same boat. Long story short, crab behaves ultra silly – if you specify concrete function type (FnMut…), then it is all good, if you specify trait (`impl Bar`) then crab gets lost and needs guidance.

In our case – specifying callbacks in form of closures for signals – identity function can't be just applied directly. We _could_ make identity function work, doing something along the lines of `signal().connect(infer_plspls!(|this| this.add_node(…)))` which is equally annoying, creates unnecessary overhead, doesn't work nicely with most IDEs and _also_ comes with its own tradeoffs.
 
For now, we went with @Houtamelo  workaround which was using macro magic to handle all the possible callback types – but it comes with its own trade offs, mainly not being able to easily extend available methods, signal connections and whatnot. It is pretty good workaround, aye, but perfect is the enemy of good!

See also: https://github.com/godot-rust/gdext/pull/1152#issuecomment-2895822640

back on track – crab needs concrete type to infer types in closure. We need some identity function, or type, which would change our closure into trait stuff, right? 
If we would work on function pointers then we could do something like `Box<dyn FnMut(..)> -> Box<dyn Bar>` conversion… But we can't really do `Fn(???) -> impl Bar`. Or can we? Let's make a step back, to get a better view… Like a view function? Yeah, view function sounds good, let's call it Intermediary. 

Let's make concrete type from our Intermediary. Something simple and elegant, such as `<&mut Func as Into<Intermediary<'c, Func, Params, Ret>>>`. This looks like beautiful concrete type that makes our crab happy!

I mean, really 

```rs
use std::marker::PhantomData;

trait Bar<Params, Ret> {
    fn call(&mut self, c: Params) -> Ret;
}

impl<F, Params, Ret> Bar<Params, Ret> for F
where
    F: FnMut(Params) -> Ret + 'static,
{
    fn call(&mut self, c: Params) -> Ret {
        self(c)
    }
}

fn baz<Func, Params, Ret>(mut x: Func, p: Params)
where
    Func: Bar<Params, Ret> + 'static,
    for<'c> Intermediary<'c, Func, Params, Ret>: From<&'c mut Func>,
{
    // Yes, <_, _, _> is required. Don't ask too many questions, we are in sillness domain. 
    <&mut Func as Into<Intermediary<_, _, _>>>::into(&mut x)
        .inner
        .call(p);
}

fn main() {
    baz(|i| i + 1, 4);

    // Compiles again
    baz(
        |i| {
            println!("henlo :)");
            let x = i.abs();
            x
        },
        -33i32,
    );
}

struct Intermediary<'c, Func, Params, Ret>
where
    Func: Bar<Params, Ret> + 'static,
{
    inner: &'c mut Func,
    params: PhantomData<Params>,
    ret: PhantomData<Ret>,
}

impl<'c, Func, Params, Ret> From<&'c mut Func> for Intermediary<'c, Func, Params, Ret>
where
    Func: FnMut(Params) -> Ret + Bar<Params, Ret> + 'static,
{
    fn from(value: &'c mut Func) -> Self {
        Intermediary {
            inner: value,
            params: PhantomData,
            ret: PhantomData,
        }
    }
}
```

it's all so silly…
I wouldn't call this hack elegant, but hey, it works! 


Hopefully, the new trait solver will render this whole issue null: https://rustc-dev-guide.rust-lang.org/solve/significant-changes.html#deferred-alias-equality. If next-gen trait solver fixes this issue, we can just get rid of Intermediary, go back to function trait and call it a day (`Intermediary` is just a view function, so it will be no-brainer).