### PR TITLE
Address `clippy::nursery` lint errors in macros.

### DIFF
--- a/godot-ffi/src/plugins.rs
+++ b/godot-ffi/src/plugins.rs
@@ -59,26 +59,15 @@ macro_rules! plugin_execute_pre_main {
     };
 }
 
-/// Register a plugin by executing code pre-main that adds the plugin to the registry.
-#[doc(hidden)]
-#[macro_export]
-macro_rules! plugin_add_inner {
-    ($registry:path; $plugin:expr) => {
-        $crate::plugin_execute_pre_main!({
-            let mut guard = $registry.lock().unwrap();
-
-            guard.push($plugin);
-        });
-    };
-}
-
 /// Register a plugin to a registry.
 #[doc(hidden)]
 #[macro_export]
 macro_rules! plugin_add {
     ( $registry:path; $plugin:expr ) => {
-		$crate::plugin_add_inner!($registry; $plugin);
-	};
+        $crate::plugin_execute_pre_main!({
+            $registry.lock().unwrap().push($plugin);
+        });
+    };
 }
 
 #[doc(hidden)]

--- a/godot-macros/src/class/derive_godot_class.rs
+++ b/godot-macros/src/class/derive_godot_class.rs
@@ -393,6 +393,8 @@ fn make_oneditor_panic_inits(class_name: &Ident, all_fields: &[Field]) -> TokenS
 
     if !on_editor_fields_checks.is_empty() {
         quote! {
+            // Triggers `clippy::useless_let_if_seq` lint if only one `#on_editor_fields_checks` is present.
+            #[allow(clippy::useless_let_if_seq)]
             fn __are_oneditor_fields_initalized(this: &#class_name) -> bool {
                 // Early return for `#[class(tool)]`.
                 if #is_in_editor {


### PR DESCRIPTION
Following code:

```rs
#[derive(GodotClass)]
#[class(init, base = Node2D)]
struct BreaksClippyNursery {
    field: OnEditor<Gd<Node>>,
    base: Base<Node2D>
}

#[godot_api]
impl BreaksClippyNursery {}

#[godot_api]
impl INode2D for BreaksClippyNursery {
    fn draw(&mut self) {
    }
}
```

Was tripping `clippy::nursery` lints.

```rs
warning: `if _ { .. } else { .. }` is an expression
  --> src/lib.rs:13:10
   |
13 | #[derive(GodotClass)]
   |          ^^^^^^^^^^
   |
   = note: you might not need `mut` at all
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_let_if_seq
note: the lint level is defined here
  --> src/lib.rs:1:9
   |
1  | #![warn(clippy::useless_let_if_seq)]
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
   = note: this warning originates in the derive macro `GodotClass` (in Nightly builds, run with -Z macro-backtrace for more info)
```

This one happens when only one `OnEditor` field is present. Handled with `#[allow(...)]` (making three versions depending on amount of OnEditor fields would be silly).

```rs
warning: temporary with significant `Drop` can be early dropped
  --> src/lib.rs:27:1
   |
27 | #[godot_api]
   | ^^^^^^^^^^^^ temporary `guard` is currently being dropped at the end of its contained scope
   |
   = note: this might lead to unnecessary resource contention
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#significant_drop_tightening
note: the lint level is defined here
  --> src/lib.rs:2:9
   |
2  | #![warn(clippy::significant_drop_tightening)]
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   = note: this warning originates in the macro `$crate::plugin_add_inner` which comes from the expansion of the attribute macro `godot_api` (in Nightly builds, run with -Z macro-backtrace for more info)
```

Triggered by plugin registry, `let mut guard = ...; guard.do_something(...)`; handled with `#[allow(...)]` (the lint is silly and I would like to keep it somewhat readable, thank you).