### PR TITLE
Require that classes starting with "Editor" be marked internal

### DIFF
--- a/godot-macros/src/class/derive_godot_class.rs
+++ b/godot-macros/src/class/derive_godot_class.rs
@@ -537,6 +537,15 @@ fn parse_struct_attributes(class: &venial::Struct) -> ParseResult<ClassAttribute
         if let Some(span) = parser.handle_alone_with_span("internal")? {
             require_api_version!("4.2", span, "#[class(internal)]")?;
             is_internal = true;
+        } else {
+            // Godot has an edge case where classes starting with "Editor" are implicitly hidden:
+            // https://github.com/godotengine/godot/blob/ca452113d430cb96de409a297ff5b52389f1c9d9/editor/gui/create_dialog.cpp#L171-L173
+            if class.name.to_string().starts_with("Editor") {
+                return bail!(
+                    class.name.span(),
+                    "Classes starting with `Editor` are implicitly hidden by Godot; use #[class(internal)] to make this explicit",
+                );
+            }
         }
 
         // Deprecated #[class(hidden)]

--- a/godot-macros/src/lib.rs
+++ b/godot-macros/src/lib.rs
@@ -452,7 +452,9 @@ use crate::util::{bail, ident, KvParser};
 ///
 /// ## Class hiding
 ///
-/// If you want to register a class with Godot, but not have it show up in the editor then you can use `#[class(internal)]`.
+/// If you want to register a class with Godot, but not display in the editor (e.g. when creating a new node), you can use `#[class(internal)]`.
+///
+/// Classes starting with "Editor" are auto-hidden by Godot. They *must* be marked as internal in godot-rust.
 ///
 /// ```
 /// # use godot::prelude::*;
@@ -540,7 +542,8 @@ use crate::util::{bail, ident, KvParser};
     alias = "var",
     alias = "export",
     alias = "tool",
-    alias = "rename"
+    alias = "rename",
+    alias = "internal"
 )]
 #[proc_macro_derive(
     GodotClass,


### PR DESCRIPTION
Make this edge case explicit to users: [create_dialog.cpp#L171-L173](https://github.com/godotengine/godot/blob/ca452113d430cb96de409a297ff5b52389f1c9d9/editor/gui/create_dialog.cpp#L171-L173)

Effect:

```rs
#[derive(GodotClass)]
#[class(init)]
pub struct EditorObject {}
```

<img width="932" height="121" alt="image" src="https://github.com/user-attachments/assets/6517e912-537b-4feb-bdcd-56439d7fbf21" />

---

The current PR does not allow registering classes starting with `Editor` in <4.2 _at all_, but we're anyway going to phase out Godot 4.1 for godot-rust v0.4.