### PR TITLE
drop_strong_ref – make sure that given instance haven't been freed before dropping stored StrongRef.

### DIFF
--- a/godot-core/src/obj/base.rs
+++ b/godot-core/src/obj/base.rs
@@ -246,6 +246,13 @@ impl<T: GodotClass> Base<T> {
                 "Base unexpectedly had its strong ref rug-pulled"
             );
 
+            // Editor creates instances of given class for various purposes (getting class docs, default values...)
+            // and frees them instantly before our callable can be executed.
+            // Perform "weak" drop instead of "strong" one iff our instance is no longer valid.
+            if !instance_id.lookup_validity() {
+                strong_ref.unwrap().drop_weak();
+            }
+
             // Triggers RawGd::drop() -> dec-ref -> possibly object destruction.
         });
     }


### PR DESCRIPTION
Silly workaround for #1296. Trying to execute drop on already freed instance was causing a panic.

No tests, because it can't be properly tested outside the editor in CI :/. We are not checking if we are in editor or not, since 1) bug can happen at runtime as well 2) Editor check is as costly as validity check.

Ideally it should be addressed in the upstream with Godot 4.6.