### PR TITLE
Clarify lifetimes: `GdRef<T>` -> `GdRef<'_, T>` 

### DIFF
--- a/godot-core/src/builtin/callable.rs
+++ b/godot-core/src/builtin/callable.rs
@@ -448,7 +448,7 @@ impl Callable {
     }
 
     #[doc(hidden)]
-    pub fn as_inner(&self) -> inner::InnerCallable {
+    pub fn as_inner(&self) -> inner::InnerCallable<'_> {
         inner::InnerCallable::from_outer(self)
     }
 }

--- a/godot-core/src/builtin/collections/array.rs
+++ b/godot-core/src/builtin/collections/array.rs
@@ -910,12 +910,12 @@ impl<T: ArrayElement> Array<T> {
     /// In particular this means that all reads are fine, since all values can be converted to `Variant`. However, writes are only OK
     /// if they match the type `T`.
     #[doc(hidden)]
-    pub unsafe fn as_inner_mut(&self) -> inner::InnerArray {
+    pub unsafe fn as_inner_mut(&self) -> inner::InnerArray<'_> {
         // The memory layout of `Array<T>` does not depend on `T`.
         inner::InnerArray::from_outer_typed(self)
     }
 
-    fn as_inner(&self) -> ImmutableInnerArray {
+    fn as_inner(&self) -> ImmutableInnerArray<'_> {
         ImmutableInnerArray {
             // SAFETY: We can only read from the array.
             inner: unsafe { self.as_inner_mut() },

--- a/godot-core/src/builtin/collections/dictionary.rs
+++ b/godot-core/src/builtin/collections/dictionary.rs
@@ -365,7 +365,7 @@ impl Dictionary {
     }
 
     #[doc(hidden)]
-    pub fn as_inner(&self) -> inner::InnerDictionary {
+    pub fn as_inner(&self) -> inner::InnerDictionary<'_> {
         inner::InnerDictionary::from_outer(self)
     }
 

--- a/godot-core/src/builtin/color.rs
+++ b/godot-core/src/builtin/color.rs
@@ -350,7 +350,7 @@ impl Color {
             && self.a <= 1.0
     }
 
-    fn as_inner(&self) -> InnerColor {
+    fn as_inner(&self) -> InnerColor<'_> {
         InnerColor::from_outer(self)
     }
 }

--- a/godot-core/src/builtin/projection.rs
+++ b/godot-core/src/builtin/projection.rs
@@ -8,9 +8,10 @@
 use godot_ffi as sys;
 use sys::{ffi_methods, ExtVariantType, GodotFfi};
 
-use crate::builtin::inner::InnerProjection;
 use crate::builtin::math::{ApproxEq, GlamConv, GlamType};
-use crate::builtin::{real, Plane, RMat4, RealConv, Transform3D, Vector2, Vector4, Vector4Axis};
+use crate::builtin::{
+    inner, real, Plane, RMat4, RealConv, Transform3D, Vector2, Vector4, Vector4Axis,
+};
 
 use std::ops::Mul;
 
@@ -470,8 +471,8 @@ impl Projection {
     }
 
     #[doc(hidden)]
-    pub(crate) fn as_inner(&self) -> InnerProjection {
-        InnerProjection::from_outer(self)
+    pub(crate) fn as_inner(&self) -> inner::InnerProjection<'_> {
+        inner::InnerProjection::from_outer(self)
     }
 }
 

--- a/godot-core/src/builtin/quaternion.rs
+++ b/godot-core/src/builtin/quaternion.rs
@@ -259,7 +259,7 @@ impl Quaternion {
     }
 
     #[doc(hidden)]
-    pub fn as_inner(&self) -> inner::InnerQuaternion {
+    pub fn as_inner(&self) -> inner::InnerQuaternion<'_> {
         inner::InnerQuaternion::from_outer(self)
     }
 

--- a/godot-core/src/builtin/signal.rs
+++ b/godot-core/src/builtin/signal.rs
@@ -158,7 +158,7 @@ impl Signal {
     }
 
     #[doc(hidden)]
-    pub fn as_inner(&self) -> inner::InnerSignal {
+    pub fn as_inner(&self) -> inner::InnerSignal<'_> {
         inner::InnerSignal::from_outer(self)
     }
 }

--- a/godot-core/src/builtin/string/gstring.rs
+++ b/godot-core/src/builtin/string/gstring.rs
@@ -257,7 +257,7 @@ impl GString {
     }
 
     #[doc(hidden)]
-    pub fn as_inner(&self) -> inner::InnerString {
+    pub fn as_inner(&self) -> inner::InnerString<'_> {
         inner::InnerString::from_outer(self)
     }
 }

--- a/godot-core/src/builtin/string/node_path.rs
+++ b/godot-core/src/builtin/string/node_path.rs
@@ -180,7 +180,7 @@ impl NodePath {
     }
 
     #[doc(hidden)]
-    pub fn as_inner(&self) -> inner::InnerNodePath {
+    pub fn as_inner(&self) -> inner::InnerNodePath<'_> {
         inner::InnerNodePath::from_outer(self)
     }
 }

--- a/godot-core/src/builtin/string/string_name.rs
+++ b/godot-core/src/builtin/string/string_name.rs
@@ -247,7 +247,7 @@ impl StringName {
     }
 
     #[doc(hidden)]
-    pub fn as_inner(&self) -> inner::InnerStringName {
+    pub fn as_inner(&self) -> inner::InnerStringName<'_> {
         inner::InnerStringName::from_outer(self)
     }
 

--- a/godot-core/src/builtin/vectors/vector2.rs
+++ b/godot-core/src/builtin/vectors/vector2.rs
@@ -160,7 +160,7 @@ impl Vector2 {
 
     #[doc(hidden)]
     #[inline]
-    pub fn as_inner(&self) -> inner::InnerVector2 {
+    pub fn as_inner(&self) -> inner::InnerVector2<'_> {
         inner::InnerVector2::from_outer(self)
     }
 }

--- a/godot-core/src/builtin/vectors/vector2i.rs
+++ b/godot-core/src/builtin/vectors/vector2i.rs
@@ -78,7 +78,7 @@ impl Vector2i {
 
     #[doc(hidden)]
     #[inline]
-    pub fn as_inner(&self) -> inner::InnerVector2i {
+    pub fn as_inner(&self) -> inner::InnerVector2i<'_> {
         inner::InnerVector2i::from_outer(self)
     }
 }

--- a/godot-core/src/builtin/vectors/vector3.rs
+++ b/godot-core/src/builtin/vectors/vector3.rs
@@ -95,7 +95,7 @@ impl_vector_fns!(Vector3, RVec3, real, (x, y, z));
 impl Vector3 {
     #[doc(hidden)]
     #[inline]
-    pub fn as_inner(&self) -> inner::InnerVector3 {
+    pub fn as_inner(&self) -> inner::InnerVector3<'_> {
         inner::InnerVector3::from_outer(self)
     }
 

--- a/godot-core/src/builtin/vectors/vector3i.rs
+++ b/godot-core/src/builtin/vectors/vector3i.rs
@@ -83,7 +83,7 @@ impl Vector3i {
 
     #[doc(hidden)]
     #[inline]
-    pub fn as_inner(&self) -> inner::InnerVector3i {
+    pub fn as_inner(&self) -> inner::InnerVector3i<'_> {
         inner::InnerVector3i::from_outer(self)
     }
 }

--- a/godot-core/src/builtin/vectors/vector4.rs
+++ b/godot-core/src/builtin/vectors/vector4.rs
@@ -74,7 +74,7 @@ impl_vector_fns!(Vector4, RVec4, real, (x, y, z, w));
 impl Vector4 {
     #[doc(hidden)]
     #[inline]
-    pub fn as_inner(&self) -> inner::InnerVector4 {
+    pub fn as_inner(&self) -> inner::InnerVector4<'_> {
         inner::InnerVector4::from_outer(self)
     }
 }

--- a/godot-core/src/builtin/vectors/vector4i.rs
+++ b/godot-core/src/builtin/vectors/vector4i.rs
@@ -87,7 +87,7 @@ impl Vector4i {
 
     #[doc(hidden)]
     #[inline]
-    pub fn as_inner(&self) -> inner::InnerVector4i {
+    pub fn as_inner(&self) -> inner::InnerVector4i<'_> {
         inner::InnerVector4i::from_outer(self)
     }
 }

--- a/godot-core/src/meta/error/string_error.rs
+++ b/godot-core/src/meta/error/string_error.rs
@@ -12,7 +12,7 @@ use std::fmt;
 #[derive(Debug)]
 pub struct StringError {
     message: String,
-    source: Option<Box<(dyn Error + 'static)>>,
+    source: Option<Box<dyn Error + 'static>>,
 }
 
 impl fmt::Display for StringError {
@@ -41,7 +41,7 @@ impl StringError {
 
     pub(crate) fn with_source(
         message: impl Into<String>,
-        source: impl Into<Box<(dyn Error + 'static)>>,
+        source: impl Into<Box<dyn Error + 'static>>,
     ) -> Self {
         Self {
             message: message.into(),

--- a/godot-core/src/obj/dyn_gd.rs
+++ b/godot-core/src/obj/dyn_gd.rs
@@ -256,7 +256,7 @@ where
     /// The resulting guard implements `Deref<Target = D>`, allowing shared access to the trait's methods.
     ///
     /// See [`Gd::bind()`][Gd::bind] for borrow checking semantics and panics.
-    pub fn dyn_bind(&self) -> DynGdRef<D> {
+    pub fn dyn_bind(&self) -> DynGdRef<'_, D> {
         self.erased_obj.dyn_bind()
     }
 
@@ -265,7 +265,7 @@ where
     /// The resulting guard implements `DerefMut<Target = D>`, allowing exclusive mutable access to the trait's methods.
     ///
     /// See [`Gd::bind_mut()`][Gd::bind_mut] for borrow checking semantics and panics.
-    pub fn dyn_bind_mut(&mut self) -> DynGdMut<D> {
+    pub fn dyn_bind_mut(&mut self) -> DynGdMut<'_, D> {
         self.erased_obj.dyn_bind_mut()
     }
 
@@ -466,8 +466,8 @@ trait ErasedGd<D>
 where
     D: ?Sized + 'static,
 {
-    fn dyn_bind(&self) -> DynGdRef<D>;
-    fn dyn_bind_mut(&mut self) -> DynGdMut<D>;
+    fn dyn_bind(&self) -> DynGdRef<'_, D>;
+    fn dyn_bind_mut(&mut self) -> DynGdMut<'_, D>;
 
     fn clone_box(&self) -> Box<dyn ErasedGd<D>>;
 }
@@ -477,11 +477,11 @@ where
     T: AsDyn<D> + Bounds<Declarer = bounds::DeclUser>,
     D: ?Sized + 'static,
 {
-    fn dyn_bind(&self) -> DynGdRef<D> {
+    fn dyn_bind(&self) -> DynGdRef<'_, D> {
         DynGdRef::from_guard::<T>(Gd::bind(self))
     }
 
-    fn dyn_bind_mut(&mut self) -> DynGdMut<D> {
+    fn dyn_bind_mut(&mut self) -> DynGdMut<'_, D> {
         DynGdMut::from_guard::<T>(Gd::bind_mut(self))
     }
 

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -172,7 +172,7 @@ where
     /// * If there is an ongoing function call from GDScript to Rust, which currently holds a `&mut T`
     ///   reference to the user instance. This can happen through re-entrancy (Rust -> GDScript -> Rust call).
     // Note: possible names: write/read, hold/hold_mut, r/w, r/rw, ...
-    pub fn bind(&self) -> GdRef<T> {
+    pub fn bind(&self) -> GdRef<'_, T> {
         self.raw.bind()
     }
 
@@ -189,7 +189,7 @@ where
     /// * If another `Gd` smart pointer pointing to the same Rust instance has a live `GdRef` or `GdMut` guard bound.
     /// * If there is an ongoing function call from GDScript to Rust, which currently holds a `&T` or `&mut T`
     ///   reference to the user instance. This can happen through re-entrancy (Rust -> GDScript -> Rust call).
-    pub fn bind_mut(&mut self) -> GdMut<T> {
+    pub fn bind_mut(&mut self) -> GdMut<'_, T> {
         self.raw.bind_mut()
     }
 }

--- a/godot-core/src/obj/raw_gd.rs
+++ b/godot-core/src/obj/raw_gd.rs
@@ -405,7 +405,7 @@ where
     ///
     /// See [`crate::obj::Gd::bind()`] for a more in depth explanation.
     // Note: possible names: write/read, hold/hold_mut, r/w, r/rw, ...
-    pub(crate) fn bind(&self) -> GdRef<T> {
+    pub(crate) fn bind(&self) -> GdRef<'_, T> {
         self.check_rtti("bind");
         GdRef::from_guard(self.storage().unwrap().get())
     }
@@ -413,7 +413,7 @@ where
     /// Hands out a guard for an exclusive borrow, through which the user instance can be read and written.
     ///
     /// See [`crate::obj::Gd::bind_mut()`] for a more in depth explanation.
-    pub(crate) fn bind_mut(&mut self) -> GdMut<T> {
+    pub(crate) fn bind_mut(&mut self) -> GdMut<'_, T> {
         self.check_rtti("bind_mut");
         GdMut::from_guard(self.storage().unwrap().get_mut())
     }

--- a/godot-core/src/obj/script.rs
+++ b/godot-core/src/obj/script.rs
@@ -450,7 +450,7 @@ impl<'a, T: ScriptInstance> SiMut<'a, T> {
     ///     # fn get_method_argument_count(&self, _: StringName) -> Option<u32> { todo!() }
     /// }
     /// ```
-    pub fn base(&self) -> ScriptBaseRef<T> {
+    pub fn base(&self) -> ScriptBaseRef<'_, T> {
         ScriptBaseRef::new(self.base_ref.to_gd(), self.mut_ref)
     }
 
@@ -512,7 +512,7 @@ impl<'a, T: ScriptInstance> SiMut<'a, T> {
     ///     # fn get_method_argument_count(&self, _: StringName) -> Option<u32> { todo!() }
     /// }
     /// ```
-    pub fn base_mut(&mut self) -> ScriptBaseMut<T> {
+    pub fn base_mut(&mut self) -> ScriptBaseMut<'_, T> {
         let guard = self.cell.make_inaccessible(self.mut_ref).unwrap();
 
         ScriptBaseMut::new(self.base_ref.to_gd(), guard)

--- a/itest/rust/src/object_tests/virtual_methods_test.rs
+++ b/itest/rust/src/object_tests/virtual_methods_test.rs
@@ -280,7 +280,10 @@ impl IRefCounted for RevertTest {
             // No UB or anything else like a crash or panic should happen when `property_can_revert` and `property_get_revert` return
             // inconsistent values, but in case something like that happens we should be able to detect it through this function.
             "property_changes" => {
-                if INC.fetch_add(1, std::sync::atomic::Ordering::AcqRel) % 2 == 0 {
+                if INC
+                    .fetch_add(1, std::sync::atomic::Ordering::AcqRel)
+                    .is_multiple_of(2)
+                {
                     None
                 } else {
                     Some(true.to_variant())


### PR DESCRIPTION
Addresses several warnings on nightly rustc.

Not too fond of this change though :thinking:
I think it's a bit patronizing, we might consider turning off the lint...
```diff
-                if INC.fetch_add(1, std::sync::atomic::Ordering::AcqRel) % 2 == 0 {
+                if INC
+                    .fetch_add(1, std::sync::atomic::Ordering::AcqRel)
+                    .is_multiple_of(2)
+                {
```