### PR TITLE
Nightly rustfmt + internals (once-calls, robust refcounts)

### DIFF
--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -49,6 +49,7 @@ jobs:
       - name: "Install Rust"
         uses: ./.github/composite/rust
         with:
+          rust: nightly
           components: rustfmt
 
       - name: "Check rustfmt"

--- a/.github/workflows/minimal-ci.yml
+++ b/.github/workflows/minimal-ci.yml
@@ -47,6 +47,7 @@ jobs:
       - name: "Install Rust"
         uses: ./.github/composite/rust
         with:
+          rust: nightly
           components: rustfmt
 
       - name: "Check rustfmt"

--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -120,7 +120,7 @@ jobs:
           ref: ${{ github.ref }}
 
       - name: "Install Rust (uncached)"
-        run: rustup update stable
+        run: rustup update nightly && rustup default nightly
 
       - name: "Check rustfmt"
         run: cargo fmt --all -- --check

--- a/godot-core/src/obj/call_deferred.rs
+++ b/godot-core/src/obj/call_deferred.rs
@@ -61,14 +61,11 @@ where
             is_main_thread(),
             "`apply_deferred` must be called on the main thread"
         );
-        let mut rust_fn_once = Some(rust_function);
+
         let mut this = self.to_signal_obj().clone();
-        let callable = Callable::from_local_fn("apply_deferred", move |_| {
-            let rust_fn_once = rust_fn_once
-                .take()
-                .expect("rust_fn_once was already consumed");
+        let callable = Callable::from_once_fn("apply_deferred", move |_| {
             let mut this_mut = T::object_as_mut(&mut this);
-            rust_fn_once(this_mut.deref_mut());
+            rust_function(this_mut.deref_mut());
             Ok(Variant::nil())
         });
         callable.call_deferred(&[]);

--- a/itest/rust/src/builtin_tests/containers/callable_test.rs
+++ b/itest/rust/src/builtin_tests/containers/callable_test.rs
@@ -648,6 +648,20 @@ pub mod custom_callable {
         assert!(signal.is_connected(&identical_callable));
     }
 
+    #[cfg(since_api = "4.2")]
+    #[itest]
+    fn callable_from_once_fn() {
+        let callable = Callable::__once_fn("once_test", move |_| Ok(42.to_variant()));
+
+        // First call should succeed.
+        let result = callable.call(&[]);
+        assert_eq!(result.to::<i32>(), 42);
+
+        // Second call should fail (panic currently isn't propagated, see other tests).
+        let result = callable.call(&[]);
+        assert!(result.is_nil());
+    }
+
     // ------------------------------------------------------------------------------------------------------------------------------------------
     // Helper structs and functions for custom callables
 


### PR DESCRIPTION
Uses nightly toolchain for `rustfmt` CI, since the new rules from #1269 aren't enforced otherwise.

Also small improvements to `Gd`/`Callable` internals.