### PR TITLE
Implement `Default` trait for `Rid`

### DIFF
--- a/godot-core/src/builtin/rid.rs
+++ b/godot-core/src/builtin/rid.rs
@@ -100,6 +100,12 @@ impl Rid {
     }
 }
 
+impl Default for Rid {
+    fn default() -> Self {
+        Self::Invalid
+    }
+}
+
 impl std::fmt::Display for Rid {
     /// Formats `Rid` to match Godot's string representation.
     ///


### PR DESCRIPTION
Can't define a field of `[Rid; N]` in struct with `#[class(init)]` because Rid doesn't implement `Default` trait currently. `Rid` should also implement `Default` like other built-in types.
