### PR TITLE
Start phasing out `dict!` macro in favor of `vdict!`

### DIFF
--- a/godot-core/src/builtin/collections/array.rs
+++ b/godot-core/src/builtin/collections/array.rs
@@ -1531,7 +1531,7 @@ impl<T: ArrayElement> PartialOrd for Array<T> {
 /// # See also
 /// To create an `Array` of variants, see the [`varray!`] macro.
 ///
-/// For dictionaries, a similar macro [`dict!`] exists.
+/// For dictionaries, a similar macro [`vdict!`] exists.
 #[macro_export]
 macro_rules! array {
     ($($elements:expr),* $(,)?) => {
@@ -1558,7 +1558,7 @@ macro_rules! array {
 /// # See also
 /// To create a typed `Array` with a single element type, see the [`array!`] macro.
 ///
-/// For dictionaries, a similar macro [`dict!`] exists.
+/// For dictionaries, a similar macro [`vdict!`] exists.
 ///
 /// To construct slices of variants, use [`vslice!`].
 #[macro_export]
@@ -1604,7 +1604,7 @@ macro_rules! varray {
 /// # See also
 /// To create typed and untyped `Array`s, use the [`array!`] and [`varray!`] macros respectively.
 ///
-/// For dictionaries, a similar macro [`dict!`] exists.
+/// For dictionaries, a similar macro [`vdict!`] exists.
 #[macro_export]
 macro_rules! vslice {
     // Note: use to_variant() and not Variant::from(), as that works with both references and values

--- a/godot-core/src/builtin/collections/dictionary.rs
+++ b/godot-core/src/builtin/collections/dictionary.rs
@@ -34,7 +34,7 @@ use std::{fmt, ptr};
 /// dict.set(coord, "Tile77");
 ///
 /// // Or create the same dictionary in a single expression.
-/// let dict = dict! {
+/// let dict = vdict! {
 ///    "str": "Hello",
 ///    "num": 23,
 ///    coord: "Tile77",
@@ -762,10 +762,10 @@ fn u8_to_bool(u: u8) -> bool {
 ///
 /// # Example
 /// ```no_run
-/// use godot::builtin::{dict, Variant};
+/// use godot::builtin::{vdict, Variant};
 ///
 /// let key = "my_key";
-/// let d = dict! {
+/// let d = vdict! {
 ///     "key1": 10,
 ///     "another": Variant::nil(),
 ///     key: true,
@@ -777,7 +777,7 @@ fn u8_to_bool(u: u8) -> bool {
 ///
 /// For arrays, similar macros [`array!`][macro@crate::builtin::array] and [`varray!`][macro@crate::builtin::varray] exist.
 #[macro_export]
-macro_rules! dict {
+macro_rules! vdict {
     ($($key:tt: $value:expr),* $(,)?) => {
         {
             let mut d = $crate::builtin::Dictionary::new();
@@ -789,5 +789,15 @@ macro_rules! dict {
             )*
             d
         }
+    };
+}
+
+#[macro_export]
+#[deprecated = "Migrate to `vdict!`. The name `dict!` will be used in the future for typed dictionaries."]
+macro_rules! dict {
+    ($($key:tt: $value:expr),* $(,)?) => {
+        $crate::vdict!(
+            $($key: $value),*
+        )
     };
 }

--- a/godot-core/src/builtin/mod.rs
+++ b/godot-core/src/builtin/mod.rs
@@ -14,7 +14,8 @@
 //! [extended documentation page](../__docs/index.html#builtin-api-design).
 
 // Re-export macros.
-pub use crate::{array, dict, real, reals, varray};
+#[allow(deprecated)] // dict
+pub use crate::{array, dict, real, reals, varray, vdict};
 
 // Re-export generated enums.
 pub use crate::gen::central::global_reexported_enums::{Corner, EulerOrder, Side, VariantOperator};
@@ -48,7 +49,7 @@ pub mod __prelude_reexport {
     pub use vectors::*;
 
     pub use super::{EulerOrder, Side, VariantOperator, VariantType};
-    pub use crate::{array, dict, real, reals, varray, vslice};
+    pub use crate::{array, real, reals, varray, vdict, vslice};
 }
 
 pub use __prelude_reexport::*;

--- a/godot-core/src/registry/rpc_config.rs
+++ b/godot-core/src/registry/rpc_config.rs
@@ -10,7 +10,7 @@ use crate::classes::multiplayer_api::RpcMode;
 use crate::classes::multiplayer_peer::TransferMode;
 use crate::classes::Node;
 use crate::meta::{AsArg, ToGodot};
-use crate::{arg_into_ref, dict};
+use crate::{arg_into_ref, vdict};
 
 /// Configuration for a remote procedure call, used with `#[rpc(config = ...)]`.
 ///
@@ -45,7 +45,7 @@ impl RpcConfig {
 
     /// Returns a [`Dictionary`] populated with the values required for a call to [`Node::rpc_config()`].
     pub fn to_dictionary(&self) -> Dictionary {
-        dict! {
+        vdict! {
             "rpc_mode": self.rpc_mode,
             "transfer_mode": self.transfer_mode,
             "call_local": self.call_local,

--- a/itest/rust/build.rs
+++ b/itest/rust/build.rs
@@ -193,7 +193,7 @@ fn collect_inputs() -> Vec<Input> {
 
     pushs!(inputs; Dictionary, Dictionary,
         r#"{"key": 83, -3: Vector2(1, 2), 0.03: true}"#,
-        dict! { "key": 83, (-3): Vector2::new(1.0, 2.0), 0.03: true },
+        vdict! { "key": 83, (-3): Vector2::new(1.0, 2.0), 0.03: true },
         true, true, None
     );
 

--- a/itest/rust/src/builtin_tests/containers/callable_test.rs
+++ b/itest/rust/src/builtin_tests/containers/callable_test.rs
@@ -7,7 +7,7 @@
 
 use crate::framework::itest;
 use godot::builtin::{
-    array, dict, varray, vslice, Array, Callable, Color, GString, NodePath, StringName, Variant,
+    array, varray, vdict, vslice, Array, Callable, Color, GString, NodePath, StringName, Variant,
     VariantArray, Vector2,
 };
 use godot::classes::{Node2D, Object, RefCounted};
@@ -102,7 +102,7 @@ fn callable_object_method() {
 #[cfg(since_api = "4.3")]
 fn callable_variant_method() {
     // Dictionary
-    let dict = dict! { "one": 1, "value": 2 };
+    let dict = vdict! { "one": 1, "value": 2 };
     let dict_get = Callable::from_variant_method(&dict.to_variant(), "get");
     assert_eq!(dict_get.call(vslice!["one"]), 1.to_variant());
 

--- a/itest/rust/src/builtin_tests/containers/dictionary_test.rs
+++ b/itest/rust/src/builtin_tests/containers/dictionary_test.rs
@@ -7,7 +7,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use godot::builtin::{dict, varray, Dictionary, Variant};
+use godot::builtin::{varray, vdict, Dictionary, Variant};
 use godot::meta::{FromGodot, ToGodot};
 use godot::sys::GdextBuild;
 
@@ -55,7 +55,7 @@ fn dictionary_from() {
 
 #[itest]
 fn dictionary_macro() {
-    let dictionary = dict! {
+    let dictionary = vdict! {
         "foo": 0,
         "bar": true,
         "baz": "foobar"
@@ -74,11 +74,11 @@ fn dictionary_macro() {
         "key = \"baz\""
     );
 
-    let empty = dict!();
+    let empty = vdict!();
     assert!(empty.is_empty());
 
     let key = "num";
-    let dict_complex = dict! {
+    let dict_complex = vdict! {
         key: 10,
         "bool": true,
         (1 + 2): Variant::nil(),
@@ -90,11 +90,11 @@ fn dictionary_macro() {
 
 #[itest]
 fn dictionary_clone() {
-    let subdictionary = dict! {
+    let subdictionary = vdict! {
         "baz": true,
         "foobar": false
     };
-    let dictionary = dict! {
+    let dictionary = vdict! {
         "foo": 0,
         "bar": subdictionary.clone()
     };
@@ -109,17 +109,17 @@ fn dictionary_clone() {
 fn dictionary_hash() {
     use godot::builtin::Vector2i;
 
-    let a = dict! {
+    let a = vdict! {
         "foo": 0,
         "bar": true,
         (Vector2i::new(4, -1)): "foobar",
     };
-    let b = dict! {
+    let b = vdict! {
         "foo": 0,
         "bar": true,
         (Vector2i::new(4, -1)): "foobar" // No comma to test macro.
     };
-    let c = dict! {
+    let c = vdict! {
         "foo": 0,
         (Vector2i::new(4, -1)): "foobar",
         "bar": true,
@@ -133,16 +133,16 @@ fn dictionary_hash() {
     );
 
     // NaNs are not equal (since Godot 4.2) but share same hash.
-    assert_eq!(dict! {772: f32::NAN}.hash(), dict! {772: f32::NAN}.hash());
+    assert_eq!(vdict! {772: f32::NAN}.hash(), vdict! {772: f32::NAN}.hash());
 }
 
 #[itest]
 fn dictionary_duplicate_deep() {
-    let subdictionary = dict! {
+    let subdictionary = vdict! {
         "baz": true,
         "foobar": false
     };
-    let dictionary = dict! {
+    let dictionary = vdict! {
         "foo": 0,
         "bar": subdictionary.clone()
     };
@@ -157,11 +157,11 @@ fn dictionary_duplicate_deep() {
 
 #[itest]
 fn dictionary_duplicate_shallow() {
-    let subdictionary = dict! {
+    let subdictionary = vdict! {
         "baz": true,
         "foobar": false
     };
-    let dictionary = dict! {
+    let dictionary = vdict! {
         "foo": 0,
         "bar": subdictionary.clone()
     };
@@ -181,7 +181,7 @@ fn dictionary_duplicate_shallow() {
 
 #[itest]
 fn dictionary_get() {
-    let dictionary = dict! {
+    let dictionary = vdict! {
         "foo": 0,
         "bar": true,
         "baz": "foobar",
@@ -212,7 +212,7 @@ fn dictionary_get() {
 
 #[itest]
 fn dictionary_at() {
-    let dictionary = dict! {
+    let dictionary = vdict! {
         "foo": 0,
         "baz": "foobar",
         "nil": Variant::nil(),
@@ -228,15 +228,15 @@ fn dictionary_at() {
 
 #[itest]
 fn dictionary_set() {
-    let mut dictionary = dict! { "zero": 0, "one": 1 };
+    let mut dictionary = vdict! { "zero": 0, "one": 1 };
 
     dictionary.set("zero", 2);
-    assert_eq!(dictionary, dict! { "zero": 2, "one": 1 });
+    assert_eq!(dictionary, vdict! { "zero": 2, "one": 1 });
 }
 
 #[itest]
 fn dictionary_set_readonly() {
-    let mut dictionary = dict! { "zero": 0, "one": 1 }.into_read_only();
+    let mut dictionary = vdict! { "zero": 0, "one": 1 }.into_read_only();
 
     #[cfg(debug_assertions)]
     expect_panic("Mutating read-only dictionary in Debug mode", || {
@@ -251,7 +251,7 @@ fn dictionary_set_readonly() {
 
 #[itest]
 fn dictionary_insert() {
-    let mut dictionary = dict! {
+    let mut dictionary = vdict! {
         "foo": 0,
         "bar": 1,
     };
@@ -276,13 +276,13 @@ fn dictionary_insert() {
 
 #[itest]
 fn dictionary_insert_multiple() {
-    let mut dictionary = dict! {};
+    let mut dictionary = vdict! {};
     assert!(dictionary.is_empty());
 
     dictionary.set(1, true);
     assert_eq!(dictionary.get(1), Some(true.to_variant()));
 
-    let mut other = dict! {};
+    let mut other = vdict! {};
     assert!(other.is_empty());
 
     other.set(1, 2);
@@ -290,7 +290,7 @@ fn dictionary_insert_multiple() {
 }
 #[itest]
 fn dictionary_insert_long() {
-    let mut dictionary = dict! {};
+    let mut dictionary = vdict! {};
     let old = dictionary.insert("abcdefghijklmnopqrstuvwxyz", "zabcdefghijklmnopqrstuvwxy");
     assert_eq!(old, None);
     assert_eq!(
@@ -301,12 +301,12 @@ fn dictionary_insert_long() {
 
 #[itest]
 fn dictionary_extend() {
-    let mut dictionary = dict! {
+    let mut dictionary = vdict! {
         "foo": 0,
         "bar": true,
     };
     assert_eq!(dictionary.get("foo"), Some(0.to_variant()));
-    let other = dict! {
+    let other = vdict! {
         "bar": "new",
         "baz": Variant::nil(),
     };
@@ -314,10 +314,10 @@ fn dictionary_extend() {
     assert_eq!(dictionary.get("bar"), Some(true.to_variant()));
     assert_eq!(dictionary.get("baz"), Some(Variant::nil()));
 
-    let mut dictionary = dict! {
+    let mut dictionary = vdict! {
         "bar": true,
     };
-    let other = dict! {
+    let other = vdict! {
         "bar": "new",
     };
     dictionary.extend_dictionary(&other, true);
@@ -326,7 +326,7 @@ fn dictionary_extend() {
 
 #[itest]
 fn dictionary_remove() {
-    let mut dictionary = dict! {
+    let mut dictionary = vdict! {
         "foo": 0,
     };
     assert_eq!(dictionary.remove("foo"), Some(0.to_variant()));
@@ -336,7 +336,7 @@ fn dictionary_remove() {
 
 #[itest]
 fn dictionary_clear() {
-    let mut dictionary = dict! {
+    let mut dictionary = vdict! {
         "foo": 0,
         "bar": true,
         "baz": "foobar"
@@ -349,7 +349,7 @@ fn dictionary_clear() {
 
 #[itest]
 fn dictionary_find_key() {
-    let dictionary = dict! {
+    let dictionary = vdict! {
         "foo": 0,
         "bar": true,
     };
@@ -360,7 +360,7 @@ fn dictionary_find_key() {
 
 #[itest]
 fn dictionary_contains_keys() {
-    let dictionary = dict! {
+    let dictionary = vdict! {
         "foo": 0,
         "bar": true,
     };
@@ -380,7 +380,7 @@ fn dictionary_contains_keys() {
 
 #[itest]
 fn dictionary_keys_values() {
-    let dictionary = dict! {
+    let dictionary = vdict! {
         "foo": 0,
         "bar": true,
     };
@@ -391,20 +391,20 @@ fn dictionary_keys_values() {
 
 #[itest]
 fn dictionary_equal() {
-    assert_eq!(dict! {"foo": "bar"}, dict! {"foo": "bar"});
-    assert_ne!(dict! {"foo": "bar"}, dict! {"bar": "foo"});
+    assert_eq!(vdict! {"foo": "bar"}, vdict! {"foo": "bar"});
+    assert_ne!(vdict! {"foo": "bar"}, vdict! {"bar": "foo"});
 
     // Changed in https://github.com/godotengine/godot/pull/74588.
     if GdextBuild::before_api("4.2") {
-        assert_eq!(dict! {1: f32::NAN}, dict! {1: f32::NAN});
+        assert_eq!(vdict! {1: f32::NAN}, vdict! {1: f32::NAN});
     } else {
-        assert_ne!(dict! {1: f32::NAN}, dict! {1: f32::NAN});
+        assert_ne!(vdict! {1: f32::NAN}, vdict! {1: f32::NAN});
     }
 }
 
 #[itest]
 fn dictionary_iter() {
-    let dictionary = dict! {
+    let dictionary = vdict! {
         "foo": 0,
         "bar": true,
         "baz": "foobar",
@@ -430,7 +430,7 @@ fn dictionary_iter_size_hint() {
     assert_eq!(iter.size_hint(), (0, Some(0)));
 
     // Test a full dictionary being emptied.
-    let dictionary = dict! {
+    let dictionary = vdict! {
         "foo": 0,
         "bar": true,
         "baz": "foobar",
@@ -476,7 +476,7 @@ fn dictionary_iter_equals_big() {
 
 #[itest]
 fn dictionary_iter_insert() {
-    let dictionary = dict! {
+    let dictionary = vdict! {
         "foo": 0,
         "bar": true,
         "baz": "foobar",
@@ -500,7 +500,7 @@ fn dictionary_iter_insert() {
 
 #[itest]
 fn dictionary_iter_insert_after_completion() {
-    let dictionary = dict! {
+    let dictionary = vdict! {
         "foo": 0,
         "bar": true,
         "baz": "foobar",
@@ -539,7 +539,7 @@ fn dictionary_iter_big() {
 
 #[itest]
 fn dictionary_iter_simultaneous() {
-    let dictionary = dict! {
+    let dictionary = vdict! {
         "foo": 10,
         "bar": true,
         "baz": "foobar",
@@ -615,7 +615,7 @@ fn dictionary_iter_panics() {
 
 #[itest]
 fn dictionary_iter_clear() {
-    let dictionary = dict! {
+    let dictionary = vdict! {
         "foo": 0,
         "bar": true,
         "baz": "foobar",
@@ -656,7 +656,7 @@ fn dictionary_iter_clear() {
 
 #[itest]
 fn dictionary_iter_erase() {
-    let dictionary = dict! {
+    let dictionary = vdict! {
         "foo": 0,
         "bar": true,
         "baz": "foobar",
@@ -701,7 +701,7 @@ fn dictionary_should_format_with_display() {
     let d = Dictionary::new();
     assert_eq!(format!("{d}"), "{  }");
 
-    let d = dict! {
+    let d = vdict! {
         "one": 1,
         "two": true,
         "three": Variant::nil()

--- a/itest/rust/src/builtin_tests/containers/packed_array_test.rs
+++ b/itest/rust/src/builtin_tests/containers/packed_array_test.rs
@@ -7,7 +7,7 @@
 
 use crate::framework::{expect_panic, itest};
 use godot::builtin::{
-    dict, Color, GString, PackedByteArray, PackedColorArray, PackedFloat32Array, PackedInt32Array,
+    vdict, Color, GString, PackedByteArray, PackedColorArray, PackedFloat32Array, PackedInt32Array,
     PackedStringArray, Variant,
 };
 use godot::prelude::ToGodot;
@@ -371,7 +371,7 @@ fn packed_byte_array_encode_decode() {
 
 #[itest]
 fn packed_byte_array_encode_decode_variant() {
-    let variant = dict! {
+    let variant = vdict! {
         "s": "some string",
         "i": -12345,
     }

--- a/itest/rust/src/builtin_tests/containers/variant_test.rs
+++ b/itest/rust/src/builtin_tests/containers/variant_test.rs
@@ -10,7 +10,7 @@ use std::fmt;
 use std::fmt::Display;
 
 use godot::builtin::{
-    array, dict, varray, vslice, Array, Color, GString, NodePath, PackedInt32Array,
+    array, varray, vdict, vslice, Array, Color, GString, NodePath, PackedInt32Array,
     PackedStringArray, Projection, Quaternion, Signal, StringName, Transform2D, Transform3D,
     Variant, Vector2, Vector2i, Vector3, Vector3i,
 };
@@ -618,7 +618,7 @@ fn variant_stringify() {
         gstr("[1, \"hello\", false]")
     );
     assert_eq!(
-        dict! { "KEY": 50 }.to_variant().stringify(),
+        vdict! { "KEY": 50 }.to_variant().stringify(),
         gstr("{ \"KEY\": 50 }")
     );
 }
@@ -628,7 +628,7 @@ fn variant_booleanize() {
     assert!(gstr("string").to_variant().booleanize());
     assert!(10.to_variant().booleanize());
     assert!(varray![""].to_variant().booleanize());
-    assert!(dict! { "Key": 50 }.to_variant().booleanize());
+    assert!(vdict! { "Key": 50 }.to_variant().booleanize());
 
     assert!(!Dictionary::new().to_variant().booleanize());
     assert!(!varray![].to_variant().booleanize());
@@ -640,7 +640,7 @@ fn variant_booleanize() {
 #[itest]
 fn variant_hash() {
     let hash_is_not_0 = [
-        dict! {}.to_variant(),
+        vdict! {}.to_variant(),
         gstr("").to_variant(),
         varray![].to_variant(),
     ];
@@ -648,7 +648,7 @@ fn variant_hash() {
         gstr("string").to_variant(),
         varray![false, true, 4, "7"].to_variant(),
         0.to_variant(),
-        dict! { 0 : dict!{ 0: 1 } }.to_variant(),
+        vdict! { 0 : vdict!{ 0: 1 } }.to_variant(),
     ];
 
     for variant in hash_is_not_0 {
@@ -662,7 +662,7 @@ fn variant_hash() {
 
     // It's not guaranteed that different object will have different hash, but it is
     // extremely unlikely for a collision to happen.
-    assert_ne!(dict! { 0: dict! { 0: 0 } }, dict! { 0: dict! { 0: 1 } });
+    assert_ne!(vdict! { 0: vdict! { 0: 0 } }, vdict! { 0: vdict! { 0: 1 } });
 }
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------

--- a/itest/rust/src/builtin_tests/convert_test.rs
+++ b/itest/rust/src/builtin_tests/convert_test.rs
@@ -6,7 +6,7 @@
  */
 
 use godot::builtin::{
-    array, dict, Array, Dictionary, GString, NodePath, StringName, Variant, VariantArray, Vector2,
+    array, vdict, Array, Dictionary, GString, NodePath, StringName, Variant, VariantArray, Vector2,
     Vector2Axis,
 };
 use godot::classes::{Node, Resource};
@@ -110,7 +110,7 @@ impl ToGodot for ConvertedStruct {
     type ToVia<'v> = Dictionary;
 
     fn to_godot(&self) -> Self::ToVia<'_> {
-        dict! {
+        vdict! {
             "a": self.a,
             "b": self.b,
         }
@@ -159,7 +159,7 @@ fn custom_convert_roundtrip() {
 // method of `Variant` as they should be.
 #[itest]
 fn custom_convert_error_from_variant() {
-    let missing_a = dict! {
+    let missing_a = vdict! {
         "b": -0.001
     };
     let err = missing_a
@@ -172,7 +172,7 @@ fn custom_convert_error_from_variant() {
         ConvertedStruct::MISSING_KEY_A
     );
 
-    let missing_b = dict! {
+    let missing_b = vdict! {
         "a": 58,
     };
     let err = missing_b
@@ -185,7 +185,7 @@ fn custom_convert_error_from_variant() {
         ConvertedStruct::MISSING_KEY_B
     );
 
-    let too_many_keys = dict! {
+    let too_many_keys = vdict! {
         "a": 12,
         "b": 777.777,
         "c": "bar"
@@ -200,7 +200,7 @@ fn custom_convert_error_from_variant() {
         ConvertedStruct::TOO_MANY_KEYS
     );
 
-    let wrong_type_a = dict! {
+    let wrong_type_a = vdict! {
         "a": "hello",
         "b": 28.41,
     };
@@ -215,7 +215,7 @@ fn custom_convert_error_from_variant() {
         format!("{:?}", "hello".to_variant())
     );
 
-    let wrong_type_b = dict! {
+    let wrong_type_b = vdict! {
         "a": 29,
         "b": Vector2::new(1.0, 23.4),
     };
@@ -230,7 +230,7 @@ fn custom_convert_error_from_variant() {
         format!("{:?}", Vector2::new(1.0, 23.4).to_variant())
     );
 
-    let too_big_value = dict! {
+    let too_big_value = vdict! {
         "a": i64::MAX,
         "b": f32::NAN
     };

--- a/itest/rust/src/object_tests/property_test.rs
+++ b/itest/rust/src/object_tests/property_test.rs
@@ -5,7 +5,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use godot::builtin::{dict, vslice, Color, Dictionary, GString, Variant, VariantType};
+use godot::builtin::{vdict, vslice, Color, Dictionary, GString, Variant, VariantType};
 use godot::classes::{INode, IRefCounted, Node, Object, RefCounted, Resource, Texture};
 use godot::global::{PropertyHint, PropertyUsageFlags};
 use godot::meta::{GodotConvert, PropertyHintInfo, ToGodot};
@@ -194,7 +194,7 @@ impl GodotConvert for NotExportable {
 
 impl Var for NotExportable {
     fn get_property(&self) -> Self::Via {
-        dict! {
+        vdict! {
             "a": self.a,
             "b": self.b
         }


### PR DESCRIPTION
With [typed dictionaries](https://github.com/godotengine/godot-proposals/issues/56) becoming part of Godot 4.4 through pull request https://github.com/godotengine/godot/pull/78656, we will eventually support them in godot-rust, too.

This PR starts phasing out the `dict!` macro in favor of `vdict!` ("variant dictionary"), consistent with `array!` + `varray!`. This will free the `dict!` identifier to be used for typed dictionaries in the future. The old name will remain deprecated for a while.

A similar change will be necessary for the `Dictionary` type itself. I'm not sure if `VariantDictionary` isn't getting too long for being so ubiquitous. Maybe `VArray` + `VDictionary` would be more appropriate in the long-term.