### PR TITLE
`StringName`: remove `From` impl for `&'static CStr`

### DIFF
--- a/godot-codegen/src/util.rs
+++ b/godot-codegen/src/util.rs
@@ -41,7 +41,7 @@ pub fn c_str(string: &str) -> Literal {
 pub fn make_string_name(identifier: &str) -> TokenStream {
     let lit = c_str(identifier);
 
-    quote! { StringName::from(#lit) }
+    quote! { StringName::__static_cstr(#lit) }
 }
 
 pub fn make_sname_ptr(identifier: &str) -> TokenStream {

--- a/godot-codegen/src/util.rs
+++ b/godot-codegen/src/util.rs
@@ -41,7 +41,7 @@ pub fn c_str(string: &str) -> Literal {
 pub fn make_string_name(identifier: &str) -> TokenStream {
     let lit = c_str(identifier);
 
-    quote! { StringName::__static_cstr(#lit) }
+    quote! { StringName::__cstr(#lit) }
 }
 
 pub fn make_sname_ptr(identifier: &str) -> TokenStream {

--- a/godot-core/src/builtin/mod.rs
+++ b/godot-core/src/builtin/mod.rs
@@ -41,7 +41,7 @@ pub mod __prelude_reexport {
     pub use rect2i::*;
     pub use rid::*;
     pub use signal::*;
-    pub use string::{static_name, Encoding, GString, NodePath, StringName};
+    pub use string::{Encoding, GString, NodePath, StringName};
     pub use transform2d::*;
     pub use transform3d::*;
     pub use variant::*;
@@ -54,6 +54,9 @@ pub mod __prelude_reexport {
     #[allow(deprecated)]
     #[rustfmt::skip] // Do not reorder.
     pub use crate::dict;
+
+    #[cfg(feature = "trace")] // Test only.
+    pub use crate::static_sname;
 }
 
 pub use __prelude_reexport::*;

--- a/godot-core/src/builtin/string/mod.rs
+++ b/godot-core/src/builtin/string/mod.rs
@@ -20,7 +20,6 @@ pub use string_name::*;
 use crate::meta;
 use crate::meta::error::ConvertError;
 use crate::meta::{FromGodot, GodotConvert, ToGodot};
-pub use crate::static_name;
 
 impl GodotConvert for &str {
     type Via = GString;

--- a/godot-core/src/builtin/string/string_name.rs
+++ b/godot-core/src/builtin/string/string_name.rs
@@ -8,7 +8,6 @@
 use std::fmt;
 
 use godot_ffi as sys;
-use godot_ffi::interface_fn;
 use sys::{ffi_methods, ExtVariantType, GodotFfi};
 
 use crate::builtin::{inner, Encoding, GString, NodePath, Variant};
@@ -84,7 +83,7 @@ impl StringName {
             let is_static = sys::conv::SYS_FALSE;
             let s = unsafe {
                 Self::new_with_string_uninit(|string_ptr| {
-                    let ctor = interface_fn!(string_name_new_with_latin1_chars);
+                    let ctor = sys::interface_fn!(string_name_new_with_latin1_chars);
                     ctor(
                         string_ptr,
                         cstr.as_ptr() as *const std::ffi::c_char,
@@ -245,9 +244,20 @@ impl StringName {
         inner::InnerStringName::from_outer(self)
     }
 
+    #[doc(hidden)] // Private for now. Needs API discussion, also regarding overlap with try_from_cstr().
+    pub fn __cstr(c_str: &'static std::ffi::CStr) -> Self {
+        // This used to be set to true, but `p_is_static` parameter in Godot should only be enabled if the result is indeed stored
+        // in a static. See discussion in https://github.com/godot-rust/gdext/pull/1316. We may unify this into a regular constructor,
+        // or provide a dedicated StringName cache (similar to ClassId cache) in the future, which would be freed on shutdown.
+        let is_static = false;
+
+        Self::__cstr_with_static(c_str, is_static)
+    }
+
     /// Creates a `StringName` from a static ASCII/Latin-1 `c"string"`.
     ///
-    /// This avoids unnecessary copies and allocations and directly uses the backing buffer. Useful for literals.
+    /// If `is_static` is true, avoids unnecessary copies and allocations and directly uses the backing buffer. However, this must
+    /// be stored in an actual `static` to not cause leaks/error messages with Godot. For literals, use `is_static=false`.
     ///
     /// Note that while Latin-1 encoding is the most common encoding for c-strings, it isn't a requirement. So if your c-string
     /// uses a different encoding (e.g. UTF-8), it is possible that some characters will not show up as expected.
@@ -260,17 +270,17 @@ impl StringName {
     /// use godot::builtin::StringName;
     ///
     /// // '±' is a Latin-1 character with codepoint 0xB1. Note that this is not UTF-8, where it would need two bytes.
-    /// let sname = StringName::__static_cstr(c"\xb1 Latin-1 string");
+    /// let sname = StringName::__cstr(c"\xb1 Latin-1 string");
     /// ```
     #[doc(hidden)] // Private for now. Needs API discussion, also regarding overlap with try_from_cstr().
-    pub fn __static_cstr(c_str: &'static std::ffi::CStr) -> Self {
+    pub fn __cstr_with_static(c_str: &'static std::ffi::CStr, is_static: bool) -> Self {
         // SAFETY: c_str is nul-terminated and remains valid for entire program duration.
         unsafe {
             Self::new_with_string_uninit(|ptr| {
                 sys::interface_fn!(string_name_new_with_latin1_chars)(
                     ptr,
                     c_str.as_ptr(),
-                    sys::conv::SYS_TRUE, // p_is_static
+                    sys::conv::bool_to_sys(is_static),
                 )
             })
         }
@@ -488,6 +498,7 @@ mod serialize {
 }
 
 // TODO(v0.4.x): consider re-exposing in public API. Open questions: thread-safety, performance, memory leaks, global overhead.
+// Possibly in a more general StringName cache, similar to ClassId. See https://github.com/godot-rust/gdext/pull/1316.
 /// Creates and gets a reference to a static `StringName` from a ASCII/Latin-1 `c"string"`.
 ///
 /// This is the fastest way to create a StringName repeatedly, with the result being cached and never released, like `SNAME` in Godot source code. Suitable for scenarios where high performance is required.
@@ -498,6 +509,6 @@ macro_rules! static_sname {
 
         let c_str: &'static std::ffi::CStr = $str;
         static SNAME: OnceLock<StringName> = OnceLock::new();
-        SNAME.get_or_init(|| StringName::__static_cstr(c_str))
+        SNAME.get_or_init(|| StringName::__cstr_with_static(c_str, true))
     }};
 }

--- a/godot-core/src/meta/args/as_arg.rs
+++ b/godot-core/src/meta/args/as_arg.rs
@@ -5,8 +5,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::ffi::CStr;
-
 use crate::builtin::{GString, NodePath, StringName, Variant};
 use crate::meta::sealed::Sealed;
 use crate::meta::traits::{GodotFfiVariant, GodotNullableFfi};
@@ -557,12 +555,6 @@ impl AsArg<StringName> for &str {
 }
 
 impl AsArg<StringName> for &String {
-    fn into_arg<'arg>(self) -> CowArg<'arg, StringName> {
-        CowArg::Owned(StringName::from(self))
-    }
-}
-
-impl AsArg<StringName> for &'static CStr {
     fn into_arg<'arg>(self) -> CowArg<'arg, StringName> {
         CowArg::Owned(StringName::from(self))
     }

--- a/godot-core/src/meta/class_id.rs
+++ b/godot-core/src/meta/class_id.rs
@@ -263,7 +263,7 @@ impl ClassIdSource {
     fn to_string_name(&self) -> StringName {
         match self {
             ClassIdSource::Owned(s) => StringName::from(s),
-            ClassIdSource::Borrowed(cstr) => StringName::from(*cstr),
+            ClassIdSource::Borrowed(cstr) => StringName::__cstr(cstr),
         }
     }
 

--- a/godot-macros/src/class/data_models/inherent_impl.rs
+++ b/godot-macros/src/class/data_models/inherent_impl.rs
@@ -459,7 +459,7 @@ fn add_virtual_script_call(
 
     let code = quote! {
         let object_ptr = #object_ptr;
-        let method_sname = ::godot::builtin::StringName::__static_cstr(#method_name_cstr);
+        let method_sname = ::godot::builtin::StringName::__cstr(#method_name_cstr);
         let method_sname_ptr = method_sname.string_sys();
         let has_virtual_override = unsafe { ::godot::private::has_virtual_script_method(object_ptr, method_sname_ptr) };
 

--- a/godot-macros/src/class/data_models/inherent_impl.rs
+++ b/godot-macros/src/class/data_models/inherent_impl.rs
@@ -459,7 +459,7 @@ fn add_virtual_script_call(
 
     let code = quote! {
         let object_ptr = #object_ptr;
-        let method_sname = ::godot::builtin::StringName::from(#method_name_cstr);
+        let method_sname = ::godot::builtin::StringName::__static_cstr(#method_name_cstr);
         let method_sname_ptr = method_sname.string_sys();
         let has_virtual_override = unsafe { ::godot::private::has_virtual_script_method(object_ptr, method_sname_ptr) };
 

--- a/itest/rust/src/builtin_tests/convert_test.rs
+++ b/itest/rust/src/builtin_tests/convert_test.rs
@@ -344,7 +344,6 @@ fn strings_as_arg() {
     // Note: CowArg is an internal type.
 
     let str = "GodotRocks";
-    let cstr = c"GodotRocks";
     let gstring = GString::from("GodotRocks");
     let sname = StringName::from("GodotRocks");
     let npath = NodePath::from("GodotRocks");
@@ -355,7 +354,6 @@ fn strings_as_arg() {
     assert_eq!(as_gstr_arg(npath.arg()), CowArg::Owned(gstring.clone()));
 
     assert_eq!(as_sname_arg(str), CowArg::Owned(sname.clone()));
-    assert_eq!(as_sname_arg(cstr), CowArg::Owned(sname.clone()));
     assert_eq!(as_sname_arg(&sname), CowArg::Borrowed(&sname));
     assert_eq!(as_sname_arg(gstring.arg()), CowArg::Owned(sname.clone()));
     assert_eq!(as_sname_arg(npath.arg()), CowArg::Owned(sname.clone()));

--- a/itest/rust/src/builtin_tests/string/string_name_test.rs
+++ b/itest/rust/src/builtin_tests/string/string_name_test.rs
@@ -127,7 +127,7 @@ fn string_name_from_cstr() {
     ];
 
     for (bytes, string) in cases.into_iter() {
-        let a = StringName::__static_cstr(bytes);
+        let a = StringName::__cstr(bytes);
         let b = StringName::from(string);
 
         assert_eq!(a, b);

--- a/itest/rust/src/builtin_tests/string/string_name_test.rs
+++ b/itest/rust/src/builtin_tests/string/string_name_test.rs
@@ -7,7 +7,7 @@
 
 use std::collections::HashSet;
 
-use godot::builtin::{static_name, Encoding, GString, NodePath, StringName};
+use godot::builtin::{static_sname, Encoding, GString, NodePath, StringName};
 
 use crate::framework::{assert_eq_self, itest};
 
@@ -135,24 +135,24 @@ fn string_name_from_cstr() {
 }
 
 #[itest]
-fn string_name_static_name() {
-    let a = static_name!(c"pure ASCII\t[~]").clone();
+fn string_name_static_sname() {
+    let a = static_sname!(c"pure ASCII\t[~]").clone();
     let b = StringName::from("pure ASCII\t[~]");
 
     assert_eq!(a, b);
 
     let a1 = a.clone();
-    let a2 = static_name!(c"pure ASCII\t[~]").clone();
+    let a2 = static_sname!(c"pure ASCII\t[~]").clone();
 
     assert_eq!(a, a1);
     assert_eq!(a1, a2);
 
-    let a = static_name!(c"\xB1").clone();
+    let a = static_sname!(c"\xB1").clone();
     let b = StringName::from("±");
 
     assert_eq!(a, b);
 
-    let a = static_name!(c"Latin-1 \xA3 \xB1 text \xBE").clone();
+    let a = static_sname!(c"Latin-1 \xA3 \xB1 text \xBE").clone();
     let b = StringName::from("Latin-1 £ ± text ¾");
 
     assert_eq!(a, b);

--- a/itest/rust/src/builtin_tests/string/string_name_test.rs
+++ b/itest/rust/src/builtin_tests/string/string_name_test.rs
@@ -127,7 +127,7 @@ fn string_name_from_cstr() {
     ];
 
     for (bytes, string) in cases.into_iter() {
-        let a = StringName::from(bytes);
+        let a = StringName::__static_cstr(bytes);
         let b = StringName::from(string);
 
         assert_eq!(a, b);


### PR DESCRIPTION
Discussion in #1307 made it unclear whether `&'static CStr` will still be useful from a memory-management and performance point of view. This being the only point of such a `From` impl, I'd rather remove that and re-think the API, however this needs to happen before v0.4 due to SemVer. Any additions can happen later.

For now I also removed `AsArg` that allowed passing as `c"string"`. This could also be reconsidered based on use.

Keep in mind that construction from `CStr` is still possible through [`StringName::try_from_cstr()`](https://godot-rust.github.io/docs/gdext/master/godot/prelude/struct.StringName.html#method.try_from_cstr).