### PR TITLE
Support `@export_storage` attribute

### DIFF
--- a/godot-core/src/registry/property.rs
+++ b/godot-core/src/registry/property.rs
@@ -517,6 +517,7 @@ pub mod export_info_functions {
     // right side are the corresponding property hint. Godot is not always consistent between the two, such
     // as `export_multiline` being `PROPERTY_HINT_MULTILINE_TEXT`.
     default_export_funcs!(
+        export_storage => NONE, // Storage exports don't display in the editor.
         export_flags_2d_physics => LAYERS_2D_PHYSICS,
         export_flags_2d_render => LAYERS_2D_RENDER,
         export_flags_2d_navigation => LAYERS_2D_NAVIGATION,

--- a/godot-macros/src/class/data_models/property.rs
+++ b/godot-macros/src/class/data_models/property.rs
@@ -53,10 +53,17 @@ pub fn make_property_impl(class_name: &Ident, fields: &Fields) -> TokenStream {
 
         // Ensure we add a var if the user only provided a `#[export]`.
         let var = match (export, var) {
-            (Some(_), None) => Some(FieldVar {
-                usage_flags: UsageFlags::InferredExport,
-                ..Default::default()
-            }),
+            (Some(export), None) => {
+                let usage_flags = if let Some(usage) = export.to_export_usage() {
+                    UsageFlags::Custom(vec![usage])
+                } else {
+                    UsageFlags::InferredExport
+                };
+                Some(FieldVar {
+                    usage_flags,
+                    ..Default::default()
+                })
+            }
 
             (_, var) => var.clone(),
         };

--- a/godot-macros/src/lib.rs
+++ b/godot-macros/src/lib.rs
@@ -243,7 +243,11 @@ use crate::util::{bail, ident, KvParser};
 ///     // @export
 ///     #[export]
 ///     float: f64,
-///     
+///
+///     // @export_storage
+///     #[export(storage)]
+///     hidden_string: GString,
+///
 ///     // @export_range(0.0, 10.0, or_greater)
 ///     #[export(range = (0.0, 10.0, or_greater))]
 ///     range_f64: f64,

--- a/itest/rust/build.rs
+++ b/itest/rust/build.rs
@@ -472,6 +472,9 @@ fn generate_property_template(inputs: &[Input]) -> PropertyTests {
         TokenStream::new()
     } else {
         quote! {
+            #[export(storage)]
+            export_storage: GString,
+
             #[export(file)]
             export_file_array: Array<GString>,
             #[export(file)]
@@ -597,6 +600,7 @@ fn generate_property_template(inputs: &[Input]) -> PropertyTests {
 
     // Only available in Godot 4.3+.
     let advanced_exports_4_3 = r#"
+@export_storage var export_storage: String
 @export_file var export_file_array: Array[String]
 @export_file var export_file_parray: PackedStringArray
 @export_file("*.txt") var export_file_wildcard_array: Array[String]


### PR DESCRIPTION
Partially completes #1128

See [GDScript: Add `@export_storage` annotation godotengine/godot#82122](https://github.com/godotengine/godot/pull/82122) added in Godot **4.3**

Adds the ability to annotate a field with `@export_storage`:
```rust
#[derive(GodotClass)]
#[class(base=RigidBody3D)]
struct Vehicle {
    /// Equivalent to:
    /// ```gdscript
    /// @export_storage var steering_angle: float
    /// ```
    #[export(storage)]
    steering_angle: f64,

    base: Base<RigidBody3D>
}
```