### PR TITLE
Derive `Hash` for `Rect2i`

### DIFF
--- a/godot-core/src/builtin/color.rs
+++ b/godot-core/src/builtin/color.rs
@@ -373,7 +373,7 @@ impl ApproxEq for Color {
 }
 
 /// Defines how individual color channels are laid out in memory.
-#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd, Debug)]
 pub enum ColorChannelOrder {
     /// RGBA channel order. Godot's default.
     RGBA,

--- a/godot-core/src/builtin/projection.rs
+++ b/godot-core/src/builtin/projection.rs
@@ -595,7 +595,7 @@ impl ProjectionPlane {
 }
 
 /// The eye to create a projection for, when creating a projection adjusted for head-mounted displays.
-#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd, Debug)]
 #[repr(C)]
 pub enum ProjectionEye {
     LEFT = 1,

--- a/godot-core/src/builtin/rect2i.rs
+++ b/godot-core/src/builtin/rect2i.rs
@@ -31,7 +31,7 @@ use sys::{ffi_methods, ExtVariantType, GodotFfi};
 /// # Godot docs
 ///
 /// [`Rect2i` (stable)](https://docs.godotengine.org/en/stable/classes/class_rect2i.html)
-#[derive(Default, Copy, Clone, Eq, PartialEq, Debug)]
+#[derive(Default, Copy, Clone, Eq, PartialEq, Hash, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(C)]
 pub struct Rect2i {

--- a/godot-core/src/builtin/vectors/vector_axis.rs
+++ b/godot-core/src/builtin/vectors/vector_axis.rs
@@ -16,7 +16,7 @@ macro_rules! impl_vector_axis_enum {
         ///
         #[doc = concat!("`", stringify!($Vector), "` implements `Index<", stringify!($AxisEnum), ">` and `IndexMut<", stringify!($AxisEnum), ">`")]
         #[doc = ", so you can use this type to access a vector component as `vec[axis]`."]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
+        #[derive(Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd, Debug)]
         #[repr(i32)]
         pub enum $AxisEnum {
             $(


### PR DESCRIPTION
Also add `Hash`, `PartialOrd` and `Ord` for some enums while I have my eyes on them.

Related issue: #505. There seems to be no objective to keep Godot and Rust hashes the same, so this change should be fine, and is indeed consistent with prior art of deriving `Hash` on e.g. `Vector2i`.