### PR TITLE
Add groups export.

### DIFF
--- a/godot-core/src/registry/godot_register_wrappers.rs
+++ b/godot-core/src/registry/godot_register_wrappers.rs
@@ -7,7 +7,7 @@
 
 //! Internal registration machinery used by proc-macro APIs.
 
-use crate::builtin::StringName;
+use crate::builtin::{GString, StringName};
 use crate::global::PropertyUsageFlags;
 use crate::meta::{ClassName, GodotConvert, GodotType, PropertyHintInfo, PropertyInfo};
 use crate::obj::GodotClass;
@@ -76,6 +76,36 @@ fn register_var_or_export_inner(
             std::ptr::addr_of!(property_info_sys),
             setter_name.string_sys(),
             getter_name.string_sys(),
+        );
+    }
+}
+
+pub fn register_group<C: GodotClass>(group_name: &str) {
+    let group_name = GString::from(group_name);
+    let prefix = GString::default();
+    let class_name = C::class_name();
+
+    unsafe {
+        sys::interface_fn!(classdb_register_extension_class_property_group)(
+            sys::get_library(),
+            class_name.string_sys(),
+            group_name.string_sys(),
+            prefix.string_sys(),
+        );
+    }
+}
+
+pub fn register_subgroup<C: GodotClass>(subgroup_name: &str) {
+    let subgroup_name = GString::from(subgroup_name);
+    let prefix = GString::default();
+    let class_name = C::class_name();
+
+    unsafe {
+        sys::interface_fn!(classdb_register_extension_class_property_subgroup)(
+            sys::get_library(),
+            class_name.string_sys(),
+            subgroup_name.string_sys(),
+            prefix.string_sys(),
         );
     }
 }

--- a/godot-macros/src/class/data_models/field.rs
+++ b/godot-macros/src/class/data_models/field.rs
@@ -5,6 +5,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+use crate::class::data_models::group_export::FieldGroup;
 use crate::class::{FieldExport, FieldVar};
 use crate::util::{error, KvParser};
 use proc_macro2::{Ident, Span, TokenStream};
@@ -16,6 +17,7 @@ pub struct Field {
     pub default_val: Option<FieldDefault>,
     pub var: Option<FieldVar>,
     pub export: Option<FieldExport>,
+    pub group: Option<FieldGroup>,
     pub is_onready: bool,
     pub is_oneditor: bool,
     #[cfg(feature = "register-docs")]
@@ -31,6 +33,7 @@ impl Field {
             default_val: None,
             var: None,
             export: None,
+            group: None,
             is_onready: false,
             is_oneditor: false,
             #[cfg(feature = "register-docs")]
@@ -108,20 +111,6 @@ pub enum FieldCond {
     // None, - enable once needed.
     IsOnReady,
     IsOnEditor,
-}
-
-pub struct Fields {
-    /// All fields except `base_field`.
-    pub all_fields: Vec<Field>,
-
-    /// The field with type `Base<T>`, if available.
-    pub base_field: Option<Field>,
-
-    /// Deprecation warnings.
-    pub deprecations: Vec<TokenStream>,
-
-    /// Errors during macro evaluation that shouldn't abort the execution of the macro.
-    pub errors: Vec<venial::Error>,
 }
 
 #[derive(Clone)]

--- a/godot-macros/src/class/data_models/fields.rs
+++ b/godot-macros/src/class/data_models/fields.rs
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+use crate::class::Field;
+use crate::util::bail;
+use crate::ParseResult;
+use proc_macro2::{Punct, TokenStream};
+use std::fmt::Display;
+
+pub struct Fields {
+    /// Names of all the declared groups and subgroups for this struct.
+    // In the future might be split in two (for groups and subgroups) & used to define the priority (order) of said groups.
+    // Currently order of declaration declares the group priority (i.e. – groups declared first are shown as the first in the editor).
+    // This order is not guaranteed but so far proved to work reliably.
+    pub groups: Vec<String>,
+
+    /// All fields except `base_field`.
+    pub all_fields: Vec<Field>,
+
+    /// The field with type `Base<T>`, if available.
+    pub base_field: Option<Field>,
+
+    /// Deprecation warnings.
+    pub deprecations: Vec<TokenStream>,
+
+    /// Errors during macro evaluation that shouldn't abort the execution of the macro.
+    pub errors: Vec<venial::Error>,
+}
+
+impl Fields {
+    /// Remove surrounding quotes to display declared "group name" in editor as `group name` instead of `"group name"`.
+    /// Should be called after parsing all the fields to avoid unnecessary operations.
+    pub fn format_groups(&mut self) {
+        self.groups
+            .iter_mut()
+            .for_each(|g| *g = g.trim_matches('"').to_string());
+    }
+}
+
+/// Fetches data for all named fields for a struct.
+///
+/// Errors if `class` is a tuple struct.
+pub fn named_fields(
+    class: &venial::Struct,
+    derive_macro_name: impl Display,
+) -> ParseResult<Vec<(venial::NamedField, Punct)>> {
+    // This is separate from parse_fields to improve compile errors. The errors from here demand larger and more non-local changes from the API
+    // user than those from parse_struct_attributes, so this must be run first.
+    match &class.fields {
+        // TODO disallow unit structs in the future
+        // It often happens that over time, a registered class starts to require a base field.
+        // Extending a {} struct requires breaking less code, so we should encourage it from the start.
+        venial::Fields::Unit => Ok(vec![]),
+        venial::Fields::Tuple(_) => bail!(
+            &class.fields,
+            "{derive_macro_name} is not supported for tuple structs",
+        )?,
+        venial::Fields::Named(fields) => Ok(fields.fields.inner.clone()),
+    }
+}

--- a/godot-macros/src/class/data_models/group_export.rs
+++ b/godot-macros/src/class/data_models/group_export.rs
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use crate::class::data_models::fields::Fields;
+use crate::util::KvParser;
+use std::cmp::Ordering;
+
+/// Points to index of a given group name in [Fields.groups](field@Fields::groups).
+///
+/// Two fields with the same GroupIdentifier belong to the same group.
+pub type GroupIdentifier = usize;
+
+pub struct FieldGroup {
+    pub group_name_index: Option<GroupIdentifier>,
+    pub subgroup_name_index: Option<GroupIdentifier>,
+}
+
+impl FieldGroup {
+    fn parse_group(
+        expr: &'static str,
+        parser: &mut KvParser,
+        groups: &mut Vec<String>,
+    ) -> Option<GroupIdentifier> {
+        let group = parser.handle_expr(expr).unwrap_or(None)?.to_string();
+
+        if let Some(group_index) = groups
+            .iter()
+            .position(|existing_group| existing_group == &group)
+        {
+            Some(group_index)
+        } else {
+            groups.push(group);
+            Some(groups.len() - 1)
+        }
+    }
+
+    pub(crate) fn new_from_kv(parser: &mut KvParser, groups: &mut Vec<String>) -> Self {
+        Self {
+            group_name_index: Self::parse_group("group", parser, groups),
+            subgroup_name_index: Self::parse_group("subgroup", parser, groups),
+        }
+    }
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// Ordering
+
+pub(crate) struct ExportGroupOrdering {
+    /// Allows to identify given export group.
+    /// `None` for root.
+    identifier: Option<GroupIdentifier>,
+    /// Contains subgroups of given ordering (subgroups for groups, subgroups&groups for root).
+    /// Ones parsed first have higher priority, i.e. are displayed as the first.
+    subgroups: Vec<ExportGroupOrdering>,
+}
+
+impl ExportGroupOrdering {
+    /// Creates root which holds all the groups&subgroups.
+    fn root() -> Self {
+        Self {
+            identifier: None,
+            subgroups: Vec::new(),
+        }
+    }
+
+    /// Represents individual group & its subgroups.
+    fn child(identifier: GroupIdentifier) -> Self {
+        Self {
+            identifier: Some(identifier),
+            subgroups: Vec::new(),
+        }
+    }
+
+    /// Returns registered group index. Registers given group if not present.
+    fn group_index(&mut self, identifier: &GroupIdentifier) -> usize {
+        self.subgroups
+            .iter()
+            // Will never fail – non-root orderings must have an identifier.
+            .position(|sub| identifier == sub.identifier.as_ref().expect("Tried to parse an undefined export group. This is a bug, please report it."))
+            .unwrap_or_else(|| {
+                // Register new subgroup.
+                self.subgroups.push(ExportGroupOrdering::child(*identifier));
+                self.subgroups.len() - 1
+            })
+    }
+}
+
+// Note: GDExtension doesn't support categories for some reason(s?).
+// It probably expects us to use inheritance instead?
+enum OrderingStage {
+    Group,
+    SubGroup,
+}
+
+// It is recursive but max recursion depth is 1 so it's fine.
+fn compare_by_group_and_declaration_order(
+    field_a: &FieldGroup,
+    field_b: &FieldGroup,
+    ordering: &mut ExportGroupOrdering,
+    stage: OrderingStage,
+) -> Ordering {
+    let (lhs, rhs, next_stage) = match stage {
+        OrderingStage::Group => (
+            &field_a.group_name_index,
+            &field_b.group_name_index,
+            Some(OrderingStage::SubGroup),
+        ),
+        OrderingStage::SubGroup => (
+            &field_a.subgroup_name_index,
+            &field_b.subgroup_name_index,
+            None,
+        ),
+    };
+
+    match (lhs, rhs) {
+        // Ungrouped fields or fields with subgroup only always have higher priority (i.e. are displayed on top).
+        (Some(_), None) => Ordering::Greater,
+        (None, Some(_)) => Ordering::Less,
+
+        // Same group/subgroup.
+        (Some(group_a), Some(group_b)) => {
+            if group_a == group_b {
+                let Some(next_stage) = next_stage else {
+                    return Ordering::Equal;
+                };
+
+                let next_ordering_position = ordering.group_index(group_a);
+
+                // Fields belong to the same group – check the subgroup.
+                compare_by_group_and_declaration_order(
+                    field_a,
+                    field_b,
+                    &mut ordering.subgroups[next_ordering_position],
+                    next_stage,
+                )
+            } else {
+                // Parsed earlier => greater priority.
+                let (priority_a, priority_b) = (
+                    usize::MAX - ordering.group_index(group_a),
+                    usize::MAX - ordering.group_index(group_b),
+                );
+                priority_b.cmp(&priority_a)
+            }
+        }
+
+        (None, None) => {
+            // Fields don't belong to any subgroup nor group.
+            let Some(next_stage) = next_stage else {
+                return Ordering::Equal;
+            };
+
+            compare_by_group_and_declaration_order(field_a, field_b, ordering, next_stage)
+        }
+    }
+}
+
+/// Sorts fields by their group and subgroup association.
+///
+/// Fields without group nor subgroup are first.
+/// Fields with subgroup only come in next, in order of their declaration on the class struct.
+/// Finally fields with groups are displayed – firstly ones without subgroups followed by
+/// fields with given group & subgroup (in the same order as above).
+///
+/// Group membership for properties in Godot is based on the order of their registration.
+/// All the properties belong to group or subgroup registered beforehand – thus the need to sort them.
+pub(crate) fn sort_fields_by_group(fields: &mut Fields) {
+    let mut initial_ordering = ExportGroupOrdering::root();
+
+    // `sort_by` instead of `sort_unstable_by` to preserve original order of declaration.
+    // Which is not guaranteed by the way albeit worked reliably so far.
+    fields.all_fields.sort_unstable_by(|a, b| {
+        let (group_a, group_b) = match (&a.group, &b.group) {
+            (Some(a), Some(b)) => (a, b),
+            (Some(_), None) => return Ordering::Greater,
+            (None, Some(_)) => return Ordering::Less,
+            // We don't care about ordering of fields without a `#[export]`.
+            _ => return Ordering::Equal,
+        };
+
+        compare_by_group_and_declaration_order(
+            group_a,
+            group_b,
+            &mut initial_ordering,
+            OrderingStage::Group,
+        )
+    });
+
+    fields.format_groups();
+}

--- a/godot-macros/src/class/derive_godot_class.rs
+++ b/godot-macros/src/class/derive_godot_class.rs
@@ -5,9 +5,11 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+use crate::class::data_models::fields::{named_fields, Fields};
+use crate::class::data_models::group_export::{sort_fields_by_group, FieldGroup};
 use crate::class::{
     make_property_impl, make_virtual_callback, BeforeKind, Field, FieldCond, FieldDefault,
-    FieldExport, FieldVar, Fields, SignatureInfo,
+    FieldExport, FieldVar, SignatureInfo,
 };
 use crate::util::{
     bail, error, format_funcs_collection_struct, ident, path_ends_with_complex,
@@ -33,9 +35,11 @@ pub fn derive_godot_class(item: venial::Item) -> ParseResult<TokenStream> {
     }
 
     let mut modifiers = Vec::new();
-    let named_fields = named_fields(class)?;
+    let named_fields = named_fields(class, "#[derive(GodotClass)]")?;
     let mut struct_cfg = parse_struct_attributes(class)?;
     let mut fields = parse_fields(named_fields, struct_cfg.init_strategy)?;
+    sort_fields_by_group(&mut fields);
+
     if struct_cfg.is_editor_plugin() {
         modifiers.push(quote! { with_editor_plugin })
     }
@@ -559,25 +563,6 @@ fn parse_struct_attributes(class: &venial::Struct) -> ParseResult<ClassAttribute
     })
 }
 
-/// Fetches data for all named fields for a struct.
-///
-/// Errors if `class` is a tuple struct.
-fn named_fields(class: &venial::Struct) -> ParseResult<Vec<(venial::NamedField, Punct)>> {
-    // This is separate from parse_fields to improve compile errors. The errors from here demand larger and more non-local changes from the API
-    // user than those from parse_struct_attributes, so this must be run first.
-    match &class.fields {
-        // TODO disallow unit structs in the future
-        // It often happens that over time, a registered class starts to require a base field.
-        // Extending a {} struct requires breaking less code, so we should encourage it from the start.
-        venial::Fields::Unit => Ok(vec![]),
-        venial::Fields::Tuple(_) => bail!(
-            &class.fields,
-            "#[derive(GodotClass)] is not supported for tuple structs",
-        )?,
-        venial::Fields::Named(fields) => Ok(fields.fields.inner.clone()),
-    }
-}
-
 /// Returns field names and 1 base field, if available.
 fn parse_fields(
     named_fields: Vec<(venial::NamedField, Punct)>,
@@ -587,6 +572,7 @@ fn parse_fields(
     let mut base_field = Option::<Field>::None;
     let mut deprecations = vec![];
     let mut errors = vec![];
+    let mut groups = vec![];
 
     // Attributes on struct fields
     for (named_field, _punct) in named_fields {
@@ -680,6 +666,8 @@ fn parse_fields(
         if let Some(mut parser) = KvParser::parse(&named_field.attributes, "export")? {
             let export = FieldExport::new_from_kv(&mut parser)?;
             field.export = Some(export);
+            let group = FieldGroup::new_from_kv(&mut parser, &mut groups);
+            field.group = Some(group);
             parser.finish()?;
         }
 
@@ -749,6 +737,7 @@ fn parse_fields(
     }
 
     Ok(Fields {
+        groups,
         all_fields,
         base_field,
         deprecations,

--- a/godot-macros/src/class/mod.rs
+++ b/godot-macros/src/class/mod.rs
@@ -8,12 +8,15 @@
 mod derive_godot_class;
 mod godot_api;
 mod godot_dyn;
+
 mod data_models {
     pub mod constant;
     pub mod field;
     pub mod field_export;
     pub mod field_var;
+    pub mod fields;
     pub mod func;
+    pub mod group_export;
     pub mod inherent_impl;
     pub mod interface_trait_impl;
     pub mod property;

--- a/godot-macros/src/lib.rs
+++ b/godot-macros/src/lib.rs
@@ -300,6 +300,33 @@ use crate::util::{bail, ident, KvParser};
 /// }
 /// ```
 ///
+/// To declare groups and subgroups append `group` key to a `#[export]` attribute. Fields without group will be exported first,
+/// followed by properties with subgroup only, tailed by ones with group declaration.
+///
+///```
+/// # use godot::prelude::*;
+/// const MAX_HEALTH: f64 = 100.0;
+///
+/// #[derive(GodotClass)]
+/// # #[class(init)]
+/// struct MyStruct {
+///     #[export(group = "my_group", subgroup = "my_subgroup")]
+///     will_be_displayed_as_4th: u32,
+///
+///     #[export]
+///     will_be_displayed_as_1st: i64,
+///
+///     #[export(subgroup = "my_other_subgroup_with_no_group")]
+///     will_be_displayed_as_the_2nd: i64,
+///
+///     #[export(range = (0.0, MAX_HEALTH), group = "my_group")]
+///     will_be_displayed_as_3rd: f64,
+///
+///     #[export(group = "last_group")]
+///     will_be_displayed_last: i64
+/// }
+///```
+///
 /// ## Low-level property hints and usage
 ///
 /// You can specify custom property hints, hint strings, and usage flags in a `#[var]` attribute using the `hint`, `hint_string`

--- a/itest/rust/src/object_tests/property_test.rs
+++ b/itest/rust/src/object_tests/property_test.rs
@@ -239,6 +239,15 @@ struct CheckAllExports {
     #[export]
     normal: GString,
 
+    #[export(group = "test_group")]
+    grouped: i64,
+
+    #[export(subgroup = "test_subgroup")]
+    subgrouped: i64,
+
+    #[export(group = "test_group", subgroup = "test_subgroup")]
+    grouped_with_subgroup: i64,
+
     // `suffix = "px"` should be in the third slot to test that key-value pairs in that position no longer error.
     #[export(range = (0.0, 10.0, suffix = "px", or_greater, or_less, exp, degrees, hide_slider))]
     range_exported: f64,


### PR DESCRIPTION
# What does this PR solve?

Adds groups and subgroup.

## How does it work?

I checked few options and finally went with a `clap` API (suggested by @ttencate) which requires specifying the group directly inside a `#[export]` attribute – everything else turned out to be too limiting, too messy or too janky :unamused:.

<details>

<summary> Example usage  </summary>

```rs
#[derive(GodotClass)]
#[class(init, base=Node)]
struct Initializer {
    #[export(group = "g1765")]
    #[init( val = 124 )]
    pub rust_field_with_group_1: i32,

    pub rust_field_without_group_1: i32,

    #[export]
    pub export_without_group: i32,

    #[var]
    pub random_var: i64,

    #[export(subgroup = "some subgroup 2")]
    #[init( val = 444 )]
    pub export_with_subgroup3: i32,

    #[export(subgroup = "some subgroup")]
    pub export_with_subgroup: i32,
    #[export(subgroup = "some subgroup")]
    pub export_with_subgroup2: i32,

    #[export(range = (0.0, 10.0, or_greater), group = "g1765")]
    pub rust_field_with_group_7: f32,

    #[export(group = "g1", subgroup = "some subgroup")]
    pub export_with_group_and_subgroup: i32,

    #[export(group = "g2", subgroup = "some subgroup 2")]
    pub export_with_other_group_and_subgroup: i32,

    #[export(group = "g1", subgroup = "some subgroup 2")]
    pub export_with_yet_another_group_and_subgroup: i32,
    
    #[export(group = "g1765", subgroup = "some subgroup 3")]
    pub first_group_but_subgroup: i32,

    #[export(subgroup = "some subgroup 2")]
    #[init( val = 444 )]
    pub export_with_subgroup31: i32,

    base: Base<Node>,
}
```

![image](https://github.com/user-attachments/assets/27ed1deb-f393-420e-9339-2dae3334b1d2)

</details>

## Problems etc 

Initially I wanted to ship it with struct extensions but they can be added in separate PR (I'll create the issue for that later). The leftovers of that is `Fields` struct being moved to separate file – I don't see anything wrong with that though, so I left it like that (not sure about `named_fields` function though).

I experimented with organizing fields into something along the lines of
```rs
struct Field {
    Parsed(Field),
    Group(GroupName),
    ClassExtension(ClassExtensionData)
}
```

but it turned out to be silly, unnecessary and unnecessary overcomplicated.

I am not really happy with `GroupIdentifier` (`usize` which simply points to some index holding group names) but it is kinda the sanest solution – idents make no sense (and use "to_string()" underneath anyway), strings require too many unnecessary allocations, `*const String` is… uh… let's not do that.