### PR TITLE
Work around breaking change in GDExtension API (`VisualShader` class)

### DIFF
--- a/godot-codegen/src/special_cases/special_cases.rs
+++ b/godot-codegen/src/special_cases/special_cases.rs
@@ -65,6 +65,10 @@ pub fn is_class_method_deleted(class_name: &TyName, method: &JsonClassMethod, ct
         | ("VisualShaderNodeComment", "get_title")
         | ("VisualShaderNodeComment", "set_description")
         | ("VisualShaderNodeComment", "get_description")
+
+        // Removed in https://github.com/godotengine/godot/pull/98566
+        | ("VisualShader", "set_graph_offset")
+        | ("VisualShader", "get_graph_offset")
         => true,
 
         // Thread APIs


### PR DESCRIPTION
Restores CI to pass again, after breaking change introduced by upstream PR https://github.com/godotengine/godot/pull/98566.

Retroactively removes the following APIs across all Godot versions:
- `VisualShader::set_graph_offset`
- `VisualShader::get_graph_offset`

Why all Godot versions? Because these APIs are supposedly not useful and it's a compatibility hazard to leave them exposed :slightly_smiling_face: so better a compile-time error.