### PR TITLE
Mark GString as Send

### DIFF
--- a/godot-core/src/builtin/string/gstring.rs
+++ b/godot-core/src/builtin/string/gstring.rs
@@ -72,6 +72,9 @@ pub struct GString {
     _opaque: OpaqueString,
 }
 
+// SAFETY: The Godot implementation of String uses an atomic copy on write pointer, making this thread-safe as we never write to it unless we own it.
+unsafe impl Send for GString {}
+
 impl GString {
     /// Construct a new empty `GString`.
     pub fn new() -> Self {


### PR DESCRIPTION
Since String is actually thread-safe (even though not listed, the cow implementation of String uses an atomic usize)

https://github.com/godotengine/godot/blob/master/core/templates/safe_refcount.h
https://github.com/godotengine/godot/blob/c81fd6c51233a727da528cf7f74137d56b5d6efe/core/templates/cowdata.h#L79
and finally,
https://github.com/godotengine/godot/blob/c81fd6c51233a727da528cf7f74137d56b5d6efe/core/string/ustring.h#L267

With a simple read and write test, i've verified and made sure that no clang data race warnings are emitted when using this. (engine built with ThreadSanitizer)
<img width="464" height="810" alt="image" src="https://github.com/user-attachments/assets/c69e7953-2749-4423-8661-901fb0ea48aa" />
