### PR TITLE
Deny manual `init()` if `#[class(init|no_init)]` is present

### DIFF
--- a/godot-macros/src/class/data_models/interface_trait_impl.rs
+++ b/godot-macros/src/class/data_models/interface_trait_impl.rs
@@ -227,8 +227,12 @@ fn handle_init<'a>(
         godot_init_impl, ..
     } = decls;
 
+    // If #[class(init)] or #[class(no_init)] is provided, deny overriding manual init().
+    let deny_manual_init_macro = util::format_class_deny_manual_init_macro(class_name);
+
     *godot_init_impl = quote! {
         #godot_init_impl
+        #deny_manual_init_macro!();
 
         #(#cfg_attrs)*
         impl ::godot::obj::cap::GodotDefault for #class_name {

--- a/godot-macros/src/util/mod.rs
+++ b/godot-macros/src/util/mod.rs
@@ -418,3 +418,8 @@ pub fn format_class_visibility_macro(class_name: &Ident) -> Ident {
 pub fn format_class_base_field_macro(class_name: &Ident) -> Ident {
     format_ident!("__godot_{class_name}_has_base_field_macro")
 }
+
+/// Returns the name of the macro used to deny manual `init()` for incompatible init strategies.
+pub fn format_class_deny_manual_init_macro(class_name: &Ident) -> Ident {
+    format_ident!("__deny_manual_init_{class_name}")
+}

--- a/itest/rust/src/engine_tests/codegen_test.rs
+++ b/itest/rust/src/engine_tests/codegen_test.rs
@@ -142,7 +142,7 @@ impl CodegenTest2 {
 macro_rules! make_class {
     ($ClassName:ident, $BaseName:ident) => {
         #[derive(GodotClass)]
-        #[class(no_init, base=$BaseName)]
+        #[class(base=$BaseName)]
         pub struct $ClassName {
             base: Base<godot::classes::$BaseName>,
         }


### PR DESCRIPTION
No longer allows manually overridden `init()` constructors, if either `#[class(init)]` or `#[class(no_init)]` is specified.
Should catch bugs with conflicting init strategies.

While technically breaking, this only enforces invariants that were already documented to be invalid.