### PR TITLE
Clarify `Export` semantics for objects

### DIFF
--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -90,6 +90,16 @@ use crate::{classes, out};
 ///
 /// For type conversions, please read the [`godot::meta` module docs][crate::meta].
 ///
+/// # Exporting
+///
+/// The [`Export`][crate::registry::property::Export] trait is not directly implemented for `Gd<T>`, because the editor expects object-based
+/// properties to be nullable, while `Gd<T>` can't be null. Instead, `Export` is implemented for [`OnEditor<Gd<T>>`][crate::obj::OnEditor],
+/// which validates that objects have been set by the editor. For the most flexible but least ergonomic option, you can also export
+/// `Option<Gd<T>>` fields.
+///
+/// Objects can only be exported if `T: Inherits<Node>` or `T: Inherits<Resource>`, just like GDScript.
+/// This means you cannot use `#[export]` with `OnEditor<Gd<RefCounted>>`, for example.
+///
 /// [book]: https://godot-rust.github.io/book/godot-api/objects.html
 /// [`Object`]: classes::Object
 /// [`RefCounted`]: classes::RefCounted
@@ -949,6 +959,7 @@ impl<T: GodotClass> Var for Gd<T> {
     }
 }
 
+/// See [`Gd` Exporting](struct.Gd.html#exporting) section.
 impl<T> Export for Option<Gd<T>>
 where
     T: GodotClass + Bounds<Exportable = bounds::Yes>,
@@ -991,6 +1002,7 @@ where
     }
 }
 
+/// See [`Gd` Exporting](struct.Gd.html#exporting) section.
 impl<T> Export for OnEditor<Gd<T>>
 where
     Self: Var,

--- a/godot-core/src/registry/property.rs
+++ b/godot-core/src/registry/property.rs
@@ -54,8 +54,7 @@ pub trait Var: GodotConvert {
 // Note: HTML link for #[export] works if this symbol is inside prelude, but not in register::property.
 /// Trait implemented for types that can be used as [`#[export]`](../register/derive.GodotClass.html#properties-and-exports) fields.
 ///
-/// `Export` is only implemented for objects `Gd<T>` if either `T: Inherits<Node>` or `T: Inherits<Resource>`, just like GDScript.
-/// This means you cannot use `#[export]` with `Gd<RefCounted>`, for example.
+/// To export objects, see the [_Exporting_ section of `Gd<T>`](../obj/struct.Gd.html#exporting).
 ///
 /// For enums, this trait can be derived using the [`#[derive(Export)]`](../derive.Export.html) macro.
 #[doc(alias = "property")]


### PR DESCRIPTION
Corrects outdated info about `#[export]` being available for `Gd`/`DynGd` and elaborates what to use instead.