### PR TITLE
try to add doc comments to functions 

### DIFF
--- a/godot-codegen/src/generator/builtins.rs
+++ b/godot-codegen/src/generator/builtins.rs
@@ -8,7 +8,7 @@
 use crate::context::Context;
 use crate::generator::functions_common::{FnCode, FnDefinition, FnDefinitions};
 use crate::generator::method_tables::MethodTableKey;
-use crate::generator::{enums, functions_common};
+use crate::generator::{docs, enums, functions_common};
 use crate::models::domain::{
     BuiltinClass, BuiltinMethod, ClassLike, ExtensionApi, FnDirection, Function, ModName, RustTy,
     TyName,
@@ -276,6 +276,7 @@ fn make_builtin_method_definition(
         )
     };
 
+    let doc = docs::make_method_doc(builtin_class.name(), method.name());
     let safety_doc = method_safety_doc(builtin_class.name(), method);
 
     functions_common::make_function_definition(
@@ -287,6 +288,7 @@ fn make_builtin_method_definition(
             is_virtual_required: false,
             is_varcall_fallible: false,
         },
+        Some(quote! {#[doc = #doc] }),
         safety_doc,
         &TokenStream::new(),
     )

--- a/godot-codegen/src/generator/builtins.rs
+++ b/godot-codegen/src/generator/builtins.rs
@@ -8,7 +8,7 @@
 use crate::context::Context;
 use crate::generator::functions_common::{FnCode, FnDefinition, FnDefinitions};
 use crate::generator::method_tables::MethodTableKey;
-use crate::generator::{docs, enums, functions_common};
+use crate::generator::{enums, functions_common};
 use crate::models::domain::{
     BuiltinClass, BuiltinMethod, ClassLike, ExtensionApi, FnDirection, Function, ModName, RustTy,
     TyName,
@@ -276,7 +276,6 @@ fn make_builtin_method_definition(
         )
     };
 
-    let doc = docs::make_method_doc(builtin_class.name(), method.name());
     let safety_doc = method_safety_doc(builtin_class.name(), method);
 
     functions_common::make_function_definition(
@@ -288,7 +287,7 @@ fn make_builtin_method_definition(
             is_virtual_required: false,
             is_varcall_fallible: false,
         },
-        Some(quote! {#[doc = #doc] }),
+        None,
         safety_doc,
         &TokenStream::new(),
     )

--- a/godot-codegen/src/generator/classes.rs
+++ b/godot-codegen/src/generator/classes.rs
@@ -574,7 +574,7 @@ fn make_class_method_definition(
     let rust_method_name = method.name();
     let godot_method_name = method.godot_name();
 
-    let doc = docs::make_method_doc(&class, &method.name());
+    let doc = docs::make_method_doc(class, method.name());
 
     let receiver = functions_common::make_receiver(method.qualifier(), quote! { self.object_ptr });
 

--- a/godot-codegen/src/generator/classes.rs
+++ b/godot-codegen/src/generator/classes.rs
@@ -574,7 +574,7 @@ fn make_class_method_definition(
     let rust_method_name = method.name();
     let godot_method_name = method.godot_name();
 
-    let doc = docs::make_method_doc(&class.name(), &method.name());
+    let doc = docs::make_method_doc(&class, &method.name());
 
     let receiver = functions_common::make_receiver(method.qualifier(), quote! { self.object_ptr });
 

--- a/godot-codegen/src/generator/classes.rs
+++ b/godot-codegen/src/generator/classes.rs
@@ -574,6 +574,8 @@ fn make_class_method_definition(
     let rust_method_name = method.name();
     let godot_method_name = method.godot_name();
 
+    let doc = docs::make_method_doc(&class.name(), &method.name());
+
     let receiver = functions_common::make_receiver(method.qualifier(), quote! { self.object_ptr });
 
     let table_index = ctx.get_table_index(&MethodTableKey::from_class(class, method));
@@ -634,6 +636,7 @@ fn make_class_method_definition(
             is_virtual_required: false,
             is_varcall_fallible: true,
         },
+        Some(quote! {#[doc = #doc] }),
         None,
         cfg_attributes,
     )

--- a/godot-codegen/src/generator/docs.rs
+++ b/godot-codegen/src/generator/docs.rs
@@ -158,3 +158,47 @@ pub fn make_module_doc(class_name: &TyName) -> String {
         See also [Godot docs for `{godot_ty}` enums]({online_link}).\n\n"
     )
 }
+
+pub fn make_method_doc(class_name: &TyName, method_name: &str) -> String {
+    let TyName { rust_ty, godot_ty } = class_name;
+
+    let class_name_lower = godot_ty.to_ascii_lowercase();
+    let method_name_slug = method_name.to_ascii_lowercase().replace('_', "-");
+
+    // note: godot properties are in the method table of the json file
+    let is_property = method_name.starts_with("get_") || method_name.starts_with("set_");
+    let is_actual_method = !is_property;
+
+    if is_actual_method {
+        let online_link = format!(
+        "https://docs.godotengine.org/en/stable/classes/class_{class_name_lower}.html#class-{class_name_lower}-method-{method_name_slug}"
+    );
+
+        format!(
+            "Method `{method_name}` of class [`{rust_ty}`][crate::classes::{rust_ty}].\
+        \n\n
+        See also [Godot docs for `{godot_ty}.{method_name}`]({online_link}).\n\n"
+        )
+    } else
+    /* it's a property */
+    {
+        let prop_name = method_name[4..].to_string();
+        let prop_name_slug = prop_name.to_ascii_lowercase().replace('_', "-");
+
+        let getter_setter = if method_name.starts_with("get_") {
+            "Getter"
+        } else {
+            "Setter"
+        };
+
+        let online_link = format!(
+        "https://docs.godotengine.org/en/stable/classes/class_{class_name_lower}.html#class-{class_name_lower}-property-{prop_name_slug}"
+    );
+
+        format!(
+            "{getter_setter} function for Property `{prop_name}` of class [`{rust_ty}`][crate::classes::{rust_ty}].\
+        \n\n
+        See also [Godot docs for `{godot_ty}.{prop_name}`]({online_link}).\n\n"
+        )
+    }
+}

--- a/godot-codegen/src/generator/docs.rs
+++ b/godot-codegen/src/generator/docs.rs
@@ -10,7 +10,7 @@
 //! Single module for documentation, rather than having it in each symbol-specific file, so it's easier to keep docs consistent.
 
 use crate::generator::signals;
-use crate::models::domain::{ModName, TyName};
+use crate::models::domain::{Class, ClassLike as _, ModName, TyName};
 use crate::special_cases;
 use proc_macro2::Ident;
 
@@ -159,46 +159,55 @@ pub fn make_module_doc(class_name: &TyName) -> String {
     )
 }
 
-pub fn make_method_doc(class_name: &TyName, method_name: &str) -> String {
+pub fn make_method_doc(class: &Class, method_name: &str) -> String {
+    let class_name = class.name();
     let TyName { rust_ty, godot_ty } = class_name;
 
     let class_name_lower = godot_ty.to_ascii_lowercase();
     let method_name_slug = method_name.to_ascii_lowercase().replace('_', "-");
 
-    // note: godot properties are in the method table of the json file
-    let is_property = method_name.starts_with("get_") || method_name.starts_with("set_");
-    let is_actual_method = !is_property;
+    let getter_for = class
+        .properties
+        .iter()
+        .find(|prop| prop.getter == Some(method_name.to_string()));
+    let setter_for = class
+        .properties
+        .iter()
+        .find(|prop| prop.setter == Some(method_name.to_string()));
 
-    if is_actual_method {
-        let online_link = format!(
+    let property_for = getter_for.or(setter_for);
+
+    match property_for {
+        None => {
+            let online_link = format!(
         "https://docs.godotengine.org/en/stable/classes/class_{class_name_lower}.html#class-{class_name_lower}-method-{method_name_slug}"
     );
 
-        format!(
-            "Method `{method_name}` of class [`{rust_ty}`][crate::classes::{rust_ty}].\
+            format!(
+                "Method `{method_name}` of class [`{rust_ty}`][crate::classes::{rust_ty}].\
         \n\n\
         See also [Godot docs for `{godot_ty}.{method_name}`]({online_link}).\n\n"
-        )
-    } else
-    /* it's a property */
-    {
-        let prop_name = method_name[4..].to_string();
-        let prop_name_slug = prop_name.to_ascii_lowercase().replace('_', "-");
+            )
+        }
+        Some(prop) => {
+            let prop_name = &prop.name;
+            let prop_name_slug = prop_name.to_ascii_lowercase().replace('_', "-");
 
-        let getter_setter = if method_name.starts_with("get_") {
-            "Getter"
-        } else {
-            "Setter"
-        };
+            let getter_setter = if getter_for.is_some() {
+                "Getter"
+            } else {
+                "Setter"
+            };
 
-        let online_link = format!(
+            let online_link = format!(
         "https://docs.godotengine.org/en/stable/classes/class_{class_name_lower}.html#class-{class_name_lower}-property-{prop_name_slug}"
     );
 
-        format!(
+            format!(
             "{getter_setter} function for Property `{prop_name}` of class [`{rust_ty}`][crate::classes::{rust_ty}].\
         \n\n\
         See also [Godot docs for `{godot_ty}.{prop_name}`]({online_link}).\n\n"
         )
+        }
     }
 }

--- a/godot-codegen/src/generator/docs.rs
+++ b/godot-codegen/src/generator/docs.rs
@@ -176,7 +176,7 @@ pub fn make_method_doc(class_name: &TyName, method_name: &str) -> String {
 
         format!(
             "Method `{method_name}` of class [`{rust_ty}`][crate::classes::{rust_ty}].\
-        \n\n
+        \n\n\
         See also [Godot docs for `{godot_ty}.{method_name}`]({online_link}).\n\n"
         )
     } else
@@ -197,7 +197,7 @@ pub fn make_method_doc(class_name: &TyName, method_name: &str) -> String {
 
         format!(
             "{getter_setter} function for Property `{prop_name}` of class [`{rust_ty}`][crate::classes::{rust_ty}].\
-        \n\n
+        \n\n\
         See also [Godot docs for `{godot_ty}.{prop_name}`]({online_link}).\n\n"
         )
     }

--- a/godot-codegen/src/generator/functions_common.rs
+++ b/godot-codegen/src/generator/functions_common.rs
@@ -103,6 +103,7 @@ pub struct FnParamTokens {
 pub fn make_function_definition(
     sig: &dyn Function,
     code: &FnCode,
+    doc: Option<TokenStream>,
     safety_doc: Option<TokenStream>,
     cfg_attributes: &TokenStream,
 ) -> FnDefinition {
@@ -113,6 +114,12 @@ pub fn make_function_definition(
         quote! { pub(crate) }
     } else {
         make_vis(sig.is_private())
+    };
+
+    let maybe_doc = if let Some(doc) = doc {
+        doc
+    } else {
+        TokenStream::new()
     };
 
     // Functions are marked unsafe as soon as raw pointers are involved, irrespectively of whether they appear in parameter or return type
@@ -196,6 +203,7 @@ pub fn make_function_definition(
 
         quote! {
             #maybe_safety_doc
+            #maybe_doc
             #maybe_unsafe fn #primary_fn_name (
                 #receiver_param
                 #( #params, )*
@@ -211,6 +219,7 @@ pub fn make_function_definition(
         if !code.is_varcall_fallible {
             quote! {
                 #maybe_safety_doc
+                #maybe_doc
                 #vis #maybe_unsafe fn #primary_fn_name (
                     #receiver_param
                     #( #params, )*
@@ -243,6 +252,7 @@ pub fn make_function_definition(
                 /// This is a _varcall_ method, meaning parameters and return values are passed as `Variant`.
                 /// It can detect call failures and will panic in such a case.
                 #maybe_safety_doc
+                #maybe_doc
                 #vis #maybe_unsafe fn #primary_fn_name (
                     #receiver_param
                     #( #params, )*
@@ -256,6 +266,7 @@ pub fn make_function_definition(
                 /// This is a _varcall_ method, meaning parameters and return values are passed as `Variant`.
                 /// It can detect call failures and will return `Err` in such a case.
                 #maybe_safety_doc
+                #maybe_doc
                 #vis #maybe_unsafe fn #try_fn_name(
                     #receiver_param
                     #( #params, )*
@@ -278,6 +289,7 @@ pub fn make_function_definition(
 
         quote! {
             #maybe_safety_doc
+            #maybe_doc
             #vis #maybe_unsafe fn #primary_fn_name #fn_lifetime (
                 #receiver_param
                 #( #params, )*

--- a/godot-codegen/src/generator/utility_functions.rs
+++ b/godot-codegen/src/generator/utility_functions.rs
@@ -74,6 +74,7 @@ pub(crate) fn make_utility_function_definition(function: &UtilityFunction) -> To
             is_varcall_fallible: false,
         },
         None,
+        None,
         &TokenStream::new(),
     );
 

--- a/godot-codegen/src/generator/virtual_traits.rs
+++ b/godot-codegen/src/generator/virtual_traits.rs
@@ -203,6 +203,7 @@ fn make_virtual_method(
             is_varcall_fallible: true,
         },
         None,
+        None,
         &TokenStream::new(),
     );
 

--- a/godot-codegen/src/models/domain.rs
+++ b/godot-codegen/src/models/domain.rs
@@ -168,6 +168,7 @@ pub struct Class {
     pub enums: Vec<Enum>,
     pub methods: Vec<ClassMethod>,
     pub signals: Vec<ClassSignal>,
+    pub properties: Vec<ClassProperty>,
 }
 
 impl ClassLike for Class {
@@ -449,6 +450,14 @@ pub struct ClassSignal {
     pub name: String,
     pub parameters: Vec<FnParam>,
     pub surrounding_class: TyName,
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+
+pub struct ClassProperty {
+    pub name: String,
+    pub getter: Option<String>,
+    pub setter: Option<String>,
 }
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------

--- a/godot-codegen/src/models/domain_mapping.rs
+++ b/godot-codegen/src/models/domain_mapping.rs
@@ -23,7 +23,6 @@ use crate::util::{get_api_level, ident, option_as_slice};
 use crate::{conv, special_cases};
 use proc_macro2::Ident;
 use std::collections::HashMap;
-use std::option;
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Top-level

--- a/godot-codegen/src/models/domain_mapping.rs
+++ b/godot-codegen/src/models/domain_mapping.rs
@@ -8,21 +8,22 @@
 use crate::context::Context;
 use crate::models::domain::{
     BuildConfiguration, BuiltinClass, BuiltinMethod, BuiltinSize, BuiltinVariant, Class,
-    ClassCommons, ClassConstant, ClassConstantValue, ClassMethod, ClassSignal, Constructor, Enum,
-    Enumerator, EnumeratorValue, ExtensionApi, FnDirection, FnParam, FnQualifier, FnReturn,
-    FunctionCommon, GodotApiVersion, ModName, NativeStructure, Operator, RustTy, Singleton, TyName,
-    UtilityFunction,
+    ClassCommons, ClassConstant, ClassConstantValue, ClassMethod, ClassProperty, ClassSignal,
+    Constructor, Enum, Enumerator, EnumeratorValue, ExtensionApi, FnDirection, FnParam,
+    FnQualifier, FnReturn, FunctionCommon, GodotApiVersion, ModName, NativeStructure, Operator,
+    RustTy, Singleton, TyName, UtilityFunction,
 };
 use crate::models::json::{
     JsonBuiltinClass, JsonBuiltinMethod, JsonBuiltinSizes, JsonClass, JsonClassConstant,
     JsonClassMethod, JsonConstructor, JsonEnum, JsonEnumConstant, JsonExtensionApi, JsonHeader,
-    JsonMethodReturn, JsonNativeStructure, JsonOperator, JsonSignal, JsonSingleton,
+    JsonMethodReturn, JsonNativeStructure, JsonOperator, JsonProperty, JsonSignal, JsonSingleton,
     JsonUtilityFunction,
 };
 use crate::util::{get_api_level, ident, option_as_slice};
 use crate::{conv, special_cases};
 use proc_macro2::Ident;
 use std::collections::HashMap;
+use std::option;
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Top-level
@@ -128,6 +129,11 @@ impl Class {
             })
             .collect();
 
+        let properties = option_as_slice(&json.properties)
+            .iter()
+            .map(|p| ClassProperty::from_json(p, ctx))
+            .collect::<Vec<_>>();
+
         let base_class = json
             .inherits
             .as_ref()
@@ -148,6 +154,7 @@ impl Class {
             enums,
             methods,
             signals,
+            properties,
         })
     }
 }
@@ -587,6 +594,15 @@ impl ClassSignal {
             parameters: FnParam::new_range(&json_signal.arguments, ctx),
             surrounding_class: surrounding_class.clone(),
         })
+    }
+}
+impl ClassProperty {
+    pub fn from_json(json_property: &JsonProperty, _ctx: &mut Context) -> Self {
+        Self {
+            name: json_property.name.clone(),
+            getter: json_property.getter.clone(),
+            setter: json_property.setter.clone(),
+        }
     }
 }
 

--- a/godot-codegen/src/models/json.rs
+++ b/godot-codegen/src/models/json.rs
@@ -79,7 +79,7 @@ pub struct JsonClass {
     pub constants: Option<Vec<JsonClassConstant>>,
     pub enums: Option<Vec<JsonEnum>>,
     pub methods: Option<Vec<JsonClassMethod>>,
-    // pub properties: Option<Vec<Property>>,
+    pub properties: Option<Vec<JsonProperty>>,
     pub signals: Option<Vec<JsonSignal>>,
 }
 
@@ -173,12 +173,12 @@ pub struct JsonMember {
 #[derive(DeJson)]
 #[allow(dead_code)]
 pub struct JsonProperty {
-    #[nserde(rename = "type")]
-    type_: String,
-    name: String,
-    setter: String,
-    getter: String,
-    index: i32, // can be -1
+    // #[nserde(rename = "type")]
+    // type_: String,
+    pub name: String,
+    pub setter: Option<String>,
+    pub getter: Option<String>,
+    // index: Option<i32>,
 }
 
 #[derive(DeJson)]


### PR DESCRIPTION
I'm attempting to add more documentation to the API and opened the PR relatively early to gather feedback.


---

Currently, there is no documentation on the autogenerated functions from the godot API:

Example:

https://godot-rust.github.io/docs/gdext/master/godot/classes/struct.Camera2D.html

![image](https://github.com/user-attachments/assets/6f6b5986-c415-4d40-8592-9b097e1d3433)



This PR adds some boilerplate text, and a link to the godot online docs:

![image](https://github.com/user-attachments/assets/c82cb629-bae6-4a02-893a-0b6fa0b49572)

--------------

At minimum I'll need to properly detect properties by reading the field from the json (https://raw.githubusercontent.com/godot-rust/godot4-prebuilt/refs/heads/4.4/res/extension_api.json), in the rust code it's currently commented out:

https://github.com/godot-rust/gdext/blob/20cd3464ab2500b74021dd2e2c680d4706af1274/godot-codegen/src/models/json.rs#L63

This is relevant for link generation, and I'm trying to auto-detect it by the ``get_ / set_`` prefixes, but there are godot methods with a ``get_`` prefix, for example [Camera2D.get_limit](https://docs.godotengine.org/en/stable/classes/class_camera2d.html#class-camera2d-method-get-limit), which now falsely get detected as a property.


----------

Additionally it would be great to verbatim include the documentation, and this is available in XML format [here](https://github.com/godotengine/godot/tree/4.4/doc/classes).
