### PR TITLE
Emit proper compile error while trying to `#[export]` `Gd<T>` or `DynGd<T, D>`.

### DIFF
--- a/godot-core/src/registry/property.rs
+++ b/godot-core/src/registry/property.rs
@@ -64,7 +64,8 @@ pub trait Var: GodotConvert {
 #[diagnostic::on_unimplemented(
     message = "`#[var]` properties require `Var` trait; #[export] ones require `Export` trait",
     label = "type cannot be used as a property",
-    note = "see also: https://godot-rust.github.io/book/register/properties.html"
+    note = "see also: https://godot-rust.github.io/book/register/properties.html",
+    note = "`Gd` and `DynGd` cannot be exported directly; wrap them in `Option<...>` or `OnEditor<...>`."
 )]
 pub trait Export: Var {
     /// The export info to use for an exported field of this type, if no other export info is specified.


### PR DESCRIPTION
Changes compile error from:
```rs
error[E0271]: type mismatch resolving `<Node as Bounds>::Memory == MemRefCounted`
  --> src/lib.rs:15:5
   |
15 |     #[export]
   |     ^ expected `MemRefCounted`, found `MemManual`
   |
   = note: required for `godot::prelude::Gd<godot::prelude::Node>` to implement `Default`

error[E0277]: `#[var]` properties require `Var` trait; #[export] ones require `Export` trait
  --> src/lib.rs:16:20
   |
16 |     faulty_export: Gd<Node>,
   |                    ^^^^^^^^ type cannot be used as a property
   |
   = help: the trait `Export` is not implemented for `godot::prelude::Gd<godot::prelude::Node>`
   = note: see also: https://godot-rust.github.io/book/register/properties.html
   = help: the following other types implement trait `Export`:
             Aabb
             Array<DynGd<T, D>>
             Array<T>
             Array<godot::prelude::Gd<T>>
             Basis
             Color
             Dictionary
             GString
           and 42 others

Some errors have detailed explanations: E0271, E0277.
For more information about an error, try `rustc --explain E0271`.
error: could not compile `docstest` (lib) due to 3 previous errors

```

to:
```rs
error: `Gd` and `DynGd` cannot be used directly as properties because they are non-nullable. Use `OnEditor<T>` or `Option<T>` instead.
  --> src/lib.rs:16:20
   |
16 |     faulty_export: Gd<Node>,
   |                    ^^

error: could not compile `docstest` (lib) due to 1 previous error
```

in case if one tries to export non-nullable property such as:
```rs
    #[export]
    faulty_export: Gd<Node>,
```

I'm not sure if adding extra info/note to `diagnostic::on_unimplemented` wouldn't be better choice though :thinking:. It doesn't seem to break or change anything :thinking: (checked with two medium-sized projects + our tests obviously). `Gd<T>` couldn't be an `#[export]` anyway, so :thinking: 

It provides a bit better IDE experience (notes are omitted by Zed and RustRover): 

<img width="1359" height="84" alt="image" src="https://github.com/user-attachments/assets/5da9dccb-7d09-4a0e-a4f8-1d25ac388e8a" />

<img width="988" height="245" alt="image" src="https://github.com/user-attachments/assets/0ed8fc61-8989-47e7-9c09-58a8c228a4bc" />
