### PR TITLE
`AsArg` for objects now consistently passes by reference

### DIFF
--- a/godot-core/src/meta/args/cow_arg.rs
+++ b/godot-core/src/meta/args/cow_arg.rs
@@ -228,7 +228,7 @@ impl<T> Deref for CowArg<'_, T> {
             CowArg::Owned(value) => value,
             CowArg::Borrowed(value) => value,
             CowArg::FfiObject(_) => {
-                todo!("Deref not implemented for FfiObject variant")
+                unreachable!("deref(): FfiObject path should only be used for FFI logic")
             }
         }
     }

--- a/godot-core/src/meta/args/cow_arg.rs
+++ b/godot-core/src/meta/args/cow_arg.rs
@@ -12,15 +12,20 @@ use godot_ffi::{ExtVariantType, GodotFfi, GodotNullableFfi, PtrcallType};
 
 use crate::builtin::Variant;
 use crate::meta::error::ConvertError;
-use crate::meta::{FromGodot, GodotConvert, GodotFfiVariant, RefArg, ToGodot};
+use crate::meta::{FromGodot, GodotConvert, GodotFfiVariant, ObjectArg, RefArg, ToGodot};
 use crate::sys;
 
 /// Owned or borrowed value, used when passing arguments through `impl AsArg` to Godot APIs.
 #[doc(hidden)]
 #[derive(PartialEq)]
-pub enum CowArg<'r, T> {
+pub enum CowArg<'arg, T> {
     Owned(T),
-    Borrowed(&'r T),
+    Borrowed(&'arg T),
+
+    /// Raw object pointer for efficient FFI argument passing without cloning.
+    ///
+    /// Only valid for object types (`Gd<T>`, `Option<Gd<T>>`). Can avoid the `Owned` creation.
+    FfiObject(ObjectArg),
 }
 
 impl<T> CowArg<'_, T> {
@@ -31,6 +36,9 @@ impl<T> CowArg<'_, T> {
         match self {
             CowArg::Owned(v) => v,
             CowArg::Borrowed(r) => r.clone(),
+            CowArg::FfiObject(_obj) => {
+                unreachable!("cow_into_owned(): FfiObject path should only be used for FFI logic");
+            }
         }
     }
 
@@ -38,6 +46,9 @@ impl<T> CowArg<'_, T> {
         match self {
             CowArg::Owned(v) => v,
             CowArg::Borrowed(r) => r,
+            CowArg::FfiObject(_) => {
+                unreachable!("cow_as_ref(): FfiObject path should only be used for FFI logic");
+            }
         }
     }
 
@@ -46,7 +57,22 @@ impl<T> CowArg<'_, T> {
     /// [`CowArg`] does not implement [`AsArg<T>`] because a differently-named method is more explicit (fewer errors in codegen),
     /// and because [`AsArg::into_arg()`] is not meaningful.
     pub fn cow_as_arg(&self) -> RefArg<'_, T> {
-        RefArg::new(self.cow_as_ref())
+        match self {
+            CowArg::FfiObject(_) => {
+                unreachable!("cow_as_arg(): FfiObject path should only be used for FFI logic");
+            }
+            _ => RefArg::new(self.cow_as_ref()),
+        }
+    }
+
+    /// Extracts ObjectArg directly for ByObject FFI conversion.
+    ///
+    /// Returns Some(ObjectArg) if this contains FfiObject, None otherwise.
+    pub fn try_extract_object_arg(&self) -> Option<ObjectArg> {
+        match self {
+            CowArg::FfiObject(obj_arg) => Some(obj_arg.clone()),
+            _ => None,
+        }
     }
 }
 
@@ -74,6 +100,8 @@ where
 
     fn to_godot(&self) -> crate::meta::ToArg<'_, Self::Via, Self::Pass> {
         // Forward to the wrapped type's to_godot implementation
+        // For FfiObject, cow_as_ref() will panic, but ByObject's ref_to_ffi
+        // should never call this - it should use as_object_arg() directly
         self.cow_as_ref().to_godot()
     }
 
@@ -106,6 +134,7 @@ where
         match self {
             CowArg::Owned(v) => write!(f, "CowArg::Owned({v:?})"),
             CowArg::Borrowed(r) => write!(f, "CowArg::Borrowed({r:?})"),
+            CowArg::FfiObject(obj_arg) => write!(f, "CowArg::FfiObject({obj_arg:?})"),
         }
     }
 }
@@ -130,7 +159,10 @@ where
     }
 
     fn sys(&self) -> sys::GDExtensionConstTypePtr {
-        self.cow_as_ref().sys()
+        match self {
+            CowArg::FfiObject(obj_arg) => obj_arg.sys(),
+            _ => self.cow_as_ref().sys(),
+        }
     }
 
     fn sys_mut(&mut self) -> sys::GDExtensionTypePtr {
@@ -140,7 +172,10 @@ where
     // This function must be overridden; the default delegating to sys() is wrong for e.g. RawGd<T>.
     // See also other manual overrides of as_arg_ptr().
     fn as_arg_ptr(&self) -> sys::GDExtensionConstTypePtr {
-        self.cow_as_ref().as_arg_ptr()
+        match self {
+            CowArg::FfiObject(obj_arg) => obj_arg.as_arg_ptr(),
+            _ => self.cow_as_ref().as_arg_ptr(),
+        }
     }
 
     unsafe fn from_arg_ptr(_ptr: sys::GDExtensionTypePtr, _call_type: PtrcallType) -> Self {
@@ -158,7 +193,10 @@ where
     T: GodotFfiVariant,
 {
     fn ffi_to_variant(&self) -> Variant {
-        self.cow_as_ref().ffi_to_variant()
+        match self {
+            CowArg::FfiObject(obj_arg) => obj_arg.ffi_to_variant(),
+            _ => self.cow_as_ref().ffi_to_variant(),
+        }
     }
 
     fn ffi_from_variant(_variant: &Variant) -> Result<Self, ConvertError> {
@@ -175,7 +213,10 @@ where
     }
 
     fn is_null(&self) -> bool {
-        self.cow_as_ref().is_null()
+        match self {
+            CowArg::FfiObject(obj_arg) => obj_arg.is_null(),
+            _ => self.cow_as_ref().is_null(),
+        }
     }
 }
 
@@ -186,6 +227,9 @@ impl<T> Deref for CowArg<'_, T> {
         match self {
             CowArg::Owned(value) => value,
             CowArg::Borrowed(value) => value,
+            CowArg::FfiObject(_) => {
+                todo!("Deref not implemented for FfiObject variant")
+            }
         }
     }
 }

--- a/godot-core/src/meta/args/object_arg.rs
+++ b/godot-core/src/meta/args/object_arg.rs
@@ -59,6 +59,11 @@ impl ObjectArg {
     pub fn is_null(&self) -> bool {
         self.object_ptr.is_null()
     }
+
+    /// Returns the raw object pointer.
+    pub fn obj_sys(&self) -> sys::GDExtensionObjectPtr {
+        self.object_ptr
+    }
 }
 
 // #[derive(Clone)] doesn't seem to get bounds right.

--- a/godot-core/src/obj/dyn_gd.rs
+++ b/godot-core/src/obj/dyn_gd.rs
@@ -586,9 +586,9 @@ where
     TBase: GodotClass,
     D: ?Sized + 'static,
 {
-    fn into_arg<'cow>(self) -> meta::CowArg<'cow, DynGd<TBase, D>>
+    fn into_arg<'arg>(self) -> meta::CowArg<'arg, DynGd<TBase, D>>
     where
-        'r: 'cow,
+        'r: 'arg,
     {
         meta::CowArg::Owned(self.clone().upcast::<TBase>())
     }

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -823,9 +823,9 @@ where
         where
             T: GodotClass,
         {
-            fn into_arg<'r>(self) -> CowArg<'r, Option<Gd<T>>>
+            fn into_arg<'arg>(self) -> CowArg<'arg, Option<Gd<T>>>
             where
-                Self: 'r,
+                Self: 'arg,
             {
                 CowArg::Owned(None)
             }
@@ -978,30 +978,6 @@ impl<T: GodotClass> ArrayElement for Option<Gd<T>> {
         Gd::<T>::element_type_string()
     }
 }
-
-/*
-// TODO find a way to generalize AsArg to derived->base conversions without breaking type inference in array![].
-// Possibly we could use a "canonical type" with unambiguous mapping (&Gd<T> -> &Gd<T>, not &Gd<T> -> &Gd<TBase>).
-// See also regression test in array_test.rs.
-
-impl<'r, T, TBase> AsArg<Gd<TBase>> for &'r Gd<T>
-where
-    T: Inherits<TBase>,
-    TBase: GodotClass,
-{
-    #[doc(hidden)] // Repeated despite already hidden in trait; some IDEs suggest this otherwise.
-    fn into_arg<'cow>(self) -> CowArg<'cow, Gd<TBase>>
-    where
-        'r: 'cow, // Original reference must be valid for at least as long as the returned cow.
-    {
-        // Performance: clones unnecessarily, which has overhead for ref-counted objects.
-        // A result of being generic over base objects and allowing T: Inherits<Base> rather than just T == Base.
-        // Was previously `CowArg::Borrowed(self)`. Borrowed() can maybe be specialized for objects, or combined with AsObjectArg.
-
-        CowArg::Owned(self.clone().upcast::<TBase>())
-    }
-}
-*/
 
 impl<T> Default for Gd<T>
 where

--- a/godot-core/src/obj/traits.rs
+++ b/godot-core/src/obj/traits.rs
@@ -134,10 +134,18 @@ unsafe impl Bounds for NoBase {
 /// This trait must only be implemented for subclasses of `Base`.
 ///
 /// Importantly, this means it is always safe to upcast a value of type `Gd<Self>` to `Gd<Base>`.
-pub unsafe trait Inherits<Base: GodotClass>: GodotClass {}
+pub unsafe trait Inherits<Base: GodotClass>: GodotClass {
+    /// True iff `Self == Base`.
+    ///
+    /// Exists because something like C++'s [`std::is_same`](https://en.cppreference.com/w/cpp/types/is_same.html) is notoriously difficult
+    /// in stable Rust, due to lack of specialization.
+    const IS_SAME_CLASS: bool = false;
+}
 
 // SAFETY: Every class is a subclass of itself.
-unsafe impl<T: GodotClass> Inherits<T> for T {}
+unsafe impl<T: GodotClass> Inherits<T> for T {
+    const IS_SAME_CLASS: bool = true;
+}
 
 /// Trait that defines a `T` -> `dyn Trait` relation for use in [`DynGd`][crate::obj::DynGd].
 ///

--- a/itest/rust/src/builtin_tests/convert_test.rs
+++ b/itest/rust/src/builtin_tests/convert_test.rs
@@ -327,15 +327,15 @@ fn slice_to_array() {
     assert!(to.is_err());
 }
 
-fn as_gstr_arg<'a, T: 'a + AsArg<GString>>(t: T) -> CowArg<'a, GString> {
+fn as_gstr_arg<'arg, T: 'arg + AsArg<GString>>(t: T) -> CowArg<'arg, GString> {
     t.into_arg()
 }
 
-fn as_sname_arg<'a, T: 'a + AsArg<StringName>>(t: T) -> CowArg<'a, StringName> {
+fn as_sname_arg<'arg, T: 'arg + AsArg<StringName>>(t: T) -> CowArg<'arg, StringName> {
     t.into_arg()
 }
 
-fn as_npath_arg<'a, T: 'a + AsArg<NodePath>>(t: T) -> CowArg<'a, NodePath> {
+fn as_npath_arg<'arg, T: 'arg + AsArg<NodePath>>(t: T) -> CowArg<'arg, NodePath> {
     t.into_arg()
 }
 

--- a/itest/rust/src/object_tests/object_arg_test.rs
+++ b/itest/rust/src/object_tests/object_arg_test.rs
@@ -5,12 +5,14 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use godot::builtin::Variant;
-use godot::classes::{ClassDb, Node, ResourceFormatLoader, ResourceLoader};
+use godot::builtin::{vslice, Variant};
+use godot::classes::{ClassDb, Node, RefCounted, ResourceFormatLoader, ResourceLoader};
 use godot::global;
+use godot::meta::ToGodot;
 use godot::obj::{Gd, NewAlloc, NewGd};
+use godot::register::{godot_api, GodotClass};
 
-use crate::framework::itest;
+use crate::framework::{create_gdscript, itest};
 use crate::object_tests::object_test::{user_refc_instance, RefcPayload};
 
 /*
@@ -142,6 +144,73 @@ fn object_arg_owned_default_params() {
     ResourceLoader::singleton().remove_resource_format_loader(&b);
 }
 
+// Gd<RefCounted> passed to GDScript should not create unnecessary clones.
+#[itest]
+fn refcount_asarg_gdscript_calls() {
+    let script = create_gdscript(
+        r#"
+extends RefCounted
+
+func observe_refcount_ptrcall(obj: RefCounted) -> int:
+    return obj.get_reference_count()
+
+func observe_refcount_varcall(obj) -> int:
+    if obj == null:
+        return 0
+    return obj.get_reference_count()
+"#,
+    );
+
+    let mut test_instance = RefCounted::new_gd();
+    test_instance.set_script(&script);
+
+    // Already pack into Variant, to have 1 less reference count increment.
+    let refc = RefCounted::new_gd().to_variant();
+    assert_eq!(refc.call("get_reference_count", &[]), 1.to_variant());
+
+    let refcount_typed: i32 = test_instance
+        .call("observe_refcount_ptrcall", &[refc])
+        .to::<i32>();
+
+    let refc = RefCounted::new_gd().to_variant();
+    let refcount_untyped = test_instance
+        .call("observe_refcount_varcall", &[refc])
+        .to::<i32>();
+
+    let refcount_none = test_instance
+        .call("observe_refcount_varcall", vslice![Variant::nil()])
+        .to::<i32>();
+
+    // Both should result in refcount 2: 1 variant in Rust + 1 reference created on GDScript side.
+    assert_eq!(refcount_typed, 2, "typed GDScript param (ptrcall)");
+    assert_eq!(refcount_untyped, 2, "untyped GDScript param (varcall)");
+    assert_eq!(refcount_none, 0, "None/null parameter should return 0");
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// Tests with engine APIs + AsArg below, in module.
+
+#[derive(GodotClass)]
+#[class(base = RefCounted, init)]
+pub struct RefCountAsArgTest;
+
+#[godot_api]
+impl RefCountAsArgTest {
+    #[func]
+    fn accept_option_refcounted(&self, obj: Option<Gd<RefCounted>>) -> i32 {
+        match obj {
+            Some(gd) => gd.get_reference_count(),
+            None => 0,
+        }
+    }
+
+    #[func]
+    fn accept_object(&self, obj: Gd<godot::classes::Object>) -> bool {
+        // Just verify we can receive an Object (for upcast testing).
+        !obj.get_class().is_empty()
+    }
+}
+
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Helpers
 
@@ -163,4 +232,140 @@ where
     assert_eq!(refc2.bind().value, -123);
 
     manual2.free();
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// Tests requiring codegen-full feature
+
+#[cfg(feature = "codegen-full")]
+mod engine_api_tests {
+    use std::cell::Cell;
+
+    use godot::builtin::{Rid, Variant};
+    use godot::classes::{base_material_3d, ITexture2D, StandardMaterial3D, Texture2D};
+    use godot::meta::ToGodot;
+    use godot::obj::{Base, Gd, NewGd, WithBaseField};
+    use godot::register::{godot_api, GodotClass};
+
+    use crate::framework::itest;
+
+    const ALBEDO: base_material_3d::TextureParam = base_material_3d::TextureParam::ALBEDO;
+
+    /// Various internal references are created during `set_texture()`, thus 4. This also matches GDScript code doing the same.
+    /// Verified that before this optimization, the refcount was 5.
+    const EXPECTED_REFCOUNT: i32 = 4;
+
+    fn verify_refcount<F>(exp_refcount: i32, arg_desription: &str, operation: F)
+    where
+        F: FnOnce(&mut Gd<StandardMaterial3D>, &Gd<ArgTestTexture>),
+    {
+        let texture = ArgTestTexture::new_gd();
+        let mut material = StandardMaterial3D::new_gd();
+
+        operation(&mut material, &texture);
+
+        let captured = texture.bind().get_captured_refcount();
+        assert_eq!(captured, exp_refcount, "{}", arg_desription);
+    }
+
+    #[itest]
+    fn refcount_asarg_ref() {
+        verify_refcount(EXPECTED_REFCOUNT, "&object", |mat, tex| {
+            // Sanity check: refcount is 1 before call.
+            assert_eq!(tex.get_reference_count(), 1);
+
+            mat.set_texture(ALBEDO, tex);
+        });
+
+        // Derived -> base conversion. 1 extra due to clone().
+        verify_refcount(EXPECTED_REFCOUNT + 1, "&base_obj", |mat, tex| {
+            let base = tex.clone().upcast::<Texture2D>();
+            mat.set_texture(ALBEDO, &base);
+        });
+    }
+
+    #[itest]
+    fn refcount_asarg_option() {
+        verify_refcount(EXPECTED_REFCOUNT, "Some(&object)", |mat, tex| {
+            mat.set_texture(ALBEDO, Some(tex));
+        });
+
+        // Derived -> base conversion. 1 extra due to clone().
+        verify_refcount(EXPECTED_REFCOUNT + 1, "Some(&base_obj)", |mat, tex| {
+            let base = tex.clone().upcast::<Texture2D>();
+            mat.set_texture(ALBEDO, Some(&base));
+        });
+
+        verify_refcount(0, "None [derived]", |mat, _tex| {
+            mat.set_texture(ALBEDO, None::<&Gd<ArgTestTexture>>);
+        });
+
+        verify_refcount(0, "None [base]", |mat, _tex| {
+            mat.set_texture(ALBEDO, None::<&Gd<Texture2D>>);
+        });
+    }
+
+    #[itest]
+    fn refcount_asarg_null_arg() {
+        verify_refcount(0, "Gd::null_arg()", |mat, _tex| {
+            mat.set_texture(ALBEDO, Gd::null_arg());
+        });
+    }
+
+    #[itest]
+    fn refcount_asarg_variant() {
+        verify_refcount(EXPECTED_REFCOUNT, "&Variant(tex)", |mat, tex| {
+            mat.set("albedo_texture", &tex.to_variant());
+        });
+
+        verify_refcount(0, "&Variant(nil)", |mat, _tex| {
+            mat.set("albedo_texture", &Variant::nil());
+        });
+    }
+
+    // ------------------------------------------------------------------------------------------------------------------------------------------
+    // Test classes for AsArg testing
+
+    #[derive(GodotClass)]
+    #[class(base = Texture2D)]
+    pub struct ArgTestTexture {
+        base: Base<Texture2D>,
+        captured_refcount: Cell<i32>,
+        rid: Rid,
+    }
+
+    #[godot_api]
+    impl ArgTestTexture {
+        fn get_captured_refcount(&self) -> i32 {
+            self.captured_refcount.get()
+        }
+    }
+
+    #[godot_api]
+    impl ITexture2D for ArgTestTexture {
+        fn init(base: Base<Texture2D>) -> Self {
+            Self {
+                base,
+                captured_refcount: Cell::new(0),
+                rid: Rid::new(0),
+            }
+        }
+
+        // Override this method because it's called by StandardMaterial3D::set_texture().
+        // We use it as a hook to observe the reference count from the engine side (after passing through AsArg).
+        fn get_rid(&self) -> Rid {
+            self.captured_refcount
+                .set(self.base().get_reference_count());
+
+            self.rid
+        }
+
+        fn get_width(&self) -> i32 {
+            1
+        }
+
+        fn get_height(&self) -> i32 {
+            1
+        }
+    }
 }


### PR DESCRIPTION
There were situations where `AsArg` used cloning, due to the recent refactorings of argument passing:
- https://github.com/godot-rust/gdext/pull/1308
- https://github.com/godot-rust/gdext/pull/1310

This changes the private API of `AsArg` in ways that allow us to exploit direct FFI passing of objects, like it used to be with the old `ObjectArg`. This includes the case where objects are passed inside `Option`.

Also adds several tests with `Gd<RefCounted>` introspection, protecting against potential perf regressions in future refactorings.

Also adds `IS_SAME_CLASS` const to the `Inherits<T>` trait, which is true if and only if `Self == T`. What sounds silly, is unfortunately necessary, as it's exceedingly hard to do something like [`std::is_same`](https://en.cppreference.com/w/cpp/types/is_same.html) in Rust.