### PR TITLE
Remove by-value `From` conversions between strings

### DIFF
--- a/godot-core/src/builtin/callable.rs
+++ b/godot-core/src/builtin/callable.rs
@@ -713,7 +713,7 @@ mod custom_callable {
         r_out: sys::GDExtensionStringPtr,
     ) {
         let c: &T = CallableUserdata::inner_from_raw(callable_userdata);
-        let s = crate::builtin::GString::from(c.to_string());
+        let s = GString::from(&c.to_string());
 
         s.move_into_string_ptr(r_out);
         *r_is_valid = sys::conv::SYS_TRUE;

--- a/godot-core/src/builtin/collections/array.rs
+++ b/godot-core/src/builtin/collections/array.rs
@@ -1334,7 +1334,7 @@ impl<T: ArrayElement> GodotType for Array<T> {
         // Typed arrays use type hint.
         PropertyHintInfo {
             hint: crate::global::PropertyHint::ARRAY_TYPE,
-            hint_string: GString::from(element_godot_type_name::<T>()),
+            hint_string: GString::from(&element_godot_type_name::<T>()),
         }
     }
 }

--- a/godot-core/src/builtin/string/gstring.rs
+++ b/godot-core/src/builtin/string/gstring.rs
@@ -359,12 +359,6 @@ impl From<&[char]> for GString {
     }
 }
 
-impl From<String> for GString {
-    fn from(value: String) -> Self {
-        value.as_str().into()
-    }
-}
-
 impl From<&String> for GString {
     fn from(value: &String) -> Self {
         value.as_str().into()
@@ -424,15 +418,6 @@ impl From<&StringName> for GString {
     }
 }
 
-impl From<StringName> for GString {
-    /// Converts this `StringName` to a `GString`.
-    ///
-    /// This is identical to `GString::from(&string_name)`, and as such there is no performance benefit.
-    fn from(string_name: StringName) -> Self {
-        Self::from(&string_name)
-    }
-}
-
 impl From<&NodePath> for GString {
     fn from(path: &NodePath) -> Self {
         unsafe {
@@ -442,15 +427,6 @@ impl From<&NodePath> for GString {
                 ctor(self_ptr, args.as_ptr());
             })
         }
-    }
-}
-
-impl From<NodePath> for GString {
-    /// Converts this `NodePath` to a `GString`.
-    ///
-    /// This is identical to `GString::from(&path)`, and as such there is no performance benefit.
-    fn from(path: NodePath) -> Self {
-        Self::from(&path)
     }
 }
 

--- a/godot-core/src/builtin/string/node_path.rs
+++ b/godot-core/src/builtin/string/node_path.rs
@@ -233,20 +233,16 @@ impl fmt::Debug for NodePath {
 impl_rust_string_conv!(NodePath);
 
 impl From<&str> for NodePath {
+    // NodePath doesn't offer direct construction from bytes; go via GString.
     fn from(s: &str) -> Self {
-        GString::from(s).into()
-    }
-}
-
-impl From<String> for NodePath {
-    fn from(s: String) -> Self {
-        GString::from(s).into()
+        Self::from(&GString::from(s))
     }
 }
 
 impl From<&String> for NodePath {
     fn from(s: &String) -> Self {
-        GString::from(s).into()
+        // NodePath doesn't offer direct construction from bytes; go via GString.
+        Self::from(&GString::from(s))
     }
 }
 
@@ -262,27 +258,9 @@ impl From<&GString> for NodePath {
     }
 }
 
-impl From<GString> for NodePath {
-    /// Converts this `GString` to a `NodePath`.
-    ///
-    /// This is identical to `NodePath::from(&string)`, and as such there is no performance benefit.
-    fn from(string: GString) -> Self {
-        Self::from(&string)
-    }
-}
-
 impl From<&StringName> for NodePath {
-    fn from(string_name: &StringName) -> Self {
-        Self::from(GString::from(string_name))
-    }
-}
-
-impl From<StringName> for NodePath {
-    /// Converts this `StringName` to a `NodePath`.
-    ///
-    /// This is identical to `NodePath::from(&string_name)`, and as such there is no performance benefit.
-    fn from(string_name: StringName) -> Self {
-        Self::from(GString::from(string_name))
+    fn from(s: &StringName) -> Self {
+        Self::from(&GString::from(s))
     }
 }
 

--- a/godot-core/src/builtin/string/string_name.rs
+++ b/godot-core/src/builtin/string/string_name.rs
@@ -126,7 +126,7 @@ impl StringName {
                 // This branch is short-circuited if invoked for CStr and Godot 4.2+, which uses `string_name_new_with_latin1_chars`
                 // (requires nul-termination). In general, fall back to GString conversion.
                 GString::try_from_bytes_with_nul_check(bytes, Encoding::Latin1, check_nul)
-                    .map(Self::from)
+                    .map(|s| Self::from(&s))
             }
             Encoding::Utf8 => {
                 // from_utf8() also checks for intermediate NUL bytes.
@@ -344,12 +344,6 @@ impl From<&str> for StringName {
     }
 }
 
-impl From<String> for StringName {
-    fn from(value: String) -> Self {
-        value.as_str().into()
-    }
-}
-
 impl From<&String> for StringName {
     fn from(value: &String) -> Self {
         value.as_str().into()
@@ -369,27 +363,9 @@ impl From<&GString> for StringName {
     }
 }
 
-impl From<GString> for StringName {
-    /// Converts this `GString` to a `StringName`.
-    ///
-    /// This is identical to `StringName::from(&string)`, and as such there is no performance benefit.
-    fn from(string: GString) -> Self {
-        Self::from(&string)
-    }
-}
-
 impl From<&NodePath> for StringName {
     fn from(path: &NodePath) -> Self {
-        Self::from(GString::from(path))
-    }
-}
-
-impl From<NodePath> for StringName {
-    /// Converts this `NodePath` to a `StringName`.
-    ///
-    /// This is identical to `StringName::from(&path)`, and as such there is no performance benefit.
-    fn from(path: NodePath) -> Self {
-        Self::from(GString::from(path))
+        Self::from(&GString::from(path))
     }
 }
 

--- a/godot-core/src/meta/property_info.rs
+++ b/godot-core/src/meta/property_info.rs
@@ -151,7 +151,7 @@ impl PropertyInfo {
     {
         self.variant_type == VariantType::ARRAY
             && self.hint_info.hint == PropertyHint::ARRAY_TYPE
-            && self.hint_info.hint_string == T::Via::godot_type_name().into()
+            && self.hint_info.hint_string == GString::from(&T::Via::godot_type_name())
     }
 
     // ------------------------------------------------------------------------------------------------------------------------------------------
@@ -291,7 +291,7 @@ impl PropertyHintInfo {
         let hint_string = if sys::GdextBuild::since_api("4.3") {
             GString::new()
         } else {
-            GString::from(type_name)
+            GString::from(&type_name)
         };
 
         Self {
@@ -304,7 +304,7 @@ impl PropertyHintInfo {
     pub fn var_array_element<T: ArrayElement>() -> Self {
         Self {
             hint: PropertyHint::ARRAY_TYPE,
-            hint_string: GString::from(element_godot_type_name::<T>()),
+            hint_string: GString::from(&element_godot_type_name::<T>()),
         }
     }
 
@@ -312,7 +312,7 @@ impl PropertyHintInfo {
     pub fn export_array_element<T: ArrayElement>() -> Self {
         Self {
             hint: PropertyHint::TYPE_STRING,
-            hint_string: GString::from(T::element_type_string()),
+            hint_string: GString::from(&T::element_type_string()),
         }
     }
 
@@ -320,7 +320,7 @@ impl PropertyHintInfo {
     pub fn export_packed_array_element<T: PackedArrayElement>() -> Self {
         Self {
             hint: PropertyHint::TYPE_STRING,
-            hint_string: GString::from(T::element_type_string()),
+            hint_string: GString::from(&T::element_type_string()),
         }
     }
 
@@ -349,7 +349,7 @@ impl PropertyHintInfo {
         D: ?Sized + 'static,
     {
         PropertyHintInfo {
-            hint_string: GString::from(get_dyn_property_hint_string::<T, D>()),
+            hint_string: GString::from(&get_dyn_property_hint_string::<T, D>()),
             ..PropertyHintInfo::export_gd::<T>()
         }
     }

--- a/godot-core/src/registry/property/mod.rs
+++ b/godot-core/src/registry/property/mod.rs
@@ -315,7 +315,7 @@ pub mod export_info_functions {
 
         PropertyHintInfo {
             hint: PropertyHint::RANGE,
-            hint_string: hint_string.into(),
+            hint_string: GString::from(&hint_string),
         }
     }
 
@@ -381,7 +381,7 @@ pub mod export_info_functions {
 
         PropertyHintInfo {
             hint: PropertyHint::ENUM,
-            hint_string: hint_string.into(),
+            hint_string: GString::from(&hint_string),
         }
     }
 
@@ -390,7 +390,7 @@ pub mod export_info_functions {
 
         PropertyHintInfo {
             hint: PropertyHint::EXP_EASING,
-            hint_string: hint_string.into(),
+            hint_string: GString::from(&hint_string),
         }
     }
 
@@ -414,7 +414,7 @@ pub mod export_info_functions {
 
         PropertyHintInfo {
             hint: PropertyHint::FLAGS,
-            hint_string: hint_string.into(),
+            hint_string: GString::from(&hint_string),
         }
     }
 
@@ -493,7 +493,7 @@ pub mod export_info_functions {
 
         PropertyHintInfo {
             hint: PropertyHint::TYPE_STRING,
-            hint_string: format!("{hint_string}:{filter}").into(),
+            hint_string: GString::from(&format!("{hint_string}:{filter}")),
         }
     }
 

--- a/godot-core/src/storage/instance_storage.rs
+++ b/godot-core/src/storage/instance_storage.rs
@@ -217,7 +217,7 @@ pub unsafe fn destroy_storage<T: GodotClass>(instance_ptr: sys::GDExtensionClass
         // In Debug mode, crash which may trigger breakpoint.
         // In Release mode, leak player object (Godot philosophy: don't crash if somehow avoidable). Likely leads to follow-up issues.
         if cfg!(debug_assertions) {
-            let error = crate::builtin::GString::from(error);
+            let error = crate::builtin::GString::from(&error);
             crate::classes::Os::singleton().crash(&error);
         } else {
             leak_rust_object = true;

--- a/godot-macros/src/derive/data_models/c_style_enum.rs
+++ b/godot-macros/src/derive/data_models/c_style_enum.rs
@@ -115,7 +115,8 @@ impl CStyleEnum {
         }
 
         quote! {
-            format!(#fmt, #(#fmt_args),*)
+            // & because it is passed to GString::from().
+            &format!(#fmt, #(#fmt_args),*)
         }
     }
 

--- a/itest/rust/src/builtin_tests/string/gstring_test.rs
+++ b/itest/rust/src/builtin_tests/string/gstring_test.rs
@@ -28,11 +28,6 @@ fn string_conversion() {
     let back = String::from(&second);
 
     assert_eq!(string, back);
-
-    let second = GString::from(string.clone());
-    let back = String::from(second);
-
-    assert_eq!(string, back);
 }
 
 #[itest]
@@ -75,7 +70,7 @@ fn string_chars() {
 
     let string = String::from("ö🍎A💡");
     let string_chars: Vec<char> = string.chars().collect();
-    let gstring = GString::from(string);
+    let gstring = GString::from(&string);
 
     assert_eq!(gstring.chars(), string_chars.as_slice());
     assert_eq!(

--- a/itest/rust/src/builtin_tests/string/node_path_test.rs
+++ b/itest/rust/src/builtin_tests/string/node_path_test.rs
@@ -26,11 +26,6 @@ fn node_path_conversion() {
     let back = GString::from(&name);
 
     assert_eq!(string, back);
-
-    let second = NodePath::from(string.clone());
-    let back = GString::from(second);
-
-    assert_eq!(string, back);
 }
 
 #[itest]

--- a/itest/rust/src/builtin_tests/string/string_name_test.rs
+++ b/itest/rust/src/builtin_tests/string/string_name_test.rs
@@ -28,11 +28,6 @@ fn string_name_conversion() {
     let back = GString::from(&name);
 
     assert_eq!(string, back);
-
-    let second = StringName::from(string.clone());
-    let back = GString::from(second);
-
-    assert_eq!(string, back);
 }
 
 #[itest]
@@ -40,11 +35,6 @@ fn string_name_node_path_conversion() {
     let string = StringName::from("some string");
     let name = NodePath::from(&string);
     let back = StringName::from(&name);
-
-    assert_eq!(string, back);
-
-    let second = NodePath::from(string.clone());
-    let back = StringName::from(second);
 
     assert_eq!(string, back);
 }

--- a/itest/rust/src/object_tests/dyn_gd_test.rs
+++ b/itest/rust/src/object_tests/dyn_gd_test.rs
@@ -4,7 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
-
+use godot::global::godot_str;
 // Test that all important dyn-related symbols are in the prelude.
 use godot::prelude::*;
 
@@ -552,7 +552,7 @@ struct RefcHealth {
 #[godot_api]
 impl IRefCounted for RefcHealth {
     fn to_string(&self) -> GString {
-        format!("RefcHealth(hp={})", self.hp).into()
+        godot_str!("RefcHealth(hp={})", self.hp)
     }
 }
 

--- a/itest/rust/src/object_tests/object_test.rs
+++ b/itest/rust/src/object_tests/object_test.rs
@@ -15,6 +15,7 @@ use godot::builtin::{GString, StringName, Variant, Vector3};
 use godot::classes::{
     file_access, Engine, FileAccess, IRefCounted, Node, Node2D, Node3D, Object, RefCounted,
 };
+use godot::global::godot_str;
 #[allow(deprecated)]
 use godot::meta::{FromGodot, GodotType, ToGodot};
 use godot::obj::{Base, Gd, Inherits, InstanceId, NewAlloc, NewGd, RawGd};
@@ -939,7 +940,7 @@ impl IRefCounted for RefcPayload {
     }
 
     fn to_string(&self) -> GString {
-        format!("value={}", self.value).into()
+        godot_str!("value={}", self.value)
     }
 }
 

--- a/itest/rust/src/object_tests/virtual_methods_test.rs
+++ b/itest/rust/src/object_tests/virtual_methods_test.rs
@@ -17,6 +17,7 @@ use godot::classes::{
     IEditorPlugin, INode, INode2D, IPrimitiveMesh, IRefCounted, InputEvent, InputEventAction, Node,
     Node2D, Object, PrimitiveMesh, RefCounted, Window,
 };
+use godot::global::godot_str;
 use godot::meta::ToGodot;
 use godot::obj::{Base, Gd, NewAlloc, NewGd};
 use godot::private::class_macros::assert_eq_approx;
@@ -44,7 +45,7 @@ struct VirtualMethodTest {
 #[godot_api]
 impl IRefCounted for VirtualMethodTest {
     fn to_string(&self) -> GString {
-        format!("VirtualMethodTest[integer={}]", self.integer).into()
+        godot_str!("VirtualMethodTest[integer={}]", self.integer)
     }
 }
 

--- a/itest/rust/src/register_tests/func_virtual_test.rs
+++ b/itest/rust/src/register_tests/func_virtual_test.rs
@@ -10,6 +10,7 @@
 
 use godot::builtin::vslice;
 use godot::classes::GDScript;
+use godot::global::godot_str;
 use godot::prelude::*;
 
 use crate::framework::itest;
@@ -24,17 +25,17 @@ struct VirtualScriptCalls {
 impl VirtualScriptCalls {
     #[func(virtual)]
     fn greet_lang(&self, i: i32) -> GString {
-        GString::from(format!("Rust#{i}"))
+        godot_str!("Rust#{i}")
     }
 
     #[func(virtual, rename = greet_lang2)]
     fn gl2(&self, s: GString) -> GString {
-        GString::from(format!("{s} Rust"))
+        godot_str!("{s} Rust")
     }
 
     #[func(virtual, gd_self)]
     fn greet_lang3(_this: Gd<Self>, s: GString) -> GString {
-        GString::from(format!("{s} Rust"))
+        godot_str!("{s} Rust")
     }
 
     #[func(virtual)]


### PR DESCRIPTION
Closes #1259.

Rationale: there is no "move into" or "reuse buffer" optimization possible when converting between String, GString, StringName and NodePath. However, consuming the source string suggests that there is such a benefit.

Implementing `From` only on references makes this clearer and leaves the original string intact for further use.

---

This change has the potential to break quite a bit of code and make a few occurrences less nice to use, `GString::from(&s)` instead of `s.into()`. While I personally do like the explicitness, it's still rather wordy.

One way would be to introduce named methods `to_gstring`, `to_string_name`, `to_node_path` over time. Might need a new trait `StringConv`, as inherent methods couldn't support `String`, possibly one of the most common sources.

At that point, it begs the question whether we still need `From` between strings at all, also in light of [our API design](https://godot-rust.github.io/docs/gdext/master/godot/__docs/index.html#4-prefer-explicit-conversions-over-from-trait). The strings are more or less the only place where we still use `From` in such an extent... :thinking: