### PR TITLE
Allow to use `#[func(gd_self)]` with Interface methods.

### DIFF
--- a/godot-core/src/obj/traits.rs
+++ b/godot-core/src/obj/traits.rs
@@ -656,6 +656,7 @@ pub mod cap {
     use crate::builtin::{StringName, Variant};
     use crate::meta::PropertyInfo;
     use crate::obj::{Base, Bounds, Gd};
+    use crate::storage::{IntoVirtualMethodReceiver, VirtualMethodReceiver};
 
     /// Trait for all classes that are default-constructible from the Godot engine.
     ///
@@ -712,7 +713,10 @@ pub mod cap {
     #[doc(hidden)]
     pub trait GodotToString: GodotClass {
         #[doc(hidden)]
-        fn __godot_to_string(&self) -> GString;
+        type Recv: IntoVirtualMethodReceiver<Self>;
+
+        #[doc(hidden)]
+        fn __godot_to_string(this: VirtualMethodReceiver<Self>) -> GString;
     }
 
     // TODO Evaluate whether we want this public or not
@@ -732,32 +736,62 @@ pub mod cap {
     #[doc(hidden)]
     pub trait GodotGet: GodotClass {
         #[doc(hidden)]
-        fn __godot_get_property(&self, property: StringName) -> Option<Variant>;
+        type Recv: IntoVirtualMethodReceiver<Self>;
+
+        #[doc(hidden)]
+        fn __godot_get_property(
+            this: VirtualMethodReceiver<Self>,
+            property: StringName,
+        ) -> Option<Variant>;
     }
 
     #[doc(hidden)]
     pub trait GodotSet: GodotClass {
         #[doc(hidden)]
-        fn __godot_set_property(&mut self, property: StringName, value: Variant) -> bool;
+        type Recv: IntoVirtualMethodReceiver<Self>;
+
+        #[doc(hidden)]
+        fn __godot_set_property(
+            this: VirtualMethodReceiver<Self>,
+            property: StringName,
+            value: Variant,
+        ) -> bool;
     }
 
     #[doc(hidden)]
     pub trait GodotGetPropertyList: GodotClass {
         #[doc(hidden)]
-        fn __godot_get_property_list(&mut self) -> Vec<crate::meta::PropertyInfo>;
+        type Recv: IntoVirtualMethodReceiver<Self>;
+
+        #[doc(hidden)]
+        fn __godot_get_property_list(
+            this: VirtualMethodReceiver<Self>,
+        ) -> Vec<crate::meta::PropertyInfo>;
     }
 
     #[doc(hidden)]
     pub trait GodotPropertyGetRevert: GodotClass {
         #[doc(hidden)]
-        fn __godot_property_get_revert(&self, property: StringName) -> Option<Variant>;
+        type Recv: IntoVirtualMethodReceiver<Self>;
+
+        #[doc(hidden)]
+        fn __godot_property_get_revert(
+            this: VirtualMethodReceiver<Self>,
+            property: StringName,
+        ) -> Option<Variant>;
     }
 
     #[doc(hidden)]
     #[cfg(since_api = "4.2")]
     pub trait GodotValidateProperty: GodotClass {
         #[doc(hidden)]
-        fn __godot_validate_property(&self, property: &mut PropertyInfo);
+        type Recv: IntoVirtualMethodReceiver<Self>;
+
+        #[doc(hidden)]
+        fn __godot_validate_property(
+            this: VirtualMethodReceiver<Self>,
+            property: &mut PropertyInfo,
+        );
     }
 
     /// Auto-implemented for `#[godot_api] impl MyClass` blocks

--- a/godot-core/src/private.rs
+++ b/godot-core/src/private.rs
@@ -33,7 +33,10 @@ mod reexport_pub {
     };
     #[cfg(since_api = "4.2")]
     pub use crate::registry::signal::priv_re_export::*;
-    pub use crate::storage::{as_storage, Storage};
+    pub use crate::storage::{
+        as_storage, IntoVirtualMethodReceiver, RecvGdSelf, RecvMut, RecvRef, Storage,
+        VirtualMethodReceiver,
+    };
     pub use crate::sys::out;
 }
 pub use reexport_pub::*;

--- a/godot-macros/src/lib.rs
+++ b/godot-macros/src/lib.rs
@@ -823,6 +823,58 @@ pub fn derive_godot_class(input: TokenStream) -> TokenStream {
 /// [`TransferMode`]: ../classes/multiplayer_peer/struct.TransferMode.html
 /// [`RpcConfig`]: ../register/struct.RpcConfig.html
 ///
+/// # Lifecycle functions with custom receivers
+///
+/// Functions inside I* interface impls, similarly to user-defined `#[func]`s, can be annotated with `#[func(gd_self)]` to use `Gd<Self>` receiver and
+/// avoid binding the instance.
+///
+/// ```no_run
+/// # use godot::prelude::*;
+/// #[derive(GodotClass)]
+/// #[class(init, base=Node)]
+/// pub struct MyNode;
+///
+/// #[godot_api]
+/// impl INode for MyNode {
+///     #[func(gd_self)]
+///     fn ready(this: Gd<Self>) {
+///         godot_print!("I'm ready!");
+///     }
+/// }
+/// ```
+///
+/// Only methods with `self` receiver can be used with `#[func(gd_self)]`:
+/// ```compile_fail
+/// # use godot::prelude::*;
+/// #[derive(GodotClass)]
+/// #[class(init, base=Node)]
+/// pub struct MyNode;
+///
+/// #[godot_api]
+/// impl INode for MyNode {
+///     #[func(gd_self)]
+///     fn init(this: Gd<Self>) -> Self {
+///         todo!()
+///     }
+/// }
+/// ```
+///
+/// Currently, `on_notification` can't be used with `[func(gd_self)]`, either:
+///
+/// ```compile_fail
+/// # use godot::prelude::*;
+/// #[derive(GodotClass)]
+/// #[class(init, base=Node)]
+/// pub struct MyNode;
+///
+/// #[godot_api]
+/// impl INode for MyNode {
+///     #[func(gd_self)]
+///     fn on_notification(this: Gd<Self>, what: ObjectNotification) {
+///         todo!()
+///     }
+/// }
+/// ```
 ///
 /// # Signals
 ///


### PR DESCRIPTION
Adds `#[func(gd_self)]` to virtual methods. 



Functions annotated with this attribute are being moved from Trait Impl to Inherent Impl and are registered accordingly. (I'm not sure if I they should be renamed as well – i.e. `__godot_virtual_{virtual_method_name}` instead of `{virtual_method_name}`.

Multiple callbacks are being handled by enum/wrapper/whatever which holds the inner instance; It has been done so to keep storage and whatnot isolated. Initially I wanted to return dereferenced value (`wrapper.recv()`) but compiler was throwing tantrum and demanding polluting everything with lifetimes which was ultra silly – thus a respectable `impl Deref<Target = T> + use<'a, T>` was used instead (I think it is better design choice anyway?). Unfortunately it requires doing some silly things with `std::mem::replace`.



Supports everything, but errors which pop out while trying to use `#[gd_self]` with methods that have other receiver than `self` are annoying. I think I'll just hardcode all such cases later (:roll_eyes:) (so far only callbacks are "shielded").