### PR TITLE
Numeric `#[export]` limits and type checks

### DIFF
--- a/godot-core/src/builtin/string/node_path.rs
+++ b/godot-core/src/builtin/string/node_path.rs
@@ -8,7 +8,7 @@
 use std::fmt;
 
 use godot_ffi as sys;
-use godot_ffi::{ffi_methods, ExtVariantType, GdextBuild, GodotFfi};
+use godot_ffi::{ffi_methods, ExtVariantType, GodotFfi};
 
 use super::{GString, StringName};
 use crate::builtin::inner;
@@ -160,7 +160,7 @@ impl NodePath {
     pub fn subpath(&self, range: impl SignedRange) -> NodePath {
         let (from, exclusive_end) = range.signed();
         // Polyfill for bug https://github.com/godotengine/godot/pull/100954, fixed in 4.4.
-        let begin = if GdextBuild::since_api("4.4") {
+        let begin = if sys::GdextBuild::since_api("4.4") {
             from
         } else {
             let name_count = self.get_name_count() as i64;

--- a/godot-core/src/meta/property_info.rs
+++ b/godot-core/src/meta/property_info.rs
@@ -15,7 +15,7 @@ use crate::meta::{
 use crate::obj::{bounds, Bounds, EngineBitfield, EngineEnum, GodotClass};
 use crate::registry::class::get_dyn_property_hint_string;
 use crate::registry::property::{Export, Var};
-use crate::{classes, sys};
+use crate::{classes, godot_str, sys};
 
 /// Describes a property in Godot.
 ///
@@ -297,6 +297,13 @@ impl PropertyHintInfo {
         Self {
             hint: PropertyHint::NONE,
             hint_string,
+        }
+    }
+
+    pub fn type_name_range<T: GodotType + std::fmt::Display>(lower: T, upper: T) -> Self {
+        Self {
+            hint: PropertyHint::RANGE,
+            hint_string: godot_str!("{lower},{upper}"), // also valid for <4.3.
         }
     }
 

--- a/godot-core/src/registry/property/mod.rs
+++ b/godot-core/src/registry/property/mod.rs
@@ -16,6 +16,14 @@ use crate::classes;
 use crate::global::PropertyHint;
 use crate::meta::{ClassName, FromGodot, GodotConvert, GodotType, PropertyHintInfo, ToGodot};
 use crate::obj::{EngineEnum, GodotClass};
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// Child modules
+
+mod phantom_var;
+
+pub use phantom_var::PhantomVar;
+
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Trait definitions
 
@@ -224,6 +232,7 @@ where
 /// Each function is named the same as the equivalent Godot annotation.  
 /// For instance, `@export_range` in Godot is `fn export_range` here.
 pub mod export_info_functions {
+    use std::fmt;
     use std::fmt::Write;
 
     use godot_ffi::VariantType;
@@ -233,7 +242,7 @@ pub mod export_info_functions {
     use crate::meta::{GodotType, PropertyHintInfo, PropertyInfo};
     use crate::obj::EngineEnum;
     use crate::registry::property::Export;
-    use crate::sys;
+    use crate::{godot_str, sys};
 
     /// Turn a list of variables into a comma separated string containing only the identifiers corresponding
     /// to a true boolean variable.
@@ -267,17 +276,18 @@ pub mod export_info_functions {
     /// #[derive(GodotClass)]
     /// #[class(init, base=Node)]
     /// struct MyClassWithRangedValues {
-    ///     #[export(range=(0.0, 400.0, 1.0, or_greater, suffix="px"))]
+    ///     #[export(range=(0, 400, 1, or_greater, suffix="px"))]
     ///     icon_width: i32,
+    ///
     ///     #[export(range=(-180.0, 180.0, degrees))]
     ///     angle: f32,
     /// }
     /// ```
     #[allow(clippy::too_many_arguments)]
-    pub fn export_range(
-        min: f64,
-        max: f64,
-        step: Option<f64>,
+    pub fn export_range<T: Export + fmt::Display>(
+        min: T,
+        max: T,
+        step: Option<T>,
         or_greater: bool,
         or_less: bool,
         exp: bool,
@@ -314,7 +324,7 @@ pub mod export_info_functions {
 
         PropertyHintInfo {
             hint: PropertyHint::RANGE,
-            hint_string: GString::from(hint_string),
+            hint_string: GString::from(&hint_string),
         }
     }
 
@@ -377,7 +387,7 @@ pub mod export_info_functions {
 
         PropertyHintInfo {
             hint: PropertyHint::ENUM,
-            hint_string: GString::from(hint_string),
+            hint_string: GString::from(&hint_string),
         }
     }
 
@@ -386,7 +396,7 @@ pub mod export_info_functions {
 
         PropertyHintInfo {
             hint: PropertyHint::EXP_EASING,
-            hint_string: GString::from(hint_string),
+            hint_string: GString::from(&hint_string),
         }
     }
 
@@ -410,7 +420,7 @@ pub mod export_info_functions {
 
         PropertyHintInfo {
             hint: PropertyHint::FLAGS,
-            hint_string: GString::from(hint_string),
+            hint_string: GString::from(&hint_string),
         }
     }
 
@@ -489,14 +499,14 @@ pub mod export_info_functions {
 
         PropertyHintInfo {
             hint: PropertyHint::TYPE_STRING,
-            hint_string: GString::from(format!("{hint_string}:{filter}")),
+            hint_string: godot_str!("{hint_string}:{filter}"),
         }
     }
 
-    pub fn export_placeholder<S: AsRef<str>>(placeholder: S) -> PropertyHintInfo {
+    pub fn export_placeholder(placeholder: &str) -> PropertyHintInfo {
         PropertyHintInfo {
             hint: PropertyHint::PLACEHOLDER_TEXT,
-            hint_string: GString::from(placeholder.as_ref()),
+            hint_string: GString::from(placeholder),
         }
     }
 

--- a/godot-ffi/src/toolbox.rs
+++ b/godot-ffi/src/toolbox.rs
@@ -177,10 +177,11 @@ where
         // String formatting by itself is an infallible operation.
         // Read more at: https://doc.rust-lang.org/stable/std/fmt/index.html#formatting-traits
         write!(&mut result, "{first}", first = format_elem(&first))
-            .expect("Formatter should not fail!");
+            .expect("formatter should not fail");
+
         for item in iter {
             write!(&mut result, "{sep}{item}", item = format_elem(&item))
-                .expect("Formatter should not fail!");
+                .expect("formatter should not fail");
         }
     }
     result

--- a/godot-macros/src/class/data_models/field_export.rs
+++ b/godot-macros/src/class/data_models/field_export.rs
@@ -12,16 +12,18 @@ use quote::quote;
 
 use crate::util::{ident, KvParser, ListParser};
 use crate::ParseResult;
-
 pub struct FieldExport {
     pub export_type: ExportType,
     pub span: Span,
 }
 
 impl FieldExport {
-    pub(crate) fn new_from_kv(parser: &mut KvParser) -> ParseResult<Self> {
+    pub(crate) fn new_from_kv(
+        parser: &mut KvParser,
+        field_ty: venial::TypeExpr,
+    ) -> ParseResult<Self> {
         let span = parser.span();
-        let export_type = ExportType::new_from_kv(parser)?;
+        let export_type = ExportType::new_from_kv(parser, field_ty)?;
         Ok(Self { export_type, span })
     }
 
@@ -65,6 +67,7 @@ pub enum ExportType {
     /// ### Property hints
     /// - `RANGE`
     Range {
+        field_ty: venial::TypeExpr,
         min: TokenStream,
         max: TokenStream,
         step: TokenStream,
@@ -168,13 +171,15 @@ impl ExportType {
     /// - `@export_{flags/enum}("elem1", "elem2:key2", ...)`
     ///   becomes
     ///   `#[export(flags/enum = (elem1, elem2 = key2, ...))]`
-    pub(crate) fn new_from_kv(parser: &mut KvParser) -> ParseResult<Self> {
+    pub(crate) fn new_from_kv(
+        parser: &mut KvParser,
+        field_ty: venial::TypeExpr,
+    ) -> ParseResult<Self> {
         if parser.handle_alone("storage")? {
             return Self::new_storage();
         }
-
         if let Some(list_parser) = parser.handle_list("range")? {
-            return Self::new_range_list(list_parser);
+            return Self::new_range_list(list_parser, field_ty);
         }
 
         if let Some(list_parser) = parser.handle_list("enum")? {
@@ -300,7 +305,7 @@ impl ExportType {
         Ok(Self::Storage)
     }
 
-    fn new_range_list(mut parser: ListParser) -> ParseResult<Self> {
+    fn new_range_list(mut parser: ListParser, field_ty: venial::TypeExpr) -> ParseResult<Self> {
         const FLAG_OPTIONS: [&str; 7] = [
             "or_greater",
             "or_less",
@@ -314,6 +319,7 @@ impl ExportType {
 
         let min = parser.next_expr()?;
         let max = parser.next_expr()?;
+
         // If there is a next element, and it is a literal, we take its tokens directly.
         let step = if parser.peek().is_some_and(|kv| kv.as_literal().is_ok()) {
             let value = parser
@@ -330,6 +336,7 @@ impl ExportType {
         loop {
             let key_maybe_value =
                 parser.next_allowed_key_optional_value(&FLAG_OPTIONS, &KV_OPTIONS)?;
+
             match key_maybe_value {
                 Some((option, None)) => {
                     flags.insert(option.to_string());
@@ -344,6 +351,7 @@ impl ExportType {
         parser.finish()?;
 
         Ok(Self::Range {
+            field_ty,
             min,
             max,
             step,
@@ -411,9 +419,16 @@ impl ExportType {
 }
 
 macro_rules! quote_export_func {
-    ($function_name:ident($($tt:tt)*)) => {
+    ($function_name:ident ($($tt:tt)*) ) => {
         Some(quote! {
             ::godot::register::property::export_info_functions::$function_name($($tt)*)
+        })
+    };
+
+    // Use [ ] for generic args due to parsing ambiguity with ::< > turbofish.
+    ($function_name:ident [ $($generic_args:tt)* ] ($($tt:tt)*) ) => {
+        Some(quote! {
+            ::godot::register::property::export_info_functions::$function_name::< $($generic_args)* >($($tt)*)
         })
     };
 
@@ -434,6 +449,7 @@ impl ExportType {
             Self::Storage => quote_export_func! { export_storage() },
 
             Self::Range {
+                field_ty,
                 min,
                 max,
                 step,
@@ -451,9 +467,11 @@ impl ExportType {
                 } else {
                     quote! { None }
                 };
+
                 let export_func = quote_export_func! {
-                    export_range(#min, #max, #step, #or_greater, #or_less, #exp, #radians_as_degrees || #radians, #degrees, #hide_slider, #suffix)
+                    export_range [ #field_ty ] (#min, #max, #step, #or_greater, #or_less, #exp, #radians_as_degrees || #radians, #degrees, #hide_slider, #suffix)
                 }?;
+
                 let deprecation_warning = if *radians {
                     // For some reason, rustfmt formatting like this.  Probably a bug.
                     // See https://github.com/godot-rust/gdext/pull/783#discussion_r1669105958 and
@@ -465,6 +483,7 @@ impl ExportType {
                 } else {
                     quote! { #export_func }
                 };
+
                 Some(quote! {
                     #deprecation_warning
                 })

--- a/godot-macros/src/class/derive_godot_class.rs
+++ b/godot-macros/src/class/derive_godot_class.rs
@@ -678,7 +678,7 @@ fn parse_fields(
 
         // #[export]
         if let Some(mut parser) = KvParser::parse(&named_field.attributes, "export")? {
-            let export = FieldExport::new_from_kv(&mut parser)?;
+            let export = FieldExport::new_from_kv(&mut parser, named_field.ty.clone())?;
             field.export = Some(export);
             parser.finish()?;
         }

--- a/godot-macros/src/derive/data_models/c_style_enum.rs
+++ b/godot-macros/src/derive/data_models/c_style_enum.rs
@@ -122,6 +122,8 @@ impl CStyleEnum {
 
     /// Return a hint string for use with `PropertyHint::ENUM` where the variants are just kept as strings.
     pub fn to_string_hint(&self) -> TokenStream {
+        // See also export_info_functions::slice_as_hint_string(), some code duplication.
+
         let hint_string = self
             .enumerator_names
             .iter()

--- a/itest/rust/src/builtin_tests/containers/signal_test.rs
+++ b/itest/rust/src/builtin_tests/containers/signal_test.rs
@@ -96,8 +96,13 @@ fn signal_symbols_external() {
         });
     }
 
-    // Self-modifying method.
-    sig.connect_self(Emitter::self_receive);
+    // Self-modifying method. Have 2 branches just to ensure they compile.
+    if std::hint::black_box(true) {
+        sig.connect_self(Emitter::self_receive);
+    } else {
+        // Needs explicit type here.
+        sig.connect_self(|this: &mut Emitter, i| this.self_receive(i));
+    }
 
     // Connect to other object.
     let receiver = Receiver::new_alloc();

--- a/itest/rust/src/object_tests/property_template_test.rs
+++ b/itest/rust/src/object_tests/property_template_test.rs
@@ -56,19 +56,19 @@ fn property_template_test(ctx: &TestContext) {
             continue;
         };
 
-        let mut rust_usage = rust_prop.at("usage").to::<i64>();
+        let mut rust_usage = rust_prop.at("usage").to::<PropertyUsageFlags>();
 
-        // The GDSscript variables are script variables, and so have `PROPERTY_USAGE_SCRIPT_VARIABLE` set.
+        // The GDScript variables are script variables, and so have `PROPERTY_USAGE_SCRIPT_VARIABLE` set.
         // Before 4.3, `PROPERTY_USAGE_SCRIPT_VARIABLE` did the same thing as `PROPERTY_USAGE_STORAGE` and
         // so GDScript didn't set both if it didn't need to.
         if GdextBuild::before_api("4.3") {
-            if rust_usage == PropertyUsageFlags::STORAGE.ord() as i64 {
-                rust_usage = PropertyUsageFlags::SCRIPT_VARIABLE.ord() as i64
+            if rust_usage == PropertyUsageFlags::STORAGE {
+                rust_usage = PropertyUsageFlags::SCRIPT_VARIABLE
             } else {
-                rust_usage |= PropertyUsageFlags::SCRIPT_VARIABLE.ord() as i64;
+                rust_usage |= PropertyUsageFlags::SCRIPT_VARIABLE;
             }
         } else {
-            rust_usage |= PropertyUsageFlags::SCRIPT_VARIABLE.ord() as i64;
+            rust_usage |= PropertyUsageFlags::SCRIPT_VARIABLE;
         }
 
         rust_prop.set("usage", rust_usage);

--- a/itest/rust/src/object_tests/property_test.rs
+++ b/itest/rust/src/object_tests/property_test.rs
@@ -267,6 +267,10 @@ struct CheckAllExports {
     #[export(range = (0.0, 10.0, 0.2, or_greater, or_less, exp, radians_as_degrees, hide_slider))]
     range_exported_with_step: f64,
 
+    // Fails to compile if literal is floating-point or outside i8 range.
+    #[export(range = (-5, 127))]
+    int_exported: i8,
+
     #[export(enum = (A = 10, B, C, D = 20))]
     enum_exported: i64,
 


### PR DESCRIPTION
Previously, all literals were expected to be floating-point, which meant:

* By default, there were no bound checks.
   `u16` could still be set to values >= 65536, for example.
* Even integers required float literals.
   `#[export(range = (1.0, 5.0))] field: i8`
* Literals were unchecked.
   `#[export(range = (1.0, 500.0))] field: i8`

---

Now, this code with out-of-bounds literals:
```rs
    #[export(range = (-5, 128))]
    int_exported: i8,
```
results in:
<img width="727" height="204" alt="image" src="https://github.com/user-attachments/assets/8027b977-3487-4f11-8e38-a24f8a05c81d" />

---

Using wrong type:
```rs
    #[export(range = (-5.0, 127.0))]
    int_exported: i8,
```
<img width="705" height="377" alt="image" src="https://github.com/user-attachments/assets/07dd2224-ddab-44ac-9b84-ab7f7179cdb4" />

---

Default bounds are now inferred from the type, even without explicit `range` key:
```rs
    #[export]
    limited_number: u8,
```

https://github.com/user-attachments/assets/bb1cd5ba-40fc-4cc3-996d-4a129921980c

