### PR TITLE
Relaxed Variant conversions

### DIFF
--- a/godot-core/src/builtin/aabb.rs
+++ b/godot-core/src/builtin/aabb.rs
@@ -6,7 +6,7 @@
  */
 
 use godot_ffi as sys;
-use sys::{ffi_methods, GodotFfi};
+use sys::{ffi_methods, ExtVariantType, GodotFfi};
 
 use crate::builtin::math::ApproxEq;
 use crate::builtin::{real, Plane, Vector3, Vector3Axis};
@@ -448,7 +448,7 @@ impl std::fmt::Display for Aabb {
 // SAFETY:
 // This type is represented as `Self` in Godot, so `*mut Self` is sound.
 unsafe impl GodotFfi for Aabb {
-    const VARIANT_TYPE: sys::VariantType = sys::VariantType::AABB;
+    const VARIANT_TYPE: ExtVariantType = ExtVariantType::Concrete(sys::VariantType::AABB);
 
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Self; .. }
 }

--- a/godot-core/src/builtin/basis.rs
+++ b/godot-core/src/builtin/basis.rs
@@ -6,7 +6,7 @@
  */
 
 use godot_ffi as sys;
-use sys::{ffi_methods, GodotFfi};
+use sys::{ffi_methods, ExtVariantType, GodotFfi};
 
 use crate::builtin::math::{ApproxEq, FloatExt, GlamConv, GlamType, XformInv};
 use crate::builtin::real_consts::FRAC_PI_2;
@@ -631,7 +631,7 @@ impl XformInv<Vector3> for Basis {
 // SAFETY:
 // This type is represented as `Self` in Godot, so `*mut Self` is sound.
 unsafe impl GodotFfi for Basis {
-    const VARIANT_TYPE: sys::VariantType = sys::VariantType::BASIS;
+    const VARIANT_TYPE: ExtVariantType = ExtVariantType::Concrete(sys::VariantType::BASIS);
 
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Self; .. }
 }

--- a/godot-core/src/builtin/callable.rs
+++ b/godot-core/src/builtin/callable.rs
@@ -14,7 +14,7 @@ use crate::obj::bounds::DynMemory;
 use crate::obj::Bounds;
 use crate::obj::{Gd, GodotClass, InstanceId};
 use std::{fmt, ptr};
-use sys::{ffi_methods, GodotFfi};
+use sys::{ffi_methods, ExtVariantType, GodotFfi};
 
 #[cfg(all(since_api = "4.2", before_api = "4.3"))]
 type CallableCustomInfo = sys::GDExtensionCallableCustomInfo;
@@ -441,7 +441,7 @@ impl_builtin_traits! {
 // The `opaque` in `Callable` is just a pair of pointers, and requires no special initialization or cleanup
 // beyond what is done in `from_opaque` and `drop`. So using `*mut Opaque` is safe.
 unsafe impl GodotFfi for Callable {
-    const VARIANT_TYPE: sys::VariantType = sys::VariantType::CALLABLE;
+    const VARIANT_TYPE: ExtVariantType = ExtVariantType::Concrete(sys::VariantType::CALLABLE);
 
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Opaque;
         fn new_from_sys;

--- a/godot-core/src/builtin/collections/array.rs
+++ b/godot-core/src/builtin/collections/array.rs
@@ -13,8 +13,8 @@ use crate::meta;
 use crate::meta::error::{ConvertError, FromGodotError, FromVariantError};
 use crate::meta::{
     element_godot_type_name, element_variant_type, ArrayElement, ArrayTypeInfo, AsArg, ClassName,
-    CowArg, FromGodot, GodotConvert, GodotFfiVariant, GodotType, ParamType, PropertyHintInfo,
-    RefArg, ToGodot,
+    CowArg, ExtVariantType, FromGodot, GodotConvert, GodotFfiVariant, GodotType, ParamType,
+    PropertyHintInfo, RefArg, ToGodot,
 };
 use crate::obj::{bounds, Bounds, DynGd, Gd, GodotClass};
 use crate::registry::property::{BuiltinExport, Export, Var};
@@ -1110,7 +1110,7 @@ impl VariantArray {
 //   Arrays are properly initialized through a `from_sys` call, but the ref-count should be incremented
 //   as that is the callee's responsibility. Which we do by calling `std::mem::forget(array.clone())`.
 unsafe impl<T: ArrayElement> GodotFfi for Array<T> {
-    const VARIANT_TYPE: VariantType = VariantType::ARRAY;
+    const VARIANT_TYPE: ExtVariantType = ExtVariantType::Concrete(VariantType::ARRAY);
 
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Opaque; .. }
 }
@@ -1371,9 +1371,9 @@ impl<T: ArrayElement> GodotFfiVariant for Array<T> {
 
     fn ffi_from_variant(variant: &Variant) -> Result<Self, ConvertError> {
         // First check if the variant is an array. The array conversion shouldn't be called otherwise.
-        if variant.get_type() != Self::VARIANT_TYPE {
+        if variant.get_type() != Self::VARIANT_TYPE.variant_as_nil() {
             return Err(FromVariantError::BadType {
-                expected: Self::VARIANT_TYPE,
+                expected: Self::VARIANT_TYPE.variant_as_nil(),
                 actual: variant.get_type(),
             }
             .into_error(variant.clone()));

--- a/godot-core/src/builtin/collections/dictionary.rs
+++ b/godot-core/src/builtin/collections/dictionary.rs
@@ -8,7 +8,7 @@
 use godot_ffi as sys;
 
 use crate::builtin::{inner, Variant, VariantArray};
-use crate::meta::{FromGodot, ToGodot};
+use crate::meta::{ExtVariantType, FromGodot, ToGodot};
 use sys::types::OpaqueDictionary;
 use sys::{ffi_methods, interface_fn, GodotFfi};
 
@@ -394,7 +394,7 @@ impl Dictionary {
 //   incremented as that is the callee's responsibility. Which we do by calling
 //   `std::mem::forget(dictionary.clone())`.
 unsafe impl GodotFfi for Dictionary {
-    const VARIANT_TYPE: sys::VariantType = sys::VariantType::DICTIONARY;
+    const VARIANT_TYPE: ExtVariantType = ExtVariantType::Concrete(sys::VariantType::DICTIONARY);
 
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Opaque; .. }
 }

--- a/godot-core/src/builtin/collections/packed_array.rs
+++ b/godot-core/src/builtin/collections/packed_array.rs
@@ -17,7 +17,7 @@ use crate::meta::{AsArg, ToGodot};
 use std::mem::size_of;
 use std::{fmt, ops, ptr};
 use sys::types::*;
-use sys::{ffi_methods, interface_fn, GodotFfi};
+use sys::{ffi_methods, interface_fn, ExtVariantType, GodotFfi};
 
 use crate::classes::file_access::CompressionMode;
 use crate::meta;
@@ -625,7 +625,7 @@ macro_rules! impl_packed_array {
         }
 
         unsafe impl GodotFfi for $PackedArray {
-            const VARIANT_TYPE: sys::VariantType = sys::VariantType::$VariantType;
+            const VARIANT_TYPE: ExtVariantType = ExtVariantType::Concrete(sys::VariantType::$VariantType);
 
             ffi_methods! { type sys::GDExtensionTypePtr = *mut Opaque; .. }
         }

--- a/godot-core/src/builtin/color.rs
+++ b/godot-core/src/builtin/color.rs
@@ -13,7 +13,7 @@ use crate::builtin::{ColorHsv, GString};
 use crate::meta::{arg_into_ref, AsArg};
 use godot_ffi as sys;
 use std::ops;
-use sys::{ffi_methods, GodotFfi};
+use sys::{ffi_methods, ExtVariantType, GodotFfi};
 
 /// Color built-in type, in floating-point RGBA format.
 ///
@@ -358,7 +358,7 @@ impl Color {
 // SAFETY:
 // This type is represented as `Self` in Godot, so `*mut Self` is sound.
 unsafe impl GodotFfi for Color {
-    const VARIANT_TYPE: sys::VariantType = sys::VariantType::COLOR;
+    const VARIANT_TYPE: ExtVariantType = ExtVariantType::Concrete(sys::VariantType::COLOR);
 
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Self; .. }
 }

--- a/godot-core/src/builtin/plane.rs
+++ b/godot-core/src/builtin/plane.rs
@@ -6,7 +6,7 @@
  */
 
 use godot_ffi as sys;
-use sys::{ffi_methods, GodotFfi};
+use sys::{ffi_methods, ExtVariantType, GodotFfi};
 
 use crate::builtin::math::{ApproxEq, FloatExt};
 use crate::builtin::{real, Vector3};
@@ -265,7 +265,7 @@ impl Neg for Plane {
 // SAFETY:
 // This type is represented as `Self` in Godot, so `*mut Self` is sound.
 unsafe impl GodotFfi for Plane {
-    const VARIANT_TYPE: sys::VariantType = sys::VariantType::PLANE;
+    const VARIANT_TYPE: ExtVariantType = ExtVariantType::Concrete(sys::VariantType::PLANE);
 
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Self;
         fn new_from_sys;

--- a/godot-core/src/builtin/projection.rs
+++ b/godot-core/src/builtin/projection.rs
@@ -6,7 +6,7 @@
  */
 
 use godot_ffi as sys;
-use sys::{ffi_methods, GodotFfi};
+use sys::{ffi_methods, ExtVariantType, GodotFfi};
 
 use crate::builtin::inner::InnerProjection;
 use crate::builtin::math::{ApproxEq, GlamConv, GlamType};
@@ -557,7 +557,7 @@ impl GlamConv for Projection {
 
 // SAFETY: This type is represented as `Self` in Godot, so `*mut Self` is sound.
 unsafe impl GodotFfi for Projection {
-    const VARIANT_TYPE: sys::VariantType = sys::VariantType::PROJECTION;
+    const VARIANT_TYPE: ExtVariantType = ExtVariantType::Concrete(sys::VariantType::PROJECTION);
 
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Self; .. }
 }

--- a/godot-core/src/builtin/quaternion.rs
+++ b/godot-core/src/builtin/quaternion.rs
@@ -6,7 +6,7 @@
  */
 
 use godot_ffi as sys;
-use sys::{ffi_methods, GodotFfi};
+use sys::{ffi_methods, ExtVariantType, GodotFfi};
 
 use crate::builtin::math::{ApproxEq, FloatExt, GlamConv, GlamType};
 use crate::builtin::{inner, real, Basis, EulerOrder, RQuat, RealConv, Vector3};
@@ -337,7 +337,7 @@ impl Mul<Vector3> for Quaternion {
 // SAFETY:
 // This type is represented as `Self` in Godot, so `*mut Self` is sound.
 unsafe impl GodotFfi for Quaternion {
-    const VARIANT_TYPE: sys::VariantType = sys::VariantType::QUATERNION;
+    const VARIANT_TYPE: ExtVariantType = ExtVariantType::Concrete(sys::VariantType::QUATERNION);
 
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Self; .. }
 }

--- a/godot-core/src/builtin/rect2.rs
+++ b/godot-core/src/builtin/rect2.rs
@@ -6,7 +6,7 @@
  */
 
 use godot_ffi as sys;
-use sys::{ffi_methods, GodotFfi};
+use sys::{ffi_methods, ExtVariantType, GodotFfi};
 
 use crate::builtin::math::ApproxEq;
 use crate::builtin::{real, Rect2i, Side, Vector2};
@@ -269,7 +269,7 @@ impl Rect2 {
 // SAFETY:
 // This type is represented as `Self` in Godot, so `*mut Self` is sound.
 unsafe impl GodotFfi for Rect2 {
-    const VARIANT_TYPE: sys::VariantType = sys::VariantType::RECT2;
+    const VARIANT_TYPE: ExtVariantType = ExtVariantType::Concrete(sys::VariantType::RECT2);
 
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Self; .. }
 }

--- a/godot-core/src/builtin/rect2i.rs
+++ b/godot-core/src/builtin/rect2i.rs
@@ -10,7 +10,7 @@ use std::cmp;
 use crate::builtin::{Rect2, Side, Vector2i};
 
 use godot_ffi as sys;
-use sys::{ffi_methods, GodotFfi};
+use sys::{ffi_methods, ExtVariantType, GodotFfi};
 
 /// 2D axis-aligned integer bounding box.
 ///
@@ -282,7 +282,7 @@ impl Rect2i {
 // SAFETY:
 // This type is represented as `Self` in Godot, so `*mut Self` is sound.
 unsafe impl GodotFfi for Rect2i {
-    const VARIANT_TYPE: sys::VariantType = sys::VariantType::RECT2I;
+    const VARIANT_TYPE: ExtVariantType = ExtVariantType::Concrete(sys::VariantType::RECT2I);
 
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Self; .. }
 }

--- a/godot-core/src/builtin/rid.rs
+++ b/godot-core/src/builtin/rid.rs
@@ -8,7 +8,7 @@
 use std::num::NonZeroU64;
 
 use godot_ffi as sys;
-use sys::{ffi_methods, static_assert, static_assert_eq_size_align, GodotFfi};
+use sys::{ffi_methods, static_assert, static_assert_eq_size_align, ExtVariantType, GodotFfi};
 
 /// A RID ("resource ID") is an opaque handle that refers to a Godot `Resource`.
 ///
@@ -121,7 +121,7 @@ impl std::fmt::Display for Rid {
 // SAFETY:
 // This type is represented as `Self` in Godot, so `*mut Self` is sound.
 unsafe impl GodotFfi for Rid {
-    const VARIANT_TYPE: sys::VariantType = sys::VariantType::RID;
+    const VARIANT_TYPE: ExtVariantType = ExtVariantType::Concrete(sys::VariantType::RID);
 
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Self;
         fn new_from_sys;

--- a/godot-core/src/builtin/signal.rs
+++ b/godot-core/src/builtin/signal.rs
@@ -17,7 +17,7 @@ use crate::meta;
 use crate::meta::{FromGodot, GodotType, ToGodot};
 use crate::obj::bounds::DynMemory;
 use crate::obj::{Bounds, Gd, GodotClass, InstanceId};
-use sys::{ffi_methods, GodotFfi};
+use sys::{ffi_methods, ExtVariantType, GodotFfi};
 
 /// Untyped Godot signal.
 ///
@@ -167,7 +167,7 @@ impl Signal {
 // The `opaque` in `Signal` is just a pair of pointers, and requires no special initialization or cleanup
 // beyond what is done in `from_opaque` and `drop`. So using `*mut Opaque` is safe.
 unsafe impl GodotFfi for Signal {
-    const VARIANT_TYPE: sys::VariantType = sys::VariantType::SIGNAL;
+    const VARIANT_TYPE: ExtVariantType = ExtVariantType::Concrete(sys::VariantType::SIGNAL);
 
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Opaque;
         fn new_from_sys;

--- a/godot-core/src/builtin/string/gstring.rs
+++ b/godot-core/src/builtin/string/gstring.rs
@@ -11,7 +11,7 @@ use std::fmt::Write;
 
 use godot_ffi as sys;
 use sys::types::OpaqueString;
-use sys::{ffi_methods, interface_fn, GodotFfi};
+use sys::{ffi_methods, interface_fn, ExtVariantType, GodotFfi};
 
 use crate::builtin::string::{pad_if_needed, Encoding};
 use crate::builtin::{inner, NodePath, StringName, Variant};
@@ -272,7 +272,7 @@ impl GString {
 //   incremented as that is the callee's responsibility. Which we do by calling
 //   `std::mem::forget(string.clone())`.
 unsafe impl GodotFfi for GString {
-    const VARIANT_TYPE: sys::VariantType = sys::VariantType::STRING;
+    const VARIANT_TYPE: ExtVariantType = ExtVariantType::Concrete(sys::VariantType::STRING);
 
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Self; .. }
 }

--- a/godot-core/src/builtin/string/node_path.rs
+++ b/godot-core/src/builtin/string/node_path.rs
@@ -8,7 +8,7 @@
 use std::fmt;
 
 use godot_ffi as sys;
-use godot_ffi::{ffi_methods, GdextBuild, GodotFfi};
+use godot_ffi::{ffi_methods, ExtVariantType, GdextBuild, GodotFfi};
 
 use crate::builtin::inner;
 
@@ -195,7 +195,7 @@ impl NodePath {
 //   incremented as that is the callee's responsibility. Which we do by calling
 //   `std::mem::forget(node_path.clone())`.
 unsafe impl GodotFfi for NodePath {
-    const VARIANT_TYPE: sys::VariantType = sys::VariantType::NODE_PATH;
+    const VARIANT_TYPE: ExtVariantType = ExtVariantType::Concrete(sys::VariantType::NODE_PATH);
 
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Opaque; .. }
 }

--- a/godot-core/src/builtin/string/string_name.rs
+++ b/godot-core/src/builtin/string/string_name.rs
@@ -8,7 +8,7 @@ use std::fmt;
 
 use godot_ffi as sys;
 use godot_ffi::interface_fn;
-use sys::{ffi_methods, GodotFfi};
+use sys::{ffi_methods, ExtVariantType, GodotFfi};
 
 use crate::builtin::{inner, Encoding, GString, NodePath, Variant};
 use crate::meta::error::StringError;
@@ -268,7 +268,7 @@ impl StringName {
 //   incremented as that is the callee's responsibility. Which we do by calling
 //   `std::mem::forget(string_name.clone())`.
 unsafe impl GodotFfi for StringName {
-    const VARIANT_TYPE: sys::VariantType = sys::VariantType::STRING_NAME;
+    const VARIANT_TYPE: ExtVariantType = ExtVariantType::Concrete(sys::VariantType::STRING_NAME);
 
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Opaque; .. }
 }

--- a/godot-core/src/builtin/transform2d.rs
+++ b/godot-core/src/builtin/transform2d.rs
@@ -6,7 +6,7 @@
  */
 
 use godot_ffi as sys;
-use sys::{ffi_methods, GodotFfi};
+use sys::{ffi_methods, ExtVariantType, GodotFfi};
 
 use crate::builtin::math::{assert_ne_approx, ApproxEq, FloatExt, GlamConv, GlamType, XformInv};
 use crate::builtin::real_consts::PI;
@@ -462,7 +462,7 @@ impl GlamConv for Transform2D {
 // SAFETY:
 // This type is represented as `Self` in Godot, so `*mut Self` is sound.
 unsafe impl GodotFfi for Transform2D {
-    const VARIANT_TYPE: sys::VariantType = sys::VariantType::TRANSFORM2D;
+    const VARIANT_TYPE: ExtVariantType = ExtVariantType::Concrete(sys::VariantType::TRANSFORM2D);
 
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Self; .. }
 }

--- a/godot-core/src/builtin/transform3d.rs
+++ b/godot-core/src/builtin/transform3d.rs
@@ -6,7 +6,7 @@
  */
 
 use godot_ffi as sys;
-use sys::{ffi_methods, GodotFfi};
+use sys::{ffi_methods, ExtVariantType, GodotFfi};
 
 use crate::builtin::math::{ApproxEq, GlamConv, GlamType, XformInv};
 use crate::builtin::{real, Aabb, Basis, Plane, Projection, RAffine3, Vector3};
@@ -469,7 +469,7 @@ impl GlamConv for Transform3D {
 // SAFETY:
 // This type is represented as `Self` in Godot, so `*mut Self` is sound.
 unsafe impl GodotFfi for Transform3D {
-    const VARIANT_TYPE: sys::VariantType = sys::VariantType::TRANSFORM3D;
+    const VARIANT_TYPE: ExtVariantType = ExtVariantType::Concrete(sys::VariantType::TRANSFORM3D);
 
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Self; .. }
 }

--- a/godot-core/src/builtin/variant/impls.rs
+++ b/godot-core/src/builtin/variant/impls.rs
@@ -47,9 +47,9 @@ macro_rules! impl_ffi_variant {
 
             fn ffi_from_variant(variant: &Variant) -> Result<Self, ConvertError> {
                 // Type check -- at the moment, a strict match is required.
-                if variant.get_type() != Self::VARIANT_TYPE {
+                if variant.get_type() != Self::VARIANT_TYPE.variant_as_nil() {
                     return Err(FromVariantError::BadType {
-                        expected: Self::VARIANT_TYPE,
+                        expected: Self::VARIANT_TYPE.variant_as_nil(),
                         actual: variant.get_type(),
                     }
                     .into_error(variant.clone()));
@@ -249,13 +249,13 @@ const _: () = {
 
     #[cfg(before_api = "4.2")]
     const fn variant_type<T: GodotType + ArrayElement>() -> VariantType {
-        <T::Ffi as sys::GodotFfi>::VARIANT_TYPE
+        <T::Ffi as sys::GodotFfi>::VARIANT_TYPE.variant_as_nil()
     }
 
     #[cfg(since_api = "4.2")]
     const fn variant_type<T: crate::task::IntoDynamicSend + GodotType + ArrayElement>(
     ) -> VariantType {
-        <T::Ffi as sys::GodotFfi>::VARIANT_TYPE
+        <T::Ffi as sys::GodotFfi>::VARIANT_TYPE.variant_as_nil()
     }
 
     const NIL: VariantType = variant_type::<Variant>();
@@ -423,7 +423,7 @@ impl GodotType for Variant {
 
     fn property_info(property_name: &str) -> PropertyInfo {
         PropertyInfo {
-            variant_type: Self::VARIANT_TYPE,
+            variant_type: Self::VARIANT_TYPE.variant_as_nil(),
             class_name: Self::class_name(),
             property_name: StringName::from(property_name),
             hint_info: PropertyHintInfo::none(),

--- a/godot-core/src/builtin/variant/mod.rs
+++ b/godot-core/src/builtin/variant/mod.rs
@@ -8,8 +8,10 @@
 use crate::builtin::{
     GString, StringName, VariantArray, VariantDispatch, VariantOperator, VariantType,
 };
-use crate::meta::error::ConvertError;
-use crate::meta::{arg_into_ref, ArrayElement, AsArg, FromGodot, ToGodot};
+use crate::meta::error::{ConvertError, FromVariantError};
+use crate::meta::{
+    arg_into_ref, ffi_variant_type, ArrayElement, AsArg, FromGodot, GodotType, ToGodot,
+};
 use godot_ffi as sys;
 use std::{fmt, ptr};
 use sys::{ffi_methods, interface_fn, GodotFfi};
@@ -63,9 +65,53 @@ impl Variant {
 
     /// Convert to type `T`, returning `Err` on failure.
     ///
+    /// The conversion only succeeds if the type stored in the variant matches `T`'s FFI representation.
+    /// For lenient conversions like in GDScript, use [`try_to_relaxed()`](Self::try_to_relaxed) instead.
+    ///
     /// Equivalent to [`T::try_from_variant(&self)`][FromGodot::try_from_variant].
     pub fn try_to<T: FromGodot>(&self) -> Result<T, ConvertError> {
         T::try_from_variant(self)
+    }
+
+    /// Convert to `T` using Godot's less strict conversion rules.
+    ///
+    /// More lenient than [`try_to()`](Self::try_to), which only allows exact type matches.
+    /// Enables conversions between related types that Godot considers compatible under its conversion rules.
+    ///
+    /// Precisely matches GDScript's behavior to converts arguments, when a function declares a parameter of different type.
+    ///
+    /// # Conversion diagram
+    /// Exhaustive list of all possible conversions, as of Godot 4.4. The arrow `──►` means "converts to".
+    ///
+    /// ```text
+    ///                                                               * ───► Variant
+    ///                                                               * ───► itself (reflexive)
+    ///         float          StringName
+    ///         ▲   ▲             ▲                            Vector2 ◄───► Vector2i
+    ///        ╱     ╲            │                            Vector3 ◄───► Vector3i
+    ///       ▼       ▼           ▼                            Vector4 ◄───► Vector4i
+    ///    bool ◄───► int       GString ◄───► NodePath           Rect2 ◄───► Rect2i
+    ///                 ╲       ╱
+    ///                  ╲     ╱                                 Array ◄───► Packed*Array
+    ///                   ▼   ▼
+    ///                   Color                                   Gd<T> ───► Rid
+    ///                                                             nil ───► Option<Gd<T>>
+    ///
+    ///                                Basis ◄───► Quaternion
+    ///                                    ╲       ╱
+    ///                                     ╲     ╱
+    ///                                      ▼   ▼
+    ///                 Transform2D ◄───► Transform3D ◄───► Projection
+    /// ```
+    ///
+    /// # Godot implementation details
+    /// See [GDExtension interface](https://github.com/godotengine/godot/blob/4.4-stable/core/extension/gdextension_interface.h#L1353-L1364)
+    /// and [C++ implementation](https://github.com/godotengine/godot/blob/4.4-stable/core/variant/variant.cpp#L532) (Godot 4.4 at the time of
+    /// writing). The "strict" part refers to excluding certain conversions, such as between `int` and `GString`.
+    ///
+    // ASCII arsenal: / ╱ ⟋ ⧸ ⁄ ╱ ↗ ╲ \ ╲ ⟍ ⧹ ∖
+    pub fn try_to_relaxed<T: FromGodot>(&self) -> Result<T, ConvertError> {
+        try_from_variant_relaxed(self)
     }
 
     /// Checks whether the variant is empty (`null` value in GDScript).
@@ -528,5 +574,63 @@ impl fmt::Debug for Variant {
             // VariantDispatch also includes dead objects via `FreedObject` enumerator, which maps to "<Freed Object>".
             _ => VariantDispatch::from_variant(self).fmt(f),
         }
+    }
+}
+
+fn try_from_variant_relaxed<T: FromGodot>(variant: &Variant) -> Result<T, ConvertError> {
+    // See C++ implementation mentioned in RustDoc comment of `try_to_relaxed()`.
+
+    // First check if the current type can be converted using strict rules.
+    let from_type = variant.get_type();
+    let to_type = ffi_variant_type::<T>();
+
+    // If types are the same, use the regular conversion.
+    // This is both an optimization (avoids FFI calls) and ensures consistency
+    // between strict and relaxed conversions for identical types.
+    if from_type == to_type {
+        return T::try_from_variant(variant);
+    }
+
+    // Non-NIL types can technically be converted to NIL according to `variant_can_convert_strict()`, however that makes no sense -- from
+    // neither a type perspective (NIL is unit, not never type), nor a practical one. Disallow any such conversions.
+    if to_type == VariantType::NIL || !can_convert_godot_strict(from_type, to_type) {
+        return Err(FromVariantError::BadType {
+            expected: to_type,
+            actual: from_type,
+        }
+        .into_error(variant.clone()));
+    }
+
+    // Find correct from->to conversion constructor.
+    let converter = unsafe {
+        let get_constructor = interface_fn!(get_variant_to_type_constructor);
+        get_constructor(to_type.sys())
+    };
+
+    // Must be available, since we checked with `variant_can_convert_strict`.
+    let converter =
+        converter.unwrap_or_else(|| panic!("missing converter for {from_type:?} -> {to_type:?}"));
+
+    // Perform actual conversion on the FFI types. The GDExtension conversion constructor only works with types supported
+    // by Godot (i.e. GodotType), not GodotConvert (like i8).
+    let ffi_result = unsafe {
+        <<T::Via as GodotType>::Ffi as GodotFfi>::new_with_uninit(|result_ptr| {
+            converter(result_ptr, sys::SysPtr::force_mut(variant.var_sys()));
+        })
+    };
+
+    // Try to convert the FFI types back to the user type. Can still fail, e.g. i64 -> i8.
+    let via = <T::Via as GodotType>::try_from_ffi(ffi_result)?;
+    let concrete = T::try_from_godot(via)?;
+
+    Ok(concrete)
+}
+
+fn can_convert_godot_strict(from_type: VariantType, to_type: VariantType) -> bool {
+    // Godot "strict" conversion is still quite permissive.
+    // See Variant::can_convert_strict() in C++, https://github.com/godotengine/godot/blob/master/core/variant/variant.cpp#L532-L532.
+    unsafe {
+        let can_convert_fn = interface_fn!(variant_can_convert_strict);
+        can_convert_fn(from_type.sys(), to_type.sys()) == sys::conv::SYS_TRUE
     }
 }

--- a/godot-core/src/builtin/variant/mod.rs
+++ b/godot-core/src/builtin/variant/mod.rs
@@ -114,6 +114,17 @@ impl Variant {
         try_from_variant_relaxed(self)
     }
 
+    /// Helper function for relaxed variant conversion with panic on failure.
+    /// Similar to [`to()`](Self::to) but uses relaxed conversion rules.
+    pub(crate) fn to_relaxed_or_panic<T, F>(&self, context: F) -> T
+    where
+        T: FromGodot,
+        F: FnOnce() -> String,
+    {
+        self.try_to_relaxed::<T>()
+            .unwrap_or_else(|err| panic!("{}: {err}", context()))
+    }
+
     /// Checks whether the variant is empty (`null` value in GDScript).
     ///
     /// See also [`get_type()`][Self::get_type].

--- a/godot-core/src/builtin/vectors/vector2.rs
+++ b/godot-core/src/builtin/vectors/vector2.rs
@@ -7,7 +7,7 @@
 
 use core::cmp::Ordering;
 use godot_ffi as sys;
-use sys::{ffi_methods, GodotFfi};
+use sys::{ffi_methods, ExtVariantType, GodotFfi};
 
 use crate::builtin::math::{FloatExt, GlamConv, GlamType};
 use crate::builtin::vectors::Vector2Axis;
@@ -181,7 +181,7 @@ impl fmt::Display for Vector2 {
 // SAFETY:
 // This type is represented as `Self` in Godot, so `*mut Self` is sound.
 unsafe impl GodotFfi for Vector2 {
-    const VARIANT_TYPE: sys::VariantType = sys::VariantType::VECTOR2;
+    const VARIANT_TYPE: ExtVariantType = ExtVariantType::Concrete(sys::VariantType::VECTOR2);
 
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Self; .. }
 }

--- a/godot-core/src/builtin/vectors/vector2i.rs
+++ b/godot-core/src/builtin/vectors/vector2i.rs
@@ -7,7 +7,7 @@
 
 use godot_ffi as sys;
 use std::cmp::Ordering;
-use sys::{ffi_methods, GodotFfi};
+use sys::{ffi_methods, ExtVariantType, GodotFfi};
 
 use crate::builtin::math::{GlamConv, GlamType};
 use crate::builtin::{inner, real, RVec2, Vector2, Vector2Axis};
@@ -98,7 +98,7 @@ impl fmt::Display for Vector2i {
 // SAFETY:
 // This type is represented as `Self` in Godot, so `*mut Self` is sound.
 unsafe impl GodotFfi for Vector2i {
-    const VARIANT_TYPE: sys::VariantType = sys::VariantType::VECTOR2I;
+    const VARIANT_TYPE: ExtVariantType = ExtVariantType::Concrete(sys::VariantType::VECTOR2I);
 
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Self; .. }
 }

--- a/godot-core/src/builtin/vectors/vector3.rs
+++ b/godot-core/src/builtin/vectors/vector3.rs
@@ -7,7 +7,7 @@
 
 use core::cmp::Ordering;
 use godot_ffi as sys;
-use sys::{ffi_methods, GodotFfi};
+use sys::{ffi_methods, ExtVariantType, GodotFfi};
 
 use crate::builtin::math::{FloatExt, GlamConv, GlamType};
 use crate::builtin::vectors::Vector3Axis;
@@ -252,7 +252,7 @@ impl fmt::Display for Vector3 {
 // SAFETY:
 // This type is represented as `Self` in Godot, so `*mut Self` is sound.
 unsafe impl GodotFfi for Vector3 {
-    const VARIANT_TYPE: sys::VariantType = sys::VariantType::VECTOR3;
+    const VARIANT_TYPE: ExtVariantType = ExtVariantType::Concrete(sys::VariantType::VECTOR3);
 
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Self; .. }
 }

--- a/godot-core/src/builtin/vectors/vector3i.rs
+++ b/godot-core/src/builtin/vectors/vector3i.rs
@@ -9,7 +9,7 @@ use std::cmp::Ordering;
 use std::fmt;
 
 use godot_ffi as sys;
-use sys::{ffi_methods, GodotFfi};
+use sys::{ffi_methods, ExtVariantType, GodotFfi};
 
 use crate::builtin::math::{GlamConv, GlamType};
 use crate::builtin::{inner, real, RVec3, Vector3, Vector3Axis};
@@ -102,7 +102,7 @@ impl fmt::Display for Vector3i {
 // SAFETY:
 // This type is represented as `Self` in Godot, so `*mut Self` is sound.
 unsafe impl GodotFfi for Vector3i {
-    const VARIANT_TYPE: sys::VariantType = sys::VariantType::VECTOR3I;
+    const VARIANT_TYPE: ExtVariantType = ExtVariantType::Concrete(sys::VariantType::VECTOR3I);
 
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Self; .. }
 }

--- a/godot-core/src/builtin/vectors/vector4.rs
+++ b/godot-core/src/builtin/vectors/vector4.rs
@@ -7,7 +7,7 @@
 
 use core::cmp::Ordering;
 use godot_ffi as sys;
-use sys::{ffi_methods, GodotFfi};
+use sys::{ffi_methods, ExtVariantType, GodotFfi};
 
 use crate::builtin::math::{FloatExt, GlamConv, GlamType};
 use crate::builtin::{inner, real, RVec4, Vector4Axis, Vector4i};
@@ -95,7 +95,7 @@ impl fmt::Display for Vector4 {
 // SAFETY:
 // This type is represented as `Self` in Godot, so `*mut Self` is sound.
 unsafe impl GodotFfi for Vector4 {
-    const VARIANT_TYPE: sys::VariantType = sys::VariantType::VECTOR4;
+    const VARIANT_TYPE: ExtVariantType = ExtVariantType::Concrete(sys::VariantType::VECTOR4);
 
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Self; .. }
 }

--- a/godot-core/src/builtin/vectors/vector4i.rs
+++ b/godot-core/src/builtin/vectors/vector4i.rs
@@ -7,7 +7,7 @@
 
 use core::cmp::Ordering;
 use godot_ffi as sys;
-use sys::{ffi_methods, GodotFfi};
+use sys::{ffi_methods, ExtVariantType, GodotFfi};
 
 use crate::builtin::math::{GlamConv, GlamType};
 use crate::builtin::{inner, real, RVec4, Vector4, Vector4Axis};
@@ -105,7 +105,7 @@ impl fmt::Display for Vector4i {
 // SAFETY:
 // This type is represented as `Self` in Godot, so `*mut Self` is sound.
 unsafe impl GodotFfi for Vector4i {
-    const VARIANT_TYPE: sys::VariantType = sys::VariantType::VECTOR4I;
+    const VARIANT_TYPE: ExtVariantType = ExtVariantType::Concrete(sys::VariantType::VECTOR4I);
 
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Self; .. }
 }

--- a/godot-core/src/meta/args/cow_arg.rs
+++ b/godot-core/src/meta/args/cow_arg.rs
@@ -9,7 +9,7 @@ use crate::builtin::Variant;
 use crate::meta::error::ConvertError;
 use crate::meta::{FromGodot, GodotConvert, GodotFfiVariant, RefArg, ToGodot};
 use crate::sys;
-use godot_ffi::{GodotFfi, GodotNullableFfi, PtrcallType};
+use godot_ffi::{ExtVariantType, GodotFfi, GodotNullableFfi, PtrcallType};
 use std::fmt;
 
 /// Owned or borrowed value, used when passing arguments through `impl AsArg` to Godot APIs.
@@ -119,7 +119,7 @@ unsafe impl<T> GodotFfi for CowArg<'_, T>
 where
     T: GodotFfi,
 {
-    const VARIANT_TYPE: sys::VariantType = T::VARIANT_TYPE;
+    const VARIANT_TYPE: ExtVariantType = T::VARIANT_TYPE;
 
     unsafe fn new_from_sys(_ptr: sys::GDExtensionConstTypePtr) -> Self {
         wrong_direction!(new_from_sys)

--- a/godot-core/src/meta/args/object_arg.rs
+++ b/godot-core/src/meta/args/object_arg.rs
@@ -10,7 +10,7 @@ use crate::meta::error::ConvertError;
 use crate::meta::{ClassName, FromGodot, GodotConvert, GodotFfiVariant, GodotType, ToGodot};
 use crate::obj::{bounds, Bounds, DynGd, Gd, GodotClass, Inherits, RawGd};
 use crate::{obj, sys};
-use godot_ffi::{GodotFfi, GodotNullableFfi, PtrcallType};
+use godot_ffi::{ExtVariantType, GodotFfi, GodotNullableFfi, PtrcallType};
 use std::ptr;
 
 /// Objects that can be passed as arguments to Godot engine functions.
@@ -274,7 +274,7 @@ where
 {
     // If anything changes here, keep in sync with RawGd impl.
 
-    const VARIANT_TYPE: sys::VariantType = sys::VariantType::OBJECT;
+    const VARIANT_TYPE: ExtVariantType = ExtVariantType::Concrete(sys::VariantType::OBJECT);
 
     unsafe fn new_from_sys(_ptr: sys::GDExtensionConstTypePtr) -> Self {
         unreachable!("ObjectArg should only be passed *to* Godot, not *from*.")

--- a/godot-core/src/meta/args/ref_arg.rs
+++ b/godot-core/src/meta/args/ref_arg.rs
@@ -9,7 +9,7 @@ use crate::builtin::Variant;
 use crate::meta::error::ConvertError;
 use crate::meta::{FromGodot, GodotConvert, GodotFfiVariant, ToGodot};
 use crate::sys;
-use godot_ffi::{GodotFfi, GodotNullableFfi, PtrcallType};
+use godot_ffi::{ExtVariantType, GodotFfi, GodotNullableFfi, PtrcallType};
 use std::fmt;
 
 /// Simple reference wrapper, used when passing arguments by-ref to Godot APIs.
@@ -122,7 +122,7 @@ unsafe impl<T> GodotFfi for RefArg<'_, T>
 where
     T: GodotFfi,
 {
-    const VARIANT_TYPE: sys::VariantType = T::VARIANT_TYPE;
+    const VARIANT_TYPE: ExtVariantType = T::VARIANT_TYPE;
 
     unsafe fn new_from_sys(_ptr: sys::GDExtensionConstTypePtr) -> Self {
         wrong_direction!(new_from_sys)

--- a/godot-core/src/meta/mod.rs
+++ b/godot-core/src/meta/mod.rs
@@ -67,7 +67,7 @@ pub use uniform_object_deref::UniformObjectDeref;
 
 pub(crate) use array_type_info::ArrayTypeInfo;
 pub(crate) use traits::{
-    element_godot_type_name, element_variant_type, GodotFfiVariant, GodotNullableFfi,
+    element_godot_type_name, ffi_variant_type, element_variant_type, GodotFfiVariant, GodotNullableFfi,
 };
 
 use crate::registry::method::MethodParamOrReturnInfo;

--- a/godot-core/src/meta/mod.rs
+++ b/godot-core/src/meta/mod.rs
@@ -67,8 +67,8 @@ pub use uniform_object_deref::UniformObjectDeref;
 
 pub(crate) use array_type_info::ArrayTypeInfo;
 pub(crate) use traits::{
-    element_godot_type_name, element_variant_type, ffi_variant_type, GodotFfiVariant,
-    GodotNullableFfi,
+    element_godot_type_name, element_variant_type, ffi_variant_type, ExtVariantType,
+    GodotFfiVariant, GodotNullableFfi,
 };
 
 use crate::registry::method::MethodParamOrReturnInfo;

--- a/godot-core/src/meta/mod.rs
+++ b/godot-core/src/meta/mod.rs
@@ -67,7 +67,8 @@ pub use uniform_object_deref::UniformObjectDeref;
 
 pub(crate) use array_type_info::ArrayTypeInfo;
 pub(crate) use traits::{
-    element_godot_type_name, ffi_variant_type, element_variant_type, GodotFfiVariant, GodotNullableFfi,
+    element_godot_type_name, element_variant_type, ffi_variant_type, GodotFfiVariant,
+    GodotNullableFfi,
 };
 
 use crate::registry::method::MethodParamOrReturnInfo;

--- a/godot-core/src/meta/param_tuple.rs
+++ b/godot-core/src/meta/param_tuple.rs
@@ -47,6 +47,7 @@ pub trait InParamTuple: ParamTuple {
     ///
     /// - `args_ptr` must be a pointer to an array of length [`Self::LEN`](ParamTuple::LEN)
     /// - Each element of `args_ptr` must be reborrowable as a `&Variant` with a lifetime that lasts for the duration of the call.
+    #[doc(hidden)] // Hidden since v0.3.2.
     unsafe fn from_varcall_args(
         args_ptr: *const sys::GDExtensionConstVariantPtr,
         call_ctx: &CallContext,
@@ -58,6 +59,7 @@ pub trait InParamTuple: ParamTuple {
     ///
     /// - `args_ptr` must be a pointer to a valid array of length [`Self::LEN`](ParamTuple::LEN)
     /// - each element of `args_ptr` must be of the same type as each element of `Self`
+    #[doc(hidden)] // Hidden since v0.3.2.
     unsafe fn from_ptrcall_args(
         args_ptr: *const sys::GDExtensionConstTypePtr,
         call_type: sys::PtrcallType,
@@ -79,11 +81,13 @@ pub trait OutParamTuple: ParamTuple {
         F: FnOnce(&[Variant]) -> R;
 
     /// Call `f` on the tuple `self` by first converting `self` to an array of [`Variant`] pointers.
+    #[doc(hidden)] // Hidden since v0.3.2.
     fn with_variant_pointers<F, R>(self, f: F) -> R
     where
         F: FnOnce(&[sys::GDExtensionConstVariantPtr]) -> R;
 
     /// Call `f` on the tuple `self` by first converting `self` to an array of Godot type pointers.
+    #[doc(hidden)] // Hidden since v0.3.2.
     fn with_type_pointers<F, R>(self, f: F) -> R
     where
         F: FnOnce(&[sys::GDExtensionConstTypePtr]) -> R;

--- a/godot-core/src/meta/signature.rs
+++ b/godot-core/src/meta/signature.rs
@@ -21,8 +21,6 @@ use godot_ffi::{self as sys, GodotFfi};
 
 pub(super) type CallResult<R> = Result<R, CallError>;
 
-//mod impls;
-
 /// A full signature for a function.
 ///
 /// For in-calls (that is, calls from the Godot engine to Rust code) `Params` will implement [`InParamTuple`] and `Ret`
@@ -30,6 +28,7 @@ pub(super) type CallResult<R> = Result<R, CallError>;
 ///
 /// For out-calls (that is calls from Rust code to the Godot engine) `Params` will implement [`OutParamTuple`] and `Ret`
 /// will implement [`FromGodot`].
+#[doc(hidden)] // Hidden since v0.3.2.
 pub struct Signature<Params, Ret> {
     _p: PhantomData<Params>,
     _r: PhantomData<Ret>,

--- a/godot-core/src/meta/traits.rs
+++ b/godot-core/src/meta/traits.rs
@@ -195,7 +195,12 @@ pub trait ArrayElement: ToGodot + FromGodot + sealed::Sealed + meta::ParamType {
 // Non-polymorphic helper functions, to avoid constant `<T::Via as GodotType>::` in the code.
 
 #[doc(hidden)]
-pub(crate) fn element_variant_type<T: ArrayElement>() -> VariantType {
+pub(crate) const fn element_variant_type<T: ArrayElement>() -> VariantType {
+    <T::Via as GodotType>::Ffi::VARIANT_TYPE
+}
+
+#[doc(hidden)]
+pub(crate) const fn ffi_variant_type<T: GodotConvert>() -> VariantType {
     <T::Via as GodotType>::Ffi::VARIANT_TYPE
 }
 

--- a/godot-core/src/meta/traits.rs
+++ b/godot-core/src/meta/traits.rs
@@ -17,7 +17,7 @@ use godot_ffi as sys;
 // Re-export sys traits in this module, so all are in one place.
 use crate::registry::property::builtin_type_string;
 use crate::{builtin, meta};
-pub use sys::{GodotFfi, GodotNullableFfi};
+pub use sys::{ExtVariantType, GodotFfi, GodotNullableFfi};
 
 /// Conversion of [`GodotFfi`] types to/from [`Variant`].
 #[doc(hidden)]
@@ -89,7 +89,7 @@ pub trait GodotType: GodotConvert<Via = Self> + sealed::Sealed + Sized + 'static
     #[doc(hidden)]
     fn property_info(property_name: &str) -> PropertyInfo {
         PropertyInfo {
-            variant_type: Self::Ffi::VARIANT_TYPE,
+            variant_type: Self::Ffi::VARIANT_TYPE.variant_as_nil(),
             class_name: Self::class_name(),
             property_name: builtin::StringName::from(property_name),
             hint_info: Self::property_hint_info(),
@@ -192,15 +192,17 @@ pub trait ArrayElement: ToGodot + FromGodot + sealed::Sealed + meta::ParamType {
     }
 }
 
+// ----------------------------------------------------------------------------------------------------------------------------------------------
 // Non-polymorphic helper functions, to avoid constant `<T::Via as GodotType>::` in the code.
 
 #[doc(hidden)]
 pub(crate) const fn element_variant_type<T: ArrayElement>() -> VariantType {
-    <T::Via as GodotType>::Ffi::VARIANT_TYPE
+    <T::Via as GodotType>::Ffi::VARIANT_TYPE.variant_as_nil()
 }
 
+/// Classifies `T` into one of Godot's builtin types. **Important:** variants are mapped to `NIL`.
 #[doc(hidden)]
-pub(crate) const fn ffi_variant_type<T: GodotConvert>() -> VariantType {
+pub(crate) const fn ffi_variant_type<T: GodotConvert>() -> ExtVariantType {
     <T::Via as GodotType>::Ffi::VARIANT_TYPE
 }
 

--- a/godot-core/src/obj/raw_gd.rs
+++ b/godot-core/src/obj/raw_gd.rs
@@ -8,7 +8,7 @@
 use std::{fmt, ptr};
 
 use godot_ffi as sys;
-use sys::{interface_fn, GodotFfi, GodotNullableFfi, PtrcallType};
+use sys::{interface_fn, ExtVariantType, GodotFfi, GodotNullableFfi, PtrcallType};
 
 use crate::builtin::{Variant, VariantType};
 use crate::meta::error::{ConvertError, FromVariantError};
@@ -482,7 +482,7 @@ where
 {
     // If anything changes here, keep in sync with ObjectArg impl.
 
-    const VARIANT_TYPE: sys::VariantType = sys::VariantType::OBJECT;
+    const VARIANT_TYPE: ExtVariantType = ExtVariantType::Concrete(sys::VariantType::OBJECT);
 
     unsafe fn new_from_sys(ptr: sys::GDExtensionConstTypePtr) -> Self {
         Self::from_obj_sys_weak(ptr as sys::GDExtensionObjectPtr)

--- a/godot-core/src/registry/godot_register_wrappers.rs
+++ b/godot-core/src/registry/godot_register_wrappers.rs
@@ -46,7 +46,7 @@ pub fn register_var<C: GodotClass, T: Var>(
     usage: PropertyUsageFlags,
 ) {
     let info = PropertyInfo {
-        variant_type: <<T as GodotConvert>::Via as GodotType>::Ffi::VARIANT_TYPE,
+        variant_type: <<T as GodotConvert>::Via as GodotType>::Ffi::VARIANT_TYPE.variant_as_nil(),
         class_name: <T as GodotConvert>::Via::class_name(),
         property_name: StringName::from(property_name),
         hint_info,

--- a/godot-core/src/registry/property.rs
+++ b/godot-core/src/registry/property.rs
@@ -659,7 +659,7 @@ mod export_impls {
 pub(crate) fn builtin_type_string<T: GodotType>() -> String {
     use sys::GodotFfi as _;
 
-    let variant_type = T::Ffi::VARIANT_TYPE;
+    let variant_type = T::Ffi::VARIANT_TYPE.variant_as_nil();
 
     // Godot 4.3 changed representation for type hints, see https://github.com/godotengine/godot/pull/90716.
     if sys::GdextBuild::since_api("4.3") {

--- a/godot-ffi/src/lib.rs
+++ b/godot-ffi/src/lib.rs
@@ -73,7 +73,9 @@ macro_rules! wasm_declare_init_fn {
     () => {};
 }
 
-pub use crate::godot_ffi::{GodotFfi, GodotNullableFfi, PrimitiveConversionError, PtrcallType};
+pub use crate::godot_ffi::{
+    ExtVariantType, GodotFfi, GodotNullableFfi, PrimitiveConversionError, PtrcallType,
+};
 
 // Method tables
 pub use gen::table_builtins::*;

--- a/itest/godot/InheritTests.gd
+++ b/itest/godot/InheritTests.gd
@@ -7,6 +7,13 @@ extends ArrayTest
 
 var test_suite: TestSuite = TestSuite.new()
 
+# Override public state management methods of TestSuite, since this is treated as a suite by the runner.
+func reset_state():
+	test_suite.reset_state()
+
+func is_test_failed() -> bool:
+	return test_suite.is_test_failed()
+
 # In order to reproduce the behavior discovered in https://github.com/godot-rust/gdext/issues/138
 # we must inherit a Godot Node. Because of this we can't just inherit TesSuite like the rest of the tests.
 func assert_that(what: bool, message: String = "") -> bool:

--- a/itest/godot/ManualFfiTests.gd
+++ b/itest/godot/ManualFfiTests.gd
@@ -98,6 +98,34 @@ func test_export_dyn_gd_should_fail_for_wrong_type():
 
 	assert_fail("`DynGdExporter.second` should only accept NodeHealth and only if it implements `InstanceIdProvider` trait")
 
+
+# Test that relaxed conversions (Variant::try_to_relaxed) are used in both varcall/ptrcall.
+func test_ffi_relaxed_conversions_in_varcall_ptrcall():
+	mark_test_pending()
+
+	# Enforce varcall by having untyped object, and ptrcall by object + arguments typed.
+	var varcaller: Variant = ConversionTest.new()
+	var ptrcaller: ConversionTest = ConversionTest.new()
+
+	var result1: String = ptrcaller.accept_f32(42)
+	assert_eq(result1, "42", "ptrcall int->f32 should work with relaxed conversion")
+
+	var result2: String = ptrcaller.accept_i32(42.7)
+	assert_eq(result2, "42", "ptrcall float->i32 should work with relaxed conversion")
+
+	var untyped_int: Variant = 42
+	var result3 = varcaller.accept_f32(untyped_int)
+	assert_eq(result3, "42", "varcall int->f32 should work with relaxed conversion")
+
+	var untyped_float: Variant = 42.7
+	var result4 = varcaller.accept_i32(untyped_float)
+	assert_eq(result4, "42", "varcall float->i32 should work with relaxed conversion")
+
+	# If we reach this point, all conversions succeeded.
+	assert_eq(ConversionTest.successful_calls(), 4, "all calls should succeed with relaxed conversion")
+	mark_test_succeeded()
+
+
 class MockObjGd extends Object:
 	var i: int = 0
 
@@ -454,4 +482,3 @@ func test_renamed_func_get_set():
 	assert_eq(obj.f1(), 84)
 
 	obj.free()
-

--- a/itest/godot/TestRunner.gd
+++ b/itest/godot/TestRunner.gd
@@ -87,11 +87,11 @@ func _ready():
 
 
 class GDScriptTestCase:
-	var suite: Object
+	var suite: RefCounted # not always TestSuite, e.g. InheritTests.
 	var method_name: String
 	var suite_name: String
 	
-	func _init(suite: Object, method_name: String):
+	func _init(suite: RefCounted, method_name: String):
 		self.suite = suite
 		self.method_name = method_name
 		self.suite_name = _suite_name(suite)
@@ -100,7 +100,7 @@ class GDScriptTestCase:
 		push_error("run unimplemented")
 		return false
 	
-	static func _suite_name(suite: Object) -> String:
+	static func _suite_name(suite: RefCounted) -> String:
 		var script: GDScript = suite.get_script()
 		return str(script.resource_path.get_file().get_basename(), ".gd")
 
@@ -108,9 +108,9 @@ class GDScriptTestCase:
 class GDScriptExecutableTestCase extends GDScriptTestCase:
 	func run():
 		# This is a no-op if the suite doesn't have this property.
-		suite.set("_assertion_failed", false)
+		suite.reset_state()
 		var result = suite.call(method_name)
-		var ok: bool = (result == true or result == null) and not suite.get("_assertion_failed")
+		var ok: bool = (result == true or result == null) and not suite.is_test_failed()
 		return ok
 
 # Hardcoded test case used for special cases where the standard testing API is not sufficient.

--- a/itest/godot/input/GenFfiTests.template.gd
+++ b/itest/godot/input/GenFfiTests.template.gd
@@ -12,6 +12,7 @@ extends TestSuite
 
 #(
 func test_varcall_IDENT():
+	mark_test_pending()
 	var ffi = GenFfi.new()
 
 	var from_rust: Variant = ffi.return_IDENT()
@@ -24,6 +25,7 @@ func test_varcall_IDENT():
 	var mirrored: Variant = ffi.mirror_IDENT(from_gdscript)
 	assert_eq(mirrored, from_gdscript, "mirrored == from_gdscript")
 	_check_callconv("mirror_IDENT", "varcall")
+	mark_test_succeeded()
 #)
 
 # Godot currently does not support calling static methods via reflection, which is why we use an instance for the return_static_IDENT() call.
@@ -32,6 +34,7 @@ func test_varcall_IDENT():
 # so Godot cannot use ptrcalls anyway.
 #(
 func test_varcall_static_IDENT():
+	mark_test_pending()
 	var instance = GenFfi.new() # workaround
 	var from_rust: Variant = instance.return_static_IDENT()
 	_check_callconv("return_static_IDENT", "varcall")
@@ -43,10 +46,12 @@ func test_varcall_static_IDENT():
 	var mirrored: Variant = GenFfi.mirror_static_IDENT(from_gdscript)
 	assert_eq(mirrored, from_gdscript, "mirrored_static == from_gdscript")
 	_check_callconv("mirror_static_IDENT", "varcall")
+	mark_test_succeeded()
 #)
 
 #(
 func test_ptrcall_IDENT():
+	mark_test_pending()
 	var ffi := GenFfi.new()
 
 	var from_rust: TYPE = ffi.return_IDENT()
@@ -59,10 +64,12 @@ func test_ptrcall_IDENT():
 	var mirrored: TYPE = ffi.mirror_IDENT(from_gdscript)
 	assert_eq(mirrored, from_gdscript, "mirrored == from_gdscript")
 	_check_callconv("mirror_IDENT", "ptrcall")
+	mark_test_succeeded()
 #)
 
 #(
 func test_ptrcall_static_IDENT():
+	mark_test_pending()
 	var from_rust: TYPE = GenFfi.return_static_IDENT()
 	_check_callconv("return_static_IDENT", "ptrcall")
 
@@ -73,6 +80,7 @@ func test_ptrcall_static_IDENT():
 	var mirrored: TYPE = GenFfi.mirror_static_IDENT(from_gdscript)
 	assert_eq(mirrored, from_gdscript, "mirrored_static == from_gdscript")
 	_check_callconv("mirror_static_IDENT", "ptrcall")
+	mark_test_succeeded()
 #)
 
 func _check_callconv(function: String, expected: String) -> void:

--- a/itest/rust/src/builtin_tests/containers/variant_test.rs
+++ b/itest/rust/src/builtin_tests/containers/variant_test.rs
@@ -127,6 +127,10 @@ fn variant_relaxed_conversions() {
     convert_relaxed_fail::<VariantArray>(Variant::nil());
     convert_relaxed_fail::<Dictionary>(Variant::nil());
 
+    // anything -> Variant
+    convert_relaxed_to(123, Variant::from(123));
+    convert_relaxed_to("hello", Variant::from("hello"));
+
     // Array -> Packed*Array
     let packed_ints = PackedInt32Array::from([1, 2, 3]);
     let packed_strings = PackedStringArray::from(["a".into(), "bb".into()]);

--- a/itest/rust/src/builtin_tests/containers/variant_test.rs
+++ b/itest/rust/src/builtin_tests/containers/variant_test.rs
@@ -6,16 +6,18 @@
  */
 
 use std::cmp::Ordering;
+use std::fmt;
 use std::fmt::Display;
 
 use godot::builtin::{
-    array, dict, varray, vslice, Array, GString, NodePath, Signal, StringName, Variant, Vector2,
-    Vector3,
+    array, dict, varray, vslice, Array, Color, GString, NodePath, PackedInt32Array,
+    PackedStringArray, Projection, Quaternion, Signal, StringName, Transform2D, Transform3D,
+    Variant, Vector2, Vector2i, Vector3, Vector3i,
 };
 use godot::builtin::{Basis, Dictionary, VariantArray, VariantOperator, VariantType};
-use godot::classes::{Node, Node2D};
+use godot::classes::{Node, Node2D, Resource};
 use godot::meta::{FromGodot, ToGodot};
-use godot::obj::{Gd, InstanceId, NewAlloc};
+use godot::obj::{Gd, InstanceId, NewAlloc, NewGd};
 use godot::sys::GodotFfi;
 
 use crate::common::roundtrip;
@@ -73,6 +75,117 @@ fn variant_conversions() {
 
     // signal
     roundtrip(Signal::invalid());
+}
+
+#[itest]
+fn variant_relaxed_conversions() {
+    // See https://github.com/godotengine/godot/blob/4.4-stable/core/variant/variant.cpp#L532.
+
+    let obj = Node::new_alloc();
+
+    // reflexive
+    convert_relaxed_to(-22i8, -22i8);
+    convert_relaxed_to("some str", GString::from("some str"));
+    convert_relaxed_to(TEST_BASIS, TEST_BASIS);
+    convert_relaxed_to(obj.clone(), obj.clone());
+
+    // int <-> float
+    convert_relaxed_to(1234567890i64, 1234567890f64);
+    convert_relaxed_to(1234567890f64, 1234567890i64);
+
+    // int <-> bool
+    convert_relaxed_to(-123, true);
+    convert_relaxed_to(0, false);
+    convert_relaxed_to(true, 1);
+    convert_relaxed_to(false, 0);
+
+    // float <-> bool
+    convert_relaxed_to(123.45, true);
+    convert_relaxed_to(0.0, false);
+    convert_relaxed_to(true, 1.0);
+    convert_relaxed_to(false, 0.0);
+
+    // GString <-> StringName
+    convert_relaxed_to("hello", StringName::from("hello"));
+    convert_relaxed_to(StringName::from("hello"), GString::from("hello"));
+
+    // GString <-> NodePath
+    convert_relaxed_to("hello", NodePath::from("hello"));
+    convert_relaxed_to(NodePath::from("hello"), GString::from("hello"));
+
+    // anything -> nil
+    convert_relaxed_to(Variant::nil(), Variant::nil());
+    convert_relaxed_to((), Variant::nil());
+    convert_relaxed_fail::<()>(obj.clone());
+    convert_relaxed_fail::<()>(123.45);
+    convert_relaxed_fail::<()>(Vector3i::new(1, 2, 3));
+
+    // nil -> anything (except Variant) - fails
+    convert_relaxed_fail::<i64>(Variant::nil());
+    convert_relaxed_fail::<GString>(Variant::nil());
+    convert_relaxed_fail::<Gd<Node>>(Variant::nil());
+    convert_relaxed_fail::<VariantArray>(Variant::nil());
+    convert_relaxed_fail::<Dictionary>(Variant::nil());
+
+    // Array -> Packed*Array
+    let packed_ints = PackedInt32Array::from([1, 2, 3]);
+    let packed_strings = PackedStringArray::from(["a".into(), "bb".into()]);
+    let strings: Array<GString> = array!["a", "bb"];
+
+    convert_relaxed_to(array![1, 2, 3], packed_ints.clone());
+    convert_relaxed_to(varray![1, 2, 3], packed_ints.clone());
+    convert_relaxed_to(strings.clone(), packed_strings.clone());
+    convert_relaxed_to(varray!["a", "bb"], packed_strings.clone());
+
+    // Packed*Array -> Array
+    convert_relaxed_to(packed_ints.clone(), array![1, 2, 3]);
+    convert_relaxed_to(packed_ints, varray![1, 2, 3]);
+    convert_relaxed_to(packed_strings.clone(), strings);
+    convert_relaxed_to(packed_strings, varray!["a", "bb"]);
+
+    // Object|nil -> optional Object
+    convert_relaxed_to(obj.clone(), Some(obj.clone()));
+    convert_relaxed_to(Variant::nil(), Option::<Gd<Node>>::None);
+
+    // Object -> Rid
+    let res = Resource::new_gd();
+    let rid = res.get_rid();
+    convert_relaxed_to(res.clone(), rid);
+
+    // Vector2 <-> Vector2i
+    convert_relaxed_to(Vector2::new(1.0, 2.0), Vector2i::new(1, 2));
+    convert_relaxed_to(Vector2i::new(1, 2), Vector2::new(1.0, 2.0));
+
+    // int|String -> Color (don't use float colors due to rounding errors / 255-vs-256 imprecision).
+    convert_relaxed_to(0xFF_80_00_40u32, Color::from_rgba8(255, 128, 0, 64));
+    convert_relaxed_to("MEDIUM_AQUAMARINE", Color::MEDIUM_AQUAMARINE);
+
+    // Everything -> Transform3D
+    convert_relaxed_to(Transform2D::IDENTITY, Transform3D::IDENTITY);
+    convert_relaxed_to(Basis::IDENTITY, Transform3D::IDENTITY);
+    convert_relaxed_to(Quaternion::IDENTITY, Transform3D::IDENTITY);
+
+    // Projection <-> Transform3D
+    convert_relaxed_to(Projection::IDENTITY, Transform3D::IDENTITY);
+    convert_relaxed_to(Transform3D::IDENTITY, Projection::IDENTITY);
+
+    // Quaternion <-> Basis
+    convert_relaxed_to(Basis::IDENTITY, Quaternion::IDENTITY);
+    convert_relaxed_to(Quaternion::IDENTITY, Basis::IDENTITY);
+
+    // Other geometric conversions between the above fail.
+    convert_relaxed_fail::<Transform2D>(Projection::IDENTITY);
+    convert_relaxed_fail::<Transform2D>(Quaternion::IDENTITY);
+    convert_relaxed_fail::<Transform2D>(Basis::IDENTITY);
+    convert_relaxed_fail::<Projection>(Transform2D::IDENTITY);
+    convert_relaxed_fail::<Projection>(Quaternion::IDENTITY);
+    convert_relaxed_fail::<Projection>(Basis::IDENTITY);
+    convert_relaxed_fail::<Quaternion>(Transform2D::IDENTITY);
+    convert_relaxed_fail::<Quaternion>(Projection::IDENTITY);
+    convert_relaxed_fail::<Basis>(Transform2D::IDENTITY);
+    convert_relaxed_fail::<Basis>(Projection::IDENTITY);
+
+    obj.free();
 }
 
 #[itest]
@@ -549,6 +662,45 @@ fn variant_hash() {
 }
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
+
+fn convert_relaxed_to<T, U>(from: T, expected_to: U)
+where
+    T: ToGodot + fmt::Debug,
+    U: FromGodot + PartialEq + fmt::Debug,
+{
+    let variant = from.to_variant();
+    let result = variant.try_to_relaxed::<U>();
+
+    match result {
+        Ok(to) => {
+            assert_eq!(
+                to, expected_to,
+                "converting {from:?} to {to:?} resulted in unexpected value"
+            );
+        }
+        Err(err) => {
+            panic!("Conversion from {from:?} to {expected_to:?} failed: {err}");
+        }
+    }
+}
+
+fn convert_relaxed_fail<U>(from: impl ToGodot + fmt::Debug)
+where
+    U: FromGodot + PartialEq + fmt::Debug,
+{
+    let variant = from.to_variant();
+    let result = variant.try_to_relaxed::<U>();
+
+    match result {
+        Ok(to) => {
+            let to_type = godot::sys::short_type_name::<U>();
+            panic!(
+                "Conversion from {from:?} to {to_type:?} unexpectedly succeeded with value: {to:?}"
+            );
+        }
+        Err(_err) => {}
+    }
+}
 
 fn truncate_bad<T>(original_value: i64)
 where

--- a/itest/rust/src/register_tests/conversion_test.rs
+++ b/itest/rust/src/register_tests/conversion_test.rs
@@ -6,6 +6,9 @@
  */
 
 use godot::prelude::*;
+use std::sync::atomic::{AtomicI32, Ordering};
+
+static SUCCESSFUL_CALLS: AtomicI32 = AtomicI32::new(0);
 
 #[derive(GodotClass)]
 #[class(init)]
@@ -15,21 +18,30 @@ struct ConversionTest {}
 impl ConversionTest {
     #[func]
     fn accept_i32(value: i32) -> String {
+        SUCCESSFUL_CALLS.fetch_add(1, Ordering::SeqCst);
         value.to_string()
     }
 
     #[func]
     fn accept_f32(value: f32) -> String {
+        SUCCESSFUL_CALLS.fetch_add(1, Ordering::SeqCst);
         value.to_string()
     }
 
     #[func]
     fn return_i32() -> i32 {
+        SUCCESSFUL_CALLS.fetch_add(1, Ordering::SeqCst);
         123
     }
 
     #[func]
     fn return_f32() -> f32 {
+        SUCCESSFUL_CALLS.fetch_add(1, Ordering::SeqCst);
         123.45
+    }
+
+    #[func]
+    fn successful_calls() -> i32 {
+        SUCCESSFUL_CALLS.load(Ordering::SeqCst)
     }
 }


### PR DESCRIPTION
Addresses some of the oldest issues in the repo:
- Closes #105.
- Closes #125.

Relaxes the `#[func]` argument passing (GDScript -> Rust data flow) to enable implicit conversions. This sounds controversial given Rust's strong typing, however this is already the case for ptrcalls anyway (i.e. when typed GDScript is used) and outside our control. This PR extends the same behavior to varcalls, which resolves the unintuitive behavior of #105, where untyped GDScript behaves more strictly.

The new relaxed conversions are also available in the API via `Variant::try_to_relaxed`, following the signature of `Variant::try_to`.