### PR TITLE
Simplify `match_class!` syntax + implementation

### DIFF
--- a/godot-core/src/classes/match_class.rs
+++ b/godot-core/src/classes/match_class.rs
@@ -13,7 +13,7 @@
 ///
 /// Requires a fallback branch, even if all direct known classes are handled. The reason for this is that there may be other subclasses which
 /// are not statically known by godot-rust (e.g. from a script or GDExtension). The fallback branch can either be `_` (discard object), or
-/// `variable @ _` to access the original object inside the fallback arm.
+/// `variable` to access the original object inside the fallback arm.
 ///
 /// # Example
 /// ```no_run
@@ -26,15 +26,15 @@
 /// // Basic syntax.
 /// let event: Gd<InputEvent> = some_input();
 ///
-/// let simple_dispatch: i32 = match_class!(event, {
+/// let simple_dispatch: i32 = match_class! { event,
 ///    button @ InputEventMouseButton => 1,
 ///    motion @ InputEventMouseMotion => 2,
 ///    action @ InputEventAction => 3,
 ///    _ => 0, // Fallback.
-/// });
+/// };
 ///
 /// // More diverse dispatch patterns are also supported.
-/// let fancy_dispatch: i32 = match_class!(some_input(), {
+/// let fancy_dispatch: i32 = match_class! { some_input(),
 ///     button @ InputEventMouseButton => 1,
 ///
 ///     // Block syntax for multiple statements:
@@ -47,58 +47,54 @@
 ///     action @ godot::classes::InputEventAction => 3,
 ///
 ///     // Fallback with variable -- retrieves original Gd<InputEvent>.
-///     // Equivalent to pattern `original @ InputEvent`.
-///     original @ _ => 0,
-/// });
+///     original => 0,
+/// };
 ///
 /// // event_type is now 0, 1, 2, or 3
 /// ```
 ///
-/// # Limitations
-/// The expression block is currently wrapped by a closure, so you cannot use control-flow statements like `?`, `return`, `continue`, `break`.
+/// # Expression and control flow
+/// The `match_class!` macro is an expression, as such it has a type. If that type is not `()`, you typically need to use the expression or
+/// end it with a semicolon.
+///
+/// Control-flow statements like `?`, `return`, `continue`, `break` can be used within the match arms.
 #[macro_export]
 // Note: annoyingly shows full implementation in docs. For workarounds, either move impl to a helper macro, or use something like
 // https://crates.io/crates/clean-macro-docs.
+// Earlier syntax expected curly braces, i.e.:  ($subject:expr, { $($tt:tt)* }) => {{ ... }};
 macro_rules! match_class {
-    // TT muncher approach: consume one arm at a time and recurse with the remaining tokens.
+    ($subject:expr, $($tt:tt)*) => {{
+        let subject = $subject;
+        $crate::match_class_muncher!(subject, $($tt)*)
+    }};
+}
 
-    // Entry point: grab subject + ENTIRE list of arms as token-trees.
-    ($subject:expr, { $($arms:tt)* }) => {
-        (|| {
-            let mut __match_subject = $subject;
-            match_class!(@munch __match_subject; $($arms)*);
-            // unreachable!("match_class hit end with no `_` fallback");
-        })()
-    };
+#[doc(hidden)]
+#[macro_export]
+macro_rules! match_class_muncher {
+    /*
+    // If we want to support `var @ _ => { ... }` syntax, use this branch first (to not match `_` as type).
+    ($subject:ident, $var:ident @ _ => $block:expr $(,)?) => {{
+        let $var = $subject;
+        $block
+    }};
+     */
 
-    // ident @ Some::Path => expr, rest...
-    (@munch $evt:ident;
-        $var:ident @ $($class:ident)::+ => $body:expr,
-        $($rest:tt)*
-    ) => {
-        // try the down‐cast
-        $evt = match $evt.try_cast::< $($class)::* >() {
-            Ok($var) => return $body,
-            Err(e) => e,
-        };
-        match_class!(@munch $evt; $($rest)*);
-    };
+    ($subject:ident, $var:ident @ $Ty:ty => $block:expr, $($rest:tt)*) => {{
+        match $subject.try_cast::<$Ty>() {
+            Ok($var) => $block,
+            Err(__obj) => {
+                $crate::match_class_muncher!(__obj, $($rest)*)
+            }
+        }
+    }};
 
-    // foo @ _ => expr
-    (@munch $evt:ident;
-        $fallback_var:ident @ $pat:tt => $fallback:expr
-        $(,)?
-    ) => {
-        // `$pat` here will only ever be `_` if no typed‐arm matched first, because `Some::Path` would hit the more specific rule above.
-        let $fallback_var = $evt;
-        return $fallback;
-    };
+    ($subject:ident, $var:ident => $block:expr $(,)?) => {{
+        let $var = $subject;
+        $block
+    }};
 
-    // _ => expr
-    (@munch $evt:ident;
-        _ => $fallback:expr
-        $(,)?
-    ) => {{
-        return $fallback;
+    ($subject:ident, _ => $block:expr $(,)?) => {{
+        $block
     }};
 }


### PR DESCRIPTION
Refines #1225.

Changes:
- `fallback @ _` -> `fallback`
- `match_class!(...)` -> `match_class! { ... }` encouraged
- `expr, { ... }` -> `expr, ...`
- Now allows control flow (`break`, `return`, etc.)

Thanks to @Houtamelo for the input!