### PR TITLE
Merge `AsObjectArg<T>` into `AsArg<Gd<T>>`

### DIFF
--- a/godot-codegen/src/conv/type_conversions.rs
+++ b/godot-codegen/src/conv/type_conversions.rs
@@ -237,8 +237,7 @@ fn to_rust_type_uncached(full_ty: &GodotTy, ctx: &mut Context) -> RustTy {
 
         RustTy::EngineClass {
             tokens: quote! { Gd<#qualified_class> },
-            object_arg: quote! { ObjectArg<#qualified_class> },
-            impl_as_object_arg: quote! { impl AsObjectArg<#qualified_class> },
+            impl_as_object_arg: quote! { impl AsArg<Option<Gd<#qualified_class>>> },
             inner_class: ty,
         }
     }

--- a/godot-codegen/src/models/domain.rs
+++ b/godot-codegen/src/models/domain.rs
@@ -541,7 +541,7 @@ impl FnParam {
         }
     }
 
-    /// `impl AsObjectArg<T>` for object parameters. Only set if requested and `T` is an engine class.
+    /// `impl AsArg<Gd<T>>` for object parameters. Only set if requested and `T` is an engine class.
     pub fn new_no_defaults(method_arg: &JsonMethodArg, ctx: &mut Context) -> FnParam {
         FnParam {
             name: safe_ident(&method_arg.name),
@@ -653,10 +653,7 @@ pub enum RustTy {
         /// Tokens with full `Gd<T>` (e.g. used in return type position).
         tokens: TokenStream,
 
-        /// Tokens with `ObjectArg<T>` (used in `type CallSig` tuple types).
-        object_arg: TokenStream,
-
-        /// Signature declaration with `impl AsObjectArg<T>`.
+        /// Signature declaration with `impl AsArg<Gd<T>>`.
         impl_as_object_arg: TokenStream,
 
         /// only inner `T`

--- a/godot-codegen/src/special_cases/special_cases.rs
+++ b/godot-codegen/src/special_cases/special_cases.rs
@@ -638,7 +638,7 @@ pub fn is_class_method_const(class_name: &TyName, godot_method: &JsonClassMethod
 }
 
 /// Currently only for virtual methods; checks if the specified parameter is required (non-null) and can be declared as `Gd<T>`
-/// instead of `Option<Gd<T>>`.
+/// instead of `Option<Gd<T>>`. By default, parameters are optional since we don't have nullability information in GDExtension.
 pub fn is_class_method_param_required(
     class_name: &TyName,
     godot_method_name: &str,

--- a/godot-codegen/src/util.rs
+++ b/godot-codegen/src/util.rs
@@ -25,7 +25,7 @@ pub fn make_imports() -> TokenStream {
     quote! {
         use godot_ffi as sys;
         use crate::builtin::*;
-        use crate::meta::{AsArg, AsObjectArg, ClassName, CowArg, InParamTuple, ObjectArg, ObjectCow, OutParamTuple, ParamTuple, RefArg, Signature};
+        use crate::meta::{AsArg, ClassName, CowArg, InParamTuple, OutParamTuple, ParamTuple, RefArg, Signature};
         use crate::classes::native::*;
         use crate::classes::Object;
         use crate::obj::Gd;

--- a/godot-core/src/meta/args/mod.rs
+++ b/godot-core/src/meta/args/mod.rs
@@ -23,9 +23,8 @@ pub use as_arg::{owned_into_arg, ref_to_arg, ArgPassing, AsArg, ByRef, ByValue, 
 pub use cow_arg::CowArg;
 #[cfg(not(feature = "trace"))]
 pub(crate) use cow_arg::CowArg;
-pub use object_arg::AsObjectArg;
-#[allow(unused_imports)] // ObjectCow is used in generated code.
-pub(crate) use object_arg::{ObjectArg, ObjectCow, ObjectNullArg};
+#[allow(unused)] // TODO(v0.4): replace contents with newer changes
+pub use object_arg::ObjectArg;
 pub use ref_arg::RefArg;
 
 // #[doc(hidden)]

--- a/godot-core/src/meta/args/object_arg.rs
+++ b/godot-core/src/meta/args/object_arg.rs
@@ -9,233 +9,36 @@ use std::ptr;
 
 use godot_ffi::{ExtVariantType, GodotFfi, GodotNullableFfi, PtrcallType};
 
-use crate::builtin::Variant;
-use crate::meta::error::ConvertError;
-use crate::meta::{ClassName, FromGodot, GodotConvert, GodotFfiVariant, GodotType, ToGodot};
-use crate::obj::{bounds, Bounds, DynGd, Gd, GodotClass, Inherits, RawGd};
+use crate::obj::{Gd, GodotClass, Inherits, RawGd};
 use crate::{obj, sys};
-
-/// Objects that can be passed as arguments to Godot engine functions.
-///
-/// This trait is implemented for **shared references** in multiple ways:
-/// - [`&Gd<T>`][crate::obj::Gd]  to pass objects. Subclasses of `T` are explicitly supported.
-/// - [`Option<&Gd<T>>`][Option], to pass optional objects. `None` is mapped to a null argument.
-/// - [`Gd::null_arg()`], to pass `null` arguments without using `Option`.
-///
-/// Note that [`AsObjectArg`] is very similar to the more general [`AsArg`][crate::meta::AsArg] trait. The two may be merged in the future.
-///
-/// # Nullability
-/// <div class="warning">
-/// The GDExtension API does not inform about nullability of its function parameters. It is up to you to verify that the arguments you pass
-/// are only null when this is allowed. Doing this wrong should be safe, but can lead to the function call failing.
-/// </div>
-///
-/// # Different argument types
-/// Currently, the trait requires pass-by-ref, which helps detect accidental cloning when interfacing with Godot APIs. Plus, it is more
-/// consistent with the [`AsArg`][crate::meta::AsArg] trait (for strings, but also `AsArg<Gd<T>>` as used in
-/// [`Array::push()`][crate::builtin::Array::push] and similar methods).
-///
-/// The following table lists the possible argument types and how you can pass them. `Gd` is short for `Gd<T>`.
-///
-/// | Type              | Closest accepted type | How to transform |
-/// |-------------------|-----------------------|------------------|
-/// | `Gd`              | `&Gd`                 | `&arg`           |
-/// | `&Gd`             | `&Gd`                 | `arg`            |
-/// | `&mut Gd`         | `&Gd`                 | `&*arg`          |
-/// | `Option<Gd>`      | `Option<&Gd>`         | `arg.as_ref()`   |
-/// | `Option<&Gd>`     | `Option<&Gd>`         | `arg`            |
-/// | `Option<&mut Gd>` | `Option<&Gd>`         | `arg.as_deref()` |
-/// | (null literal)    |                       | `Gd::null_arg()` |
-#[diagnostic::on_unimplemented(
-    message = "Argument of type `{Self}` cannot be passed to an `impl AsObjectArg<{T}>` parameter",
-    note = "if you pass by value, consider borrowing instead.",
-    note = "see also `AsObjectArg` docs: https://godot-rust.github.io/docs/gdext/master/godot/meta/trait.AsObjectArg.html"
-)]
-pub trait AsObjectArg<T>
-where
-    T: GodotClass + Bounds<Declarer = bounds::DeclEngine>,
-{
-    #[doc(hidden)]
-    fn as_object_arg(&self) -> ObjectArg<T>;
-
-    /// Returns
-    #[doc(hidden)]
-    fn consume_arg(self) -> ObjectCow<T>;
-}
-
-/*
-Currently not implemented for values, to be consistent with AsArg for by-ref builtins. The idea is that this can discover patterns like
-api.method(refc.clone()), and encourage better performance with api.method(&refc). However, we need to see if there's a notable ergonomic
-impact, and consider that for nodes, Gd<T> copies are relatively cheap (no ref-counting). There is also some value in prematurely ending
-the lifetime of a Gd<T> by moving out, so it's not accidentally used later.
-
-impl<T, U> AsObjectArg<T> for Gd<U>
-where
-    T: GodotClass + Bounds<Declarer = bounds::DeclEngine>,
-    U: Inherits<T>,
-{
-    fn as_object_arg(&self) -> ObjectArg<T> {
-        <&Gd<U>>::as_object_arg(&self)
-    }
-
-    fn consume_arg(self) -> ObjectCow<T> {
-        ObjectCow::Owned(self.upcast())
-    }
-}
-*/
-
-impl<T, U> AsObjectArg<T> for &Gd<U>
-where
-    T: GodotClass + Bounds<Declarer = bounds::DeclEngine>,
-    U: Inherits<T>,
-{
-    fn as_object_arg(&self) -> ObjectArg<T> {
-        // SAFETY: In the context where as_object_arg() is called (a Godot engine call), the original Gd is guaranteed to remain valid.
-        // This function is not part of the public API.
-        unsafe { ObjectArg::from_raw_gd(&self.raw) }
-    }
-
-    fn consume_arg(self) -> ObjectCow<T> {
-        ObjectCow::Borrowed(self.as_object_arg())
-    }
-}
-
-impl<T, U, D> AsObjectArg<T> for &DynGd<U, D>
-where
-    T: GodotClass + Bounds<Declarer = bounds::DeclEngine>,
-    U: Inherits<T>,
-    D: ?Sized,
-{
-    fn as_object_arg(&self) -> ObjectArg<T> {
-        // Reuse Deref.
-        let gd: &Gd<U> = self;
-        <&Gd<U>>::as_object_arg(&gd)
-    }
-
-    fn consume_arg(self) -> ObjectCow<T> {
-        // Reuse Deref.
-        let gd: &Gd<U> = self;
-        <&Gd<U>>::consume_arg(gd)
-    }
-}
-
-impl<T, U> AsObjectArg<T> for Option<U>
-where
-    T: GodotClass + Bounds<Declarer = bounds::DeclEngine>,
-    U: AsObjectArg<T>,
-{
-    fn as_object_arg(&self) -> ObjectArg<T> {
-        self.as_ref()
-            .map_or_else(ObjectArg::null, AsObjectArg::as_object_arg)
-    }
-
-    fn consume_arg(self) -> ObjectCow<T> {
-        match self {
-            Some(obj) => obj.consume_arg(),
-            None => Gd::null_arg().consume_arg(),
-        }
-    }
-}
-
-/*
-It's relatively common that Godot APIs return `Option<Gd<T>>` or pass this type in virtual functions. To avoid excessive `as_ref()` calls, we
-**could** directly support `&Option<Gd>` in addition to `Option<&Gd>`. However, this is currently not done as it hides nullability,
-especially in situations where a return type is directly propagated:
-    api(create_obj().as_ref())
-    api(&create_obj())
-While the first is slightly longer, it looks different from a function create_obj() that returns Gd<T> and thus can never be null.
-In some scenarios, it's better to immediately ensure non-null (e.g. through `unwrap()`) instead of propagating nulls to the engine.
-It's also quite idiomatic to use as_ref() for inner-option transforms in Rust.
-
-impl<T, U> AsObjectArg<T> for &Option<U>
-where
-    T: GodotClass + Bounds<Declarer = bounds::DeclEngine>,
-    for<'a> &'a U: AsObjectArg<T>,
-{
-    fn as_object_arg(&self) -> ObjectArg<T> {
-        match self {
-            Some(obj) => obj.as_object_arg(),
-            None => ObjectArg::null(),
-        }
-    }
-
-    fn consume_arg(self) -> ObjectCow<T> {
-        match self {
-            Some(obj) => obj.consume_arg(),
-            None => Gd::null_arg().consume_arg(),
-        }
-    }
-}
-*/
-
-impl<T> AsObjectArg<T> for ObjectNullArg<T>
-where
-    T: GodotClass + Bounds<Declarer = bounds::DeclEngine>,
-{
-    fn as_object_arg(&self) -> ObjectArg<T> {
-        ObjectArg::null()
-    }
-
-    fn consume_arg(self) -> ObjectCow<T> {
-        // Null pointer is safe to borrow.
-        ObjectCow::Borrowed(ObjectArg::null())
-    }
-}
-
-// ----------------------------------------------------------------------------------------------------------------------------------------------
-
-#[doc(hidden)]
-pub struct ObjectNullArg<T>(pub(crate) std::marker::PhantomData<*mut T>);
-
-/// Exists for cases where a value must be moved, and retaining `ObjectArg<T>` may not be possible if the source is owned.
-///
-/// Only used in default-param extender structs.
-#[doc(hidden)]
-pub enum ObjectCow<T: GodotClass> {
-    Owned(Gd<T>),
-    Borrowed(ObjectArg<T>),
-}
-
-impl<T> ObjectCow<T>
-where
-    T: GodotClass + Bounds<Declarer = bounds::DeclEngine>,
-{
-    /// Returns the actual `ObjectArg` to be passed to function calls.
-    ///
-    /// [`ObjectCow`] does not implement [`AsObjectArg<T>`] because a differently-named method is more explicit (fewer errors in codegen),
-    /// and because [`AsObjectArg::consume_arg()`] is not meaningful.
-    pub fn cow_as_object_arg(&self) -> ObjectArg<T> {
-        match self {
-            ObjectCow::Owned(gd) => gd.as_object_arg(),
-            ObjectCow::Borrowed(obj) => obj.clone(),
-        }
-    }
-}
-
-// ----------------------------------------------------------------------------------------------------------------------------------------------
 
 /// View for object arguments passed to the Godot engine. Never owning; must be null or backed by `Gd<T>`.
 ///
-/// Could technically have a lifetime, but this makes the whole calling code more complex, e.g. `type CallSig`. Since usage is quite localized
-/// and this type doesn't use `Drop` or is propagated further, this should be fine.
-#[derive(Debug)]
+/// This type stores only an untyped object pointer, allowing efficient borrowing for object arguments
+/// without cloning. It supports nullable object passing for optional object arguments.
+#[derive(Debug, PartialEq)]
 #[doc(hidden)]
-pub struct ObjectArg<T: GodotClass> {
+pub struct ObjectArg {
     // Never dropped since it's just a view; see constructor.
     object_ptr: sys::GDExtensionObjectPtr,
-    _marker: std::marker::PhantomData<*mut T>,
 }
 
-impl<T> ObjectArg<T>
-where
-    T: GodotClass,
-{
+impl ObjectArg {
+    /// Creates `ObjectArg` from a `Gd`.
+    ///
+    /// # Safety
+    /// The referenced `Gd` must remain valid for the lifetime of this `ObjectArg`.
+    pub unsafe fn from_gd<T: GodotClass>(obj: &Gd<T>) -> Self {
+        Self {
+            object_ptr: obj.obj_sys(),
+        }
+    }
+
+    /// Creates `ObjectArg` from a `RawGd`.
+    ///
     /// # Safety
     /// The referenced `RawGd` must remain valid for the lifetime of this `ObjectArg`.
-    pub unsafe fn from_raw_gd<Derived>(obj: &RawGd<Derived>) -> Self
-    where
-        Derived: Inherits<T>,
-    {
+    pub unsafe fn from_raw_gd<T: GodotClass>(obj: &RawGd<T>) -> Self {
         // Runtime check is necessary, to ensure that object is still alive and has correct runtime type.
         if !obj.is_null() {
             obj.check_rtti("from_raw_gd");
@@ -243,37 +46,50 @@ where
 
         Self {
             object_ptr: obj.obj_sys(),
-            _marker: std::marker::PhantomData,
         }
     }
 
+    /// Creates `ObjectArg` from `Option<&Gd<U>>`, handling upcast to target type `T`.
+    pub fn from_option_gd_ref<T, U>(opt: Option<&Gd<U>>) -> Self
+    where
+        T: GodotClass,
+        U: GodotClass + Inherits<T>,
+    {
+        match opt {
+            Some(gd) => unsafe { Self::from_gd(gd) },
+            None => Self::null(),
+        }
+    }
+
+    /// Creates a null ObjectArg
     pub fn null() -> Self {
         Self {
             object_ptr: ptr::null_mut(),
-            _marker: std::marker::PhantomData,
         }
     }
 
+    /// Returns true if this ObjectArg represents null
     pub fn is_null(&self) -> bool {
         self.object_ptr.is_null()
+    }
+
+    /// Returns the raw object pointer
+    pub fn raw_ptr(&self) -> sys::GDExtensionObjectPtr {
+        self.object_ptr
     }
 }
 
 // #[derive(Clone)] doesn't seem to get bounds right.
-impl<T: GodotClass> Clone for ObjectArg<T> {
+impl Clone for ObjectArg {
     fn clone(&self) -> Self {
         Self {
             object_ptr: self.object_ptr,
-            _marker: std::marker::PhantomData,
         }
     }
 }
 
 // SAFETY: see impl GodotFfi for RawGd.
-unsafe impl<T> GodotFfi for ObjectArg<T>
-where
-    T: GodotClass,
-{
+unsafe impl GodotFfi for ObjectArg {
     // If anything changes here, keep in sync with RawGd impl.
 
     const VARIANT_TYPE: ExtVariantType = ExtVariantType::Concrete(sys::VariantType::OBJECT);
@@ -314,63 +130,7 @@ where
     }
 }
 
-impl<T: GodotClass> GodotConvert for ObjectArg<T> {
-    type Via = Self;
-}
-
-impl<T: GodotClass> ToGodot for ObjectArg<T> {
-    type Pass = crate::meta::ByRef;
-
-    fn to_godot(&self) -> &Self::Via {
-        self
-    }
-}
-
-// TODO refactor signature tuples into separate in+out traits, so FromGodot is no longer needed.
-impl<T: GodotClass> FromGodot for ObjectArg<T> {
-    fn try_from_godot(_via: Self::Via) -> Result<Self, ConvertError> {
-        unreachable!("ObjectArg should only be passed *to* Godot, not *from*.")
-    }
-}
-
-impl<T: GodotClass> GodotType for ObjectArg<T> {
-    type Ffi = Self;
-    type ToFfi<'f> = Self; // TODO: maybe ObjectArg becomes redundant with RefArg?
-
-    fn to_ffi(&self) -> Self::ToFfi<'_> {
-        (*self).clone()
-    }
-
-    fn into_ffi(self) -> Self::Ffi {
-        self
-    }
-
-    fn try_from_ffi(_ffi: Self::Ffi) -> Result<Self, ConvertError> {
-        //unreachable!("ObjectArg should only be passed *to* Godot, not *from*.")
-        Ok(_ffi)
-    }
-
-    fn class_name() -> ClassName {
-        T::class_name()
-    }
-
-    fn godot_type_name() -> String {
-        T::class_name().to_string()
-    }
-}
-
-impl<T: GodotClass> GodotFfiVariant for ObjectArg<T> {
-    fn ffi_to_variant(&self) -> Variant {
-        // Note: currently likely not invoked since there are no known varcall APIs taking Object parameters; however this might change.
-        obj::object_ffi_to_variant(self)
-    }
-
-    fn ffi_from_variant(_variant: &Variant) -> Result<Self, ConvertError> {
-        unreachable!("ObjectArg should only be passed *to* Godot, not *from*.")
-    }
-}
-
-impl<T: GodotClass> GodotNullableFfi for ObjectArg<T> {
+impl GodotNullableFfi for ObjectArg {
     fn null() -> Self {
         Self::null()
     }

--- a/godot-core/src/meta/mod.rs
+++ b/godot-core/src/meta/mod.rs
@@ -40,8 +40,7 @@
 //! "T-compatible" arguments into `T`. This library specializes this idea with two traits:
 //!
 //! - [`AsArg<T>`] allows argument conversions from arguments into `T`. This is most interesting in the context of strings (so you can pass
-//!   `&str` to a function expecting `GString`), but is generic to support e.g. array insertion.
-//! - [`AsObjectArg<T>`] is a more specialized version of `AsArg` that is used for object arguments, i.e. `Gd<T>`.
+//!   `&str` to a function expecting `GString`), but is generic to support object arguments like `Gd<T>` and array insertion.
 
 mod args;
 mod array_type_info;

--- a/godot-core/src/meta/sealed.rs
+++ b/godot-core/src/meta/sealed.rs
@@ -62,7 +62,6 @@ impl<T: ArrayElement> Sealed for Array<T> {}
 impl<T: GodotClass> Sealed for Gd<T> {}
 impl<T: GodotClass> Sealed for RawGd<T> {}
 impl<T: GodotClass, D: ?Sized> Sealed for DynGd<T, D> {}
-impl<T: GodotClass> Sealed for meta::ObjectArg<T> {}
 impl<T> Sealed for Option<T>
 where
     T: GodotType,

--- a/godot-core/src/obj/dyn_gd.rs
+++ b/godot-core/src/obj/dyn_gd.rs
@@ -555,7 +555,7 @@ where
 {
     type Pass = <Gd<T> as ToGodot>::Pass;
 
-    fn to_godot(&self) -> &Self::Via {
+    fn to_godot(&self) -> Self::Via {
         self.obj.to_godot()
     }
 

--- a/itest/rust/src/builtin_tests/containers/array_test.rs
+++ b/itest/rust/src/builtin_tests/containers/array_test.rs
@@ -565,16 +565,15 @@ fn array_resize() {
     assert_eq!(a, Array::new());
 }
 
-// Tests that arrays of objects can be declared without explicit type annotations. A similar test exists for DynGd in dyn_gd_test.rs.
-// This has deliberately been added to guard against regressions in case `AsArg` is extended (T: Inherits<Base> support broke this).
 fn __array_type_inference() {
     let a = Node::new_alloc();
-    let b = Node::new_alloc();
-    let _array = array![&a, &b];
+    let b = Node2D::new_alloc(); // will be implicitly upcast.
+    let _array: Array<Gd<Node>> = array![&a, &b];
 
     let c = ArrayTest::new_gd();
     let d = ArrayTest::new_gd();
-    let _array = array![&c, &d];
+    let _array: Array<Gd<ArrayTest>> = array![&c, &d];
+    // Earlier versions supported `let _array = array[&a, &b]`. This is nice, but allows no upcasting support -- it's a trade-off.
 }
 
 #[derive(GodotClass, Debug)]

--- a/itest/rust/src/builtin_tests/containers/signal_test.rs
+++ b/itest/rust/src/builtin_tests/containers/signal_test.rs
@@ -142,8 +142,8 @@ fn signal_symbols_complex_emit() {
         });
     }
 
-    // Forward compat: .upcast() here becomes a breaking change if we generalize AsArg to include derived->base conversions.
-    sig.emit(&arg.upcast(), "hello");
+    // Allows upcasting.
+    sig.emit(&arg, "hello");
 
     emitter.free();
 }

--- a/itest/rust/src/object_tests/dyn_gd_test.rs
+++ b/itest/rust/src/object_tests/dyn_gd_test.rs
@@ -413,19 +413,21 @@ fn dyn_gd_store_in_godot_array() {
     let a = Gd::from_object(RefcHealth { hp: 33 }).into_dyn();
     let b = foreign::NodeHealth::new_alloc().into_dyn();
 
-    // Forward compat: .upcast() here becomes a breaking change if we generalize AsArg to include derived->base conversions.
-    let array: Array<DynGd<Object, _>> = array![&a.upcast(), &b.upcast()];
+    // Also tests AsArg impl for DynGd, which previously suffered from UB.
+    let array: Array<DynGd<Object, _>> = array![&a, &b];
 
     assert_eq!(array.at(0).dyn_bind().get_hitpoints(), 33);
     assert_eq!(array.at(1).dyn_bind().get_hitpoints(), 100);
 
     array.at(1).free();
 
-    // Tests also type inference of array![]. Independent variable c.
+    // Used to support type inference of array![]. Not anymore with unified AsArg<..> + upcast support.
+    /*
     let c: DynGd<RefcHealth, dyn Health> = Gd::from_object(RefcHealth { hp: 33 }).into_dyn();
     let c = c.upcast::<RefCounted>();
     let array_inferred /*: Array<DynGd<RefCounted, _>>*/ = array![&c];
     assert_eq!(array_inferred.at(0).dyn_bind().get_hitpoints(), 33);
+    */
 }
 
 #[itest]

--- a/itest/rust/src/object_tests/object_test.rs
+++ b/itest/rust/src/object_tests/object_test.rs
@@ -1026,8 +1026,7 @@ pub mod object_test_gd {
 
         #[func]
         fn return_nested_self() -> Array<Gd<<Self as GodotClass>::Base>> {
-            // Forward compat: .upcast() here becomes a breaking change if we generalize AsArg to include derived->base conversions.
-            array![&Self::return_self().upcast()]
+            array![&Self::return_self()] // implicit upcast
         }
 
         #[func]


### PR DESCRIPTION
Remove `AsObjectArg` trait in favor of `AsArg`. 

- Unifies a large amount of special handling for object argument passing, which led to subtle discrepancies between engine APIs and things like `Array::push()`.

- Enables auto-upcasting for `&Gd<Derived>` to `&Gd<Base>` for `AsArg`.

- Comes at the cost of no longer type-inferring `array![&gd]` due to multiple possible types. This limitation already exists for other array literals like `array!["string"]`.

---

This is a baseline PR which has some known flaws, e.g. pass-by-value for `Gd` and `Option<Gd>`. I'm working on these, but given the scale of this refactoring, I'd like to first have an intermediate version merged to reduce the mental load.