### PR TITLE
Clarify + test `Packed*Array` behavior w.r.t. copy-and-write + `#[var]`

### DIFF
--- a/godot-core/src/builtin/collections/packed_array.rs
+++ b/godot-core/src/builtin/collections/packed_array.rs
@@ -68,11 +68,11 @@ macro_rules! impl_packed_array {
         ///
         /// # Registering properties
         ///
-        /// You can use both `#[var]` and `#[export]` with packed arrays. However, since they use copy-on-write, GDScript (for `#[var]`) and the
-        /// editor (for `#[export]`) will effectively keep an independent copy of the array. Writes to the packed array from Rust are thus not
-        /// reflected on the other side -- you may need to replace the entire array.
+        /// You can use both `#[var]` and `#[export]` with packed arrays. In godot-rust, modifications to packed array properties are
+        /// properly synchronized between Rust and GDScript/reflection access.
         ///
-        /// See also [godot/#76150](https://github.com/godotengine/godot/issues/76150) for details.
+        /// In GDScript, mutating methods like `append_array()` may not work on `Packed*Array` properties of engine classes.
+        /// See [godot/#76150](https://github.com/godotengine/godot/issues/76150) for details.
         ///
         /// # Thread safety
         ///


### PR DESCRIPTION
There was some misconception in #576, according to which it wouldn't be possible to modify exported packed arrays due to copy-on-write only affecting the instance in the inspector. This seems to be only the case in GDScript, but not Rust.

This PR updates docs and writes a small integration test, which does a bit less: check if changes to a packed array property are visible, when done in Rust, and when done via reflection.