### PR TITLE
Re-export deprecated `dict!` macro

### DIFF
--- a/godot-core/src/builtin/mod.rs
+++ b/godot-core/src/builtin/mod.rs
@@ -50,6 +50,9 @@ pub mod __prelude_reexport {
 
     pub use super::{EulerOrder, Side, VariantOperator, VariantType};
     pub use crate::{array, real, reals, varray, vdict, vslice};
+
+    #[allow(deprecated)]
+    pub use crate::dict;
 }
 
 pub use __prelude_reexport::*;

--- a/godot-macros/Cargo.toml
+++ b/godot-macros/Cargo.toml
@@ -16,6 +16,7 @@ api-custom-json = ["godot-bindings/api-custom-json"]
 codegen-full = ["godot/__codegen-full"]
 experimental-wasm = []
 register-docs = ["dep:markdown", "dep:litrs"]
+trace = []
 
 [lib]
 proc-macro = true

--- a/godot-macros/src/class/derive_godot_class.rs
+++ b/godot-macros/src/class/derive_godot_class.rs
@@ -667,7 +667,10 @@ fn parse_fields(
             parser.finish()?;
         }
 
+        // TODO(v0.3.5): re-enable groups. Currently enabled in tests.
+
         // #[export_group(name = ..., prefix = ...)]
+        #[cfg(feature = "trace")]
         if let Some(mut parser) = KvParser::parse(&named_field.attributes, "export_group")? {
             let group = FieldGroup::new_from_kv(&mut parser)?;
             field.group = Some(group);
@@ -675,6 +678,7 @@ fn parse_fields(
         }
 
         // #[export_subgroup(name = ..., prefix = ...)]
+        #[cfg(feature = "trace")]
         if let Some(mut parser) = KvParser::parse(&named_field.attributes, "export_subgroup")? {
             let subgroup = FieldGroup::new_from_kv(&mut parser)?;
             field.subgroup = Some(subgroup);

--- a/godot-macros/src/lib.rs
+++ b/godot-macros/src/lib.rs
@@ -300,6 +300,7 @@ use crate::util::{bail, ident, KvParser};
 /// }
 /// ```
 ///
+/*
 /// It is possible to group your exported properties inside the Inspector with the `#[export_group(name = "...", prefix =  "...")]` attribute.
 /// Every exported property after this attribute will be added to the group. Start a new group or use `#[export_group(name = "")]` (with an empty name) to break out.
 ///
@@ -357,6 +358,7 @@ use crate::util::{bail, ident, KvParser};
 ///```
 ///
 ///
+ */
 /// ## Low-level property hints and usage
 ///
 /// You can specify custom property hints, hint strings, and usage flags in a `#[var]` attribute using the `hint`, `hint_string`
@@ -539,9 +541,16 @@ use crate::util::{bail, ident, KvParser};
     alias = "tool",
     alias = "rename"
 )]
-#[proc_macro_derive(
-    GodotClass,
-    attributes(class, base, hint, var, export, export_group, export_subgroup, init)
+#[cfg_attr(
+    feature = "trace",
+    proc_macro_derive(
+        GodotClass,
+        attributes(class, init, base, hint, var, export, export_group, export_subgroup)
+    )
+)]
+#[cfg_attr(
+    not(feature = "trace"),
+    proc_macro_derive(GodotClass, attributes(class, init, base, hint, var, export))
 )]
 pub fn derive_godot_class(input: TokenStream) -> TokenStream {
     translate(input, class::derive_godot_class)

--- a/godot/Cargo.toml
+++ b/godot/Cargo.toml
@@ -48,7 +48,7 @@ default = ["__codegen-full"]
 # Private features, they are under no stability guarantee
 __codegen-full = ["godot-core/codegen-full", "godot-macros/codegen-full"]
 __debug-log = ["godot-core/debug-log"]
-__trace = ["godot-core/trace"]
+__trace = ["godot-core/trace", "godot-macros/trace"]
 
 [dependencies]
 godot-core = { path = "../godot-core", version = "=0.3.3" }


### PR DESCRIPTION
Accidental breaking change when using `prelude`.

Second commit disables export groups, which were merged to see some testing, but aren't stable enough for a patch release yet. We should be able to simply revert that later.