### PR TITLE
Fix `is_main_thread` being gated behind `#[cfg(not(wasm_nothreads))]` despite being necessary to build wasm nothread.

### DIFF
--- a/godot-core/src/init/mod.rs
+++ b/godot-core/src/init/mod.rs
@@ -16,8 +16,9 @@ use crate::out;
 
 pub use sys::GdextBuild;
 
+pub use sys::is_main_thread;
 #[cfg(not(wasm_nothreads))]
-pub use sys::{is_main_thread, main_thread_id};
+pub use sys::main_thread_id;
 
 #[doc(hidden)]
 #[deny(unsafe_op_in_unsafe_fn)]


### PR DESCRIPTION
Broken in: https://github.com/godot-rust/gdext/commit/b1d9ee8a90a075d327c9cab8a2c483e05b588e0d#commitcomment-162904348 (reported by [@fstx](https://github.com/fstxz))

Building for wasm_nothread was failing because `is_main_thread` was wrongly gated for wasm-nothread.

I only tested it manually:

<details>
<summary> Current master </summary>

```rs
$ cargo +nightly build -p godot -Zbuild-std --target wasm32-unknown-emscripten --features experimental-wasm-nothreads,experimental-wasm
warning: /home/irwin/apps/godot/opensource-contr/missing_docs/gdext/godot/Cargo.toml: unused manifest key: target.wasm32-unknown-emscripten.rustflags
    Blocking waiting for file lock on build directory
   Compiling compiler_builtins v0.1.160 (/home/irwin/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/compiler-builtins/compiler-builtins)
   Compiling core v0.0.0 (/home/irwin/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core)
   Compiling godot-bindings v0.3.4 (/home/irwin/apps/godot/opensource-contr/missing_docs/gdext/godot-bindings)
   Compiling gdextension-api v0.2.2 (https://github.com/godot-rust/godot4-prebuilt?branch=releases#09432b4c)
   Compiling libc v0.2.174
   Compiling proc-macro2 v1.0.95
   Compiling unicode-ident v1.0.18
   Compiling object v0.37.1
   Compiling regex-syntax v0.8.5
   Compiling std v0.0.0 (/home/irwin/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std)
   Compiling nanoserde-derive v0.2.1
   Compiling heck v0.5.0
   Compiling quote v1.0.40
   Compiling venial v0.6.1
   Compiling nanoserde v0.2.1
   Compiling regex-automata v0.4.9
   Compiling godot-codegen v0.3.4 (/home/irwin/apps/godot/opensource-contr/missing_docs/gdext/godot-codegen)
   Compiling godot-macros v0.3.4 (/home/irwin/apps/godot/opensource-contr/missing_docs/gdext/godot-macros)
   Compiling regex v1.11.1
   Compiling godot-ffi v0.3.4 (/home/irwin/apps/godot/opensource-contr/missing_docs/gdext/godot-ffi)
   Compiling godot-core v0.3.4 (/home/irwin/apps/godot/opensource-contr/missing_docs/gdext/godot-core)
   Compiling rustc-std-workspace-core v1.99.0 (/home/irwin/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/rustc-std-workspace-core)
   Compiling alloc v0.0.0 (/home/irwin/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc)
   Compiling panic_abort v0.0.0 (/home/irwin/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/panic_abort)
   Compiling cfg-if v1.0.1
   Compiling memchr v2.7.5
   Compiling adler2 v2.0.1
   Compiling rustc-demangle v0.1.25
   Compiling unwind v0.0.0 (/home/irwin/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/unwind)
   Compiling rustc-std-workspace-alloc v1.99.0 (/home/irwin/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/rustc-std-workspace-alloc)
   Compiling panic_unwind v0.0.0 (/home/irwin/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/panic_unwind)
   Compiling gimli v0.32.0
   Compiling std_detect v0.1.5 (/home/irwin/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/stdarch/crates/std_detect)
   Compiling hashbrown v0.15.4
   Compiling miniz_oxide v0.8.9
   Compiling addr2line v0.25.0
   Compiling rustc-std-workspace-std v1.99.0 (/home/irwin/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/rustc-std-workspace-std)
   Compiling rustc-literal-escaper v0.0.4
   Compiling proc_macro v0.0.0 (/home/irwin/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/proc_macro)
   Compiling glam v0.30.4
   Compiling godot-cell v0.3.4 (/home/irwin/apps/godot/opensource-contr/missing_docs/gdext/godot-cell)
error[E0425]: cannot find function `is_main_thread` in module `crate::init`
  --> godot-core/src/task/async_runtime.rs:99:22
   |
99 |         crate::init::is_main_thread(),
   |                      ^^^^^^^^^^^^^^ not found in `crate::init`
   |
note: found an item that was configured out
  --> godot-core/src/init/mod.rs:20:15
   |
20 | pub use sys::{is_main_thread, main_thread_id};
   |               ^^^^^^^^^^^^^^
note: the item is gated here
  --> godot-core/src/init/mod.rs:19:1
   |
19 | #[cfg(not(wasm_nothreads))]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
help: consider importing one of these functions
   |
8  + use crate::sys::is_main_thread;
   |
8  + use godot_ffi::is_main_thread;
   |
help: if you import `is_main_thread`, refer to it directly
   |
99 -         crate::init::is_main_thread(),
99 +         is_main_thread(),
   |

For more information about this error, try `rustc --explain E0425`.
^[[Aerror: could not compile `godot-core` (lib) due to 1 previous error
```

</details>

<details>
<summary> This branch </summary>

```rs
$ cargo +nightly build -p godot -Zbuild-std --target wasm32-unknown-emscripten --features experimental-wasm-nothreads,experimental-wasm
warning: /home/irwin/apps/godot/opensource-contr/missing_docs/gdext/godot/Cargo.toml: unused manifest key: target.wasm32-unknown-emscripten.rustflags
   Compiling godot-core v0.3.4 (/home/irwin/apps/godot/opensource-contr/missing_docs/gdext/godot-core)
   Compiling godot v0.3.4 (/home/irwin/apps/godot/opensource-contr/missing_docs/gdext/godot)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 13.30s
```

</details>