### PR TITLE
Add `ClassCodegenLevel::Core`

### DIFF
--- a/godot-codegen/src/generator/mod.rs
+++ b/godot-codegen/src/generator/mod.rs
@@ -47,6 +47,7 @@ pub fn generate_sys_module_file(sys_gen_path: &Path, submit_fn: &mut SubmitFn) {
     let code = quote! {
         pub mod table_builtins;
         pub mod table_builtins_lifecycle;
+        pub mod table_core_classes;
         pub mod table_servers_classes;
         pub mod table_scene_classes;
         pub mod table_editor_classes;

--- a/godot-codegen/src/models/domain.rs
+++ b/godot-codegen/src/models/domain.rs
@@ -805,14 +805,15 @@ impl ToTokens for ModName {
 /// At which stage a class function pointer is loaded.
 #[derive(Copy, Clone, Eq, PartialEq, Hash)]
 pub enum ClassCodegenLevel {
+    Core,
     Servers,
     Scene,
     Editor,
 }
 
 impl ClassCodegenLevel {
-    pub fn with_tables() -> [Self; 3] {
-        [Self::Servers, Self::Scene, Self::Editor]
+    pub fn with_tables() -> [Self; 4] {
+        [Self::Core, Self::Servers, Self::Scene, Self::Editor]
     }
 
     pub fn table_global_getter(self) -> Ident {
@@ -829,6 +830,7 @@ impl ClassCodegenLevel {
 
     pub fn lower(self) -> &'static str {
         match self {
+            Self::Core => "core",
             Self::Servers => "servers",
             Self::Scene => "scene",
             Self::Editor => "editor",
@@ -837,6 +839,7 @@ impl ClassCodegenLevel {
 
     fn upper(self) -> &'static str {
         match self {
+            Self::Core => "Core",
             Self::Servers => "Servers",
             Self::Scene => "Scene",
             Self::Editor => "Editor",
@@ -845,6 +848,7 @@ impl ClassCodegenLevel {
 
     pub fn to_init_level(self) -> TokenStream {
         match self {
+            Self::Core => quote! { crate::init::InitLevel::Core },
             Self::Servers => quote! { crate::init::InitLevel::Servers },
             Self::Scene => quote! { crate::init::InitLevel::Scene },
             Self::Editor => quote! { crate::init::InitLevel::Editor },

--- a/godot-codegen/src/special_cases/codegen_special_cases.rs
+++ b/godot-codegen/src/special_cases/codegen_special_cases.rs
@@ -140,6 +140,7 @@ const SELECTED_CLASSES: &[&str] = &[
     "ClassDB",
     "Engine",
     "OS",
+    "ProjectSettings",
     //
     // Editor plugins
     "EditorPlugin",

--- a/godot-codegen/src/special_cases/codegen_special_cases.rs
+++ b/godot-codegen/src/special_cases/codegen_special_cases.rs
@@ -140,7 +140,6 @@ const SELECTED_CLASSES: &[&str] = &[
     "ClassDB",
     "Engine",
     "OS",
-    "ProjectSettings",
     //
     // Editor plugins
     "EditorPlugin",

--- a/godot-codegen/src/special_cases/special_cases.rs
+++ b/godot-codegen/src/special_cases/special_cases.rs
@@ -1036,7 +1036,6 @@ pub fn classify_codegen_level(class_name: &str) -> Option<ClassCodegenLevel> {
         | "RenderSceneData" | "RenderSceneDataExtension"
         => ClassCodegenLevel::Servers,
         // Declared final (un-inheritable) in Rust, but those are still servers.
-        // NOTE: while these _types_ are available at Server level, the singletons themselves are actually not available until _even after_ Editor level.
         | "AudioServer" | "CameraServer" | "NavigationServer2D" | "NavigationServer3D" | "RenderingServer" | "TranslationServer" | "XRServer" | "DisplayServer"
         => ClassCodegenLevel::Servers,
 

--- a/itest/rust/src/lib.rs
+++ b/itest/rust/src/lib.rs
@@ -5,6 +5,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+use std::sync::Mutex;
+
 use godot::init::{gdextension, ExtensionLibrary, InitLevel};
 
 mod benchmarks;
@@ -18,10 +20,36 @@ mod register_tests;
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Entry point
 
+static LEVELS_SEEN: Mutex<Vec<InitLevel>> = Mutex::new(Vec::new());
+
 #[gdextension(entry_symbol = itest_init)]
 unsafe impl ExtensionLibrary for framework::IntegrationTests {
+    fn min_level() -> InitLevel {
+        InitLevel::Core
+    }
     fn on_level_init(level: InitLevel) {
-        // Testing that we can initialize and use `Object`-derived classes during `Servers` init level. See `object_tests::init_level_test`.
-        object_tests::initialize_init_level_test(level);
+        LEVELS_SEEN.lock().unwrap().push(level);
+        match level {
+            InitLevel::Core => {
+                // make sure we can access early core singletons
+                object_tests::test_early_core_singletons();
+            }
+            InitLevel::Servers => {}
+            InitLevel::Scene => {}
+            InitLevel::Editor => {}
+        }
+    }
+}
+
+// Ensure that we saw all the init levels expected.
+#[crate::framework::itest]
+fn observed_all_init_levels() {
+    let levels_seen = LEVELS_SEEN.lock().unwrap().clone();
+    assert_eq!(levels_seen[0], InitLevel::Core);
+    assert_eq!(levels_seen[1], InitLevel::Servers);
+    assert_eq!(levels_seen[2], InitLevel::Scene);
+    // NOTE: some tests don't see editor mode
+    if let Some(level_3) = levels_seen.get(3) {
+        assert_eq!(*level_3, InitLevel::Editor);
     }
 }

--- a/itest/rust/src/lib.rs
+++ b/itest/rust/src/lib.rs
@@ -33,11 +33,11 @@ unsafe impl ExtensionLibrary for framework::IntegrationTests {
                 // Make sure we can access early core singletons.
                 object_tests::test_early_core_singletons();
             }
-            InitLevel::Servers => {}
-            InitLevel::Scene => {
+            InitLevel::Servers => {
                 // Make sure we can access server singletons by now.
-                object_tests::test_general_singletons();
+                object_tests::test_server_singletons();
             }
+            InitLevel::Scene => {}
             InitLevel::Editor => {}
         }
     }

--- a/itest/rust/src/object_tests/init_level_test.rs
+++ b/itest/rust/src/object_tests/init_level_test.rs
@@ -34,14 +34,20 @@ impl SomeObject {
     }
 }
 
-// Run during core init level to ensure we can access core singletons.
+// Runs during core init level to ensure we can access core singletons.
 pub fn test_early_core_singletons() {
-    // ensure we can create and use an Object-derived class during Core init level.
+    // Ensure we can create and use an Object-derived class during Core init level.
     SomeObject::test();
 
-    // check the early core singletons we can access here.
-    let project_settings = godot::classes::ProjectSettings::singleton();
-    project_settings.get("application/config/name");
+    // Check the early core singletons we can access here.
+    #[cfg(feature = "codegen-full")]
+    {
+        let project_settings = godot::classes::ProjectSettings::singleton();
+        assert_eq!(
+            project_settings.get("application/config/name").get_type(),
+            godot::builtin::VariantType::STRING
+        );
+    }
 
     let engine = godot::classes::Engine::singleton();
     assert!(engine.get_physics_ticks_per_second() > 0);
@@ -51,6 +57,12 @@ pub fn test_early_core_singletons() {
 
     let time = godot::classes::Time::singleton();
     assert!(time.get_ticks_usec() <= time.get_ticks_usec());
+}
+
+// Runs during scene init level to ensure we can access general singletons in the Scene init call for the extension as a whole.
+pub fn test_general_singletons() {
+    let mut rendering = godot::classes::RenderingServer::singleton();
+    assert!(rendering.get_test_cube() != godot::builtin::Rid::Invalid);
 }
 
 // Ensure that the above function actually ran.

--- a/itest/rust/src/object_tests/init_level_test.rs
+++ b/itest/rust/src/object_tests/init_level_test.rs
@@ -60,7 +60,7 @@ pub fn test_early_core_singletons() {
 }
 
 // Runs during scene init level to ensure we can access general singletons in the Scene init call for the extension as a whole.
-pub fn test_general_singletons() {
+pub fn test_server_singletons() {
     let mut rendering = godot::classes::RenderingServer::singleton();
     assert!(rendering.get_test_cube() != godot::builtin::Rid::Invalid);
 }

--- a/itest/rust/src/object_tests/mod.rs
+++ b/itest/rust/src/object_tests/mod.rs
@@ -33,4 +33,4 @@ mod virtual_methods_niche_test;
 mod virtual_methods_test;
 
 // Need to test this in the init level method.
-pub use init_level_test::initialize_init_level_test;
+pub use init_level_test::test_early_core_singletons;

--- a/itest/rust/src/object_tests/mod.rs
+++ b/itest/rust/src/object_tests/mod.rs
@@ -33,4 +33,4 @@ mod virtual_methods_niche_test;
 mod virtual_methods_test;
 
 // Need to test this in the init level method.
-pub use init_level_test::test_early_core_singletons;
+pub use init_level_test::*;


### PR DESCRIPTION
- mostly just mimic'd the setup for server classes
- added special_case::is_class_level_core
- moved "Object" and "OpenXRExtensionWrapperExtension" based on a previous "TODO" comment
- added "ProjectSettings" to the list as it seems to also quallify (also editing project settings in Core is currently the only way to affect the initial window creation params)

Unsure if there are any gotchas here, need to do some testing locally (still trying to get my project to use a local gdext build) but wanted to open a draft PR to enable discussion on a concrete change.