### PR TITLE
Cargo feature to exclude deprecated GDExtension APIs

### DIFF
--- a/godot-codegen/Cargo.toml
+++ b/godot-codegen/Cargo.toml
@@ -20,6 +20,7 @@ api-custom = ["godot-bindings/api-custom"]
 api-custom-json = ["godot-bindings/api-custom-json"]
 experimental-godot-api = []
 experimental-threads = []
+no-deprecated = []
 
 [dependencies]
 godot-bindings = { path = "../godot-bindings", version = "=0.3.1" }

--- a/godot-core/Cargo.toml
+++ b/godot-core/Cargo.toml
@@ -23,6 +23,7 @@ double-precision = ["godot-codegen/double-precision"]
 experimental-godot-api = ["godot-codegen/experimental-godot-api"]
 experimental-threads = ["godot-ffi/experimental-threads", "godot-codegen/experimental-threads"]
 experimental-wasm-nothreads = ["godot-ffi/experimental-wasm-nothreads"]
+no-deprecated = ["godot-ffi/no-deprecated"]
 debug-log = ["godot-ffi/debug-log"]
 trace = []
 

--- a/godot-core/src/builtin/string/gstring.rs
+++ b/godot-core/src/builtin/string/gstring.rs
@@ -325,7 +325,11 @@ impl From<&str> for GString {
 
         unsafe {
             Self::new_with_string_uninit(|string_ptr| {
+                #[cfg(before_api = "4.3")]
                 let ctor = interface_fn!(string_new_with_utf8_chars_and_len);
+                #[cfg(since_api = "4.3")]
+                let ctor = interface_fn!(string_new_with_utf8_chars_and_len2);
+
                 ctor(
                     string_ptr,
                     bytes.as_ptr() as *const std::ffi::c_char,

--- a/godot-core/src/classes/class_runtime.rs
+++ b/godot-core/src/classes/class_runtime.rs
@@ -60,9 +60,14 @@ pub(crate) fn construct_engine_object<T>() -> Gd<T>
 where
     T: GodotClass + Bounds<Declarer = bounds::DeclEngine>,
 {
+    #[cfg(before_api = "4.4")]
+    let construct_fn = sys::interface_fn!(classdb_construct_object);
+    #[cfg(since_api = "4.4")]
+    let construct_fn = sys::interface_fn!(classdb_construct_object2);
+
     // SAFETY: adhere to Godot API; valid class name and returned pointer is an object.
     unsafe {
-        let object_ptr = sys::interface_fn!(classdb_construct_object)(T::class_name().string_sys());
+        let object_ptr = construct_fn(T::class_name().string_sys());
         Gd::from_obj_sys(object_ptr)
     }
 }

--- a/godot-core/src/obj/bounds.rs
+++ b/godot-core/src/obj/bounds.rs
@@ -389,9 +389,13 @@ impl Declarer for DeclEngine {
     where
         T: GodotDefault + Bounds<Declarer = Self>,
     {
+        #[cfg(before_api = "4.4")]
+        let construct_fn = sys::interface_fn!(classdb_construct_object);
+        #[cfg(since_api = "4.4")]
+        let construct_fn = sys::interface_fn!(classdb_construct_object2);
+
         unsafe {
-            let object_ptr =
-                sys::interface_fn!(classdb_construct_object)(T::class_name().string_sys());
+            let object_ptr = construct_fn(T::class_name().string_sys());
             Gd::from_obj_sys(object_ptr)
         }
     }

--- a/godot-core/src/registry/callbacks.rs
+++ b/godot-core/src/registry/callbacks.rs
@@ -91,8 +91,13 @@ where
     T: GodotClass,
     F: FnOnce(Base<T::Base>) -> T,
 {
+    #[cfg(before_api = "4.4")]
+    let construct_fn = sys::interface_fn!(classdb_construct_object);
+    #[cfg(since_api = "4.4")]
+    let construct_fn = sys::interface_fn!(classdb_construct_object2);
+
     let base_class_name = T::Base::class_name();
-    let base_ptr = unsafe { interface_fn!(classdb_construct_object)(base_class_name.string_sys()) };
+    let base_ptr = unsafe { construct_fn(base_class_name.string_sys()) };
 
     match create_rust_part_for_existing_godot_part(make_user_instance, base_ptr) {
         Ok(_extension_ptr) => Ok(base_ptr),

--- a/godot-ffi/Cargo.toml
+++ b/godot-ffi/Cargo.toml
@@ -16,6 +16,7 @@ codegen-lazy-fptrs = ["godot-codegen/codegen-lazy-fptrs"]
 experimental-godot-api = ["godot-codegen/experimental-godot-api"]
 experimental-threads = ["godot-codegen/experimental-threads"]
 experimental-wasm-nothreads = ["godot-bindings/experimental-wasm-nothreads"]
+no-deprecated = ["godot-codegen/no-deprecated"]
 debug-log = []
 
 api-custom = ["godot-bindings/api-custom"]

--- a/godot-ffi/src/interface_init.rs
+++ b/godot-ffi/src/interface_init.rs
@@ -127,8 +127,13 @@ unsafe fn runtime_version_inner(
         *const std::ffi::c_char,
     ) -> sys::GDExtensionInterfaceFunctionPtr,
 ) -> sys::GDExtensionGodotVersion {
+    #[cfg(before_api = "4.5")]
+    let godot_version_addr = b"get_godot_version\0";
+    #[cfg(since_api = "4.5")]
+    let godot_version_addr = b"get_godot_version2\0";
+
     // SAFETY: `self.0` is a valid `get_proc_address` pointer.
-    let get_godot_version = unsafe { get_proc_address(sys::c_str(b"get_godot_version\0")) }; //.expect("get_godot_version unexpectedly null");
+    let get_godot_version = unsafe { get_proc_address(sys::c_str(godot_version_addr)) }; //.expect("get_godot_version unexpectedly null");
 
     // SAFETY: `sys::GDExtensionInterfaceGetGodotVersion` is an `Option` of an `unsafe extern "C"` function pointer.
     let get_godot_version =

--- a/godot/Cargo.toml
+++ b/godot/Cargo.toml
@@ -24,6 +24,7 @@ experimental-wasm-nothreads = ["godot-core/experimental-wasm-nothreads"]
 codegen-rustfmt = ["godot-core/codegen-rustfmt"]
 lazy-function-tables = ["godot-core/codegen-lazy-fptrs"]
 serde = ["godot-core/serde"]
+no-deprecated = ["godot-core/no-deprecated"]
 
 register-docs = ["godot-macros/register-docs", "godot-core/register-docs"]
 

--- a/itest/rust/Cargo.toml
+++ b/itest/rust/Cargo.toml
@@ -16,6 +16,7 @@ codegen-full = ["godot/__codegen-full"]
 codegen-full-experimental = ["codegen-full", "godot/experimental-godot-api"]
 experimental-threads = ["godot/experimental-threads"]
 register-docs = ["godot/register-docs"]
+no-deprecated = ["godot/no-deprecated"]
 serde = ["dep:serde", "dep:serde_json", "godot/serde"]
 
 # Do not add features here that are 1:1 forwarded to the `godot` crate, unless they are needed by itest itself.


### PR DESCRIPTION
This allows using gdext with godot built with `deprecated=no`.