### PR TITLE
Verify that panic messages support UTF-8

### DIFF
--- a/godot-core/src/global/print.rs
+++ b/godot-core/src/global/print.rs
@@ -29,7 +29,7 @@ macro_rules! inner_godot_msg {
     //($($args:tt),* $(,)?) => {
         unsafe {
             let msg = format!("{}\0", format_args!($fmt $(, $args)*));
-            // assert!(msg.is_ascii(), "godot_error: message must be ASCII");
+            // Godot supports Unicode messages, not only ASCII. See `do_panic` test.
 
             // Check whether engine is loaded, otherwise fall back to stderr.
             if $crate::sys::is_initialized() {

--- a/itest/rust/src/object_tests/dynamic_call_test.rs
+++ b/itest/rust/src/object_tests/dynamic_call_test.rs
@@ -163,7 +163,7 @@ fn dynamic_call_with_panic() {
 
     let expected_error_message = "godot-rust function call failed: Object::call(&\"do_panic\")\
         \n  Source: ObjPayload::do_panic()\
-        \n    Reason: function panicked: do_panic exploded"
+        \n    Reason: function panicked: do_panic exploded 💥"
         .to_string();
 
     assert_eq!(call_error.to_string(), expected_error_message);
@@ -188,9 +188,9 @@ fn dynamic_call_with_panic() {
     // In Debug, there is a context -> message is multi-line -> '\n' is inserted after [panic ...].
     // In Release, simpler message -> single line -> no '\n'.
     let expected_panic_message = if cfg!(debug_assertions) {
-        format!("[panic {path}:{line}]\n  do_panic exploded{context}")
+        format!("[panic {path}:{line}]\n  do_panic exploded 💥{context}")
     } else {
-        format!("[panic {path}:{line}]  do_panic exploded")
+        format!("[panic {path}:{line}]  do_panic exploded 💥")
     };
 
     assert_eq!(panic_message, expected_panic_message);

--- a/itest/rust/src/object_tests/object_test.rs
+++ b/itest/rust/src/object_tests/object_test.rs
@@ -907,7 +907,8 @@ impl ObjPayload {
 
     #[func]
     fn do_panic(&self) {
-        panic!("do_panic exploded");
+        // Unicode character as regression test for https://github.com/godot-rust/gdext/issues/384.
+        panic!("do_panic exploded 💥");
     }
 
     // Obtain the line number of the panic!() call above; keep equidistant to do_panic() method.


### PR DESCRIPTION
Closes #384. Issue is already fixed, but this verifies it and prevents regressions.