### PR TITLE
Impl Display for OnEditor

### DIFF
--- a/godot-core/src/obj/on_editor.rs
+++ b/godot-core/src/obj/on_editor.rs
@@ -330,3 +330,16 @@ where
 }
 
 impl<T> BuiltinExport for OnEditor<T> {}
+
+impl<T> std::fmt::Display for OnEditor<T>
+where
+    T: std::fmt::Display,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.state {
+            OnEditorState::UninitNull => f.write_str("null"),
+            OnEditorState::UninitSentinel(_) => f.write_str("uninitialized"),
+            OnEditorState::Initialized(val) => std::fmt::Display::fmt(val, f),
+        }
+    }
+}

--- a/itest/rust/src/object_tests/oneditor_test.rs
+++ b/itest/rust/src/object_tests/oneditor_test.rs
@@ -104,3 +104,24 @@ fn oneditor_debug() {
 
     obj.free();
 }
+
+#[itest]
+fn oneditor_display() {
+    let val = OnEditor::from_sentinel(-1);
+    assert_eq!(format!("{val}"), "uninitialized");
+
+    let mut val = OnEditor::<Gd<Node>>::default();
+    assert_eq!(format!("{val}"), "null");
+
+    let obj = Node::new_alloc();
+    val.init(obj.clone());
+
+    let id = obj.instance_id();
+
+    let actual = format!("{val}");
+    let expected = format!("<Node#{id}>");
+
+    assert_eq!(actual, expected);
+
+    obj.free();
+}


### PR DESCRIPTION
As suggested by @Yarwin in my [previous PR](https://github.com/godot-rust/gdext/pull/1189#issuecomment-2948431474), I implement `Display` for `OnEditor`.

It’s a quick implementation, because I don’t know if it’s a good idea or not.