### PR TITLE
Emit `POSTINITIALIZE` notification after `init()`

### DIFF
--- a/godot-core/src/builtin/string/gstring.rs
+++ b/godot-core/src/builtin/string/gstring.rs
@@ -328,7 +328,11 @@ impl From<&str> for GString {
 
         unsafe {
             Self::new_with_string_uninit(|string_ptr| {
+                #[cfg(before_api = "4.3")]
                 let ctor = interface_fn!(string_new_with_utf8_chars_and_len);
+                #[cfg(since_api = "4.3")]
+                let ctor = interface_fn!(string_new_with_utf8_chars_and_len2);
+
                 ctor(
                     string_ptr,
                     bytes.as_ptr() as *const std::ffi::c_char,

--- a/godot-core/src/classes/class_runtime.rs
+++ b/godot-core/src/classes/class_runtime.rs
@@ -170,11 +170,15 @@ pub(crate) fn construct_engine_object<T>() -> Gd<T>
 where
     T: GodotClass + Bounds<Declarer = bounds::DeclEngine>,
 {
-    // SAFETY: adhere to Godot API; valid class name and returned pointer is an object.
-    unsafe {
-        let object_ptr = sys::interface_fn!(classdb_construct_object)(T::class_name().string_sys());
-        Gd::from_obj_sys(object_ptr)
-    }
+    let mut obj = unsafe {
+        let object_ptr = sys::classdb_construct_object(T::class_name().string_sys());
+        Gd::<T>::from_obj_sys(object_ptr)
+    };
+    #[cfg(since_api = "4.4")]
+    obj.upcast_object_mut()
+        .notify(crate::classes::notify::ObjectNotification::POSTINITIALIZE);
+
+    obj
 }
 
 pub(crate) fn ensure_object_alive(

--- a/godot-core/src/obj/base.rs
+++ b/godot-core/src/obj/base.rs
@@ -166,15 +166,15 @@ impl<T: GodotClass> Base<T> {
         (*self.obj).clone()
     }
 
-    /// Returns a [`Gd`] referencing the base object, for exclusive use during object initialization.
+    /// Returns a [`Gd`] referencing the base object, for exclusive use during object initialization and `NOTIFICATION_POSTINITIALIZE`.
     ///
-    /// Can be used during an initialization function [`I*::init()`][crate::classes::IObject::init] or [`Gd::from_init_fn()`].
+    /// Can be used during an initialization function [`I*::init()`][crate::classes::IObject::init] or [`Gd::from_init_fn()`], or [`POSTINITIALIZE`][crate::classes::notify::ObjectNotification::POSTINITIALIZE].
     ///
     /// The base pointer is only pointing to a base object; you cannot yet downcast it to the object being constructed.
     /// The instance ID is the same as the one the in-construction object will have.
     ///
     /// # Lifecycle for ref-counted classes
-    /// If `T: Inherits<RefCounted>`, then the ref-counted object is not yet fully-initialized at the time of the `init` function running.
+    /// If `T: Inherits<RefCounted>`, then the ref-counted object is not yet fully-initialized at the time of the `init` function and [`POSTINITIALIZE`][crate::classes::notify::ObjectNotification::POSTINITIALIZE] running.
     /// Accessing the base object without further measures would be dangerous. Here, godot-rust employs a workaround: the `Base` object (which
     /// holds a weak pointer to the actual instance) is temporarily upgraded to a strong pointer, preventing use-after-free.
     ///

--- a/godot-core/src/obj/bounds.rs
+++ b/godot-core/src/obj/bounds.rs
@@ -398,11 +398,7 @@ impl Declarer for DeclEngine {
     where
         T: GodotDefault + Bounds<Declarer = Self>,
     {
-        unsafe {
-            let object_ptr =
-                sys::interface_fn!(classdb_construct_object)(T::class_name().string_sys());
-            Gd::from_obj_sys(object_ptr)
-        }
+        crate::classes::construct_engine_object()
     }
 }
 

--- a/godot-ffi/src/lib.rs
+++ b/godot-ffi/src/lib.rs
@@ -471,6 +471,21 @@ pub unsafe fn discover_main_thread() {
     }
 }
 
+/// Construct Godot object.
+///
+/// "NOTIFICATION_POSTINITIALIZE" must be sent after construction since 4.4.
+///
+/// # Safety
+/// `class_name` is assumed to be valid.
+pub unsafe fn classdb_construct_object(
+    class_name: GDExtensionConstStringNamePtr,
+) -> GDExtensionObjectPtr {
+    #[cfg(before_api = "4.4")]
+    return interface_fn!(classdb_construct_object)(class_name);
+    #[cfg(since_api = "4.4")]
+    return interface_fn!(classdb_construct_object2)(class_name);
+}
+
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Macros to access low-level function bindings
 

--- a/itest/rust/src/object_tests/virtual_methods_test.rs
+++ b/itest/rust/src/object_tests/virtual_methods_test.rs
@@ -520,6 +520,8 @@ fn test_notifications() {
     assert_eq!(
         obj.bind().sequence,
         vec![
+            #[cfg(since_api = "4.4")]
+            ReceivedEvent::Notification(NodeNotification::POSTINITIALIZE),
             ReceivedEvent::Notification(NodeNotification::UNPAUSED),
             ReceivedEvent::Notification(NodeNotification::EDITOR_POST_SAVE),
             ReceivedEvent::Ready,


### PR DESCRIPTION
Changes:
- `classdb_construct_object` -> `classdb_construct_object2`
- `string_new_with_utf8_chars_and_len` -> `string_new_with_utf8_chars_and_len2`

After this PR, `NOTIFICATION_POSTINITIALIZE` will be sent after `init()` and can be received correctly in `on_notification()` in godot 4.4 or later. See also `test_notifications` in the itest.

Partially addresses #557