### PR TITLE
`match_class!` fallback branch is now optional for `()`

### DIFF
--- a/itest/rust/src/engine_tests/match_class_test.rs
+++ b/itest/rust/src/engine_tests/match_class_test.rs
@@ -148,9 +148,9 @@ fn match_class_control_flow() {
 
     let mut broken = false;
 
-    #[allow(clippy::never_loop)]
+    #[expect(clippy::never_loop)]
     for _i in 0..1 {
-        match_class! { obj.clone(),
+        let _: i32 = match_class! { obj.clone(),
             _node @ Node => 1,
             _res @ Resource => {
                 broken = true;
@@ -163,4 +163,31 @@ fn match_class_control_flow() {
     }
 
     assert!(broken, "break statement should have been executed");
+}
+
+#[itest]
+fn match_class_unit_type() {
+    let obj: Gd<Object> = Object::new_alloc();
+    let to_free = obj.clone();
+    let mut val = 0;
+
+    match_class! { obj,
+        mut node @ Node2D => {
+            require_mut_node2d(&mut node);
+            val = 1;
+        },
+        node @ Node => {
+            require_node(&node);
+            val = 2;
+        },
+        // No need for _ branch since all branches return ().
+    }
+
+    assert_eq!(val, 0);
+    to_free.free();
+
+    // Special case: no branches at all. Also test unit type.
+    let _: () = match_class! { RefCounted::new_gd(),
+        // Nothing.
+    };
 }


### PR DESCRIPTION
I commented on this on my previous PR, so I wanted to remove the need for it. I pr'd one approach, but the other one is the following:
```rust
// Shadowed fallback var.
($subject:ident, $(_ => $block:expr $(,)?)?) => {{
    $($block)?
}};
```

I also wanted to comment on this comment that is still on the macro, are there any plans for it? Why was it left as a comment?

```rust
/*
// If we want to support `var @ _ => { ... }` syntax, use this branch first (to not match `_` as type).
($subject:ident, $var:ident @ _ => $block:expr $(,)?) => {{
    let $var = $subject;
    $block
}};
 */
 ```

The reasons I'd advocate for removing the need for the last branch is because there are many use cases in which that bracket is just adding more verbosity. My concern is what would happen in a match that returns an int but no last bracket is used, then, what is the compile error? The one that appeared during testing is an error on the macro definition itself.