### PR TITLE
FFI: make `AsArg` internals safer to use

### DIFF
--- a/godot-core/src/meta/args/as_arg.rs
+++ b/godot-core/src/meta/args/as_arg.rs
@@ -10,7 +10,7 @@ use std::ffi::CStr;
 use crate::builtin::{GString, NodePath, StringName, Variant};
 use crate::meta::sealed::Sealed;
 use crate::meta::traits::{GodotFfiVariant, GodotNullableFfi};
-use crate::meta::{CowArg, GodotType, ObjectArg, ToGodot};
+use crate::meta::{CowArg, FfiArg, GodotType, ObjectArg, ToGodot};
 use crate::obj::{bounds, Bounds, DynGd, Gd, GodotClass, Inherits};
 
 /// Implicit conversions for arguments passed to Godot APIs.
@@ -97,13 +97,14 @@ where
 
     /// FFI-optimized argument conversion that may use `FfiObject` when beneficial.
     ///
-    /// Defaults to calling `into_arg()`, which always works, but might be an `Owned` for a conservative approach (e.g. object upcast).
+    /// Defaults to calling `into_arg()` and wrapping in `FfiArg::Cow()`, which always works, but might be an `Owned` for a conservative
+    /// approach (e.g. object upcast).
     #[doc(hidden)]
-    fn into_ffi_arg<'arg>(self) -> CowArg<'arg, T>
+    fn into_ffi_arg<'arg>(self) -> FfiArg<'arg, T>
     where
         Self: 'arg,
     {
-        self.into_arg()
+        FfiArg::Cow(self.into_arg())
     }
 }
 
@@ -157,12 +158,12 @@ where
         }
     }
 
-    fn into_ffi_arg<'arg>(self) -> CowArg<'arg, Gd<Base>>
+    fn into_ffi_arg<'arg>(self) -> FfiArg<'arg, Gd<Base>>
     where
         Self: 'arg,
     {
         let arg = ObjectArg::from_gd(self);
-        CowArg::FfiObject(arg)
+        FfiArg::FfiObject(arg)
     }
 }
 
@@ -189,12 +190,12 @@ where
         }
     }
 
-    fn into_ffi_arg<'arg>(self) -> CowArg<'arg, DynGd<Base, D>>
+    fn into_ffi_arg<'arg>(self) -> FfiArg<'arg, DynGd<Base, D>>
     where
         Self: 'arg,
     {
         let arg = ObjectArg::from_gd(self);
-        CowArg::FfiObject(arg)
+        FfiArg::FfiObject(arg)
     }
 }
 
@@ -213,7 +214,7 @@ where
         AsArg::into_arg(gd_ref)
     }
 
-    fn into_ffi_arg<'arg>(self) -> CowArg<'arg, Gd<Base>>
+    fn into_ffi_arg<'arg>(self) -> FfiArg<'arg, Gd<Base>>
     where
         Self: 'arg,
     {
@@ -242,12 +243,12 @@ where
         }
     }
 
-    fn into_ffi_arg<'arg>(self) -> CowArg<'arg, Option<Gd<Base>>>
+    fn into_ffi_arg<'arg>(self) -> FfiArg<'arg, Option<Gd<Base>>>
     where
         Self: 'arg,
     {
         let arg = ObjectArg::from_option_gd(self);
-        CowArg::FfiObject(arg)
+        FfiArg::FfiObject(arg)
     }
 }
 
@@ -265,12 +266,12 @@ where
         CowArg::Owned(Some(self.clone().upcast::<Base>()))
     }
 
-    fn into_ffi_arg<'arg>(self) -> CowArg<'arg, Option<Gd<Base>>>
+    fn into_ffi_arg<'arg>(self) -> FfiArg<'arg, Option<Gd<Base>>>
     where
         Self: 'arg,
     {
         let arg = ObjectArg::from_gd(self);
-        CowArg::FfiObject(arg)
+        FfiArg::FfiObject(arg)
     }
 }
 
@@ -289,7 +290,7 @@ where
         AsArg::into_arg(gd_ref)
     }
 
-    fn into_ffi_arg<'arg>(self) -> CowArg<'arg, Option<Gd<Base>>>
+    fn into_ffi_arg<'arg>(self) -> FfiArg<'arg, Option<Gd<Base>>>
     where
         Self: 'arg,
     {

--- a/godot-core/src/meta/args/as_arg.rs
+++ b/godot-core/src/meta/args/as_arg.rs
@@ -161,8 +161,7 @@ where
     where
         Self: 'arg,
     {
-        // SAFETY: ObjectArg exists only during FFI call.
-        let arg = unsafe { ObjectArg::from_gd(self) };
+        let arg = ObjectArg::from_gd(self);
         CowArg::FfiObject(arg)
     }
 }
@@ -194,8 +193,7 @@ where
     where
         Self: 'arg,
     {
-        // SAFETY: ObjectArg exists only during FFI call.
-        let arg = unsafe { ObjectArg::from_gd(self) };
+        let arg = ObjectArg::from_gd(self);
         CowArg::FfiObject(arg)
     }
 }
@@ -248,8 +246,7 @@ where
     where
         Self: 'arg,
     {
-        // SAFETY: ObjectArg exists only during FFI call.
-        let arg = unsafe { ObjectArg::from_option_gd(self) };
+        let arg = ObjectArg::from_option_gd(self);
         CowArg::FfiObject(arg)
     }
 }
@@ -272,8 +269,7 @@ where
     where
         Self: 'arg,
     {
-        // SAFETY: ObjectArg exists only during FFI call.
-        let arg = unsafe { ObjectArg::from_gd(self) };
+        let arg = ObjectArg::from_gd(self);
         CowArg::FfiObject(arg)
     }
 }
@@ -614,7 +610,7 @@ impl ArgPassing for ByObject {
     type Output<'r, T: 'r> = &'r T;
 
     type FfiOutput<'f, T>
-        = ObjectArg
+        = ObjectArg<'f>
     where
         T: GodotType + 'f;
 
@@ -627,13 +623,13 @@ impl ArgPassing for ByObject {
         value.to_godot().clone()
     }
 
-    fn ref_to_ffi<T>(value: &T) -> ObjectArg
+    fn ref_to_ffi<T>(value: &T) -> ObjectArg<'_>
     where
         T: ToGodot<Pass = Self>,
         T::Via: GodotType,
     {
         let obj_ref: &T::Via = value.to_godot(); // implements GodotType.
-        unsafe { obj_ref.as_object_arg() }
+        obj_ref.as_object_arg()
     }
 }
 

--- a/godot-core/src/meta/args/cow_arg.rs
+++ b/godot-core/src/meta/args/cow_arg.rs
@@ -25,7 +25,7 @@ pub enum CowArg<'arg, T> {
     /// Raw object pointer for efficient FFI argument passing without cloning.
     ///
     /// Only valid for object types (`Gd<T>`, `Option<Gd<T>>`). Can avoid the `Owned` creation.
-    FfiObject(ObjectArg),
+    FfiObject(ObjectArg<'arg>),
 }
 
 impl<T> CowArg<'_, T> {
@@ -68,7 +68,7 @@ impl<T> CowArg<'_, T> {
     /// Extracts ObjectArg directly for ByObject FFI conversion.
     ///
     /// Returns Some(ObjectArg) if this contains FfiObject, None otherwise.
-    pub fn try_extract_object_arg(&self) -> Option<ObjectArg> {
+    pub fn try_extract_object_arg(&self) -> Option<ObjectArg<'_>> {
         match self {
             CowArg::FfiObject(obj_arg) => Some(obj_arg.clone()),
             _ => None,

--- a/godot-core/src/meta/args/cow_arg.rs
+++ b/godot-core/src/meta/args/cow_arg.rs
@@ -12,8 +12,16 @@ use godot_ffi::{ExtVariantType, GodotFfi, GodotNullableFfi, PtrcallType};
 
 use crate::builtin::Variant;
 use crate::meta::error::ConvertError;
-use crate::meta::{FromGodot, GodotConvert, GodotFfiVariant, ObjectArg, RefArg, ToGodot};
+use crate::meta::{GodotConvert, GodotFfiVariant, ObjectArg, RefArg, ToGodot};
 use crate::sys;
+
+/// FFI-optimized argument. Like `CowArg`, but with additional "short-circuit" path to pass objects to FFI.
+#[doc(hidden)]
+#[derive(PartialEq)]
+pub enum FfiArg<'arg, T> {
+    Cow(CowArg<'arg, T>),
+    FfiObject(ObjectArg<'arg>),
+}
 
 /// Owned or borrowed value, used when passing arguments through `impl AsArg` to Godot APIs.
 #[doc(hidden)]
@@ -21,11 +29,6 @@ use crate::sys;
 pub enum CowArg<'arg, T> {
     Owned(T),
     Borrowed(&'arg T),
-
-    /// Raw object pointer for efficient FFI argument passing without cloning.
-    ///
-    /// Only valid for object types (`Gd<T>`, `Option<Gd<T>>`). Can avoid the `Owned` creation.
-    FfiObject(ObjectArg<'arg>),
 }
 
 impl<T> CowArg<'_, T> {
@@ -36,9 +39,6 @@ impl<T> CowArg<'_, T> {
         match self {
             CowArg::Owned(v) => v,
             CowArg::Borrowed(r) => r.clone(),
-            CowArg::FfiObject(_obj) => {
-                unreachable!("cow_into_owned(): FfiObject path should only be used for FFI logic");
-            }
         }
     }
 
@@ -46,9 +46,6 @@ impl<T> CowArg<'_, T> {
         match self {
             CowArg::Owned(v) => v,
             CowArg::Borrowed(r) => r,
-            CowArg::FfiObject(_) => {
-                unreachable!("cow_as_ref(): FfiObject path should only be used for FFI logic");
-            }
         }
     }
 
@@ -57,22 +54,7 @@ impl<T> CowArg<'_, T> {
     /// [`CowArg`] does not implement [`AsArg<T>`] because a differently-named method is more explicit (fewer errors in codegen),
     /// and because [`AsArg::into_arg()`] is not meaningful.
     pub fn cow_as_arg(&self) -> RefArg<'_, T> {
-        match self {
-            CowArg::FfiObject(_) => {
-                unreachable!("cow_as_arg(): FfiObject path should only be used for FFI logic");
-            }
-            _ => RefArg::new(self.cow_as_ref()),
-        }
-    }
-
-    /// Extracts ObjectArg directly for ByObject FFI conversion.
-    ///
-    /// Returns Some(ObjectArg) if this contains FfiObject, None otherwise.
-    pub fn try_extract_object_arg(&self) -> Option<ObjectArg<'_>> {
-        match self {
-            CowArg::FfiObject(obj_arg) => Some(obj_arg.clone()),
-            _ => None,
-        }
+        RefArg::new(self.cow_as_ref())
     }
 }
 
@@ -100,8 +82,6 @@ where
 
     fn to_godot(&self) -> crate::meta::ToArg<'_, Self::Via, Self::Pass> {
         // Forward to the wrapped type's to_godot implementation
-        // For FfiObject, cow_as_ref() will panic, but ByObject's ref_to_ffi
-        // should never call this - it should use as_object_arg() directly
         self.cow_as_ref().to_godot()
     }
 
@@ -116,16 +96,6 @@ where
     }
 }
 
-// TODO refactor signature tuples into separate in+out traits, so FromGodot is no longer needed.
-impl<T> FromGodot for CowArg<'_, T>
-where
-    T: FromGodot,
-{
-    fn try_from_godot(_via: Self::Via) -> Result<Self, ConvertError> {
-        wrong_direction!(try_from_godot)
-    }
-}
-
 impl<T> fmt::Debug for CowArg<'_, T>
 where
     T: fmt::Debug,
@@ -134,73 +104,7 @@ where
         match self {
             CowArg::Owned(v) => write!(f, "CowArg::Owned({v:?})"),
             CowArg::Borrowed(r) => write!(f, "CowArg::Borrowed({r:?})"),
-            CowArg::FfiObject(obj_arg) => write!(f, "CowArg::FfiObject({obj_arg:?})"),
         }
-    }
-}
-
-// SAFETY: delegated to T.
-unsafe impl<T> GodotFfi for CowArg<'_, T>
-where
-    T: GodotFfi,
-{
-    const VARIANT_TYPE: ExtVariantType = T::VARIANT_TYPE;
-
-    unsafe fn new_from_sys(_ptr: sys::GDExtensionConstTypePtr) -> Self {
-        wrong_direction!(new_from_sys)
-    }
-
-    unsafe fn new_with_uninit(_init_fn: impl FnOnce(sys::GDExtensionUninitializedTypePtr)) -> Self {
-        wrong_direction!(new_with_uninit)
-    }
-
-    unsafe fn new_with_init(_init_fn: impl FnOnce(sys::GDExtensionTypePtr)) -> Self {
-        wrong_direction!(new_with_init)
-    }
-
-    fn sys(&self) -> sys::GDExtensionConstTypePtr {
-        match self {
-            CowArg::FfiObject(obj_arg) => obj_arg.sys(),
-            _ => self.cow_as_ref().sys(),
-        }
-    }
-
-    fn sys_mut(&mut self) -> sys::GDExtensionTypePtr {
-        unreachable!("CowArg::sys_mut() currently not used by FFI marshalling layer, but only by specific functions");
-    }
-
-    // This function must be overridden; the default delegating to sys() is wrong for e.g. RawGd<T>.
-    // See also other manual overrides of as_arg_ptr().
-    fn as_arg_ptr(&self) -> sys::GDExtensionConstTypePtr {
-        match self {
-            CowArg::FfiObject(obj_arg) => obj_arg.as_arg_ptr(),
-            _ => self.cow_as_ref().as_arg_ptr(),
-        }
-    }
-
-    unsafe fn from_arg_ptr(_ptr: sys::GDExtensionTypePtr, _call_type: PtrcallType) -> Self {
-        wrong_direction!(from_arg_ptr)
-    }
-
-    unsafe fn move_return_ptr(self, _dst: sys::GDExtensionTypePtr, _call_type: PtrcallType) {
-        // This one is implemented, because it's used for return types implementing ToGodot.
-        unreachable!("Calling CowArg::move_return_ptr is a mistake, as CowArg is intended only for arguments. Use the underlying value type.");
-    }
-}
-
-impl<T> GodotFfiVariant for CowArg<'_, T>
-where
-    T: GodotFfiVariant,
-{
-    fn ffi_to_variant(&self) -> Variant {
-        match self {
-            CowArg::FfiObject(obj_arg) => obj_arg.ffi_to_variant(),
-            _ => self.cow_as_ref().ffi_to_variant(),
-        }
-    }
-
-    fn ffi_from_variant(_variant: &Variant) -> Result<Self, ConvertError> {
-        wrong_direction!(ffi_from_variant)
     }
 }
 
@@ -213,10 +117,7 @@ where
     }
 
     fn is_null(&self) -> bool {
-        match self {
-            CowArg::FfiObject(obj_arg) => obj_arg.is_null(),
-            _ => self.cow_as_ref().is_null(),
-        }
+        self.cow_as_ref().is_null()
     }
 }
 
@@ -227,9 +128,109 @@ impl<T> Deref for CowArg<'_, T> {
         match self {
             CowArg::Owned(value) => value,
             CowArg::Borrowed(value) => value,
-            CowArg::FfiObject(_) => {
-                unreachable!("deref(): FfiObject path should only be used for FFI logic")
+        }
+    }
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// FfiArg implementations
+
+impl<T> GodotNullableFfi for FfiArg<'_, T>
+where
+    T: GodotNullableFfi,
+{
+    fn null() -> Self {
+        FfiArg::Cow(CowArg::Owned(T::null()))
+    }
+
+    fn is_null(&self) -> bool {
+        match self {
+            FfiArg::Cow(cow_arg) => cow_arg.is_null(),
+            FfiArg::FfiObject(obj_arg) => obj_arg.is_null(),
+        }
+    }
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+
+/// Macro to implement similar trait impls between [`CowArg`] and [`FfiArg`].
+///
+/// Debug and null constructors are implemented manually since they're distinct enough.
+macro_rules! impl_ffi_traits {
+    ($ArgType:ident {
+        $($enum_pattern:pat => $delegate:expr),* $(,)?
+    }) => {
+        // SAFETY: delegated to inner values.
+        unsafe impl<T> GodotFfi for $ArgType<'_, T>
+        where
+            T: GodotFfi,
+        {
+            const VARIANT_TYPE: ExtVariantType = T::VARIANT_TYPE;
+
+            unsafe fn new_from_sys(_ptr: sys::GDExtensionConstTypePtr) -> Self {
+                wrong_direction!(new_from_sys)
+            }
+
+            unsafe fn new_with_uninit(_init_fn: impl FnOnce(sys::GDExtensionUninitializedTypePtr)) -> Self {
+                wrong_direction!(new_with_uninit)
+            }
+
+            unsafe fn new_with_init(_init_fn: impl FnOnce(sys::GDExtensionTypePtr)) -> Self {
+                wrong_direction!(new_with_init)
+            }
+
+            fn sys(&self) -> sys::GDExtensionConstTypePtr {
+                match self {
+                    $($enum_pattern => $delegate.sys(),)*
+                }
+            }
+
+            fn sys_mut(&mut self) -> sys::GDExtensionTypePtr {
+                unreachable!(concat!(stringify!($ArgType), "::sys_mut() currently not used by FFI marshalling layer, but only by specific functions"));
+            }
+
+            fn as_arg_ptr(&self) -> sys::GDExtensionConstTypePtr {
+                match self {
+                    $($enum_pattern => $delegate.as_arg_ptr(),)*
+                }
+            }
+
+            unsafe fn from_arg_ptr(_ptr: sys::GDExtensionTypePtr, _call_type: PtrcallType) -> Self {
+                wrong_direction!(from_arg_ptr)
+            }
+
+            unsafe fn move_return_ptr(self, _dst: sys::GDExtensionTypePtr, _call_type: PtrcallType) {
+                unreachable!(concat!("Calling ", stringify!($ArgType), "::move_return_ptr is a mistake, as ", stringify!($ArgType), " is intended only for arguments. Use the underlying value type."));
             }
         }
+
+        impl<T> GodotFfiVariant for $ArgType<'_, T>
+        where
+            T: GodotFfiVariant,
+        {
+            fn ffi_to_variant(&self) -> Variant {
+                match self {
+                    $($enum_pattern => $delegate.ffi_to_variant(),)*
+                }
+            }
+
+            fn ffi_from_variant(_variant: &Variant) -> Result<Self, ConvertError> {
+                wrong_direction!(ffi_from_variant)
+            }
+        }
+    };
+}
+
+impl_ffi_traits! {
+    CowArg {
+        CowArg::Owned(v) => v,
+        CowArg::Borrowed(r) => *r,
+    }
+}
+
+impl_ffi_traits! {
+    FfiArg {
+        FfiArg::Cow(cow_arg) => cow_arg,
+        FfiArg::FfiObject(obj_arg) => obj_arg,
     }
 }

--- a/godot-core/src/meta/args/mod.rs
+++ b/godot-core/src/meta/args/mod.rs
@@ -22,9 +22,9 @@ pub use as_arg::{
 // Solely public for itest/convert_test.rs.
 #[cfg(feature = "trace")]
 #[doc(hidden)]
-pub use cow_arg::CowArg;
+pub use cow_arg::{CowArg, FfiArg};
 #[cfg(not(feature = "trace"))]
-pub(crate) use cow_arg::CowArg;
+pub(crate) use cow_arg::{CowArg, FfiArg};
 #[allow(unused)] // TODO(v0.4): replace contents with newer changes
 pub use object_arg::ObjectArg;
 pub use ref_arg::RefArg;

--- a/godot-core/src/meta/godot_convert/impls.rs
+++ b/godot-core/src/meta/godot_convert/impls.rs
@@ -86,9 +86,9 @@ where
     }
 
     // Only relevant for object types T.
-    unsafe fn as_object_arg(&self) -> meta::ObjectArg {
+    fn as_object_arg(&self) -> meta::ObjectArg<'_> {
         match self {
-            Some(inner) => unsafe { inner.as_object_arg() },
+            Some(inner) => inner.as_object_arg(),
             None => meta::ObjectArg::null(),
         }
     }

--- a/godot-core/src/meta/traits.rs
+++ b/godot-core/src/meta/traits.rs
@@ -149,11 +149,8 @@ pub trait GodotType: GodotConvert<Via = Self> + sealed::Sealed + Sized + 'static
     /// # Panics
     /// If `Self` is not an object type (`Gd<T>`, `Option<Gd<T>>`). Note that `DynGd<T>` isn't directly implemented here, but uses `Gd<T>`'s
     /// impl on the FFI layer.
-    ///
-    /// # Safety
-    /// `self` must be kept alive while return value is in use. Might be addressed with lifetime in the future.
     #[doc(hidden)]
-    unsafe fn as_object_arg(&self) -> crate::meta::ObjectArg {
+    fn as_object_arg(&self) -> crate::meta::ObjectArg<'_> {
         panic!(
             "as_object_arg() called for non-object type: {}",
             std::any::type_name::<Self>()

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -961,7 +961,7 @@ impl<T: GodotClass> GodotType for Gd<T> {
         false
     }
 
-    unsafe fn as_object_arg(&self) -> meta::ObjectArg {
+    fn as_object_arg(&self) -> meta::ObjectArg<'_> {
         meta::ObjectArg::from_gd(self)
     }
 }


### PR DESCRIPTION
Following up argument changes:
- #1314
- #1310
- #1308

This improves type and memory safety of the private methods of `AsArg`:
- `ObjectArg` now gets a lifetime `ObjectArg<'gd>`, tracking the referred-to `Gd` instance. 
    - No more risk of use-after-free.
    - We can abandon `unsafe` constructors as a result.
- `AsArg::into_ffi_arg()` returns a type distinct from `AsArg::into_arg()`.
    - Makes clear that the `FfiObject` enum variant can only be returned from this method.
    - Gets rid of several `unreachable!` conditions.