### PR TITLE
Allow `clippy::uninlined_format_args` (Rust 1.88)

### DIFF
--- a/godot-codegen/src/generator/default_parameters.rs
+++ b/godot-codegen/src/generator/default_parameters.rs
@@ -184,6 +184,7 @@ fn make_extender_doc(sig: &dyn Function, extended_fn_name: &Ident) -> (String, T
     let surround_class_prefix;
     let builder_doc;
 
+    #[allow(clippy::uninlined_format_args)]
     match sig.surrounding_class() {
         Some(TyName { rust_ty, .. }) => {
             surround_class_prefix = quote! { re_export::#rust_ty:: };

--- a/itest/rust/src/engine_tests/save_load_test.rs
+++ b/itest/rust/src/engine_tests/save_load_test.rs
@@ -32,7 +32,7 @@ struct SavedGame {
 #[class(base=Node, init)]
 struct GameLoader {
     // Test also more complex expressions.
-    #[init(load = &format!("res://{}", RESOURCE_NAME))]
+    #[init(load = &format!("res://{RESOURCE_NAME}"))]
     game: OnReady<Gd<SavedGame>>,
 
     _base: Base<classes::Node>,
@@ -43,7 +43,7 @@ const FAULTY_PATH: &str = "no_such_path";
 
 #[itest]
 fn save_test() {
-    let res_path = format!("res://{}", RESOURCE_NAME);
+    let res_path = format!("res://{RESOURCE_NAME}");
 
     let resource = SavedGame::new_gd();
 
@@ -61,7 +61,7 @@ fn save_test() {
 #[itest]
 fn load_test() {
     let level = 2317;
-    let res_path = format!("res://{}", RESOURCE_NAME);
+    let res_path = format!("res://{RESOURCE_NAME}");
 
     let mut resource = SavedGame::new_gd();
     resource.bind_mut().set_level(level);
@@ -85,7 +85,7 @@ fn load_test() {
 
 #[itest]
 fn load_with_onready() {
-    let res_path = format!("res://{}", RESOURCE_NAME);
+    let res_path = format!("res://{RESOURCE_NAME}");
 
     let mut resource = SavedGame::new_gd();
     resource.bind_mut().set_level(555);

--- a/itest/rust/src/framework/runner.rs
+++ b/itest/rust/src/framework/runner.rs
@@ -158,6 +158,7 @@ impl IntegrationTests {
         cfg!(feature = "codegen-full")
     }
 
+    #[allow(clippy::uninlined_format_args)]
     #[func]
     fn run_all_benchmarks(&mut self, scene_tree: Gd<Node>) {
         if self.focus_run {


### PR DESCRIPTION
We break said [rule](https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args) in one place:

https://github.com/godot-rust/gdext/blob/d0fcfa56cfec5cbb5f5f7a4daace7e1e26eee822/godot-codegen/src/generator/default_parameters.rs#L187-L205

```rs
error: variables can be used directly in the `format!` string
   --> godot-codegen/src/generator/default_parameters.rs:190:27
    |
190 |               builder_doc = format!(
    |  ___________________________^
191 | |                 "Default-param extender for [`{class}::{method}`][super::{class}::{method}].",
192 | |                 class = rust_ty,
193 | |                 method = extended_fn_name,
194 | |             );
    | |_____________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
    = note: `-D clippy::uninlined-format-args` implied by `-D clippy::style`
    = help: to override `-D clippy::style` add `#[allow(clippy::uninlined_format_args)]`

error: variables can be used directly in the `format!` string
   --> godot-codegen/src/generator/default_parameters.rs:200:27
    |
200 |               builder_doc = format!(
    |  ___________________________^
201 | |                 "Default-param extender for [`{function}`][super::{function}].",
202 | |                 function = extended_fn_name
203 | |             );
    | |_____________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
```

Personally I think it is silly and makes code, paradoxically, less readable (i.e. would require making noisy comments instead) and I find aliases useful. Feel free to close PR if you think otherwise :sweat_smile: 

(idk if simple `#[allow(...)]` wouldn't be the best :shrug:)

Related issues: https://github.com/rust-lang/rust-clippy/issues?q=is%3Aissue+uninlined_format_args

I also tried workspace lints (by setting lints in `workspace` & setting `lints.workspace = true` in packages) but for some reason they don't work https://doc.rust-lang.org/cargo/reference/workspaces.html#the-lints-table