### PR TITLE
More type-safe engine APIs (mostly int -> enum)

### DIFF
--- a/godot-codegen/src/generator/classes.rs
+++ b/godot-codegen/src/generator/classes.rs
@@ -573,6 +573,8 @@ fn make_class_method_definition(
         return FnDefinition::none();
     };
 
+    // Note: parameter type replacements (int -> enum) are already handled during domain mapping.
+
     let rust_class_name = class.name().rust_ty.to_string();
     let rust_method_name = method.name();
     let godot_method_name = method.godot_name();

--- a/godot-codegen/src/generator/default_parameters.rs
+++ b/godot-codegen/src/generator/default_parameters.rs
@@ -80,7 +80,7 @@ pub fn make_function_definition_with_defaults(
         #[doc = #builder_doc]
         #[must_use]
         #cfg_attributes
-        pub struct #builder_ty<'a> {
+        #vis struct #builder_ty<'a> {
             _phantom: std::marker::PhantomData<&'a ()>,
             #( #builder_field_decls, )*
         }

--- a/godot-codegen/src/models/domain.rs
+++ b/godot-codegen/src/models/domain.rs
@@ -17,9 +17,9 @@ use proc_macro2::{Ident, Literal, TokenStream};
 use quote::{format_ident, quote, ToTokens};
 
 use crate::context::Context;
+use crate::conv;
 use crate::models::json::{JsonMethodArg, JsonMethodReturn};
 use crate::util::{ident, option_as_slice, safe_ident};
-use crate::{conv, special_cases};
 
 mod enums;
 
@@ -498,7 +498,6 @@ impl FnQualifier {
 }
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 
-#[derive(Clone)]
 pub struct FnParam {
     pub name: Ident,
 
@@ -511,29 +510,29 @@ pub struct FnParam {
 
 impl FnParam {
     /// Creates a new parameter builder for constructing function parameters with configurable options.
-    pub fn builder<'a>() -> FnParamBuilder<'a> {
+    pub fn builder() -> FnParamBuilder {
         FnParamBuilder::new()
     }
 }
 
 /// Builder for constructing `FnParam` instances with configurable enum replacements and default value handling.
-pub struct FnParamBuilder<'a> {
-    surrounding_class_method: Option<(&'a TyName, &'a str)>,
+pub struct FnParamBuilder {
+    replacements: EnumReplacements,
     no_defaults: bool,
 }
 
-impl<'a> FnParamBuilder<'a> {
-    /// Creates a new parameter builder with default settings (replacements disabled, defaults enabled).
+impl FnParamBuilder {
+    /// Creates a new parameter builder with default settings (no replacements, defaults enabled).
     pub fn new() -> Self {
         Self {
-            surrounding_class_method: None,
+            replacements: &[],
             no_defaults: false,
         }
     }
 
-    /// Configures the builder to apply enum replacements for the specified class and method context.
-    pub fn with_replacements(mut self, class_name: &'a TyName, method_name: &'a str) -> Self {
-        self.surrounding_class_method = Some((class_name, method_name));
+    /// Configures the builder to use specific enum replacements.
+    pub fn enum_replacements(mut self, replacements: EnumReplacements) -> Self {
+        self.replacements = replacements;
         self
     }
 
@@ -541,29 +540,6 @@ impl<'a> FnParamBuilder<'a> {
     pub fn no_defaults(mut self) -> Self {
         self.no_defaults = true;
         self
-    }
-
-    /// Core implementation for processing a single JSON method argument into a `FnParam`.
-    fn build_single_impl(&self, method_arg: &JsonMethodArg, ctx: &mut Context) -> FnParam {
-        let name = safe_ident(&method_arg.name);
-        let type_ = conv::to_rust_type(&method_arg.type_, method_arg.meta.as_ref(), ctx);
-        let type_ =
-            apply_enum_replacement(Some(&method_arg.name), type_, self.surrounding_class_method);
-
-        let default_value = if self.no_defaults {
-            None
-        } else {
-            method_arg
-                .default_value
-                .as_ref()
-                .map(|v| conv::to_rust_expr(v, &type_))
-        };
-
-        FnParam {
-            name,
-            type_,
-            default_value,
-        }
     }
 
     /// Builds a single function parameter from the provided JSON method argument.
@@ -581,6 +557,44 @@ impl<'a> FnParamBuilder<'a> {
             .iter()
             .map(|arg| self.build_single_impl(arg, ctx))
             .collect()
+    }
+
+    /// Core implementation for processing a single JSON method argument into a `FnParam`.
+    fn build_single_impl(&self, method_arg: &JsonMethodArg, ctx: &mut Context) -> FnParam {
+        let name = safe_ident(&method_arg.name);
+        let type_ = conv::to_rust_type(&method_arg.type_, method_arg.meta.as_ref(), ctx);
+
+        // Apply enum replacement if one exists for this parameter
+        let matching_replacement = self
+            .replacements
+            .iter()
+            .find(|(p, ..)| *p == method_arg.name);
+        let type_ = if let Some((_, enum_name, is_bitfield)) = matching_replacement {
+            if !type_.is_integer() {
+                panic!(
+                    "Parameter `{}` is of type {}, but can only replace int with enum",
+                    method_arg.name, type_
+                );
+            }
+            conv::to_enum_type_uncached(enum_name, *is_bitfield)
+        } else {
+            type_
+        };
+
+        let default_value = if self.no_defaults {
+            None
+        } else {
+            method_arg
+                .default_value
+                .as_ref()
+                .map(|v| conv::to_rust_expr(v, &type_))
+        };
+
+        FnParam {
+            name,
+            type_,
+            default_value,
+        }
     }
 }
 
@@ -604,17 +618,30 @@ pub struct FnReturn {
 
 impl FnReturn {
     pub fn new(return_value: &Option<JsonMethodReturn>, ctx: &mut Context) -> Self {
-        Self::new_with_replacements(return_value, None, ctx)
+        Self::with_enum_replacements(return_value, &[], ctx)
     }
 
-    pub fn new_with_replacements(
+    pub fn with_enum_replacements(
         return_value: &Option<JsonMethodReturn>,
-        surrounding_class_method: Option<(&TyName, &str)>,
+        replacements: EnumReplacements,
         ctx: &mut Context,
     ) -> Self {
         if let Some(ret) = return_value {
             let ty = conv::to_rust_type(&ret.type_, ret.meta.as_ref(), ctx);
-            let ty = apply_enum_replacement(None, ty, surrounding_class_method);
+
+            // Apply enum replacement if one exists for return type (indicated by empty string)
+            let matching_replacement = replacements.iter().find(|(p, ..)| p.is_empty());
+            let ty = if let Some((_, enum_name, is_bitfield)) = matching_replacement {
+                if !ty.is_integer() {
+                    panic!(
+                        "Return type is of type {}, but can only replace int with enum",
+                        ty
+                    );
+                }
+                conv::to_enum_type_uncached(enum_name, *is_bitfield)
+            } else {
+                ty
+            };
 
             Self {
                 decl: ty.return_decl(),
@@ -649,56 +676,12 @@ impl FnReturn {
 }
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
+// Int->enum replacements
 
-/// Replaces int parameters/return types with enums, if applicable.
-fn apply_enum_replacement(
-    param_or_return: Option<&str>, // None for return type, Some(name) for parameter
-    type_: RustTy,
-    surrounding: Option<(&TyName, &str)>,
-) -> RustTy {
-    // No surrounding class/method info -> caller doesn't need replacements.
-    let Some((class_name, method_name)) = surrounding else {
-        return type_;
-    };
-
-    let replacements =
-        special_cases::get_class_method_param_enum_replacement(class_name, method_name);
-
-    let matching_replacement = match param_or_return {
-        // Look for a specific parameter name.
-        Some(param_name) => replacements.iter().find(|(p, ..)| *p == param_name),
-
-        // Look for return type (empty string).
-        None => replacements.iter().find(|(p, ..)| p.is_empty()),
-    };
-
-    if let Some((_, enum_name, is_bitfield)) = matching_replacement {
-        if !type_.is_integer() {
-            let what = format_param_or_return(class_name, method_name, param_or_return);
-            panic!("{what} is of type {type_}, but can only replace int with enum");
-        }
-
-        conv::to_enum_type_uncached(enum_name, *is_bitfield)
-    } else {
-        // No replacement.
-        type_
-    }
-}
-
-fn format_param_or_return(
-    class_name: &TyName,
-    method_name: &str,
-    param_or_return: Option<&str>,
-) -> String {
-    let what = if let Some(param_name) = param_or_return {
-        format!("parameter `{param_name}`")
-    } else {
-        "return type".to_string()
-    };
-
-    let class_name = &class_name.godot_ty;
-    format!("{class_name}::{method_name} {what}")
-}
+/// Replacement of int->enum in engine APIs; each tuple being `(param_name, enum_type, is_bitfield)`.
+///
+/// Empty string `""` is used as `param_name` to denote return type replacements.
+pub type EnumReplacements = &'static [(&'static str, &'static str, bool)];
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Godot type

--- a/godot-codegen/src/models/domain_mapping.rs
+++ b/godot-codegen/src/models/domain_mapping.rs
@@ -431,7 +431,7 @@ impl ClassMethod {
 
         Self::from_json_inner(
             method,
-            rust_method_name,
+            rust_method_name.as_ref(),
             class_name,
             FnDirection::Outbound { hash },
             ctx,

--- a/godot-codegen/src/special_cases/special_cases.rs
+++ b/godot-codegen/src/special_cases/special_cases.rs
@@ -32,7 +32,9 @@ use std::borrow::Cow;
 use proc_macro2::Ident;
 
 use crate::conv::to_enum_type_uncached;
-use crate::models::domain::{ClassCodegenLevel, Enum, RustTy, TyName, VirtualMethodPresence};
+use crate::models::domain::{
+    ClassCodegenLevel, Enum, EnumReplacements, RustTy, TyName, VirtualMethodPresence,
+};
 use crate::models::json::{JsonBuiltinMethod, JsonClassMethod, JsonSignal, JsonUtilityFunction};
 use crate::special_cases::codegen_special_cases;
 use crate::util::option_as_slice;
@@ -427,7 +429,7 @@ pub fn is_class_method_replaced_with_type_safe(class_ty: &TyName, godot_method_n
 pub fn get_class_method_param_enum_replacement(
     class_ty: &TyName,
     godot_method_name: &str,
-) -> &'static [(&'static str, &'static str, bool)] {
+) -> EnumReplacements {
     let godot_class_name = class_ty.godot_ty.as_str();
 
     // Notes on replacement mechanism:

--- a/godot-codegen/src/special_cases/special_cases.rs
+++ b/godot-codegen/src/special_cases/special_cases.rs
@@ -27,8 +27,9 @@
 
 #![allow(clippy::match_like_matches_macro)] // if there is only one rule
 
-use proc_macro2::Ident;
 use std::borrow::Cow;
+
+use proc_macro2::Ident;
 
 use crate::conv::to_enum_type_uncached;
 use crate::models::domain::{ClassCodegenLevel, Enum, RustTy, TyName, VirtualMethodPresence};
@@ -397,8 +398,26 @@ pub fn is_class_method_replaced_with_type_safe(class_ty: &TyName, godot_method_n
         // Variant -> Option<Gd<Script>>
         | ("Object", "get_script")
         | ("Object", "set_script")
-        //
+
+        // u32 -> ConnectFlags
         | ("Object", "connect")
+
+        // i32 -> CallGroupFlags
+        | ("SceneTree", "call_group_flags")
+        | ("SceneTree", "notify_group")
+        | ("SceneTree", "notify_group_flags")
+        | ("SceneTree", "set_group_flags")
+
+        // i32 -> DropModeFlags
+        | ("Tree", "set_drop_mode_flags")
+        | ("Tree", "get_drop_mode_flags")
+
+        // i32 -> ModeFlags (codegen-full)
+        | ("FileAccess", "create_temp")
+
+        // u32 -> EmitFlags (codegen-full)
+        | ("GPUParticles2D", "emit_particle")
+        | ("GPUParticles3D", "emit_particle")
 
         => true, _ => false
     }
@@ -1147,6 +1166,10 @@ pub fn is_enum_bitfield(class_name: Option<&TyName>, enum_name: &str) -> Option<
     let class_name = class_name.map(|c| c.godot_ty.as_str());
     match (class_name, enum_name) {
         | (Some("Object"), "ConnectFlags")
+        | (Some("SceneTree"), "GroupCallFlags")
+        | (Some("FileAccess"), "ModeFlags")
+        | (Some("GPUParticles2D"), "EmitFlags")
+        | (Some("GPUParticles3D"), "EmitFlags")
 
         => Some(true),
         _ => None

--- a/godot-codegen/src/special_cases/special_cases.rs
+++ b/godot-codegen/src/special_cases/special_cases.rs
@@ -394,8 +394,11 @@ pub fn is_method_private(class_or_builtin_ty: &TyName, godot_method_name: &str) 
 pub fn is_class_method_replaced_with_type_safe(class_ty: &TyName, godot_method_name: &str) -> bool {
 
     match (class_ty.godot_ty.as_str(), godot_method_name) {
+        // Variant -> Option<Gd<Script>>
         | ("Object", "get_script")
         | ("Object", "set_script")
+        //
+        | ("Object", "connect")
 
         => true, _ => false
     }

--- a/godot-core/src/classes/manual_extensions.rs
+++ b/godot-core/src/classes/manual_extensions.rs
@@ -4,6 +4,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
+
+//! Adds new convenience APIs to existing classes.
+//!
+//! This should not add new functionality, but provide existing one in a slightly nicer way to use. Generally, we should be conservative
+//! about adding methods here, as it's a potentially endless quest, and many are better suited in high-level APIs or third-party crates.
+//!
+//! See also sister module [super::type_safe_replacements].
+
 use crate::builtin::NodePath;
 use crate::classes::{Node, PackedScene};
 use crate::meta::{arg_into_ref, AsArg};

--- a/godot-core/src/classes/mod.rs
+++ b/godot-core/src/classes/mod.rs
@@ -19,6 +19,7 @@
 mod class_runtime;
 mod manual_extensions;
 mod match_class;
+mod type_safe_replacements;
 
 // Re-exports all generated classes, interface traits and sidecar modules.
 pub use crate::gen::classes::*;

--- a/godot-core/src/classes/type_safe_replacements.rs
+++ b/godot-core/src/classes/type_safe_replacements.rs
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+//! Replaces existing Godot APIs with more type-safe ones where appropriate.
+//!
+//! Each entry here *must* be accompanied by
+//!
+//! See also sister module [super::manual_extensions].
+
+use crate::classes::{Object, Script};
+use crate::meta::{AsObjectArg, GodotFfiVariant};
+use crate::obj::Gd;
+
+impl Object {
+    pub fn get_script(&self) -> Option<Gd<Script>> {
+        let variant = self.raw_get_script();
+        if variant.is_nil() {
+            None
+        } else {
+            Some(variant.to())
+        }
+    }
+
+    pub fn set_script(&mut self, script: impl AsObjectArg<Script>) {
+        let variant = script.as_object_arg().ffi_to_variant();
+        self.raw_set_script(&variant);
+    }
+
+    //    pub fn  connect(
+    //     &mut self,
+    //     signal: impl AsArg<StringName>,
+    //     callable: &Callable,
+    // ) -> Error {
+    //
+    //    }
+}

--- a/godot-core/src/classes/type_safe_replacements.rs
+++ b/godot-core/src/classes/type_safe_replacements.rs
@@ -18,71 +18,7 @@ use crate::classes::scene_tree::GroupCallFlags;
 use crate::classes::{Object, SceneTree, Script};
 use crate::global::Error;
 use crate::meta::{arg_into_ref, AsArg, ToGodot};
-use crate::obj::{EngineBitfield, EngineEnum, Gd};
-
-#[cfg(feature = "codegen-full")]
-mod codegen_full {
-    use super::*;
-    use crate::builtin::{Color, Transform2D, Transform3D, Vector2, Vector3};
-    use crate::classes::file_access::{ExRawCreateTemp, ModeFlags};
-    use crate::classes::gpu_particles_2d::EmitFlags as EmitFlags2D;
-    use crate::classes::gpu_particles_3d::EmitFlags as EmitFlags3D;
-    use crate::classes::tree::DropModeFlags;
-    use crate::classes::{FileAccess, GpuParticles2D, GpuParticles3D, Tree};
-    use crate::obj::Gd;
-
-    impl Tree {
-        /// Set drop mode flags with type-safe enum instead of raw integer.
-        pub fn set_drop_mode_flags(&mut self, flags: DropModeFlags) {
-            self.raw_set_drop_mode_flags(flags.ord())
-        }
-
-        /// Get drop mode flags as type-safe enum instead of raw integer.
-        pub fn get_drop_mode_flags(&self) -> DropModeFlags {
-            DropModeFlags::from_ord(self.raw_get_drop_mode_flags())
-        }
-    }
-
-    impl FileAccess {
-        /// Create a temporary file with type-safe mode flags.
-        pub fn create_temp(mode_flags: ModeFlags) -> Option<Gd<FileAccess>> {
-            Self::raw_create_temp(mode_flags.ord() as i32)
-        }
-
-        // FIXME: warning: type `gen::classes::file_access::ExRawCreateTemp<'a>` is more private than the item `codegen_full::<impl gen::classes::file_access::re_export::FileAccess>::create_temp_ex`
-        pub fn create_temp_ex<'a>(mode_flags: ModeFlags) -> ExRawCreateTemp<'a> {
-            Self::raw_create_temp_ex(mode_flags.ord() as i32)
-        }
-    }
-
-    impl GpuParticles2D {
-        /// Emit a particle with type-safe emit flags.
-        pub fn emit_particle(
-            &mut self,
-            xform: Transform2D,
-            velocity: Vector2,
-            color: Color,
-            custom: Color,
-            flags: EmitFlags2D,
-        ) {
-            self.raw_emit_particle(xform, velocity, color, custom, flags.ord() as u32)
-        }
-    }
-
-    impl GpuParticles3D {
-        /// Emit a particle with type-safe emit flags.
-        pub fn emit_particle(
-            &mut self,
-            xform: Transform3D,
-            velocity: Vector3,
-            color: Color,
-            custom: Color,
-            flags: EmitFlags3D,
-        ) {
-            self.raw_emit_particle(xform, velocity, color, custom, flags.ord() as u32)
-        }
-    }
-}
+use crate::obj::{EngineBitfield, Gd};
 
 impl Object {
     pub fn get_script(&self) -> Option<Gd<Script>> {
@@ -154,4 +90,9 @@ impl SceneTree {
     ) {
         self.raw_notify_group_flags(call_flags.ord() as u32, group, notification.into())
     }
+}
+
+#[cfg(feature = "codegen-full")]
+mod codegen_full {
+    // For future, expanding manual replacements for classes in the codegen-full set.
 }

--- a/godot-core/src/classes/type_safe_replacements.rs
+++ b/godot-core/src/classes/type_safe_replacements.rs
@@ -11,12 +11,78 @@
 //!
 //! See also sister module [super::manual_extensions].
 
-use crate::builtin::{Callable, StringName};
+use crate::builtin::{Callable, GString, StringName, Variant};
+use crate::classes::notify::NodeNotification;
 use crate::classes::object::ConnectFlags;
-use crate::classes::{Object, Script};
+use crate::classes::scene_tree::GroupCallFlags;
+use crate::classes::{Object, SceneTree, Script};
 use crate::global::Error;
-use crate::meta::{AsArg, AsObjectArg, GodotFfiVariant};
-use crate::obj::{EngineBitfield, Gd};
+use crate::meta::{arg_into_ref, AsArg, ToGodot};
+use crate::obj::{EngineBitfield, EngineEnum, Gd};
+
+#[cfg(feature = "codegen-full")]
+mod codegen_full {
+    use super::*;
+    use crate::builtin::{Color, Transform2D, Transform3D, Vector2, Vector3};
+    use crate::classes::file_access::{ExRawCreateTemp, ModeFlags};
+    use crate::classes::gpu_particles_2d::EmitFlags as EmitFlags2D;
+    use crate::classes::gpu_particles_3d::EmitFlags as EmitFlags3D;
+    use crate::classes::tree::DropModeFlags;
+    use crate::classes::{FileAccess, GpuParticles2D, GpuParticles3D, Tree};
+    use crate::obj::Gd;
+
+    impl Tree {
+        /// Set drop mode flags with type-safe enum instead of raw integer.
+        pub fn set_drop_mode_flags(&mut self, flags: DropModeFlags) {
+            self.raw_set_drop_mode_flags(flags.ord())
+        }
+
+        /// Get drop mode flags as type-safe enum instead of raw integer.
+        pub fn get_drop_mode_flags(&self) -> DropModeFlags {
+            DropModeFlags::from_ord(self.raw_get_drop_mode_flags())
+        }
+    }
+
+    impl FileAccess {
+        /// Create a temporary file with type-safe mode flags.
+        pub fn create_temp(mode_flags: ModeFlags) -> Option<Gd<FileAccess>> {
+            Self::raw_create_temp(mode_flags.ord() as i32)
+        }
+
+        // FIXME: warning: type `gen::classes::file_access::ExRawCreateTemp<'a>` is more private than the item `codegen_full::<impl gen::classes::file_access::re_export::FileAccess>::create_temp_ex`
+        pub fn create_temp_ex<'a>(mode_flags: ModeFlags) -> ExRawCreateTemp<'a> {
+            Self::raw_create_temp_ex(mode_flags.ord() as i32)
+        }
+    }
+
+    impl GpuParticles2D {
+        /// Emit a particle with type-safe emit flags.
+        pub fn emit_particle(
+            &mut self,
+            xform: Transform2D,
+            velocity: Vector2,
+            color: Color,
+            custom: Color,
+            flags: EmitFlags2D,
+        ) {
+            self.raw_emit_particle(xform, velocity, color, custom, flags.ord() as u32)
+        }
+    }
+
+    impl GpuParticles3D {
+        /// Emit a particle with type-safe emit flags.
+        pub fn emit_particle(
+            &mut self,
+            xform: Transform3D,
+            velocity: Vector3,
+            color: Color,
+            custom: Color,
+            flags: EmitFlags3D,
+        ) {
+            self.raw_emit_particle(xform, velocity, color, custom, flags.ord() as u32)
+        }
+    }
+}
 
 impl Object {
     pub fn get_script(&self) -> Option<Gd<Script>> {
@@ -28,9 +94,10 @@ impl Object {
         }
     }
 
-    pub fn set_script(&mut self, script: impl AsObjectArg<Script>) {
-        let variant = script.as_object_arg().ffi_to_variant();
-        self.raw_set_script(&variant);
+    pub fn set_script(&mut self, script: impl AsArg<Option<Gd<Script>>>) {
+        arg_into_ref!(script);
+
+        self.raw_set_script(&script.to_variant());
     }
 
     pub fn connect(&mut self, signal: impl AsArg<StringName>, callable: &Callable) -> Error {
@@ -46,5 +113,45 @@ impl Object {
         self.raw_connect_ex(signal, callable)
             .flags(flags.ord() as u32)
             .done()
+    }
+}
+
+impl SceneTree {
+    // Note: this creates different order between call_group(), call_group_flags() in docs.
+    // Maybe worth redeclaring those as well?
+
+    pub fn call_group_flags(
+        &mut self,
+        flags: GroupCallFlags,
+        group: impl AsArg<StringName>,
+        method: impl AsArg<StringName>,
+        varargs: &[Variant],
+    ) {
+        self.raw_call_group_flags(flags.ord() as i64, group, method, varargs)
+    }
+
+    pub fn set_group_flags(
+        &mut self,
+        call_flags: GroupCallFlags,
+        group: impl AsArg<StringName>,
+        property: impl AsArg<GString>,
+        value: &Variant,
+    ) {
+        self.raw_set_group_flags(call_flags.ord() as u32, group, property, value)
+    }
+
+    /// Assumes notifications of `Node`. To relay those of derived constants, use [`NodeNotification::Unknown`].
+    pub fn notify_group(&mut self, group: impl AsArg<StringName>, notification: NodeNotification) {
+        self.raw_notify_group(group, notification.into())
+    }
+
+    /// Assumes notifications of `Node`. To relay those of derived constants, use [`NodeNotification::Unknown`].
+    pub fn notify_group_flags(
+        &mut self,
+        call_flags: GroupCallFlags,
+        group: impl AsArg<StringName>,
+        notification: NodeNotification,
+    ) {
+        self.raw_notify_group_flags(call_flags.ord() as u32, group, notification.into())
     }
 }

--- a/godot-core/src/classes/type_safe_replacements.rs
+++ b/godot-core/src/classes/type_safe_replacements.rs
@@ -11,9 +11,12 @@
 //!
 //! See also sister module [super::manual_extensions].
 
+use crate::builtin::{Callable, StringName};
+use crate::classes::object::ConnectFlags;
 use crate::classes::{Object, Script};
-use crate::meta::{AsObjectArg, GodotFfiVariant};
-use crate::obj::Gd;
+use crate::global::Error;
+use crate::meta::{AsArg, AsObjectArg, GodotFfiVariant};
+use crate::obj::{EngineBitfield, Gd};
 
 impl Object {
     pub fn get_script(&self) -> Option<Gd<Script>> {
@@ -30,11 +33,18 @@ impl Object {
         self.raw_set_script(&variant);
     }
 
-    //    pub fn  connect(
-    //     &mut self,
-    //     signal: impl AsArg<StringName>,
-    //     callable: &Callable,
-    // ) -> Error {
-    //
-    //    }
+    pub fn connect(&mut self, signal: impl AsArg<StringName>, callable: &Callable) -> Error {
+        self.raw_connect(signal, callable)
+    }
+
+    pub fn connect_flags(
+        &mut self,
+        signal: impl AsArg<StringName>,
+        callable: &Callable,
+        flags: ConnectFlags,
+    ) -> Error {
+        self.raw_connect_ex(signal, callable)
+            .flags(flags.ord() as u32)
+            .done()
+    }
 }

--- a/godot-core/src/obj/script.rs
+++ b/godot-core/src/obj/script.rs
@@ -345,16 +345,11 @@ where
     O: Inherits<Object>,
     S: Inherits<Script> + IScriptExtension + super::Bounds<Declarer = super::bounds::DeclUser>,
 {
-    let object_script_variant = object.upcast_ref().get_script();
-
-    if object_script_variant.is_nil() {
+    let Some(object_script) = object.upcast_ref().get_script() else {
         return false;
-    }
+    };
 
-    if object_script_variant
-        .object_id()
-        .is_none_or(|instance_id| instance_id != script.instance_id())
-    {
+    if object_script.instance_id() != script.instance_id() {
         return false;
     }
 

--- a/godot-core/src/registry/signal/typed_signal.rs
+++ b/godot-core/src/registry/signal/typed_signal.rs
@@ -165,17 +165,15 @@ impl<'c, C: WithSignals, Ps: meta::ParamTuple> TypedSignal<'c, C, Ps> {
         callable: Callable,
         flags: Option<ConnectFlags>,
     ) -> ConnectHandle {
-        use crate::obj::EngineBitfield;
-
         let signal_name = self.name.as_ref();
 
         let mut owned_object = self.object.to_owned_object();
         owned_object.with_object_mut(|obj| {
-            let mut c = obj.connect_ex(signal_name, &callable);
             if let Some(flags) = flags {
-                c = c.flags(flags.ord() as u32);
+                obj.connect_flags(signal_name, &callable, flags);
+            } else {
+                obj.connect(signal_name, &callable);
             }
-            c.done();
         });
 
         ConnectHandle::new(owned_object, self.name.clone(), callable)

--- a/godot-core/src/task/futures.rs
+++ b/godot-core/src/task/futures.rs
@@ -18,7 +18,7 @@ use crate::classes::object::ConnectFlags;
 use crate::godot_error;
 use crate::meta::sealed::Sealed;
 use crate::meta::InParamTuple;
-use crate::obj::{EngineBitfield, Gd, GodotClass, WithSignals};
+use crate::obj::{Gd, GodotClass, WithSignals};
 use crate::registry::signal::TypedSignal;
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
@@ -207,9 +207,9 @@ impl<R: InParamTuple + IntoDynamicSend> FallibleSignalFuture<R> {
         // The callable currently requires that the return value is Sync + Send.
         let callable = SignalFutureResolver::new(data.clone());
 
-        signal.connect(
+        signal.connect_flags(
             &Callable::from_custom(callable.clone()),
-            ConnectFlags::ONE_SHOT.ord() as i64,
+            ConnectFlags::ONE_SHOT,
         );
 
         Self {

--- a/itest/rust/src/builtin_tests/containers/array_test.rs
+++ b/itest/rust/src/builtin_tests/containers/array_test.rs
@@ -623,7 +623,7 @@ func make_array() -> Array[CustomScriptForArrays]:
     );
 
     let mut object = RefCounted::new_gd();
-    object.set_script(&gdscript.to_variant());
+    object.set_script(&gdscript);
 
     // Invoke script to return an array of itself.
     let result = object.call("make_array", &[]);

--- a/itest/rust/src/builtin_tests/containers/callable_test.rs
+++ b/itest/rust/src/builtin_tests/containers/callable_test.rs
@@ -620,7 +620,7 @@ pub mod custom_callable {
 
         let obj = RefCounted::new_gd();
         let signal = Signal::from_object_signal(&obj, "script_changed");
-        signal.connect(&some_callable, 0);
+        signal.connect(&some_callable);
 
         // Given Custom Callable is connected to signal
         // if callable with the very same hash is already connected.

--- a/itest/rust/src/builtin_tests/containers/dictionary_test.rs
+++ b/itest/rust/src/builtin_tests/containers/dictionary_test.rs
@@ -781,7 +781,7 @@ func variant_script_dict() -> Dictionary[Variant, CustomScriptForDictionaries]:
     );
 
     let mut object = RefCounted::new_gd();
-    object.set_script(&gdscript.to_variant());
+    object.set_script(&gdscript);
 
     // Test all 4 ElementType variants in alternating key/value pattern.
 

--- a/itest/rust/src/builtin_tests/containers/signal_test.rs
+++ b/itest/rust/src/builtin_tests/containers/signal_test.rs
@@ -810,7 +810,7 @@ mod custom_callable {
 
         let received = Arc::new(AtomicU32::new(0));
         let callable = callable(received.clone());
-        signal.connect(&callable, 0);
+        signal.connect(&callable);
 
         emit(&mut node);
         assert_eq!(1, received.load(Ordering::SeqCst));

--- a/itest/rust/src/builtin_tests/script/script_instance_tests.rs
+++ b/itest/rust/src/builtin_tests/script/script_instance_tests.rs
@@ -342,12 +342,12 @@ fn script_instance_exists() {
     let script = TestScript::new(language.clone());
     let mut object = Object::new_alloc();
 
-    object.set_script(&script.to_variant());
+    object.set_script(&script);
 
     let instance_exists = godot::obj::script::script_instance_exists(&object, &script);
     assert!(instance_exists);
 
-    object.set_script(&Variant::nil());
+    object.set_script(Gd::null_arg());
 
     let instance_exists = godot::obj::script::script_instance_exists(&object, &script);
     assert!(!instance_exists);

--- a/itest/rust/src/engine_tests/codegen_test.rs
+++ b/itest/rust/src/engine_tests/codegen_test.rs
@@ -196,6 +196,41 @@ impl TraitA for CodegenTest3 {
 // See retain_attributes_except() function.
 #[itest]
 #[expect(unused_variables)]
-fn test_itest_macro_attribute_retention() {
+fn itest_macro_attribute_retention() {
     let unused_var = 42; // Should not generate warning.
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// Int->enum replacements
+
+// Tests both that code compiles, and that FFI does not break by replacement.
+#[cfg(feature = "codegen-full")]
+#[itest]
+fn changed_enum_apis() {
+    use godot::classes::file_access::ModeFlags;
+    use godot::classes::gpu_particles_2d::EmitFlags;
+    use godot::classes::tree::DropModeFlags;
+    use godot::classes::{FileAccess, GpuParticles2D, Tree};
+
+    // FileAccess::create_temp() with ModeFlags.
+    let file = FileAccess::create_temp(ModeFlags::READ);
+    assert!(file.is_none());
+
+    // GPUParticles2D::emit_particle with EmitFlags.
+    let mut particles2d = GpuParticles2D::new_alloc();
+    particles2d.emit_particle(
+        Transform2D::IDENTITY,
+        Vector2::ZERO,
+        Color::RED,
+        Color::BLACK,
+        EmitFlags::POSITION | EmitFlags::ROTATION_SCALE,
+    );
+    particles2d.free();
+
+    // Tree::{set,get}_drop_mode_flags() with DropModeFlags.
+    let mut tree = Tree::new_alloc();
+    tree.set_drop_mode_flags(DropModeFlags::INBETWEEN);
+    let mode = tree.get_drop_mode_flags();
+    assert_eq!(mode, DropModeFlags::INBETWEEN);
+    tree.free();
 }

--- a/itest/rust/src/framework/runner.rs
+++ b/itest/rust/src/framework/runner.rs
@@ -459,7 +459,6 @@ fn check_async_test_task(
     ctx: &TestContext,
 ) {
     use godot::classes::object::ConnectFlags;
-    use godot::obj::EngineBitfield;
     use godot::task::has_godot_task_panicked;
 
     if !task_handle.is_pending() {
@@ -490,9 +489,7 @@ fn check_async_test_task(
     ctx.scene_tree
         .get_tree()
         .expect("The itest scene tree node is part of a Godot SceneTree")
-        .connect_ex("process_frame", &deferred)
-        .flags(ConnectFlags::ONE_SHOT.ord() as u32)
-        .done();
+        .connect_flags("process_frame", &deferred, ConnectFlags::ONE_SHOT);
 }
 
 fn print_test_pre(test_case: &str, test_file: &str, last_file: Option<&str>, flush: bool) {

--- a/itest/rust/src/register_tests/func_virtual_test.rs
+++ b/itest/rust/src/register_tests/func_virtual_test.rs
@@ -58,7 +58,7 @@ fn func_virtual() {
     assert_eq!(object.bind().greet_lang(72), GString::from("Rust#72"));
 
     // With script: "GDScript".
-    object.set_script(&make_script().to_variant());
+    object.set_script(&make_script());
     assert_eq!(object.bind().greet_lang(72), GString::from("GDScript#72"));
 
     // Dynamic call: "GDScript".
@@ -76,7 +76,7 @@ fn func_virtual_renamed() {
     );
 
     // With script: "GDScript".
-    object.set_script(&make_script().to_variant());
+    object.set_script(&make_script());
     assert_eq!(
         object.bind().gl2("Hello".into()),
         GString::from("Hello GDScript")
@@ -97,7 +97,7 @@ fn func_virtual_gd_self() {
     );
 
     // With script: "GDScript".
-    object.set_script(&make_script().to_variant());
+    object.set_script(&make_script());
     assert_eq!(
         VirtualScriptCalls::greet_lang3(object.clone(), "Hoi".into()),
         GString::from("Hoi GDScript")
@@ -111,7 +111,7 @@ fn func_virtual_gd_self() {
 #[itest]
 fn func_virtual_stateful() {
     let mut object = VirtualScriptCalls::new_gd();
-    object.set_script(&make_script().to_variant());
+    object.set_script(&make_script());
 
     let variant = Vector3i::new(1, 2, 2).to_variant();
     object.bind_mut().set_thing(variant.clone());


### PR DESCRIPTION
Addresses a large part of #756.
Closes #185.

Makes Godot APIs more type-safe through two approaches:

1. List of parameters who are declared as `int` but replaced with strongly typed enum/bitfield.
2. Hand-crafted replacements for APIs which are unnecessarily type-unsafe in Godot

## Affected APIs

Several Core APIs can benefit from type safety:

| Method                            | Change                                              |
|-----------------------------------|-----------------------------------------------------|
| `Object::get_script()`            | returns `Option<Gd<Script>>` instead of `Variant`   |
| `Object::set_script()`            | accepts `Option<Gd<Script>>` instead of `Variant`   |
| `Object::connect()`               | simplified API without flags                        |
| `Signal::connect()`               | simplified API without flags                        |
| `Object::connect_flags()`         | uses `ConnectFlags` bitfield instead of raw integer |
| `Signal::connect_flags()`         | uses `ConnectFlags` bitfield instead of raw integer |
| `SceneTree::notify_group()`       | accepts `NodeNotification` enum                     |
| `SceneTree::notify_group_flags()` | accepts `GroupCallFlags` and `NodeNotification`     |
| `SceneTree::call_group_flags()`   | accepts `GroupCallFlags`                            |
| `SceneTree::set_group_flags()`    | accepts `GroupCallFlags`                            |
| `Node::duplicate()`               | accepts `DuplicateFlags` instead of int             |


Plus, there are many others, some random samples:

```rs
impl TextEdit {
    fn set_search_flags(&mut self, flags: u32);
    // becomes:
    fn set_search_flags(&mut self, flags: SearchFlags);
}

impl GpuParticles3D {
    fn emit_particle(&mut self, xform: Transform2D, ..., flags: u32);
    // becomes:
    fn emit_particle(&mut self, xform: Transform2D, ..., flags: EmitFlags);
)

impl ProgressBar
    fn set_fill_mode(&mut self, mode: i32)
    fn get_fill_mode(&mut self) -> i32
    // becomes:
    fn set_fill_mode(&mut self, mode: FillMode)
    fn get_fill_mode(&mut self) -> FillMode
}
```

Of course, these improvements also apply to "derived" methods, such as `_ex` default-param initiators, `Ex*::method` default-param builders, `try_*` fallible methods, etc.

This PR just contains a few I found, there are definitely a lot more :slightly_smiling_face: 

> [!tip]
> Please let me know if you find others, and don't hesitate to open a PR!