### PR TITLE
Remove lifetime from `PassiveGd`

### DIFF
--- a/godot-core/src/obj/guards.rs
+++ b/godot-core/src/obj/guards.rs
@@ -198,12 +198,12 @@ macro_rules! make_base_ref {
         #[doc = concat!("This can be used to call methods on the base object of a ", $object_name, " that takes `&self` as the receiver.\n\n")]
         #[doc = concat!("See [`", stringify!($doc_type), "::base()`](", stringify!($doc_path), "::base()) for usage.")]
         pub struct $ident<'a, T: $bound> {
-            passive_gd: PassiveGd<'a, T::Base>,
+            passive_gd: PassiveGd<T::Base>,
             _instance: &'a T,
         }
 
         impl<'a, T: $bound> $ident<'a, T> {
-            pub(crate) fn new(passive_gd: PassiveGd<'a, T::Base>, instance: &'a T) -> Self {
+            pub(crate) fn new(passive_gd: PassiveGd<T::Base>, instance: &'a T) -> Self {
                 Self {
                     passive_gd,
                     _instance: instance,
@@ -231,13 +231,13 @@ macro_rules! make_base_mut {
         ///
         #[doc = concat!("See [`", stringify!($doc_type), "::base_mut()`](", stringify!($doc_path), "::base_mut()) for usage.\n")]
         pub struct $ident<'a, T: $bound> {
-            passive_gd: PassiveGd<'a, T::Base>,
+            passive_gd: PassiveGd<T::Base>,
             _inaccessible_guard: InaccessibleGuard<'a, T>,
         }
 
         impl<'a, T: $bound> $ident<'a, T> {
             pub(crate) fn new(
-                passive_gd: PassiveGd<'a, T::Base>,
+                passive_gd: PassiveGd<T::Base>,
                 inaccessible_guard: InaccessibleGuard<'a, T>,
             ) -> Self {
                 Self {

--- a/godot-core/src/obj/passive_gd.rs
+++ b/godot-core/src/obj/passive_gd.rs
@@ -5,55 +5,78 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::marker::PhantomData;
 use std::mem::ManuallyDrop;
 use std::ops::{Deref, DerefMut};
 
 use crate::obj::{Gd, GodotClass};
+use crate::sys;
 
 /// Passive (non-owning) reference to a Godot object.
 ///
-/// `PassiveGd<'gd, T>` provides a safe abstraction for weak references to Godot objects. Unlike `Gd<T>`, it does not increment/decrement
+/// `PassiveGd<T>` provides an unsafe abstraction for weak references to Godot objects. Unlike `Gd<T>`, it does not increment/decrement
 /// the reference count for `RefCounted` objects, and its `Drop` impl only cleans up metadata, not the Godot object.
 ///
-/// The lifetime `'gd` can be used to tie it to a _strong_ `Gd<T>` reference, however it can also be `'static` if more flexibility is needed.
+/// This type is for internal use only, to access base objects in guards and traits, and to wrap manual [`Gd::clone_weak()`] and
+/// [`Gd::drop_weak()`] patterns.
 ///
-/// This type is primarily used internally for base object access in guards and traits, providing a clean alternative to manual
-/// [`Gd::clone_weak()`] and [`Gd::drop_weak()`] patterns.
-pub(crate) struct PassiveGd<'gd, T: GodotClass> {
+/// # Why no lifetime?
+/// Previous versions used `PassiveGd<'gd, T>` with an explicit lifetime parameter. This caused subtle borrow-checking issues due to Rust's
+/// [drop check](https://doc.rust-lang.org/nomicon/dropck.html) rules. When a type has drop obligations (implements `Drop` or contains fields
+/// that do), the borrow checker conservatively assumes the destructor might access borrowed data reachable through that value, forcing all
+/// such borrows to strictly outlive the value. This created false conflicts when creating both shared and mutable base references from the
+/// same object, even though our `Drop` implementation never accesses the lifetime-bound data.
+///
+/// By removing the lifetime parameter and making construction `unsafe`, we eliminate these false-positive borrow conflicts while maintaining
+/// memory safety through explicit caller contracts.
+///
+/// In nightly Rust, `#[may_dangle]` on the lifetime parameter might be an alternative, to tell the compiler that our `Drop` implementation
+/// won't access the borrowed data, but this attribute requires careful safety analysis to ensure it's correctly applied.
+pub(crate) struct PassiveGd<T: GodotClass> {
     weak_gd: ManuallyDrop<Gd<T>>,
-
-    // Covariant lifetime: PassiveGd<'a, T> can be used wherever PassiveGd<'b, T> is needed, if 'a: 'b.
-    _phantom: PhantomData<&'gd ()>,
 }
 
-impl<'gd, T: GodotClass> PassiveGd<'gd, T> {
-    pub fn from_strong_ref(gd: &Gd<T>) -> Self {
-        // SAFETY:
-        // - `clone_weak()` creates a pointer conforming to `from_weak_gd()` requirements.
-        // - PassiveGd will destroy the pointer with `drop_weak()`.
+impl<T: GodotClass> PassiveGd<T> {
+    /// Creates a passive reference from a strong `Gd<T>` shared reference.
+    ///
+    /// # Safety
+    /// The caller must ensure that the underlying object remains valid for the entire lifetime of this `PassiveGd`.
+    pub unsafe fn from_strong_ref(gd: &Gd<T>) -> Self {
+        // SAFETY: clone_weak() creates valid weak reference; caller ensures object validity.
+        let weak_gd = gd.clone_weak();
+        unsafe { Self::new(weak_gd) }
+    }
+
+    /// Creates a passive reference directly from a raw object pointer.
+    ///
+    /// This is a direct constructor that avoids the intermediate `Gd::from_obj_sys_weak()` step,
+    /// providing better performance for the common pattern of creating PassiveGd from raw pointers.
+    ///
+    /// # Safety
+    /// - `obj_ptr` must be a valid, live object pointer.
+    /// - The caller must ensure that the underlying object remains valid for the entire lifetime of this `PassiveGd`.
+    pub unsafe fn from_obj_sys(obj_ptr: sys::GDExtensionObjectPtr) -> Self {
+        // SAFETY: from_obj_sys_weak() creates valid weak reference from obj_ptr; caller ensures object validity.
         unsafe {
-            let weak_gd = gd.clone_weak();
-            Self::from_weak_owned(weak_gd)
+            let weak_gd = Gd::from_obj_sys_weak(obj_ptr);
+            Self::new(weak_gd)
         }
     }
 
     /// Creates a passive reference directly from a weak `Gd<T>`.
     ///
-    /// Will invoke `Gd::drop_weak()` when dropped. Since the parameter has no lifetime, you need to provide the lifetime `'gd` explicitly.
+    /// Will invoke `Gd::drop_weak()` when dropped.
     ///
     /// # Safety
     /// - `weak_gd` must be a weakly created `Gd`, e.g. from [`Gd::clone_weak()`] or [`Gd::from_obj_sys_weak()`].
-    /// - The caller must ensure that the `weak_gd` remains valid for the lifetime `'gd`.
-    pub unsafe fn from_weak_owned(weak_gd: Gd<T>) -> Self {
+    /// - The caller must ensure that the underlying object remains valid for the entire lifetime of this `PassiveGd`.
+    unsafe fn new(weak_gd: Gd<T>) -> Self {
         Self {
             weak_gd: ManuallyDrop::new(weak_gd),
-            _phantom: PhantomData,
         }
     }
 }
 
-impl<T: GodotClass> Drop for PassiveGd<'_, T> {
+impl<T: GodotClass> Drop for PassiveGd<T> {
     fn drop(&mut self) {
         // SAFETY: Only extracted once, in Drop.
         let weak = unsafe { ManuallyDrop::take(&mut self.weak_gd) };
@@ -62,7 +85,7 @@ impl<T: GodotClass> Drop for PassiveGd<'_, T> {
     }
 }
 
-impl<T: GodotClass> Deref for PassiveGd<'_, T> {
+impl<T: GodotClass> Deref for PassiveGd<T> {
     type Target = Gd<T>;
 
     fn deref(&self) -> &Self::Target {
@@ -70,7 +93,7 @@ impl<T: GodotClass> Deref for PassiveGd<'_, T> {
     }
 }
 
-impl<T: GodotClass> DerefMut for PassiveGd<'_, T> {
+impl<T: GodotClass> DerefMut for PassiveGd<T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.weak_gd
     }

--- a/itest/rust/src/object_tests/base_test.rs
+++ b/itest/rust/src/object_tests/base_test.rs
@@ -260,6 +260,18 @@ impl Based {
         use godot::obj::WithBaseField as _;
         self.to_gd()
     }
+
+    // Regression compile test for https://github.com/godot-rust/gdext/pull/1312, causing overly restrictive borrow errors.
+    // base() + base_mut() guards' lifetime must not be extended too much.
+    fn _borrow_checks(&mut self) {
+        for _child in self.base().get_children().iter_shared() {
+            self.base_mut().rotate(10.0);
+        }
+
+        for i in 0..self.base().get_child_count() {
+            self.base_mut().rotate(i as real);
+        }
+    }
 }
 
 #[derive(GodotClass)]


### PR DESCRIPTION
Fixes regression introduced by #1302, resulting in too strict borrow checks.

The lifetime's intention was to express the "outlives" relation from `&self` to `PassiveGd<'_, T>`. This worked, however it also introduced a breaking change in the `BaseRef` + `BaseMut` guards. Code such as the following now caused borrow errors:

```rs
for i in 0..self.base().get_child_count() {
    self.base_mut().rotate(10.0);
}
```

This isn't very intuitive, nor particularly helpful for soundness. This PR reverts the `PartialGd<'gd, T>` to `PartialGd<T>` with unsafe constructors. In practice, quite some unsafety was still needed anyway (e.g. `BaseMut` needed an unsafe `'static` intermediate reference).