### PR TITLE
Emit proper compile error when `#[rpc]` attribute is used in `#[godot_api(secondary)]` block

### DIFF
--- a/godot-macros/src/class/data_models/inherent_impl.rs
+++ b/godot-macros/src/class/data_models/inherent_impl.rs
@@ -266,6 +266,13 @@ fn process_godot_fns(
 
         match attr.ty {
             ItemAttrType::Func(func, rpc_info) => {
+                if rpc_info.is_some() && is_secondary_impl {
+                    return bail!(
+                        &function,
+                        "#[rpc] is currently not supported in secondary impl blocks",
+                    )?;
+                }
+
                 let external_attributes = function.attributes.clone();
 
                 // Transforms the following.

--- a/godot-macros/src/lib.rs
+++ b/godot-macros/src/lib.rs
@@ -932,6 +932,38 @@ pub fn derive_godot_class(input: TokenStream) -> TokenStream {
 ///     pub fn two(&self) { }
 /// }
 /// ```
+///
+/// `#[signal]` and `#[rpc]` attributes are not currently supported in secondary `impl` blocks.
+///
+///```compile_fail
+/// # use godot::prelude::*;
+/// # #[derive(GodotClass)]
+/// # #[class(init, base=Node)]
+/// # pub struct MyNode { base: Base<Node> }
+/// # // Without primary `impl` block the compilation will always fail (no matter if #[signal] attribute is present or not)
+/// # #[godot_api]
+/// # impl MyNode {}
+/// #[godot_api(secondary)]
+/// impl MyNode {
+///     #[signal]
+///     fn my_signal();
+/// }
+/// ```
+///
+///```compile_fail
+/// # use godot::prelude::*;
+/// # #[derive(GodotClass)]
+/// # #[class(init, base=Node)]
+/// # pub struct MyNode { base: Base<Node> }
+/// # // Without primary `impl` block the compilation will always fail (no matter if #[rpc] attribute is present or not).
+/// # #[godot_api]
+/// # impl MyNode {}
+/// #[godot_api(secondary)]
+/// impl MyNode {
+///     #[rpc]
+///     fn foo(&mut self) {}
+/// }
+/// ```
 #[doc(
     alias = "func",
     alias = "rpc",


### PR DESCRIPTION
closes: #1293

Earlier on we were not doing any registration at all, which is confusing.