### PR TITLE
Allow custom types to be passed as `impl AsArg<T>`

### DIFF
--- a/godot-core/src/builtin/collections/array.rs
+++ b/godot-core/src/builtin/collections/array.rs
@@ -1118,15 +1118,6 @@ unsafe impl<T: ArrayElement> GodotFfi for Array<T> {
 // Only implement for untyped arrays; typed arrays cannot be nested in Godot.
 impl ArrayElement for VariantArray {}
 
-impl<'r, T: ArrayElement> AsArg<Array<T>> for &'r Array<T> {
-    fn into_arg<'cow>(self) -> CowArg<'cow, Array<T>>
-    where
-        'r: 'cow, // Original reference must be valid for at least as long as the returned cow.
-    {
-        CowArg::Borrowed(self)
-    }
-}
-
 impl<T: ArrayElement> ParamType for Array<T> {
     type Arg<'v> = CowArg<'v, Self>;
 

--- a/godot-core/src/meta/args/as_arg.rs
+++ b/godot-core/src/meta/args/as_arg.rs
@@ -16,15 +16,15 @@ use std::ffi::CStr;
 /// this trait is implemented more conservatively.
 ///
 /// As a result, `AsArg<T>` is currently only implemented for certain argument types:
-/// - `T` for by-value builtins (typically `Copy`): `i32`, `bool`, `Vector3`, `Transform2D`, ...
-/// - `&T` for by-ref builtins: `GString`, `Array`, `Dictionary`, `Packed*Array`, `Variant`...
+/// - `T` for by-value built-ins (typically `Copy`): `i32`, `bool`, `Vector3`, `Transform2D`, ...
+/// - `&T` for by-ref built-ins: `GString`, `Array`, `Dictionary`, `Packed*Array`, `Variant`...
 /// - `&str`, `&String` additionally for string types `GString`, `StringName`, `NodePath`.
 ///
 /// See also the [`AsObjectArg`][crate::meta::AsObjectArg] trait which is specialized for object arguments. It may be merged with `AsArg`
 /// in the future.
 ///
 /// # Pass by value
-/// Implicitly converting from `T` for by-ref builtins is explicitly not supported. This emphasizes that there is no need to consume the object,
+/// Implicitly converting from `T` for by-ref built-ins is explicitly not supported. This emphasizes that there is no need to consume the object,
 /// thus discourages unnecessary cloning.
 ///
 /// # Performance for strings
@@ -44,8 +44,7 @@ use std::ffi::CStr;
 /// `AsArg` is meant to be used from the function call site, not the declaration site. If you declare a parameter as `impl AsArg<...>` yourself,
 /// you can only forward it as-is to a Godot API -- there are no stable APIs to access the inner object yet.
 ///
-/// Furthermore, there is currently no benefit in implementing `AsArg` for your own types, as it's only used by Godot APIs which don't accept
-/// custom types. Classes are already supported through upcasting and [`AsObjectArg`][crate::meta::AsObjectArg].
+/// If you want to pass your own types to a Godot API i.e. to emit a signal, you should implement the [`ParamType`] trait.
 #[diagnostic::on_unimplemented(
     message = "Argument of type `{Self}` cannot be passed to an `impl AsArg<{T}>` parameter",
     note = "if you pass by value, consider borrowing instead.",
@@ -259,6 +258,10 @@ impl AsArg<NodePath> for &String {
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 
 /// Implemented for all parameter types `T` that are allowed to receive [impl `AsArg<T>`][AsArg].
+///
+/// **Deprecated**: This trait is considered deprecated and will be removed in 0.4. It is still required to be implemented by types that should
+/// be passed `AsArg` in the current version, though.
+//
 // ParamType used to be a subtrait of GodotType, but this can be too restrictive. For example, DynGd is not a "Godot canonical type"
 // (GodotType), however it's still useful to store it in arrays -- which requires AsArg and subsequently ParamType.
 //

--- a/godot-core/src/meta/args/cow_arg.rs
+++ b/godot-core/src/meta/args/cow_arg.rs
@@ -11,6 +11,7 @@ use crate::meta::{FromGodot, GodotConvert, GodotFfiVariant, RefArg, ToGodot};
 use crate::sys;
 use godot_ffi::{GodotFfi, GodotNullableFfi, PtrcallType};
 use std::fmt;
+use std::ops::Deref;
 
 /// Owned or borrowed value, used when passing arguments through `impl AsArg` to Godot APIs.
 #[doc(hidden)]
@@ -180,5 +181,16 @@ where
 
     fn is_null(&self) -> bool {
         self.cow_as_ref().is_null()
+    }
+}
+
+impl<T> Deref for CowArg<'_, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            CowArg::Owned(value) => value,
+            CowArg::Borrowed(value) => value,
+        }
     }
 }

--- a/godot-core/src/meta/args/mod.rs
+++ b/godot-core/src/meta/args/mod.rs
@@ -13,6 +13,7 @@ mod ref_arg;
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Public APIs
 
+#[expect(deprecated)]
 pub use as_arg::{AsArg, ParamType};
 pub use object_arg::AsObjectArg;
 pub use ref_arg::RefArg;

--- a/godot-core/src/meta/args/mod.rs
+++ b/godot-core/src/meta/args/mod.rs
@@ -13,8 +13,7 @@ mod ref_arg;
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Public APIs
 
-#[expect(deprecated)]
-pub use as_arg::{AsArg, ParamType};
+pub use as_arg::{val_into_arg, ArgPassing, AsArg, ByRef, ByValue, ParamType};
 pub use object_arg::AsObjectArg;
 pub use ref_arg::RefArg;
 

--- a/godot-core/src/meta/godot_convert/mod.rs
+++ b/godot-core/src/meta/godot_convert/mod.rs
@@ -60,6 +60,17 @@ pub trait ToGodot: Sized + GodotConvert {
     where
         Self: 'v;
 
+    /*
+    // TODO(v0.4): add this type, to replace ParamType::ArgPassing and possibly Self::ToVia<'v>.
+    /// Whether this type is passed by value or by reference in `AsArg` contexts.
+    ///
+    /// Can be either [`ArgPassing::ByValue`] or [`ArgPassing::ByRef`]. For types implementing `Copy`, by-value is strongly recommended.
+    ///
+    /// Will auto-implement `AsArg<T>` for either `T` (by-value) or for `&T` (by-reference). This has an influence on contexts such as
+    /// [`Array::push()`](crate::builtin::Array::push) or generated signal `emit()` signatures.
+    type ArgPassing: ArgPassing;
+     */
+
     /// Converts this type to the Godot type by reference, usually by cloning.
     fn to_godot(&self) -> Self::ToVia<'_>;
 

--- a/godot-core/src/meta/traits.rs
+++ b/godot-core/src/meta/traits.rs
@@ -36,10 +36,10 @@ pub trait GodotFfiVariant: Sized + GodotFfi {
 //
 // Unlike `GodotFfi`, types implementing this trait don't need to fully represent its corresponding Godot
 // type. For instance [`i32`] does not implement `GodotFfi` because it cannot represent all values of
-// Godot's `int` type, however it does implement `GodotType` because we can set the metadata of values with
+// Godot's `int` type, however it does implement `GodotType` because we can set the meta-data of values with
 // this type to indicate that they are 32 bits large.
 pub trait GodotType: GodotConvert<Via = Self> + sealed::Sealed + Sized + 'static
-// 'static is not technically required, but it simplifies a few things (limits e.g. ObjectArg).
+// 'static is not technically required, but it simplifies a few things (limits e.g. `ObjectArg`).
 {
     // Value type for this type's FFI representation.
     #[doc(hidden)]
@@ -122,7 +122,7 @@ pub trait GodotType: GodotConvert<Via = Self> + sealed::Sealed + Sized + 'static
     ///
     /// Examples:
     /// - `MyClass` for objects
-    /// - `StringName`, `AABB` or `int` for builtins
+    /// - `StringName`, `AABB` or `int` for built-ins
     /// - `Array` for arrays
     #[doc(hidden)]
     fn godot_type_name() -> String;
@@ -131,7 +131,7 @@ pub trait GodotType: GodotConvert<Via = Self> + sealed::Sealed + Sized + 'static
     ///
     /// Returning false only means that this is not a special case, not that it cannot be `None`. Regular checks are expected to run afterward.
     ///
-    /// This exists only for varcalls and serves a similar purpose as `GodotNullableFfi::is_null()` (although that handles general cases).
+    /// This exists only for var-calls and serves a similar purpose as `GodotNullableFfi::is_null()` (although that handles general cases).
     #[doc(hidden)]
     fn qualifies_as_special_none(_from_variant: &Variant) -> bool {
         false
@@ -164,14 +164,14 @@ pub trait GodotType: GodotConvert<Via = Self> + sealed::Sealed + Sized + 'static
 /// Also, keep in mind that Godot uses `Variant` for each element. If performance matters and you have small element types such as `u8`,
 /// consider using packed arrays (e.g. `PackedByteArray`) instead.
 //
-// TODO: The ParamType super trait is no longer needed and can be removed in 0.4. We are only keeping it for backwards compatebility.
+// TODO: The `ParamType` super trait is no longer needed and can be removed in 0.4. We are only keeping it for backwards compatibility.
 #[diagnostic::on_unimplemented(
     message = "`Array<T>` can only store element types supported in Godot arrays (no nesting).",
     label = "has invalid element type"
 )]
 pub trait ArrayElement: ToGodot + FromGodot + sealed::Sealed + ParamType + 'static {
-    // Note: several indirections in ArrayElement and the global `element_*` functions go through `GodotConvert::Via`,
-    // to not require Self: GodotType. What matters is how array elements map to Godot on the FFI level (GodotType trait).
+    // Note: several indirections in `ArrayElement` and the global `element_*` functions go through `GodotConvert::Via`,
+    // to not require Self: `GodotType`. What matters is how array elements map to Godot on the FFI level (`GodotType` trait).
 
     /// Returns the representation of this type as a type string, e.g. `"4:"` for string, or `"24:34/MyClass"` for objects.
     ///

--- a/godot-core/src/meta/traits.rs
+++ b/godot-core/src/meta/traits.rs
@@ -8,15 +8,16 @@
 use crate::builtin::{Variant, VariantType};
 use crate::global::PropertyUsageFlags;
 use crate::meta::error::ConvertError;
+#[expect(deprecated)]
 use crate::meta::{
-    sealed, ClassName, FromGodot, GodotConvert, PropertyHintInfo, PropertyInfo, ToGodot,
+    sealed, ClassName, FromGodot, GodotConvert, ParamType, PropertyHintInfo, PropertyInfo, ToGodot,
 };
 use crate::registry::method::MethodParamOrReturnInfo;
 use godot_ffi as sys;
 
 // Re-export sys traits in this module, so all are in one place.
+use crate::builtin;
 use crate::registry::property::builtin_type_string;
-use crate::{builtin, meta};
 pub use sys::{GodotFfi, GodotNullableFfi};
 
 /// Conversion of [`GodotFfi`] types to/from [`Variant`].
@@ -163,11 +164,14 @@ pub trait GodotType: GodotConvert<Via = Self> + sealed::Sealed + Sized + 'static
 ///
 /// Also, keep in mind that Godot uses `Variant` for each element. If performance matters and you have small element types such as `u8`,
 /// consider using packed arrays (e.g. `PackedByteArray`) instead.
+//
+// TODO: The ParamType super trait is no longer needed and can be removed in 0.4. We are only keeping it for backwards compatebility.
 #[diagnostic::on_unimplemented(
     message = "`Array<T>` can only store element types supported in Godot arrays (no nesting).",
     label = "has invalid element type"
 )]
-pub trait ArrayElement: ToGodot + FromGodot + sealed::Sealed + meta::ParamType {
+#[expect(deprecated)]
+pub trait ArrayElement: ToGodot + FromGodot + sealed::Sealed + ParamType + 'static {
     // Note: several indirections in ArrayElement and the global `element_*` functions go through `GodotConvert::Via`,
     // to not require Self: GodotType. What matters is how array elements map to Godot on the FFI level (GodotType trait).
 

--- a/godot-core/src/meta/traits.rs
+++ b/godot-core/src/meta/traits.rs
@@ -8,7 +8,6 @@
 use crate::builtin::{Variant, VariantType};
 use crate::global::PropertyUsageFlags;
 use crate::meta::error::ConvertError;
-#[expect(deprecated)]
 use crate::meta::{
     sealed, ClassName, FromGodot, GodotConvert, ParamType, PropertyHintInfo, PropertyInfo, ToGodot,
 };
@@ -170,7 +169,6 @@ pub trait GodotType: GodotConvert<Via = Self> + sealed::Sealed + Sized + 'static
     message = "`Array<T>` can only store element types supported in Godot arrays (no nesting).",
     label = "has invalid element type"
 )]
-#[expect(deprecated)]
 pub trait ArrayElement: ToGodot + FromGodot + sealed::Sealed + ParamType + 'static {
     // Note: several indirections in ArrayElement and the global `element_*` functions go through `GodotConvert::Via`,
     // to not require Self: GodotType. What matters is how array elements map to Godot on the FFI level (GodotType trait).

--- a/godot-core/src/obj/dyn_gd.rs
+++ b/godot-core/src/obj/dyn_gd.rs
@@ -547,6 +547,7 @@ where
 }
 */
 
+#[expect(deprecated)]
 impl<T, D> meta::ParamType for DynGd<T, D>
 where
     T: GodotClass,
@@ -556,14 +557,6 @@ where
 
     fn owned_to_arg<'v>(self) -> Self::Arg<'v> {
         meta::CowArg::Owned(self)
-    }
-
-    fn arg_to_ref<'r>(arg: &'r Self::Arg<'_>) -> &'r Self {
-        arg.cow_as_ref()
-    }
-
-    fn arg_into_owned(arg: Self::Arg<'_>) -> Self {
-        arg.cow_into_owned()
     }
 }
 

--- a/godot-core/src/obj/dyn_gd.rs
+++ b/godot-core/src/obj/dyn_gd.rs
@@ -530,19 +530,6 @@ where
     }
 }
 
-impl<'r, T, D> meta::AsArg<DynGd<T, D>> for &'r DynGd<T, D>
-where
-    T: GodotClass,
-    D: ?Sized + 'static,
-{
-    fn into_arg<'cow>(self) -> meta::CowArg<'cow, DynGd<T, D>>
-    where
-        'r: 'cow, // Original reference must be valid for at least as long as the returned cow.
-    {
-        meta::CowArg::Borrowed(self)
-    }
-}
-
 /*
 // See `impl AsArg for Gd<T>` for why this isn't yet implemented.
 impl<'r, T, TBase, D> meta::AsArg<DynGd<TBase, D>> for &'r DynGd<T, D>

--- a/godot-core/src/obj/dyn_gd.rs
+++ b/godot-core/src/obj/dyn_gd.rs
@@ -547,17 +547,12 @@ where
 }
 */
 
-#[expect(deprecated)]
 impl<T, D> meta::ParamType for DynGd<T, D>
 where
     T: GodotClass,
     D: ?Sized + 'static,
 {
-    type Arg<'v> = meta::CowArg<'v, DynGd<T, D>>;
-
-    fn owned_to_arg<'v>(self) -> Self::Arg<'v> {
-        meta::CowArg::Owned(self)
-    }
+    type ArgPassing = meta::ByRef;
 }
 
 impl<T, D> meta::ArrayElement for DynGd<T, D>

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -842,16 +842,6 @@ impl<T: GodotClass> ArrayElement for Option<Gd<T>> {
     }
 }
 
-impl<'r, T: GodotClass> AsArg<Gd<T>> for &'r Gd<T> {
-    #[doc(hidden)] // Repeated despite already hidden in trait; some IDEs suggest this otherwise.
-    fn into_arg<'cow>(self) -> CowArg<'cow, Gd<T>>
-    where
-        'r: 'cow, // Original reference must be valid for at least as long as the returned cow.
-    {
-        CowArg::Borrowed(self)
-    }
-}
-
 /*
 // TODO find a way to generalize AsArg to derived->base conversions without breaking type inference in array![].
 // Possibly we could use a "canonical type" with unambiguous mapping (&Gd<T> -> &Gd<T>, not &Gd<T> -> &Gd<TBase>).

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -13,6 +13,8 @@ use sys::{static_assert_eq_size_align, SysPtr as _};
 
 use crate::builtin::{Callable, NodePath, StringName, Variant};
 use crate::meta::error::{ConvertError, FromFfiError};
+
+#[expect(deprecated)]
 use crate::meta::{
     ArrayElement, AsArg, CallContext, ClassName, CowArg, FromGodot, GodotConvert, GodotType,
     ParamType, PropertyHintInfo, RefArg, ToGodot,
@@ -866,19 +868,12 @@ where
 }
 */
 
+#[expect(deprecated)]
 impl<T: GodotClass> ParamType for Gd<T> {
     type Arg<'v> = CowArg<'v, Gd<T>>;
 
     fn owned_to_arg<'v>(self) -> Self::Arg<'v> {
         CowArg::Owned(self)
-    }
-
-    fn arg_to_ref<'r>(arg: &'r Self::Arg<'_>) -> &'r Self {
-        arg.cow_as_ref()
-    }
-
-    fn arg_into_owned(arg: Self::Arg<'_>) -> Self {
-        arg.cow_into_owned()
     }
 }
 
@@ -892,19 +887,12 @@ impl<T: GodotClass> AsArg<Option<Gd<T>>> for Option<&Gd<T>> {
     }
 }
 
+#[expect(deprecated)]
 impl<T: GodotClass> ParamType for Option<Gd<T>> {
     type Arg<'v> = CowArg<'v, Option<Gd<T>>>;
 
     fn owned_to_arg<'v>(self) -> Self::Arg<'v> {
         CowArg::Owned(self)
-    }
-
-    fn arg_to_ref<'r>(arg: &'r Self::Arg<'_>) -> &'r Self {
-        arg.cow_as_ref()
-    }
-
-    fn arg_into_owned(arg: Self::Arg<'_>) -> Self {
-        arg.cow_into_owned()
     }
 }
 

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -13,10 +13,8 @@ use sys::{static_assert_eq_size_align, SysPtr as _};
 
 use crate::builtin::{Callable, NodePath, StringName, Variant};
 use crate::meta::error::{ConvertError, FromFfiError};
-
-#[expect(deprecated)]
 use crate::meta::{
-    ArrayElement, AsArg, CallContext, ClassName, CowArg, FromGodot, GodotConvert, GodotType,
+    ArrayElement, AsArg, ByRef, CallContext, ClassName, CowArg, FromGodot, GodotConvert, GodotType,
     ParamType, PropertyHintInfo, RefArg, ToGodot,
 };
 use crate::obj::{
@@ -868,13 +866,8 @@ where
 }
 */
 
-#[expect(deprecated)]
 impl<T: GodotClass> ParamType for Gd<T> {
-    type Arg<'v> = CowArg<'v, Gd<T>>;
-
-    fn owned_to_arg<'v>(self) -> Self::Arg<'v> {
-        CowArg::Owned(self)
-    }
+    type ArgPassing = ByRef;
 }
 
 impl<T: GodotClass> AsArg<Option<Gd<T>>> for Option<&Gd<T>> {
@@ -887,13 +880,8 @@ impl<T: GodotClass> AsArg<Option<Gd<T>>> for Option<&Gd<T>> {
     }
 }
 
-#[expect(deprecated)]
 impl<T: GodotClass> ParamType for Option<Gd<T>> {
-    type Arg<'v> = CowArg<'v, Option<Gd<T>>>;
-
-    fn owned_to_arg<'v>(self) -> Self::Arg<'v> {
-        CowArg::Owned(self)
-    }
+    type ArgPassing = ByRef;
 }
 
 impl<T> Default for Gd<T>

--- a/itest/rust/src/builtin_tests/containers/signal_test.rs
+++ b/itest/rust/src/builtin_tests/containers/signal_test.rs
@@ -9,12 +9,12 @@ use crate::framework::itest;
 use godot::builtin::{vslice, GString, Signal, StringName};
 use godot::classes::object::ConnectFlags;
 use godot::classes::{Node, Node3D, Object, RefCounted};
-use godot::meta::{FromGodot, GodotConvert, ToGodot};
+use godot::meta::{FromGodot, GodotConvert, ParamType, ToGodot};
 use godot::obj::{Base, Gd, InstanceId, NewAlloc, NewGd};
 use godot::prelude::ConvertError;
 use godot::register::{godot_api, GodotClass};
-use godot::sys;
 use godot::sys::Global;
+use godot::{meta, sys};
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 
@@ -495,8 +495,12 @@ fn enums_as_signal_args() {
         }
     }
 
+    impl ParamType for EventType {
+        type ArgPassing = meta::ByValue;
+    }
+
     impl FromGodot for EventType {
-        fn try_from_godot(via: Self::Via) -> Result<Self, godot::prelude::ConvertError> {
+        fn try_from_godot(via: Self::Via) -> Result<Self, ConvertError> {
             match via {
                 0 => Ok(Self::Ready),
                 _ => Err(ConvertError::new("value out of range")),
@@ -519,7 +523,7 @@ fn enums_as_signal_args() {
     let object = SignalObject::new_gd();
     let event = EventType::Ready;
 
-    object.signals().game_event().emit(&event);
+    object.signals().game_event().emit(event);
 }
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
I currently don't see an issue with eliminating the `ParamType` trait. It also lets us remove several references when we actually can pass by value.

This would resolve #1192.