### PR TITLE
Access all enum/bitfield values programmatically

### DIFF
--- a/.github/composite/godot-itest/action.yml
+++ b/.github/composite/godot-itest/action.yml
@@ -176,7 +176,7 @@ runs:
       #             since it's not available on Windows, use taskkill in that case.
       # * exit:     the terminated process would return 143, but this is more explicit and future-proof
       #
-      # --disallow-focus: fail if #[itest(focus)] is encountered, to prevent running only a few tests for full CI
+      # --disallow-focus: fail if #[itest (focus)] is encountered, to prevent running only a few tests for full CI
       run: |
         cd itest/godot
         echo "OUTCOME=itest" >> $GITHUB_ENV

--- a/godot-codegen/src/generator/enums.rs
+++ b/godot-codegen/src/generator/enums.rs
@@ -141,7 +141,7 @@ pub fn make_enum_definition_with(
 ///
 /// Returns `None` if `enum_` isn't an indexable enum.
 fn make_enum_index_impl(enum_: &Enum) -> Option<TokenStream> {
-    let enum_max = enum_.find_index_enum_max()?;
+    let enum_max = enum_.max_index?; // Do nothing if enum isn't sequential with a MAX constant.
     let name = &enum_.name;
 
     Some(quote! {

--- a/godot-codegen/src/models/domain/enums.rs
+++ b/godot-codegen/src/models/domain/enums.rs
@@ -129,7 +129,7 @@ pub struct Enumerator {
     pub value: EnumeratorValue,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Hash, Eq, PartialEq)]
 pub enum EnumeratorValue {
     Enum(i32),
     Bitfield(u64),

--- a/godot-codegen/src/models/domain/enums.rs
+++ b/godot-codegen/src/models/domain/enums.rs
@@ -22,6 +22,8 @@ pub struct Enum {
     pub is_private: bool,
     pub is_exhaustive: bool,
     pub enumerators: Vec<Enumerator>,
+    /// If the enum is sequential and has a `*_MAX` constant (Godot name), this is the index of it.
+    pub max_index: Option<usize>,
 }
 
 impl Enum {
@@ -73,15 +75,18 @@ impl Enum {
 
     /// Returns the maximum index of an indexable enum.
     ///
-    /// Return `None` if `self` isn't an indexable enum. Meaning it is either a bitfield, or it is an enum that can't be used as an index.
-    pub fn find_index_enum_max(&self) -> Option<usize> {
-        if self.is_bitfield {
+    /// Returns `None` if this is a bitfield, or an enum that isn't sequential with a `*_MAX` enumerator.
+    pub fn find_index_enum_max_impl(
+        is_bitfield: bool,
+        enumerators: &[Enumerator],
+    ) -> Option<usize> {
+        if is_bitfield {
             return None;
         }
 
         // Sort by ordinal value. Allocates for every enum in the JSON, but should be OK (most enums are indexable).
         let enumerators = {
-            let mut enumerators = self.enumerators.clone();
+            let mut enumerators = enumerators.to_vec();
             enumerators.sort_by_key(|v| v.value.to_i64());
             enumerators
         };

--- a/godot-codegen/src/models/domain_mapping.rs
+++ b/godot-codegen/src/models/domain_mapping.rs
@@ -662,7 +662,7 @@ impl Enum {
             conv::make_enumerator_names(godot_class_name, &rust_enum_name, godot_enumerator_names)
         };
 
-        let enumerators = json_enum
+        let enumerators: Vec<Enumerator> = json_enum
             .values
             .iter()
             .zip(rust_enumerator_names)
@@ -670,6 +670,8 @@ impl Enum {
                 Enumerator::from_json(json_constant, rust_name, is_bitfield)
             })
             .collect();
+
+        let max_index = Enum::find_index_enum_max_impl(is_bitfield, &enumerators);
 
         Self {
             name: ident(&rust_enum_name),
@@ -679,6 +681,7 @@ impl Enum {
             is_private,
             is_exhaustive,
             enumerators,
+            max_index,
         }
     }
 }

--- a/godot-core/src/builtin/vectors/vector_axis.rs
+++ b/godot-core/src/builtin/vectors/vector_axis.rs
@@ -54,6 +54,27 @@ macro_rules! impl_vector_axis_enum {
                     )+
                 }
             }
+
+            fn values() -> &'static [Self] {
+                // For vector axis enums, all values are distinct, so both are the same
+                &[
+                    $( $AxisEnum::$axis, )+
+                ]
+            }
+
+            fn all_constants() -> &'static [crate::meta::inspect::EnumConstant<$AxisEnum>] {
+                use crate::meta::inspect::EnumConstant;
+                const { &[
+                    $(
+                        EnumConstant::new(
+                            stringify!($axis),
+                            concat!("AXIS_", stringify!($axis)),
+                            $AxisEnum::$axis as i32,
+                            $AxisEnum::$axis
+                        ),
+                    )+
+                ] }
+            }
         }
 
         impl GodotConvert for $AxisEnum {

--- a/godot-core/src/builtin/vectors/vector_axis.rs
+++ b/godot-core/src/builtin/vectors/vector_axis.rs
@@ -69,7 +69,6 @@ macro_rules! impl_vector_axis_enum {
                         EnumConstant::new(
                             stringify!($axis),
                             concat!("AXIS_", stringify!($axis)),
-                            $AxisEnum::$axis as i32,
                             $AxisEnum::$axis
                         ),
                     )+

--- a/godot-core/src/meta/inspect.rs
+++ b/godot-core/src/meta/inspect.rs
@@ -7,34 +7,32 @@
 
 //! Introspection metadata for Godot engine types.
 
-/// Metadata for a single enum constant.
+/// Metadata for a single enum or bitfield constant.
+///
+/// Returned by [`EngineEnum::all_constants()`][crate::obj::EngineEnum::all_constants] and
+/// [`EngineBitfield::all_constants()`][crate::obj::EngineBitfield::all_constants].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct EnumConstant<T: Copy + 'static> {
     rust_name: &'static str,
     godot_name: &'static str,
-    ord: i32,
     value: T,
 }
 
 impl<T: Copy + 'static> EnumConstant<T> {
     /// Creates a new enum constant metadata entry.
-    pub(crate) const fn new(
-        rust_name: &'static str,
-        godot_name: &'static str,
-        ord: i32,
-        value: T,
-    ) -> Self {
+    pub(crate) const fn new(rust_name: &'static str, godot_name: &'static str, value: T) -> Self {
         Self {
             rust_name,
             godot_name,
-            ord,
             value,
         }
     }
 
-    /// Rust name of the enum variant, usually without Prefix (e.g. `"ESCAPE"` for `Key::ESCAPE`).
+    /// Rust name of the constant, usually without prefix (e.g. `"ESCAPE"` for `Key::ESCAPE`).
     ///
-    /// This is returned by [`EngineEnum::as_str()`](crate::obj::EngineEnum::as_str()).
+    /// For enums, this is the value returned by [`EngineEnum::as_str()`](crate::obj::EngineEnum::as_str()) **if the value is unique.**
+    /// If multiple enum values share the same ordinal, then this function will return each one separately, while `as_str()` will return the
+    /// first one.
     pub const fn rust_name(&self) -> &'static str {
         self.rust_name
     }
@@ -44,12 +42,9 @@ impl<T: Copy + 'static> EnumConstant<T> {
         self.godot_name
     }
 
-    /// Ordinal value of this enum variant.
-    pub const fn ord(&self) -> i32 {
-        self.ord
-    }
-
-    /// The enum value itself.
+    /// The Rust value itself.
+    ///
+    /// Use `value().ord()` to get the ordinal value.
     pub const fn value(&self) -> T {
         self.value
     }

--- a/godot-core/src/meta/inspect.rs
+++ b/godot-core/src/meta/inspect.rs
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+//! Introspection metadata for Godot engine types.
+
+/// Metadata for a single enum constant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EnumConstant<T: Copy + 'static> {
+    rust_name: &'static str,
+    godot_name: &'static str,
+    ord: i32,
+    value: T,
+}
+
+impl<T: Copy + 'static> EnumConstant<T> {
+    /// Creates a new enum constant metadata entry.
+    pub(crate) const fn new(
+        rust_name: &'static str,
+        godot_name: &'static str,
+        ord: i32,
+        value: T,
+    ) -> Self {
+        Self {
+            rust_name,
+            godot_name,
+            ord,
+            value,
+        }
+    }
+
+    /// Rust name of the enum variant, usually without Prefix (e.g. `"ESCAPE"` for `Key::ESCAPE`).
+    ///
+    /// This is returned by [`EngineEnum::as_str()`](crate::obj::EngineEnum::as_str()).
+    pub const fn rust_name(&self) -> &'static str {
+        self.rust_name
+    }
+
+    /// Godot constant name (e.g. `"KEY_ESCAPE"` for `Key::ESCAPE`).
+    pub const fn godot_name(&self) -> &'static str {
+        self.godot_name
+    }
+
+    /// Ordinal value of this enum variant.
+    pub const fn ord(&self) -> i32 {
+        self.ord
+    }
+
+    /// The enum value itself.
+    pub const fn value(&self) -> T {
+        self.value
+    }
+}

--- a/godot-core/src/meta/inspect.rs
+++ b/godot-core/src/meta/inspect.rs
@@ -18,7 +18,10 @@ pub struct EnumConstant<T: Copy + 'static> {
     value: T,
 }
 
-impl<T: Copy + 'static> EnumConstant<T> {
+impl<T> EnumConstant<T>
+where
+    T: Copy + Eq + PartialEq + 'static,
+{
     /// Creates a new enum constant metadata entry.
     pub(crate) const fn new(rust_name: &'static str, godot_name: &'static str, value: T) -> Self {
         Self {

--- a/godot-core/src/meta/mod.rs
+++ b/godot-core/src/meta/mod.rs
@@ -57,6 +57,7 @@ mod uniform_object_deref;
 pub(crate) mod sealed;
 
 pub mod error;
+pub mod inspect;
 
 pub use args::*;
 pub use class_name::ClassName;

--- a/godot-core/src/obj/traits.rs
+++ b/godot-core/src/obj/traits.rs
@@ -201,6 +201,25 @@ pub trait EngineEnum: Copy {
     /// The equivalent name of the enumerator, as specified in Godot.
     ///
     /// If the value does not match one of the known enumerators, the empty string is returned.
+    ///
+    /// # Deprecation
+    /// Design change is due to the fact that Godot enums may have multiple constants with the same ordinal value, and `godot_name()` cannot
+    /// always return a unique name for it. So there are cases where this method returns unexpected results.
+    ///
+    /// To keep the old -- possibly incorrect -- behavior, you can write the following function. However, it runs in linear rather than constant
+    /// time (which is often OK, given that there are very few constants per enum).
+    /// ```
+    /// use godot::obj::EngineEnum;
+    ///
+    /// fn godot_name<T: EngineEnum + Eq + PartialEq + 'static>(value: T) -> &'static str {
+    ///     T::all_constants()
+    ///         .iter()
+    ///         .find(|c| c.value() == value)
+    ///         .map(|c| c.godot_name())
+    ///         .unwrap_or("") // Previous behavior.
+    /// }
+    /// ```
+    #[deprecated = "Moved to introspection API, see `EngineEnum::all_constants()` and `EnumConstant::godot_name()`"]
     fn godot_name(&self) -> &'static str;
 
     /// Returns a slice of distinct enum values.

--- a/godot-core/src/obj/traits.rs
+++ b/godot-core/src/obj/traits.rs
@@ -190,10 +190,10 @@ pub trait EngineEnum: Copy {
 
     /// The name of the enumerator, as it appears in Rust.
     ///
-    /// Note that **this may not match the Rust constant name!** In case of multiple constants with the same ordinal value, this method returns
-    /// the first one in the order of definition. For example, `LayoutDirection::LOCALE.as_str()` (ord 1) returns `"APPLICATION_LOCALE"`, because
-    /// that happens to be the first constant with ordinal `1`. See [`all_constants()`][Self::all_constants] for a more robust and general
-    /// approach to introspection of enum constants.
+    /// Note that **this may not match the Rust constant name.** In case of multiple constants with the same ordinal value, this method returns
+    /// the first one in the order of definition. For example, [`LayoutDirection::LOCALE.as_str()`][crate::classes::window::LayoutDirection::LOCALE]
+    /// (ord 1) returns `"APPLICATION_LOCALE"`, because that happens to be the first constant with ordinal `1`.
+    /// See [`all_constants()`][Self::all_constants] for a more robust and general approach to introspection of enum constants.
     ///
     /// If the value does not match one of the known enumerators, the empty string is returned.
     fn as_str(&self) -> &'static str;
@@ -205,9 +205,10 @@ pub trait EngineEnum: Copy {
 
     /// Returns a slice of distinct enum values.
     ///
-    /// This excludes MAX constants and deduplicates aliases, providing only meaningful enum values.
+    /// This excludes `MAX` constants at the end (existing only to express the number of enumerators) and deduplicates aliases,
+    /// providing only meaningful enum values. See [`all_constants()`][Self::all_constants] for a complete list of all constants.
     ///
-    /// This enables iteration over distinct enum variants:
+    /// Enables iteration over distinct enum variants:
     /// ```no_run
     /// use godot::classes::window;
     /// use godot::obj::EngineEnum;
@@ -220,18 +221,19 @@ pub trait EngineEnum: Copy {
 
     /// Returns metadata for all enum constants.
     ///
-    /// This includes all constants as they appear in the enum definition, including duplicates and MAX constants.
+    /// This includes all constants as they appear in the enum definition, including duplicates and `MAX` constants.
+    /// For a list of useful, distinct values, use [`values()`][Self::values].
     ///
-    /// This enables complete introspection and debugging:
+    /// Enables introspection of available constants:
     /// ```no_run
     /// use godot::classes::window;
     /// use godot::obj::EngineEnum;
     ///
     /// for constant in window::Mode::all_constants() {
-    ///     println!("* {}: {} (ord: {})",
+    ///     println!("* window::Mode.{} (original {}) has ordinal value {}.",
     ///         constant.rust_name(),
     ///         constant.godot_name(),
-    ///         constant.ord()
+    ///         constant.value().ord()
     ///     );
     /// }
     /// ```
@@ -254,6 +256,25 @@ pub trait EngineBitfield: Copy {
     fn is_set(self, flag: Self) -> bool {
         self.ord() & flag.ord() != 0
     }
+
+    /// Returns metadata for all bitfield constants.
+    ///
+    /// This includes all constants as they appear in the bitfield definition.
+    ///
+    /// Enables introspection of available constants:
+    /// ```no_run
+    /// use godot::global::KeyModifierMask;
+    /// use godot::obj::EngineBitfield;
+    ///
+    /// for constant in KeyModifierMask::all_constants() {
+    ///     println!("* KeyModifierMask.{} (original {}) has ordinal value {}.",
+    ///         constant.rust_name(),
+    ///         constant.godot_name(),
+    ///         constant.value().ord()
+    ///     );
+    /// }
+    /// ```
+    fn all_constants() -> &'static [EnumConstant<Self>];
 }
 
 /// Trait for enums that can be used as indices in arrays.

--- a/godot-macros/src/bench.rs
+++ b/godot-macros/src/bench.rs
@@ -8,7 +8,7 @@
 use proc_macro2::TokenStream;
 use quote::quote;
 
-use crate::util::{bail, KvParser};
+use crate::util::{bail, retain_attributes_except, KvParser};
 use crate::ParseResult;
 
 const DEFAULT_REPETITIONS: usize = 100;
@@ -42,7 +42,11 @@ pub fn attribute_bench(input_decl: venial::Item) -> ParseResult<TokenStream> {
 
     let body = &func.body;
 
+    // Filter out #[bench] itself, but preserve other attributes like #[allow], #[expect], etc.
+    let other_attributes = retain_attributes_except(&func.attributes, "bench");
+
     Ok(quote! {
+        #(#other_attributes)*
         pub fn #bench_name() {
             for _ in 0..#repetitions {
                 let __ret: #ret = #body;

--- a/godot-macros/src/itest.rs
+++ b/godot-macros/src/itest.rs
@@ -8,7 +8,9 @@
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
 
-use crate::util::{bail, extract_typename, ident, path_ends_with, KvParser};
+use crate::util::{
+    bail, extract_typename, ident, path_ends_with, retain_attributes_except, KvParser,
+};
 use crate::ParseResult;
 
 pub fn attribute_itest(input_item: venial::Item) -> ParseResult<TokenStream> {
@@ -85,7 +87,11 @@ pub fn attribute_itest(input_item: venial::Item) -> ParseResult<TokenStream> {
         plugin_name = ident("__GODOT_ITEST");
     };
 
+    // Filter out #[itest] itself, but preserve other attributes like #[allow], #[expect], etc.
+    let other_attributes = retain_attributes_except(&func.attributes, "itest");
+
     Ok(quote! {
+        #(#other_attributes)*
         pub fn #test_name(#param) #return_tokens {
             #body
         }

--- a/godot-macros/src/util/mod.rs
+++ b/godot-macros/src/util/mod.rs
@@ -85,6 +85,17 @@ pub(crate) use bail;
 pub(crate) use error;
 pub(crate) use require_api_version;
 
+/// Keeps all attributes except the one specified (e.g. `"itest"`).
+pub fn retain_attributes_except<'a>(
+    attributes: &'a [venial::Attribute],
+    macro_name: &'a str,
+) -> impl Iterator<Item = &'a venial::Attribute> {
+    attributes.iter().filter(move |attr| {
+        attr.get_single_path_segment()
+            .is_none_or(|segment| segment != macro_name)
+    })
+}
+
 pub fn reduce_to_signature(function: &venial::Function) -> venial::Function {
     let mut reduced = function.clone();
     reduced.vis_marker = None; // retained outside in the case of #[signal].

--- a/itest/rust/src/engine_tests/codegen_test.rs
+++ b/itest/rust/src/engine_tests/codegen_test.rs
@@ -190,3 +190,11 @@ trait TraitA {
 impl TraitA for CodegenTest3 {
     fn exit_tree(&mut self) {}
 }
+
+// Verifies that attributes (here #[expect]) are preserved by #[itest] macro.
+// See retain_attributes_except() function.
+#[itest]
+#[expect(unused_variables)]
+fn test_itest_macro_attribute_retention() {
+    let unused_var = 42; // Should not generate warning.
+}

--- a/itest/rust/src/engine_tests/engine_enum_test.rs
+++ b/itest/rust/src/engine_tests/engine_enum_test.rs
@@ -7,7 +7,8 @@
 
 use crate::framework::itest;
 
-use godot::global::{Key, KeyModifierMask};
+use godot::classes::{mesh, window};
+use godot::global::{InlineAlignment, Key, KeyModifierMask, Orientation};
 use godot::obj::{EngineBitfield, EngineEnum};
 
 #[itest]
@@ -45,4 +46,136 @@ fn enum_with_masked_bitfield_from_ord() {
     // Not implemented, as it's hard to achieve this without breaking forward compatibility; see make_enum_engine_trait_impl().
     // let back = Key::try_from_ord(31);
     // assert_eq!(back, None, "don't deserialize invalid bitmasked enum");
+}
+
+#[itest]
+fn enum_values_class() {
+    let expected_modes = [
+        window::Mode::WINDOWED,
+        window::Mode::MINIMIZED,
+        window::Mode::MAXIMIZED,
+        window::Mode::FULLSCREEN,
+        window::Mode::EXCLUSIVE_FULLSCREEN,
+    ];
+
+    assert_eq!(window::Mode::values(), &expected_modes);
+}
+
+#[itest]
+fn enum_values_global() {
+    let expected_orientations = [Orientation::VERTICAL, Orientation::HORIZONTAL];
+
+    assert_eq!(Orientation::values(), &expected_orientations);
+}
+
+#[itest]
+fn enum_values_duplicates() {
+    // InlineAlignment has many duplicate ordinals, but values() should return only distinct ones
+    // The order matches the declaration order in the JSON API, not ordinal order
+    let expected = [
+        (InlineAlignment::TOP_TO, 0, true),
+        (InlineAlignment::CENTER_TO, 1, true),
+        (InlineAlignment::BASELINE_TO, 3, true),
+        (InlineAlignment::BOTTOM_TO, 2, true),
+        (InlineAlignment::TO_TOP, 0, false), // duplicate of TOP_TO
+        (InlineAlignment::TO_CENTER, 4, true),
+        (InlineAlignment::TO_BASELINE, 8, true),
+        (InlineAlignment::TO_BOTTOM, 12, true),
+        (InlineAlignment::TOP, 0, false), // duplicate of TOP_TO
+        (InlineAlignment::CENTER, 5, true),
+        (InlineAlignment::BOTTOM, 14, true),
+        (InlineAlignment::IMAGE_MASK, 3, false), // duplicate of BASELINE_TO
+        (InlineAlignment::TEXT_MASK, 12, false), // duplicate of TO_BOTTOM
+    ];
+
+    let all_constants = InlineAlignment::all_constants();
+    let mut expected_distinct_values = vec![];
+    for ((value, ord, is_distinct), c) in expected.into_iter().zip(all_constants) {
+        if is_distinct {
+            assert_eq!(c.rust_name(), value.as_str()); // First distinct.
+            expected_distinct_values.push(value);
+        }
+
+        assert_eq!(c.value(), value);
+        assert_eq!(c.ord(), ord);
+    }
+
+    assert_eq!(InlineAlignment::values(), &expected_distinct_values);
+
+    // Some known duplicates.
+    assert_eq!(InlineAlignment::TOP_TO, InlineAlignment::TO_TOP); // ord 0
+    assert_eq!(InlineAlignment::TOP_TO, InlineAlignment::TOP); // ord 0
+    assert_eq!(InlineAlignment::BASELINE_TO, InlineAlignment::IMAGE_MASK); // ord 3
+    assert_eq!(InlineAlignment::TO_BOTTOM, InlineAlignment::TEXT_MASK); // ord 12
+}
+
+#[itest]
+fn enum_values_max_excluded() {
+    let expected_array_types = [
+        mesh::ArrayType::VERTEX,
+        mesh::ArrayType::NORMAL,
+        mesh::ArrayType::TANGENT,
+        mesh::ArrayType::COLOR,
+        mesh::ArrayType::TEX_UV,
+        mesh::ArrayType::TEX_UV2,
+        mesh::ArrayType::CUSTOM0,
+        mesh::ArrayType::CUSTOM1,
+        mesh::ArrayType::CUSTOM2,
+        mesh::ArrayType::CUSTOM3,
+        mesh::ArrayType::BONES,
+        mesh::ArrayType::WEIGHTS,
+        mesh::ArrayType::INDEX,
+    ];
+
+    let array_types = mesh::ArrayType::values();
+    assert_eq!(array_types, &expected_array_types);
+    assert!(
+        !array_types.contains(&mesh::ArrayType::MAX),
+        "ArrayType::MAX should be excluded from values()"
+    );
+
+    // However, it should still be present in all_constants().
+    let all_constants = mesh::ArrayType::all_constants();
+    assert!(
+        all_constants
+            .iter()
+            .any(|c| c.value() == mesh::ArrayType::MAX),
+        "ArrayType::MAX should be present in all_constants()"
+    );
+}
+
+#[itest]
+fn enum_all_constants() {
+    let constants = InlineAlignment::all_constants();
+    assert!(
+        constants.len() > InlineAlignment::values().len(),
+        "all_constants() should include duplicates"
+    );
+
+    // Check one known constant.
+    let first = constants[0];
+    assert_eq!(first.rust_name(), "TOP_TO");
+    assert_eq!(first.godot_name(), "INLINE_ALIGNMENT_TOP_TO");
+    assert_eq!(first.ord(), 0);
+    assert_eq!(first.value(), InlineAlignment::TOP_TO);
+
+    // Check specific constants at known indices, with equal ordinals.
+    let known_a = constants[2];
+    let known_b = constants[11];
+
+    assert_eq!(known_a.ord(), 3);
+    assert_eq!(known_a.rust_name(), "BASELINE_TO");
+    assert_eq!(known_a.godot_name(), "INLINE_ALIGNMENT_BASELINE_TO");
+    assert_eq!(known_a.value(), InlineAlignment::BASELINE_TO);
+
+    assert_eq!(known_b.ord(), 3);
+    assert_eq!(known_b.rust_name(), "IMAGE_MASK");
+    assert_eq!(known_b.godot_name(), "INLINE_ALIGNMENT_IMAGE_MASK");
+    assert_eq!(known_b.value(), InlineAlignment::IMAGE_MASK);
+
+    // "Front-end" values are equal, too.
+    assert_eq!(
+        InlineAlignment::IMAGE_MASK.ord(),
+        InlineAlignment::BASELINE_TO.ord()
+    );
 }

--- a/itest/rust/src/engine_tests/engine_enum_test.rs
+++ b/itest/rust/src/engine_tests/engine_enum_test.rs
@@ -97,7 +97,7 @@ fn enum_values_duplicates() {
         }
 
         assert_eq!(c.value(), value);
-        assert_eq!(c.ord(), ord);
+        assert_eq!(c.value().ord(), ord);
     }
 
     assert_eq!(InlineAlignment::values(), &expected_distinct_values);
@@ -156,26 +156,38 @@ fn enum_all_constants() {
     let first = constants[0];
     assert_eq!(first.rust_name(), "TOP_TO");
     assert_eq!(first.godot_name(), "INLINE_ALIGNMENT_TOP_TO");
-    assert_eq!(first.ord(), 0);
     assert_eq!(first.value(), InlineAlignment::TOP_TO);
+    assert_eq!(first.value().ord(), 0);
 
     // Check specific constants at known indices, with equal ordinals.
     let known_a = constants[2];
     let known_b = constants[11];
 
-    assert_eq!(known_a.ord(), 3);
     assert_eq!(known_a.rust_name(), "BASELINE_TO");
     assert_eq!(known_a.godot_name(), "INLINE_ALIGNMENT_BASELINE_TO");
     assert_eq!(known_a.value(), InlineAlignment::BASELINE_TO);
+    assert_eq!(known_a.value().ord(), 3);
 
-    assert_eq!(known_b.ord(), 3);
     assert_eq!(known_b.rust_name(), "IMAGE_MASK");
     assert_eq!(known_b.godot_name(), "INLINE_ALIGNMENT_IMAGE_MASK");
     assert_eq!(known_b.value(), InlineAlignment::IMAGE_MASK);
+    assert_eq!(known_b.value().ord(), 3);
 
     // "Front-end" values are equal, too.
     assert_eq!(
         InlineAlignment::IMAGE_MASK.ord(),
         InlineAlignment::BASELINE_TO.ord()
     );
+}
+
+#[itest]
+fn bitfield_all_constants() {
+    let shift_constant = KeyModifierMask::all_constants()
+        .iter()
+        .find(|c| c.rust_name() == "SHIFT")
+        .expect("SHIFT constant should exist");
+
+    assert_eq!(shift_constant.godot_name(), "KEY_MASK_SHIFT");
+    assert_eq!(shift_constant.value(), KeyModifierMask::SHIFT);
+    assert_eq!(shift_constant.value().ord(), 1 << 25);
 }

--- a/itest/rust/src/object_tests/dynamic_call_test.rs
+++ b/itest/rust/src/object_tests/dynamic_call_test.rs
@@ -140,7 +140,7 @@ fn dynamic_call_parameter_mismatch() {
     obj.free();
 }
 
-// There seems to be a weird bug where running *only* this test with #[itest(focus)] causes panic, which then causes a
+// There seems to be a weird bug where running *only* this test with #[itest (focus)] causes panic, which then causes a
 // follow-up failure of Gd::bind_mut(), preventing benchmarks from being run. Doesn't happen with #[itest], when running all.
 #[itest]
 fn dynamic_call_with_panic() {

--- a/itest/rust/src/object_tests/enum_test.rs
+++ b/itest/rust/src/object_tests/enum_test.rs
@@ -9,6 +9,7 @@ use crate::framework::itest;
 use godot::builtin::varray;
 use godot::classes::input::CursorShape;
 use godot::classes::mesh::PrimitiveType;
+use godot::classes::window::LayoutDirection;
 use godot::classes::{time, ArrayMesh};
 use godot::global::{Key, Orientation};
 use godot::obj::NewGd;
@@ -84,6 +85,9 @@ fn enum_as_str() {
     assert_eq!(Key::ESCAPE.as_str(), "ESCAPE");
     assert_eq!(Key::TAB.as_str(), "TAB");
     assert_eq!(Key::A.as_str(), "A");
+
+    #[cfg(since_api = "4.4")] // Deprecated in Godot, LOCALE is now alias for APPLICATION_LOCALE.
+    assert_eq!(LayoutDirection::LOCALE.as_str(), "APPLICATION_LOCALE");
 }
 
 #[itest]

--- a/itest/rust/src/object_tests/enum_test.rs
+++ b/itest/rust/src/object_tests/enum_test.rs
@@ -62,7 +62,7 @@ fn enum_hash() {
     months.insert(time::Month::NOVEMBER);
     months.insert(time::Month::DECEMBER);
 
-    assert_eq!(months.len(), 12);
+    assert_eq!(months.len(), 12, "hash collisions in constants");
 }
 
 // Testing https://github.com/godot-rust/gdext/issues/335

--- a/itest/rust/src/object_tests/enum_test.rs
+++ b/itest/rust/src/object_tests/enum_test.rs
@@ -12,7 +12,7 @@ use godot::classes::mesh::PrimitiveType;
 use godot::classes::window::LayoutDirection;
 use godot::classes::{time, ArrayMesh};
 use godot::global::{Key, Orientation};
-use godot::obj::NewGd;
+use godot::obj::{EngineEnum, NewGd};
 use std::collections::HashSet;
 
 #[itest]
@@ -94,6 +94,29 @@ fn enum_as_str() {
 fn enum_godot_name() {
     use godot::obj::EngineEnum;
     assert_eq!(
+        godot_name(Orientation::VERTICAL),
+        Orientation::VERTICAL.as_str()
+    );
+    assert_eq!(
+        godot_name(Orientation::HORIZONTAL),
+        Orientation::HORIZONTAL.as_str()
+    );
+
+    assert_eq!(godot_name(Key::NONE), "KEY_NONE");
+    assert_eq!(godot_name(Key::SPECIAL), "KEY_SPECIAL");
+    assert_eq!(godot_name(Key::ESCAPE), "KEY_ESCAPE");
+    assert_eq!(godot_name(Key::TAB), "KEY_TAB");
+    assert_eq!(godot_name(Key::A), "KEY_A");
+
+    // Unknown enumerators (might come from the future).
+    assert_eq!(godot_name(Key::from_ord(1234)), "");
+}
+
+#[itest]
+#[expect(deprecated)]
+fn enum_godot_name_deprecated() {
+    use godot::obj::EngineEnum;
+    assert_eq!(
         Orientation::VERTICAL.godot_name(),
         Orientation::VERTICAL.as_str()
     );
@@ -107,4 +130,15 @@ fn enum_godot_name() {
     assert_eq!(Key::ESCAPE.godot_name(), "KEY_ESCAPE");
     assert_eq!(Key::TAB.godot_name(), "KEY_TAB");
     assert_eq!(Key::A.godot_name(), "KEY_A");
+
+    // Unknown enumerators (might come from the future).
+    assert_eq!(Key::from_ord(1234).godot_name(), "");
+}
+
+fn godot_name<T: EngineEnum + Eq + PartialEq + 'static>(value: T) -> &'static str {
+    T::all_constants()
+        .iter()
+        .find(|c| c.value() == value)
+        .map(|c| c.godot_name())
+        .unwrap_or("") // Previous behavior.
 }

--- a/itest/rust/src/register_tests/constant_test.rs
+++ b/itest/rust/src/register_tests/constant_test.rs
@@ -180,7 +180,7 @@ godot::sys::plugin_add!(
 macro_rules! test_enum_export {
     (
         $class:ty, $enum_name:ident, [$($enumerators:ident),* $(,)?];
-        // Include the `attr` here to, so we can easily do things like `#[itest(focus)]`.
+        // Include the `attr` here too, so we can easily do things like `#[itest (focus)]`.
         #$attr:tt
         fn $test_name:ident() { .. }
     ) => {


### PR DESCRIPTION
Closes #600.

Adds new APIs for introspection of enums and bitfields:
- `EngineEnum::all_constants()` listing every constant with name, Godot name and value.
- `EngineEnum::values()` listing deduplicated, and `MAX`-stripped (aka meaningful) values.
- `EngineBitfield::all_constants()`.