### PR TITLE
Add extra class docs for `ResourceFormatLoader` to mention that the `experimental-threads` feature is required

### DIFF
--- a/godot-codegen/src/special_cases/special_cases.rs
+++ b/godot-codegen/src/special_cases/special_cases.rs
@@ -773,7 +773,11 @@ pub fn get_class_extra_docs(class_name: &TyName) -> Option<&'static str> {
         "ScriptExtension" => {
             Some("Use this in combination with the [`obj::script` module][crate::obj::script].")
         }
-
+        "ResourceFormatLoader" => {
+            Some("Enable the `experimental-threads` feature when using custom `ResourceFormatLoader`s. \
+            Otherwise the application will panic when the custom `ResourceFormatLoader` is used by Godot \
+            in a thread other than the main thread.")
+        }
         _ => None,
     }
 }


### PR DESCRIPTION
Once this PR is approved I will also raise a PR to mention in the ResourceFormatLoader recipe that the experimental-threads feature is required.

Adds documentation for issue https://github.com/godot-rust/gdext/issues/1257