### PR TITLE
Remove static lifetime in `StringName::from(&CStr)`

### DIFF
--- a/godot-core/src/builtin/mod.rs
+++ b/godot-core/src/builtin/mod.rs
@@ -41,7 +41,7 @@ pub mod __prelude_reexport {
     pub use rect2i::*;
     pub use rid::*;
     pub use signal::*;
-    pub use string::{Encoding, GString, NodePath, StringName};
+    pub use string::{static_name, Encoding, GString, NodePath, StringName};
     pub use transform2d::*;
     pub use transform3d::*;
     pub use variant::*;

--- a/godot-core/src/builtin/string/mod.rs
+++ b/godot-core/src/builtin/string/mod.rs
@@ -22,6 +22,7 @@ pub use string_name::*;
 use crate::meta;
 use crate::meta::error::ConvertError;
 use crate::meta::{FromGodot, GodotConvert, ToGodot};
+pub use crate::static_name;
 
 impl GodotConvert for &str {
     type Via = GString;

--- a/itest/rust/src/builtin_tests/string/string_name_test.rs
+++ b/itest/rust/src/builtin_tests/string/string_name_test.rs
@@ -7,7 +7,7 @@
 
 use std::collections::HashSet;
 
-use godot::builtin::{Encoding, GString, NodePath, StringName};
+use godot::builtin::{static_name, Encoding, GString, NodePath, StringName};
 
 use crate::framework::{assert_eq_self, itest};
 
@@ -142,6 +142,30 @@ fn string_name_from_cstr() {
 
         assert_eq!(a, b);
     }
+}
+
+#[itest]
+fn string_name_static_name() {
+    let a = static_name!(c"pure ASCII\t[~]").clone();
+    let b = StringName::from("pure ASCII\t[~]");
+
+    assert_eq!(a, b);
+
+    let a1 = a.clone();
+    let a2 = static_name!(c"pure ASCII\t[~]").clone();
+
+    assert_eq!(a, a1);
+    assert_eq!(a1, a2);
+
+    let a = static_name!(c"\xB1").clone();
+    let b = StringName::from("±");
+
+    assert_eq!(a, b);
+
+    let a = static_name!(c"Latin-1 \xA3 \xB1 text \xBE").clone();
+    let b = StringName::from("Latin-1 £ ± text ¾");
+
+    assert_eq!(a, b);
 }
 
 #[itest]


### PR DESCRIPTION
See https://github.com/godot-rust/gdext/issues/1306 and https://github.com/godotengine/godot/blob/9b50ea8adec073c891763f7c8c2844bf207cf103/core/string/string_name.cpp#L204-L259

Godot copys the cstr to `_data->name`, so it doesn't need static lifetime. Also `p_static` just marks it's static count and should not affect performance, it's useless for godot-rust now.