### PR TITLE
Improve `Debug` impl for objects

### DIFF
--- a/godot-core/src/builtin/variant/mod.rs
+++ b/godot-core/src/builtin/variant/mod.rs
@@ -8,6 +8,7 @@
 use crate::builtin::{
     GString, StringName, VariantArray, VariantDispatch, VariantOperator, VariantType,
 };
+use crate::classes;
 use crate::meta::error::{ConvertError, FromVariantError};
 use crate::meta::{
     arg_into_ref, ffi_variant_type, ArrayElement, AsArg, ExtVariantType, FromGodot, GodotType,
@@ -582,6 +583,10 @@ impl fmt::Debug for Variant {
                 let array = unsafe { VariantArray::from_variant_unchecked(self) };
                 array.fmt(f)
             }
+
+            // Converting to objects before printing causes their refcount to increment, leading to an Observer effect
+            // where `Debug` actually changes the object statistics. As such, fetch information without instantiating Gd<T>.
+            VariantType::OBJECT => classes::debug_string_variant(self, f, "VariantGd"),
 
             // VariantDispatch also includes dead objects via `FreedObject` enumerator, which maps to "<Freed Object>".
             _ => VariantDispatch::from_variant(self).fmt(f),

--- a/godot-core/src/classes/class_runtime.rs
+++ b/godot-core/src/classes/class_runtime.rs
@@ -23,10 +23,13 @@ pub(crate) fn debug_string<T: GodotClass>(
 ) -> std::fmt::Result {
     if let Some(id) = obj.instance_id_or_none() {
         let class: StringName = obj.dynamic_class_string();
-        f.debug_struct(ty)
-            .field("id", &id)
-            .field("class", &class)
-            .finish()
+
+        let mut builder = f.debug_struct(ty);
+        builder.field("id", &id).field("class", &class);
+        if let Some(refcount) = obj.maybe_refcount() {
+            builder.field("refc", &refcount);
+        }
+        builder.finish()
     } else {
         write!(f, "{ty} {{ freed obj }}")
     }
@@ -57,11 +60,16 @@ pub(crate) fn debug_string_with_trait<T: GodotClass>(
 ) -> std::fmt::Result {
     if let Some(id) = obj.instance_id_or_none() {
         let class: StringName = obj.dynamic_class_string();
-        f.debug_struct(ty)
+
+        let mut builder = f.debug_struct(ty);
+        builder
             .field("id", &id)
             .field("class", &class)
-            .field("trait", &trt)
-            .finish()
+            .field("trait", &trt);
+        if let Some(refcount) = obj.maybe_refcount() {
+            builder.field("refc", &refcount);
+        }
+        builder.finish()
     } else {
         write!(f, "{ty} {{ freed obj }}")
     }

--- a/godot-core/src/classes/class_runtime.rs
+++ b/godot-core/src/classes/class_runtime.rs
@@ -7,7 +7,7 @@
 
 //! Runtime checks and inspection of Godot classes.
 
-use crate::builtin::{GString, StringName, Variant};
+use crate::builtin::{GString, StringName, Variant, VariantType};
 #[cfg(debug_assertions)]
 use crate::classes::{ClassDb, Object};
 use crate::meta::CallContext;
@@ -35,6 +35,8 @@ pub(crate) fn debug_string_variant(
     f: &mut std::fmt::Formatter<'_>,
     ty: &str,
 ) -> std::fmt::Result {
+    debug_assert_eq!(obj.get_type(), VariantType::OBJECT);
+
     let id = obj
         .object_id_unchecked()
         .expect("Variant must be of type OBJECT");

--- a/godot-core/src/obj/base.rs
+++ b/godot-core/src/obj/base.rs
@@ -102,6 +102,12 @@ impl<T: GodotClass> Base<T> {
     pub fn obj_sys(&self) -> sys::GDExtensionObjectPtr {
         self.obj.obj_sys()
     }
+
+    // Internal use only, do not make public.
+    #[cfg(feature = "debug-log")]
+    pub(crate) fn debug_instance_id(&self) -> crate::obj::InstanceId {
+        self.obj.instance_id()
+    }
 }
 
 impl<T: GodotClass> Debug for Base<T> {

--- a/godot-core/src/obj/bounds.rs
+++ b/godot-core/src/obj/bounds.rs
@@ -208,7 +208,7 @@ impl Sealed for MemRefCounted {}
 impl Memory for MemRefCounted {}
 impl DynMemory for MemRefCounted {
     fn maybe_init_ref<T: GodotClass>(obj: &mut RawGd<T>) {
-        out!("  MemRefc::init  <{}>", std::any::type_name::<T>());
+        out!("  MemRefc::init:  {obj:?}");
         if obj.is_null() {
             return;
         }
@@ -226,7 +226,7 @@ impl DynMemory for MemRefCounted {
     }
 
     fn maybe_inc_ref<T: GodotClass>(obj: &mut RawGd<T>) {
-        out!("  MemRefc::inc   <{}>", std::any::type_name::<T>());
+        out!("  MemRefc::inc:   {obj:?}");
         if obj.is_null() {
             return;
         }
@@ -237,7 +237,7 @@ impl DynMemory for MemRefCounted {
     }
 
     unsafe fn maybe_dec_ref<T: GodotClass>(obj: &mut RawGd<T>) -> bool {
-        out!("  MemRefc::dec   <{}>", std::any::type_name::<T>());
+        out!("  MemRefc::dec:   {obj:?}");
         if obj.is_null() {
             return false;
         }
@@ -278,7 +278,7 @@ impl MemDynamic {
 impl Sealed for MemDynamic {}
 impl DynMemory for MemDynamic {
     fn maybe_init_ref<T: GodotClass>(obj: &mut RawGd<T>) {
-        out!("  MemDyn::init  <{}>", std::any::type_name::<T>());
+        out!("  MemDyn::init:  {obj:?}");
         if Self::inherits_refcounted(obj) {
             // Will call `RefCounted::init_ref()` which checks for liveness.
             out!("    MemDyn -> MemRefc");
@@ -289,7 +289,7 @@ impl DynMemory for MemDynamic {
     }
 
     fn maybe_inc_ref<T: GodotClass>(obj: &mut RawGd<T>) {
-        out!("  MemDyn::inc   <{}>", std::any::type_name::<T>());
+        out!("  MemDyn::inc:   {obj:?}");
         if Self::inherits_refcounted(obj) {
             // Will call `RefCounted::reference()` which checks for liveness.
             MemRefCounted::maybe_inc_ref(obj)
@@ -297,7 +297,7 @@ impl DynMemory for MemDynamic {
     }
 
     unsafe fn maybe_dec_ref<T: GodotClass>(obj: &mut RawGd<T>) -> bool {
-        out!("  MemDyn::dec   <{}>", std::any::type_name::<T>());
+        out!("  MemDyn::dec:   {obj:?}");
         if obj
             .instance_id_unchecked()
             .is_some_and(|id| id.is_ref_counted())

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -305,10 +305,16 @@ impl<T: GodotClass> Gd<T> {
     /// Returns the reference count, if the dynamic object inherits `RefCounted`; and `None` otherwise.
     pub(crate) fn maybe_refcount(&self) -> Option<usize> {
         // Fast check if ref-counted without downcast.
-        self.instance_id_unchecked().is_ref_counted().then(|| {
+        self.instance_id().is_ref_counted().then(|| {
             let rc = self.raw.with_ref_counted(|refc| refc.get_reference_count());
             rc as usize
         })
+    }
+
+    #[cfg(feature = "trace")] // itest only.
+    #[doc(hidden)]
+    pub fn test_refcount(&self) -> Option<usize> {
+        self.maybe_refcount()
     }
 
     /// **Upcast:** convert into a smart pointer to a base class. Always succeeds.

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -302,6 +302,15 @@ impl<T: GodotClass> Gd<T> {
         }
     }
 
+    /// Returns the reference count, if the dynamic object inherits `RefCounted`; and `None` otherwise.
+    pub(crate) fn maybe_refcount(&self) -> Option<usize> {
+        // Fast check if ref-counted without downcast.
+        self.instance_id_unchecked().is_ref_counted().then(|| {
+            let rc = self.raw.with_ref_counted(|refc| refc.get_reference_count());
+            rc as usize
+        })
+    }
+
     /// **Upcast:** convert into a smart pointer to a base class. Always succeeds.
     ///
     /// Moves out of this value. If you want to create _another_ smart pointer instance,

--- a/godot-core/src/obj/raw_gd.rs
+++ b/godot-core/src/obj/raw_gd.rs
@@ -653,7 +653,7 @@ impl<T: GodotClass> Drop for RawGd<T> {
     fn drop(&mut self) {
         // No-op for manually managed objects
 
-        out!("RawGd::drop   <{}>", std::any::type_name::<T>());
+        out!("RawGd::drop:      {self:?}");
 
         // SAFETY: This `Gd` won't be dropped again after this.
         // If destruction is triggered by Godot, Storage already knows about it, no need to notify it
@@ -668,7 +668,7 @@ impl<T: GodotClass> Drop for RawGd<T> {
 
 impl<T: GodotClass> Clone for RawGd<T> {
     fn clone(&self) -> Self {
-        out!("RawGd::clone");
+        out!("RawGd::clone:     {self:?}  (before clone)");
 
         if self.is_null() {
             Self::null()

--- a/godot-core/src/obj/raw_gd.rs
+++ b/godot-core/src/obj/raw_gd.rs
@@ -95,8 +95,7 @@ impl<T: GodotClass> RawGd<T> {
 
     /// Returns `true` if the object is null.
     ///
-    /// This does not check if the object is dead, for that use
-    /// [`instance_id_or_none()`](Self::instance_id_or_none).
+    /// This does not check if the object is dead. For that, use [`is_instance_valid()`](Self::is_instance_valid).
     pub(crate) fn is_null(&self) -> bool {
         self.obj.is_null() || self.cached_rtti.is_none()
     }
@@ -689,12 +688,7 @@ impl<T: GodotClass> Clone for RawGd<T> {
 
 impl<T: GodotClass> fmt::Debug for RawGd<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if self.is_null() {
-            return write!(f, "{} {{ null obj }}", std::any::type_name::<T>());
-        }
-
-        let gd = super::Gd::from_ffi(self.clone());
-        write!(f, "{gd:?}")
+        classes::debug_string_nullable(self, f, "RawGd")
     }
 }
 

--- a/godot-core/src/storage/mod.rs
+++ b/godot-core/src/storage/mod.rs
@@ -53,16 +53,16 @@ fn bug_inaccessible<T>(err: Box<dyn std::error::Error>) -> ! {
     )
 }
 
-fn log_construct<T>() {
+fn log_construct<T: GodotClass>(base: &Base<T::Base>) {
     out!(
-        "    Storage::construct             <{ty}>",
+        "    Storage::construct:             {base:?}  (T={ty})",
         ty = type_name::<T>()
     );
 }
 
 fn log_inc_ref<T: StorageRefCounted>(storage: &T) {
     out!(
-        "    Storage::on_inc_ref (rc={rc})     <{ty}> -- {base:?}",
+        "    Storage::on_inc_ref (rc={rc}):  {base:?}  (T={ty})",
         rc = T::godot_ref_count(storage),
         base = storage.base(),
         ty = type_name::<T>(),
@@ -71,7 +71,7 @@ fn log_inc_ref<T: StorageRefCounted>(storage: &T) {
 
 fn log_dec_ref<T: StorageRefCounted>(storage: &T) {
     out!(
-        "  | Storage::on_dec_ref (rc={rc})     <{ty}> -- {base:?}",
+        "  | Storage::on_dec_ref (rc={rc}):  {base:?}  (T={ty})",
         rc = T::godot_ref_count(storage),
         base = storage.base(),
         ty = type_name::<T>(),
@@ -80,7 +80,7 @@ fn log_dec_ref<T: StorageRefCounted>(storage: &T) {
 
 fn log_drop<T: StorageRefCounted>(storage: &T) {
     out!(
-        "    Storage::drop (rc={rc})           <{base:?}>",
+        "    Storage::drop (rc={rc}):        {base:?}",
         rc = storage.godot_ref_count(),
         base = storage.base(),
     );
@@ -92,6 +92,7 @@ fn log_drop<T: StorageRefCounted>(storage: &T) {
 #[cfg(debug_assertions)]
 use borrow_info::DebugBorrowTracker;
 
+use crate::obj::{Base, GodotClass};
 #[cfg(not(debug_assertions))]
 use borrow_info_noop::DebugBorrowTracker;
 

--- a/godot-core/src/storage/mod.rs
+++ b/godot-core/src/storage/mod.rs
@@ -11,7 +11,6 @@ mod multi_threaded;
 #[cfg_attr(feature = "experimental-threads", allow(dead_code))]
 mod single_threaded;
 
-use godot_ffi::out;
 pub use instance_storage::*;
 use std::any::type_name;
 
@@ -53,37 +52,74 @@ fn bug_inaccessible<T>(err: Box<dyn std::error::Error>) -> ! {
     )
 }
 
-fn log_construct<T: GodotClass>(base: &Base<T::Base>) {
-    out!(
-        "    Storage::construct:             {base:?}  (T={ty})",
-        ty = type_name::<T>()
-    );
+#[cfg(feature = "debug-log")]
+use log_active::*;
+
+#[cfg(not(feature = "debug-log"))]
+use log_inactive::*;
+
+#[cfg(feature = "debug-log")]
+mod log_active {
+    use super::*;
+    use godot_ffi::out;
+
+    pub fn log_construct<T: GodotClass>(base: &Base<T::Base>) {
+        out!(
+            "    Storage::construct:             {base:?}  (T={ty})",
+            ty = type_name::<T>()
+        );
+    }
+
+    pub fn log_inc_ref<T: StorageRefCounted>(storage: &T) {
+        out!(
+            "    Storage::on_inc_ref (rc={rc}):  {base:?}  (T={ty})",
+            rc = T::godot_ref_count(storage),
+            base = storage.base(),
+            ty = type_name::<T>(),
+        );
+    }
+
+    pub fn log_dec_ref<T: StorageRefCounted>(storage: &T) {
+        out!(
+            "  | Storage::on_dec_ref (rc={rc}):  {base:?}  (T={ty})",
+            rc = T::godot_ref_count(storage),
+            base = storage.base(),
+            ty = type_name::<T>(),
+        );
+    }
+
+    pub fn log_pre_drop<T: Storage + ?Sized>(storage: &T) {
+        // Do not Debug-fmt `self.base()` object here, as the C++ destructor may already be running. Debug::fmt fetches dynamic object information
+        // (class type, virtual object_cast_to(), ...), but virtual dispatch won't run in active C++ destructors, thus causing weird behavior.
+
+        out!(
+            "    Storage::mark_destroyed_by_godot:  {base_id} (lcy={lifecycle:?})",
+            base_id = storage.base().debug_instance_id(),
+            lifecycle = storage.get_lifecycle(),
+        );
+    }
+
+    pub fn log_drop<T: StorageRefCounted>(storage: &T) {
+        // Do not Debug-fmt `self.base()` object here, see above.
+
+        out!(
+            "    Storage::drop (rc={rc}):        {base_id}",
+            rc = storage.godot_ref_count(),
+            base_id = storage.base().debug_instance_id(),
+        );
+    }
 }
 
-fn log_inc_ref<T: StorageRefCounted>(storage: &T) {
-    out!(
-        "    Storage::on_inc_ref (rc={rc}):  {base:?}  (T={ty})",
-        rc = T::godot_ref_count(storage),
-        base = storage.base(),
-        ty = type_name::<T>(),
-    );
-}
+// out! macro still mentions arguments in all cfgs, so they must exist (and may or may not be optimized away).
+#[cfg(not(feature = "debug-log"))]
+mod log_inactive {
+    use super::*;
 
-fn log_dec_ref<T: StorageRefCounted>(storage: &T) {
-    out!(
-        "  | Storage::on_dec_ref (rc={rc}):  {base:?}  (T={ty})",
-        rc = T::godot_ref_count(storage),
-        base = storage.base(),
-        ty = type_name::<T>(),
-    );
-}
-
-fn log_drop<T: StorageRefCounted>(storage: &T) {
-    out!(
-        "    Storage::drop (rc={rc}):        {base:?}",
-        rc = storage.godot_ref_count(),
-        base = storage.base(),
-    );
+    pub fn log_construct<T: GodotClass>(_base: &Base<T::Base>) {}
+    pub fn log_inc_ref<T: StorageRefCounted>(_storage: &T) {}
+    pub fn log_dec_ref<T: StorageRefCounted>(_storage: &T) {}
+    pub fn log_pre_drop<T: Storage + ?Sized>(_storage: &T) {}
+    pub fn log_drop<T: StorageRefCounted>(_storage: &T) {}
 }
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------

--- a/godot-core/src/storage/multi_threaded.rs
+++ b/godot-core/src/storage/multi_threaded.rs
@@ -43,7 +43,7 @@ unsafe impl<T: GodotClass> Storage for InstanceStorage<T> {
         user_instance: Self::Instance,
         base: Base<<Self::Instance as GodotClass>::Base>,
     ) -> Self {
-        super::log_construct::<T>();
+        super::log_construct::<T>(&base);
 
         Self {
             user_instance: GdCell::new(user_instance),

--- a/godot-core/src/storage/single_threaded.rs
+++ b/godot-core/src/storage/single_threaded.rs
@@ -43,7 +43,7 @@ unsafe impl<T: GodotClass> Storage for InstanceStorage<T> {
         user_instance: Self::Instance,
         base: Base<<Self::Instance as GodotClass>::Base>,
     ) -> Self {
-        super::log_construct::<T>();
+        super::log_construct::<T>(&base);
 
         Self {
             user_instance: GdCell::new(user_instance),

--- a/itest/rust/src/builtin_tests/containers/variant_test.rs
+++ b/itest/rust/src/builtin_tests/containers/variant_test.rs
@@ -261,14 +261,14 @@ fn variant_dead_object_conversions() {
 
     // Verify Display + Debug impl.
     assert_eq!(format!("{variant}"), "<Freed Object>");
-    assert_eq!(format!("{variant:?}"), "<Freed Object>");
+    assert_eq!(format!("{variant:?}"), "VariantGd { freed obj }");
 
     // Variant::try_to().
     let result = variant.try_to::<Gd<Node>>();
     let err = result.expect_err("Variant::try_to::<Gd>() with dead object should fail");
     assert_eq!(
         err.to_string(),
-        "variant holds object which is no longer alive: <Freed Object>"
+        "variant holds object which is no longer alive: VariantGd { freed obj }"
     );
 
     // Variant::to().
@@ -282,7 +282,7 @@ fn variant_dead_object_conversions() {
     let err = result.expect_err("Variant::try_to::<Option<Gd>>() with dead object should fail");
     assert_eq!(
         err.to_string(),
-        "variant holds object which is no longer alive: <Freed Object>"
+        "variant holds object which is no longer alive: VariantGd { freed obj }"
     );
 }
 

--- a/itest/rust/src/object_tests/dyn_gd_test.rs
+++ b/itest/rust/src/object_tests/dyn_gd_test.rs
@@ -375,15 +375,16 @@ fn dyn_gd_error_unregistered_trait() {
     let node = node.into_gd();
 
     let err = back.expect_err("DynGd::try_to() should have failed");
-    let expected_err =
-        format!("trait `dyn UnrelatedTrait` has not been registered with #[godot_dyn]: {node:?}");
+    let expected_err = // Variant Debug uses "VariantGd" prefix.
+        format!("trait `dyn UnrelatedTrait` has not been registered with #[godot_dyn]: Variant{node:?}");
 
     assert_eq!(err.to_string(), expected_err);
 
     let back = variant.try_to::<DynGd<foreign::NodeHealth, dyn InstanceIdProvider<Id = i32>>>();
 
+    // Variant Debug uses "VariantGd" prefix.
     let err = back.expect_err("DynGd::try_to() should have failed");
-    let expected_err = format!("trait `dyn InstanceIdProvider<Id = i32>` has not been registered with #[godot_dyn]: {node:?}");
+    let expected_err = format!("trait `dyn InstanceIdProvider<Id = i32>` has not been registered with #[godot_dyn]: Variant{node:?}");
 
     assert_eq!(err.to_string(), expected_err);
 
@@ -401,10 +402,9 @@ fn dyn_gd_error_unimplemented_trait() {
 
     let refc_id = obj.instance_id().to_i64();
     let expected_debug = format!(
-            "none of the classes derived from `RefCounted` have been linked to trait `dyn Health` with #[godot_dyn]: \
-         Gd {{ id: {refc_id}, class: RefCounted, refc: 3 }}")
-    ;
-    // was: {obj:?}
+        "none of the classes derived from `RefCounted` have been linked to trait `dyn Health` with #[godot_dyn]: \
+         VariantGd {{ id: {refc_id}, class: RefCounted, refc: 3 }}"
+    );
     assert_eq!(err.to_string(), expected_debug);
 
     let node = foreign::NodeHealth::new_alloc();
@@ -415,9 +415,9 @@ fn dyn_gd_error_unimplemented_trait() {
 
     // NodeHealth is manually managed (inherits Node), so no refcount in debug output.
     let node_id = node.instance_id().to_i64();
-    let expected_debug =        format!(
-            "none of the classes derived from `NodeHealth` have been linked to trait `dyn InstanceIdProvider<Id = f32>` with #[godot_dyn]: \
-         Gd {{ id: {node_id}, class: NodeHealth }}"
+    let expected_debug = format!(
+        "none of the classes derived from `NodeHealth` have been linked to trait `dyn InstanceIdProvider<Id = f32>` with #[godot_dyn]: \
+         VariantGd {{ id: {node_id}, class: NodeHealth }}"
     );
     assert_eq!(err.to_string(), expected_debug);
 

--- a/itest/rust/src/object_tests/object_test.rs
+++ b/itest/rust/src/object_tests/object_test.rs
@@ -496,11 +496,10 @@ fn object_engine_convert_variant_nil() {
     });
 }
 
-#[itest(focus)]
+#[itest]
 fn object_engine_convert_variant_error() {
     let refc = RefCounted::new_gd();
     let variant = refc.to_variant();
-
     assert_eq!(refc.test_refcount(), Some(2));
 
     let err = Gd::<Node2D>::try_from_variant(&variant)
@@ -510,11 +509,10 @@ fn object_engine_convert_variant_error() {
     assert_eq!(refc.test_refcount(), Some(3));
 
     let expected_debug = format!(
-        "cannot convert to class Node2D: Gd {{ id: {}, class: RefCounted, refc: 3 }}",
+        "cannot convert to class Node2D: VariantGd {{ id: {}, class: RefCounted, refc: 3 }}",
         refc.instance_id().to_i64()
     );
     assert_eq!(err.to_string(), expected_debug);
-    // was: format!("cannot convert to class Node2D: {refc:?}")
 }
 
 #[itest]

--- a/itest/rust/src/object_tests/object_test.rs
+++ b/itest/rust/src/object_tests/object_test.rs
@@ -496,18 +496,25 @@ fn object_engine_convert_variant_nil() {
     });
 }
 
-#[itest]
+#[itest(focus)]
 fn object_engine_convert_variant_error() {
     let refc = RefCounted::new_gd();
     let variant = refc.to_variant();
 
+    assert_eq!(refc.test_refcount(), Some(2));
+
     let err = Gd::<Node2D>::try_from_variant(&variant)
         .expect_err("`Gd<RefCounted>` should not convert to `Gd<Node2D>`");
 
-    assert_eq!(
-        err.to_string(),
-        format!("cannot convert to class Node2D: {refc:?}")
+    // ConvertError::Err holds a copy of the value, i.e. refcount is +1.
+    assert_eq!(refc.test_refcount(), Some(3));
+
+    let expected_debug = format!(
+        "cannot convert to class Node2D: Gd {{ id: {}, class: RefCounted, refc: 3 }}",
+        refc.instance_id().to_i64()
     );
+    assert_eq!(err.to_string(), expected_debug);
+    // was: format!("cannot convert to class Node2D: {refc:?}")
 }
 
 #[itest]


### PR DESCRIPTION
Continuation of #1226.

Improves `Debug` impl for `Gd`, `DynGd` and `Variant` holding objects:
- Includes a `refc` field for `RefCounted` classes.
- No longer creates a new object just for the `Debug` impl.
   - In particular, this addresses the issue that reading ref-counts in `Debug` is subject to the [Observer Effect](https://en.wikipedia.org/wiki/Observer_effect_(physics)), where debugging changes object stats.
- `Variant` now also uses a short-circuited `Debug` impl instead of converting to an object first.

Also cleans up trace logging and makes it more useful, by including dynamic object types. Fixes an issue where `Debug` is accessed during C++ destructors, making introspection unreliable.