### PR TITLE
`ClassName` construction from dynamic values

### DIFF
--- a/godot-codegen/src/generator/classes.rs
+++ b/godot-codegen/src/generator/classes.rs
@@ -248,7 +248,7 @@ fn make_class(class: &Class, ctx: &mut Context, view: &ApiView) -> GeneratedClas
                     // Optimization note: instead of lazy init, could use separate static which is manually initialized during registration.
                     static CLASS_NAME: std::sync::OnceLock<ClassName> = std::sync::OnceLock::new();
 
-                    let name: &'static ClassName = CLASS_NAME.get_or_init(|| ClassName::alloc_next_ascii(#class_name_cstr));
+                    let name: &'static ClassName = CLASS_NAME.get_or_init(|| ClassName::__alloc_next_ascii(#class_name_cstr));
                     *name
                 }
 

--- a/godot-core/src/meta/class_name.rs
+++ b/godot-core/src/meta/class_name.rs
@@ -4,6 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
+
 use std::any::TypeId;
 use std::borrow::Cow;
 use std::cell::OnceCell;
@@ -23,17 +24,211 @@ use crate::obj::GodotClass;
 // - Use HashMap and store pre-computed hash. Would need a custom S parameter for HashMap<K, V, S>, see
 //   https://doc.rust-lang.org/std/hash/trait.BuildHasher.html (the default hasher recomputes the hash repeatedly).
 //
-// First element (index 0) is always the empty string name, which is used for "no class".
-static CLASS_NAMES: Global<Vec<ClassNameEntry>> = Global::new(|| vec![ClassNameEntry::none()]);
-static DYNAMIC_INDEX_BY_CLASS_TYPE: Global<HashMap<TypeId, u16>> = Global::default();
 
-// ----------------------------------------------------------------------------------------------------------------------------------------------
+/// Global cache of class names.
+static CLASS_NAME_CACHE: Global<ClassNameCache> = Global::new(ClassNameCache::new);
 
 /// # Safety
 /// Must not use any `ClassName` APIs after this call.
 pub unsafe fn cleanup() {
-    CLASS_NAMES.lock().clear();
-    DYNAMIC_INDEX_BY_CLASS_TYPE.lock().clear();
+    CLASS_NAME_CACHE.lock().clear();
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+
+/// Name of a class registered with Godot.
+///
+/// Holds the Godot name, not the Rust name (they sometimes differ, e.g. Godot `CSGMesh3D` vs Rust `CsgMesh3D`).
+///
+/// This struct implements `Copy` and is very cheap to copy. The actual names are cached globally.
+///
+/// You can access existing classes' name using [`GodotClass::class_name()`][crate::obj::GodotClass::class_name].
+/// If you need to create your own class name, use [`new_cached()`][Self::new_cached].
+///
+/// # Ordering
+///
+/// `ClassName`s are **not** ordered lexicographically, and the ordering relation is **not** stable across multiple runs of your
+/// application. When lexicographical order is needed, it's possible to convert this type to [`GString`] or [`String`]. Note that
+/// [`StringName`] does not implement `Ord`, and its Godot comparison operators are not lexicographical either.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct ClassName {
+    global_index: u16,
+}
+
+impl ClassName {
+    /// Construct a new class name.
+    ///
+    /// You should typically only need this when implementing `GodotClass` manually, without `#[derive(GodotClass)]`, and overriding
+    /// `class_name()`. To access an existing type's class name, use [`<T as GodotClass>::class_name()`][crate::obj::GodotClass::class_name].
+    ///
+    /// This function is expensive the first time it called for a given `T`, but will be cached for subsequent calls. It can make sense to
+    /// store the result in a `static`, to further reduce lookup times, but it's not required.
+    ///
+    /// We discourage calling this function from different places for the same `T`. But if you do so, `init_fn` must return the same string.
+    ///
+    /// # Panics
+    /// If the string is not ASCII and the Godot version is older than 4.4. From Godot 4.4 onwards, class names can be Unicode.
+    pub fn new_cached<T: GodotClass>(init_fn: impl FnOnce() -> String) -> Self {
+        Self::new_cached_inner::<T>(init_fn)
+    }
+
+    // Without bounds.
+    fn new_cached_inner<T: 'static>(init_fn: impl FnOnce() -> String) -> ClassName {
+        let type_id = TypeId::of::<T>();
+        let mut cache = CLASS_NAME_CACHE.lock();
+
+        // Check if already cached by type
+        if let Some(global_index) = cache.get_by_type_id(type_id) {
+            return ClassName { global_index };
+        }
+
+        // Not cached, need to get or create entry
+        let name = init_fn();
+
+        #[cfg(before_api = "4.4")]
+        assert!(
+            name.is_ascii(),
+            "In Godot < 4.4, class name must be ASCII: '{name}'"
+        );
+
+        cache.insert_class_name(ClassNameSource::Owned(name), Some(type_id), false)
+    }
+
+    /// Create a ClassName from a runtime string (for dynamic class names).
+    ///
+    /// Will reuse existing `ClassName` entries if the string is recognized.
+    // Deliberately not public.
+    #[allow(dead_code)] // until used.
+    pub(crate) fn new_dynamic(class_name: String) -> Self {
+        let mut cache = CLASS_NAME_CACHE.lock();
+
+        cache.insert_class_name(ClassNameSource::Owned(class_name), None, false)
+    }
+
+    // Test-only APIs.
+    #[cfg(feature = "trace")] // itest only.
+    #[doc(hidden)]
+    pub fn __cached<T: 'static>(init_fn: impl FnOnce() -> String) -> Self {
+        Self::new_cached_inner::<T>(init_fn)
+    }
+
+    #[cfg(feature = "trace")] // itest only.
+    #[doc(hidden)]
+    pub fn __dynamic(class_name: &str) -> Self {
+        Self::new_dynamic(class_name.to_string())
+    }
+
+    #[doc(hidden)]
+    pub fn none() -> Self {
+        // First element is always the empty string name.
+        Self { global_index: 0 }
+    }
+
+    /// Create a new ASCII; expect to be unique. Internal, reserved for macros.
+    #[doc(hidden)]
+    pub fn __alloc_next_ascii(class_name_cstr: &'static CStr) -> Self {
+        let utf8 = class_name_cstr
+            .to_str()
+            .expect("class name is invalid UTF-8");
+
+        assert!(
+            utf8.is_ascii(),
+            "ClassName::alloc_next_ascii() with non-ASCII Unicode string '{utf8}'"
+        );
+
+        let source = ClassNameSource::Borrowed(class_name_cstr);
+        let mut cache = CLASS_NAME_CACHE.lock();
+        cache.insert_class_name(source, None, true)
+    }
+
+    /// Create a new Unicode entry; expect to be unique. Internal, reserved for macros.
+    #[doc(hidden)]
+    pub fn __alloc_next_unicode(class_name_str: &'static str) -> Self {
+        assert!(
+            cfg!(since_api = "4.4"),
+            "Before Godot 4.4, class names must be ASCII, but '{class_name_str}' is not.\nSee https://github.com/godotengine/godot/pull/96501."
+        );
+
+        assert!(
+            !class_name_str.is_ascii(),
+            "ClassName::__alloc_next_unicode() with ASCII string '{class_name_str}'"
+        );
+
+        let source = ClassNameSource::Owned(class_name_str.to_owned());
+        let mut cache = CLASS_NAME_CACHE.lock();
+        cache.insert_class_name(source, None, true)
+    }
+
+    #[doc(hidden)]
+    pub fn is_none(&self) -> bool {
+        self.global_index == 0
+    }
+    //
+    // /// Returns the class name as a string slice with static storage duration.
+    // pub fn as_str(&self) -> &'static str {
+    //     // unwrap() safe, checked in constructor
+    //     self.c_str.to_str().unwrap()
+    // }
+
+    /// Converts the class name to a `GString`.
+    pub fn to_gstring(&self) -> GString {
+        self.with_string_name(|s| s.into())
+    }
+
+    /// Converts the class name to a `StringName`.
+    pub fn to_string_name(&self) -> StringName {
+        self.with_string_name(|s| s.clone())
+    }
+
+    /// Returns an owned or borrowed `str`.
+    pub fn to_cow_str(&self) -> Cow<'static, str> {
+        let cache = CLASS_NAME_CACHE.lock();
+        let entry = cache.get_entry(self.global_index as usize);
+        entry.rust_str.as_cow_str()
+    }
+
+    /// The returned pointer is valid indefinitely, as entries are never deleted from the cache.
+    /// Since we use `Box<StringName>`, `HashMap` reallocations don't affect the validity of the StringName.
+    #[doc(hidden)]
+    pub fn string_sys(&self) -> sys::GDExtensionConstStringNamePtr {
+        self.with_string_name(|s| s.string_sys())
+    }
+
+    // Takes a closure because the mutex guard protects the reference; so the &StringName cannot leave the scope.
+    fn with_string_name<R>(&self, func: impl FnOnce(&StringName) -> R) -> R {
+        let cache = CLASS_NAME_CACHE.lock();
+        let entry = cache.get_entry(self.global_index as usize);
+
+        let string_name = entry
+            .godot_str
+            .get_or_init(|| entry.rust_str.to_string_name());
+
+        func(string_name)
+    }
+}
+
+impl fmt::Display for ClassName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.with_string_name(|s| s.fmt(f))
+    }
+}
+
+impl fmt::Debug for ClassName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let cache = CLASS_NAME_CACHE.lock();
+        let entry = cache.get_entry(self.global_index as usize);
+        let name = entry.rust_str.as_cow_str();
+
+        if name.is_empty() {
+            write!(f, "ClassName(none)")
+        } else {
+            write!(f, "ClassName({:?})", name)
+        }
+    }
+}
+
+fn ascii_cstr_to_str(cstr: &CStr) -> &str {
+    cstr.to_str().expect("should be validated ASCII")
 }
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
@@ -82,164 +277,95 @@ impl ClassNameSource {
         }
     }
 }
-
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 
-/// Name of a class registered with Godot.
-///
-/// Holds the Godot name, not the Rust name (they sometimes differ, e.g. Godot `CSGMesh3D` vs Rust `CsgMesh3D`).
-///
-/// This struct is very cheap to copy. The actual names are cached globally.
-///
-/// If you need to create your own class name, use [`new_cached()`][Self::new_cached].
-///
-/// # Ordering
-///
-/// `ClassName`s are **not** ordered lexicographically, and the ordering relation is **not** stable across multiple runs of your
-/// application. When lexicographical order is needed, it's possible to convert this type to [`GString`] or [`String`].
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-pub struct ClassName {
-    global_index: u16,
+/// Unified cache for all class name data.
+struct ClassNameCache {
+    /// All class name entries, with index representing [`ClassName::global_index`].
+    /// First element (index 0) is always the empty string name, which is used for "no class".
+    entries: Vec<ClassNameEntry>,
+    /// Cache for type-based lookups.
+    type_to_index: HashMap<TypeId, u16>,
+    /// Cache for runtime string-based lookups.
+    string_to_index: HashMap<String, u16>,
 }
 
-impl ClassName {
-    /// Construct a new class name.
-    ///
-    /// This is expensive the first time it called for a given `T`, but will be cached for subsequent calls.
-    ///
-    /// It is not specified when exactly `init_fn` is invoked. However, it must return the same value for the same `T`. Generally, we expect
-    /// to keep the invocations limited, so you can use more expensive construction in the closure.
-    ///
-    /// # Panics
-    /// If the string is not ASCII and the Godot version is older than 4.4. From Godot 4.4 onwards, class names can be Unicode.
-    pub fn new_cached<T: GodotClass>(init_fn: impl FnOnce() -> String) -> Self {
-        // Check if class name exists.
-        let type_id = TypeId::of::<T>();
-        let mut map = DYNAMIC_INDEX_BY_CLASS_TYPE.lock();
+impl ClassNameCache {
+    fn new() -> Self {
+        let mut string_to_index = HashMap::new();
+        // Pre-populate string cache with the empty string at index 0.
+        string_to_index.insert(String::new(), 0);
 
-        // Insert into linear vector. Note: this doesn't check for overlaps of TypeId between static and dynamic class names.
-        let global_index = *map.entry(type_id).or_insert_with(|| {
-            let name = init_fn();
+        Self {
+            entries: vec![ClassNameEntry::none()],
+            type_to_index: HashMap::new(),
+            string_to_index,
+        }
+    }
 
-            #[cfg(before_api = "4.4")]
+    /// Looks up entries and if not present, inserts them.
+    ///
+    /// Returns the `ClassName` for the given name.
+    ///
+    /// # Panics (Debug)
+    /// If `expect_first` is true and the string is already present in the cache.
+    fn insert_class_name(
+        &mut self,
+        source: ClassNameSource,
+        type_id: Option<TypeId>,
+        expect_first: bool,
+    ) -> ClassName {
+        let name_str = source.as_cow_str();
+
+        if expect_first {
+            // Debug verification that we're indeed the first to register this string.
+            #[cfg(debug_assertions)]
             assert!(
-                name.is_ascii(),
-                "In Godot < 4.4, class name must be ASCII: '{name}'"
+                !self.string_to_index.contains_key(name_str.as_ref()),
+                "insert_class_name() called for already-existing string: {}",
+                name_str
             );
+        } else {
+            // Check string cache first (dynamic path may reuse existing entries).
+            if let Some(&existing_index) = self.string_to_index.get(name_str.as_ref()) {
+                // Update type cache if we have a TypeId and it's not already cached (dynamic-then-static case).
+                // Note: if type_id is Some, we know it came from new_cached_inner after a failed TypeId lookup.
+                if let Some(type_id) = type_id {
+                    self.type_to_index.entry(type_id).or_insert(existing_index);
+                }
+                return ClassName {
+                    global_index: existing_index,
+                };
+            }
+        }
 
-            insert_class(ClassNameSource::Owned(name))
+        // Not found or static path - create new entry.
+        let global_index = self.entries.len().try_into().unwrap_or_else(|_| {
+            panic!("ClassName cache exceeded maximum capacity of 65536 entries")
         });
+
+        self.entries.push(ClassNameEntry::new(source));
+        self.string_to_index
+            .insert(name_str.into_owned(), global_index);
+
+        if let Some(type_id) = type_id {
+            self.type_to_index.insert(type_id, global_index);
+        }
 
         ClassName { global_index }
     }
 
-    #[doc(hidden)]
-    pub fn none() -> Self {
-        // First element is always the empty string name.
-        Self { global_index: 0 }
+    fn get_by_type_id(&self, type_id: TypeId) -> Option<u16> {
+        self.type_to_index.get(&type_id).copied()
     }
 
-    #[doc(hidden)]
-    pub fn alloc_next_ascii(class_name_cstr: &'static CStr) -> Self {
-        let utf8 = class_name_cstr
-            .to_str()
-            .expect("class name is invalid UTF-8");
-
-        assert!(
-            utf8.is_ascii(),
-            "ClassName::alloc_next_ascii() with non-ASCII Unicode string '{utf8}'"
-        );
-
-        let global_index = insert_class(ClassNameSource::Borrowed(class_name_cstr));
-
-        Self { global_index }
+    fn get_entry(&self, index: usize) -> &ClassNameEntry {
+        &self.entries[index]
     }
 
-    #[doc(hidden)]
-    pub fn alloc_next_unicode(class_name_str: &'static str) -> Self {
-        assert!(
-            cfg!(since_api = "4.4"),
-            "Before Godot 4.4, class names must be ASCII, but '{class_name_str}' is not.\nSee https://github.com/godotengine/godot/pull/96501."
-        );
-
-        assert!(
-            !class_name_str.is_ascii(),
-            "ClassName::alloc_next_unicode() with ASCII string '{class_name_str}'"
-        );
-
-        // StringNames use optimized 1-byte-per-char layout for Latin-1/ASCII, so Unicode can as well use the regular constructor.
-        let global_index = insert_class(ClassNameSource::Owned(class_name_str.to_owned()));
-
-        Self { global_index }
+    fn clear(&mut self) {
+        self.entries.clear();
+        self.type_to_index.clear();
+        self.string_to_index.clear();
     }
-
-    #[doc(hidden)]
-    pub fn is_none(&self) -> bool {
-        self.global_index == 0
-    }
-    //
-    // /// Returns the class name as a string slice with static storage duration.
-    // pub fn as_str(&self) -> &'static str {
-    //     // unwrap() safe, checked in constructor
-    //     self.c_str.to_str().unwrap()
-    // }
-
-    /// Converts the class name to a `GString`.
-    pub fn to_gstring(&self) -> GString {
-        self.with_string_name(|s| s.into())
-    }
-
-    /// Converts the class name to a `StringName`.
-    pub fn to_string_name(&self) -> StringName {
-        self.with_string_name(|s| s.clone())
-    }
-
-    /// Returns an owned or borrowed `str`.
-    pub fn to_cow_str(&self) -> Cow<'static, str> {
-        let cached_names = CLASS_NAMES.lock();
-        let entry = &cached_names[self.global_index as usize];
-
-        entry.rust_str.as_cow_str()
-    }
-
-    /// The returned pointer is valid indefinitely, as entries are never deleted from the cache.
-    /// Since we use `Box<StringName>`, `HashMap` reallocations don't affect the validity of the StringName.
-    #[doc(hidden)]
-    pub fn string_sys(&self) -> sys::GDExtensionConstStringNamePtr {
-        self.with_string_name(|s| s.string_sys())
-    }
-
-    // Takes a closure because the mutex guard protects the reference; so the &StringName cannot leave the scope.
-    fn with_string_name<R>(&self, func: impl FnOnce(&StringName) -> R) -> R {
-        let cached_names = CLASS_NAMES.lock();
-        let entry = &cached_names[self.global_index as usize];
-
-        let string_name = entry
-            .godot_str
-            .get_or_init(|| entry.rust_str.to_string_name());
-
-        func(string_name)
-    }
-}
-
-impl fmt::Display for ClassName {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.with_string_name(|s| s.fmt(f))
-    }
-}
-
-/// Adds a new class name to the cache, returning its index.
-fn insert_class(name: ClassNameSource) -> u16 {
-    let mut names = CLASS_NAMES.lock();
-    let index = names
-        .len()
-        .try_into()
-        .expect("Currently limited to 65536 class names");
-
-    names.push(ClassNameEntry::new(name));
-    index
-}
-
-fn ascii_cstr_to_str(cstr: &CStr) -> &str {
-    cstr.to_str().expect("should be validated ASCII")
 }

--- a/godot-macros/src/class/derive_godot_class.rs
+++ b/godot-macros/src/class/derive_godot_class.rs
@@ -56,11 +56,13 @@ pub fn derive_godot_class(item: venial::Item) -> ParseResult<TokenStream> {
         .to_string();
 
     // Determine if we can use ASCII for the class name (in most cases).
+    // Crate godot-macros does not have knowledge of `api-*` features (and neither does user crate where macros are generated),
+    // so we can't cause a compile error if Unicode is used before Godot 4.4. However, this causes a runtime error at startup.
     let class_name_allocation = if class_name_str.is_ascii() {
         let c_str = util::c_str(&class_name_str);
-        quote! { ClassName::alloc_next_ascii(#c_str) }
+        quote! { ClassName::__alloc_next_ascii(#c_str) }
     } else {
-        quote! { ClassName::alloc_next_unicode(#class_name_str) }
+        quote! { ClassName::__alloc_next_unicode(#class_name_str) }
     };
 
     if struct_cfg.is_internal {

--- a/itest/rust/src/object_tests/class_name_test.rs
+++ b/itest/rust/src/object_tests/class_name_test.rs
@@ -13,7 +13,7 @@ use godot::obj::bounds::implement_godot_bounds;
 use godot::obj::GodotClass;
 use godot::sys;
 
-use crate::framework::itest;
+use crate::framework::{expect_panic, itest};
 
 struct A;
 struct U;
@@ -38,7 +38,7 @@ impl GodotClass for U {
 }
 
 #[itest]
-fn class_name_dynamic() {
+fn class_name_godotclass() {
     let a = A::class_name();
     let b = A::class_name();
 
@@ -53,7 +53,7 @@ fn class_name_dynamic() {
 
 #[cfg(since_api = "4.4")]
 #[itest]
-fn class_name_dynamic_unicode() {
+fn class_name_godotclass_unicode() {
     let a = U::class_name();
     let b = U::class_name();
 
@@ -67,6 +67,39 @@ fn class_name_dynamic_unicode() {
         a.to_cow_str(),
         Cow::<'static, str>::Owned("统一码".to_string())
     );
+
+    let b = ClassName::__dynamic("统一码");
+    assert_eq!(a, b);
+}
+
+#[itest]
+fn class_name_from_dynamic() {
+    // Test that runtime-constructed class names are equal to compile-time ones.
+    let comptime = A::class_name();
+    let runtime = ClassName::__dynamic("A");
+    assert_eq!(comptime, runtime);
+    assert_eq!(sys::hash_value(&comptime), sys::hash_value(&runtime));
+    assert_eq!(comptime.to_string(), runtime.to_string());
+
+    // Test that multiple runtime constructions of the same name are equal.
+    let runtime2 = ClassName::__dynamic("A");
+    assert_eq!(runtime, runtime2);
+
+    // Test with a different name.
+    let different_runtime = ClassName::__dynamic("B");
+    assert_ne!(comptime, different_runtime);
+    assert_eq!(different_runtime.to_string(), "B");
+}
+
+#[itest]
+fn class_name_empty() {
+    // Empty string and ClassName::none() should be the same.
+    let none_dynamic = ClassName::__dynamic("");
+    let none = ClassName::none();
+
+    assert_eq!(none_dynamic, none);
+    assert_eq!(format!("{none_dynamic:?}"), "ClassName(none)");
+    assert_eq!(format!("{none:?}"), "ClassName(none)");
 }
 
 // Test Unicode proc-macro support for ClassName.
@@ -74,3 +107,71 @@ fn class_name_dynamic_unicode() {
 #[derive(godot::register::GodotClass)]
 #[class(no_init)]
 struct 统一码 {}
+
+#[itest]
+fn class_name_dynamic_then_static() {
+    struct A;
+
+    // First, insert dynamic string, then static one.
+    let dynamic_name = ClassName::__dynamic("LocalA");
+    let static_name = ClassName::__cached::<A>(|| "LocalA".to_string());
+
+    // They should be equal (same global_index), but current implementation may create duplicates
+    assert_eq!(
+        dynamic_name, static_name,
+        "Dynamic and static ClassName for same string should be equal"
+    );
+}
+
+#[itest]
+fn class_name_static_then_dynamic() {
+    struct B;
+
+    // First, insert static string, then dynamic one.
+    let static_name = ClassName::__cached::<B>(|| "LocalB".to_string());
+    let dynamic_name = ClassName::__dynamic("LocalB");
+
+    // They should be equal (same global_index)
+    assert_eq!(
+        static_name, dynamic_name,
+        "Static and dynamic ClassName for same string should be equal"
+    );
+}
+
+#[itest]
+fn class_name_debug() {
+    struct TestDebugClass;
+
+    // Test debug output for various class names
+    let none_name = ClassName::none();
+    let dynamic_name = ClassName::__dynamic("MyDynamicClass");
+    let static_name = ClassName::__cached::<TestDebugClass>(|| "MyStaticClass".to_string());
+
+    // Verify debug representations include the actual class names
+    assert_eq!(format!("{none_name:?}"), "ClassName(none)");
+    assert_eq!(format!("{dynamic_name:?}"), "ClassName(\"MyDynamicClass\")");
+    assert_eq!(format!("{static_name:?}"), "ClassName(\"MyStaticClass\")");
+}
+
+#[cfg(debug_assertions)]
+#[itest]
+fn class_name_alloc_panic() {
+    // ASCII.
+    {
+        let _1st = ClassName::__alloc_next_ascii(c"DuplicateTestClass");
+
+        expect_panic("2nd allocation with same ASCII string fails", || {
+            let _2nd = ClassName::__alloc_next_ascii(c"DuplicateTestClass");
+        });
+    }
+
+    // Unicode.
+    #[cfg(since_api = "4.4")]
+    {
+        let _1st = ClassName::__alloc_next_unicode("クラス名");
+
+        expect_panic("2nd allocation with same Unicode string fails", || {
+            let _2nd = ClassName::__alloc_next_unicode("クラス名");
+        });
+    }
+}


### PR DESCRIPTION
Extends the caching mechanism to accept not-yet-seen runtime strings and map them to ClassName instances. Useful for Godot introspection APIs returning class names.