### PR TITLE
Rename `ClassName` -> `ClassId`

### DIFF
--- a/check.sh
+++ b/check.sh
@@ -312,18 +312,18 @@ function compute_elapsed() {
 for cmd in "${cmds[@]}"; do
     "cmd_${cmd}" || {
         compute_elapsed
-        log -ne "$RED\n====================="
-        log -ne "\ngdext: checks FAILED."
-        log -ne "\n=====================\n$END"
+        log -ne "$RED\n=========================="
+        log -ne "\ngodot-rust: checks FAILED."
+        log -ne "\n==========================\n$END"
         log -ne "\nTotal duration: $elapsed.\n"
         exit 1
     }
 done
 
 compute_elapsed
-log -ne "$CYAN\n========================="
-log -ne "\ngdext: checks SUCCESSFUL."
-log -ne "\n=========================\n$END"
+log -ne "$CYAN\n=============================="
+log -ne "\ngodot-rust: checks SUCCESSFUL."
+log -ne "\n==============================\n$END"
 log -ne "\nTotal duration: $elapsed.\n"
 
 # If invoked with sh instead of bash, pressing Up arrow after executing `sh check.sh` may cause a `[A` to appear.

--- a/godot-codegen/src/generator/classes.rs
+++ b/godot-codegen/src/generator/classes.rs
@@ -244,11 +244,11 @@ fn make_class(class: &Class, ctx: &mut Context, view: &ApiView) -> GeneratedClas
                 type Base = #base_ty;
 
                 // Code duplicated in godot-macros.
-                fn class_name() -> ClassName {
+                fn class_id() -> ClassId {
                     // Optimization note: instead of lazy init, could use separate static which is manually initialized during registration.
-                    static CLASS_NAME: std::sync::OnceLock<ClassName> = std::sync::OnceLock::new();
+                    static CLASS_ID: std::sync::OnceLock<ClassId> = std::sync::OnceLock::new();
 
-                    let name: &'static ClassName = CLASS_NAME.get_or_init(|| ClassName::__alloc_next_ascii(#class_name_cstr));
+                    let name: &'static ClassId = CLASS_ID.get_or_init(|| ClassId::__alloc_next_ascii(#class_name_cstr));
                     *name
                 }
 
@@ -421,8 +421,8 @@ fn make_constructor_and_default(class: &Class, ctx: &Context) -> Construction {
     let class_name = class.name();
 
     let godot_class_stringname = make_string_name(&class_name.godot_ty);
-    // Note: this could use class_name() but is not yet done due to potential future lazy-load refactoring.
-    //let class_name_obj = quote! { <Self as crate::obj::GodotClass>::class_name() };
+    // Note: this could use class_id() but is not yet done due to potential future lazy-load refactoring.
+    //let class_name_obj = quote! { <Self as crate::obj::GodotClass>::class_id() };
 
     let (constructor, construct_doc, has_godot_default_impl);
     if ctx.is_singleton(class_name) {

--- a/godot-codegen/src/util.rs
+++ b/godot-codegen/src/util.rs
@@ -25,7 +25,7 @@ pub fn make_imports() -> TokenStream {
     quote! {
         use godot_ffi as sys;
         use crate::builtin::*;
-        use crate::meta::{AsArg, ClassName, CowArg, InParamTuple, OutParamTuple, ParamTuple, RefArg, Signature};
+        use crate::meta::{AsArg, ClassId, CowArg, InParamTuple, OutParamTuple, ParamTuple, RefArg, Signature};
         use crate::classes::native::*;
         use crate::classes::Object;
         use crate::obj::Gd;

--- a/godot-core/src/builtin/collections/array.rs
+++ b/godot-core/src/builtin/collections/array.rs
@@ -17,7 +17,7 @@ use crate::meta;
 use crate::meta::error::{ConvertError, FromGodotError, FromVariantError};
 use crate::meta::signed_range::SignedRange;
 use crate::meta::{
-    element_godot_type_name, element_variant_type, ArrayElement, AsArg, ClassName, ElementType,
+    element_godot_type_name, element_variant_type, ArrayElement, AsArg, ClassId, ElementType,
     ExtVariantType, FromGodot, GodotConvert, GodotFfiVariant, GodotType, PropertyHintInfo, RefArg,
     ToGodot,
 };
@@ -1038,7 +1038,7 @@ impl<T: ArrayElement> Array<T> {
         if let (ElementType::ScriptClass(_), ElementType::Class(expected_class)) =
             (&self_ty, &target_ty)
         {
-            if let Some(actual_base_class) = self_ty.class_name() {
+            if let Some(actual_base_class) = self_ty.class_id() {
                 if actual_base_class == *expected_class {
                     return Ok(self);
                 }
@@ -1073,8 +1073,8 @@ impl<T: ArrayElement> Array<T> {
             // A bit contrived because empty StringName is lazy-initialized but must also remain valid.
             #[allow(unused_assignments)]
             let mut empty_string_name = None;
-            let class_name = if let Some(class_name) = elem_ty.class_name() {
-                class_name.string_sys()
+            let class_name = if let Some(class_id) = elem_ty.class_id() {
+                class_id.string_sys()
             } else {
                 empty_string_name = Some(StringName::default());
                 // as_ref() crucial here -- otherwise the StringName is dropped.
@@ -1297,7 +1297,7 @@ where
     }
 
     #[doc(hidden)]
-    fn as_node_class() -> Option<ClassName> {
+    fn as_node_class() -> Option<ClassId> {
         PropertyHintInfo::object_as_node_class::<T>()
     }
 }
@@ -1315,7 +1315,7 @@ where
     }
 
     #[doc(hidden)]
-    fn as_node_class() -> Option<ClassName> {
+    fn as_node_class() -> Option<ClassId> {
         PropertyHintInfo::object_as_node_class::<T>()
     }
 }

--- a/godot-core/src/builtin/variant/impls.rs
+++ b/godot-core/src/builtin/variant/impls.rs
@@ -401,7 +401,7 @@ impl GodotType for Variant {
     fn property_info(property_name: &str) -> PropertyInfo {
         PropertyInfo {
             variant_type: Self::VARIANT_TYPE.variant_as_nil(),
-            class_name: Self::class_name(),
+            class_id: Self::class_id(),
             property_name: StringName::from(property_name),
             hint_info: PropertyHintInfo::none(),
             usage: global::PropertyUsageFlags::DEFAULT | global::PropertyUsageFlags::NIL_IS_VARIANT,

--- a/godot-core/src/classes/class_runtime.rs
+++ b/godot-core/src/classes/class_runtime.rs
@@ -12,7 +12,7 @@ use crate::builtin::{GString, StringName, Variant, VariantType};
 use crate::classes::{ClassDb, Object};
 use crate::meta::CallContext;
 #[cfg(debug_assertions)]
-use crate::meta::ClassName;
+use crate::meta::ClassId;
 use crate::obj::{bounds, Bounds, Gd, GodotClass, InstanceId, RawGd};
 use crate::sys;
 
@@ -171,7 +171,7 @@ where
     T: GodotClass + Bounds<Declarer = bounds::DeclEngine>,
 {
     let mut obj = unsafe {
-        let object_ptr = sys::classdb_construct_object(T::class_name().string_sys());
+        let object_ptr = sys::classdb_construct_object(T::class_id().string_sys());
         Gd::<T>::from_obj_sys(object_ptr)
     };
     #[cfg(since_api = "4.4")]
@@ -202,9 +202,9 @@ pub(crate) fn ensure_object_alive(
 }
 
 #[cfg(debug_assertions)]
-pub(crate) fn ensure_object_inherits(derived: ClassName, base: ClassName, instance_id: InstanceId) {
+pub(crate) fn ensure_object_inherits(derived: ClassId, base: ClassId, instance_id: InstanceId) {
     if derived == base
-        || base == Object::class_name() // for Object base, anything inherits by definition
+        || base == Object::class_id() // for Object base, anything inherits by definition
         || is_derived_base_cached(derived, base)
     {
         return;
@@ -245,12 +245,12 @@ where
 
 /// Checks if `derived` inherits from `base`, using a cache for _successful_ queries.
 #[cfg(debug_assertions)]
-fn is_derived_base_cached(derived: ClassName, base: ClassName) -> bool {
+fn is_derived_base_cached(derived: ClassId, base: ClassId) -> bool {
     use std::collections::HashSet;
 
     use sys::Global;
 
-    static CACHE: Global<HashSet<(ClassName, ClassName)>> = Global::default();
+    static CACHE: Global<HashSet<(ClassId, ClassId)>> = Global::default();
 
     let mut cache = CACHE.lock();
     let key = (derived, base);

--- a/godot-core/src/classes/manual_extensions.rs
+++ b/godot-core/src/classes/manual_extensions.rs
@@ -32,7 +32,7 @@ impl Node {
         self.try_get_node_as(path).unwrap_or_else(|| {
             panic!(
                 "There is no node of type {ty} at path `{path}`",
-                ty = T::class_name()
+                ty = T::class_id()
             )
         })
     }
@@ -66,7 +66,7 @@ impl PackedScene {
         T: Inherits<Node>,
     {
         self.try_instantiate_as::<T>()
-            .unwrap_or_else(|| panic!("Failed to instantiate {to}", to = T::class_name()))
+            .unwrap_or_else(|| panic!("Failed to instantiate {to}", to = T::class_id()))
     }
 
     /// Instantiates the scene as type `T` (fallible).

--- a/godot-core/src/docs.rs
+++ b/godot-core/src/docs.rs
@@ -7,7 +7,7 @@
 
 use std::collections::HashMap;
 
-use crate::meta::ClassName;
+use crate::meta::ClassId;
 use crate::registry::plugin::{ITraitImpl, InherentImpl, PluginItem, Struct};
 
 /// Created for documentation on
@@ -75,7 +75,7 @@ struct DocPieces {
 /// strings of not-yet-parented XML tags (or empty string if no method has been documented).
 #[doc(hidden)]
 pub fn gather_xml_docs() -> impl Iterator<Item = String> {
-    let mut map = HashMap::<ClassName, DocPieces>::new();
+    let mut map = HashMap::<ClassId, DocPieces>::new();
     crate::private::iterate_plugins(|x| {
         let class_name = x.class_name;
 

--- a/godot-core/src/meta/element_type.rs
+++ b/godot-core/src/meta/element_type.rs
@@ -70,13 +70,7 @@ impl ElementType {
     pub fn class_id(&self) -> Option<ClassId> {
         match self {
             ElementType::Class(class_name) => Some(*class_name),
-            ElementType::ScriptClass(script) => {
-                // For script classes, we return the native base class name
-                script.script().map(|s| {
-                    let base_type = s.get_instance_base_type();
-                    ClassId::new_dynamic(base_type.to_string())
-                })
-            }
+            ElementType::ScriptClass(script) => script.base_class_id(),
             _ => None,
         }
     }
@@ -227,5 +221,15 @@ impl ElementScript {
     pub fn script(&self) -> Option<Gd<Script>> {
         // Note: might also fail in the future if acquired on another thread.
         Gd::try_from_instance_id(self.script_instance_id).ok()
+    }
+
+    /// Returns the native base class of the script.
+    ///
+    /// Typically, this corresponds to the class mentioned in `extends` in GDScript.
+    pub fn base_class_id(&self) -> Option<ClassId> {
+        self.script().map(|s| {
+            let base_type = s.get_instance_base_type();
+            ClassId::new_dynamic(base_type.to_string())
+        })
     }
 }

--- a/godot-core/src/meta/error/call_error.rs
+++ b/godot-core/src/meta/error/call_error.rs
@@ -23,7 +23,7 @@ use crate::sys;
 /// _Varcall_ refers to the "variant call" calling convention, meaning that arguments and return values are passed as `Variant` (as opposed
 /// to _ptrcall_, which passes direct pointers to Rust objects).
 ///
-/// Allows to inspect the involved class and method via `class_name()` and `method_name()`. Implements the `std::error::Error` trait, so
+/// Allows to inspect the involved class and method via `class_id()` and `method_name()`. Implements the `std::error::Error` trait, so
 /// it comes with `Display` and `Error::source()` APIs.
 ///
 /// # Possible error causes

--- a/godot-core/src/meta/error/convert_error.rs
+++ b/godot-core/src/meta/error/convert_error.rs
@@ -11,7 +11,7 @@ use std::fmt;
 use godot_ffi::VariantType;
 
 use crate::builtin::Variant;
-use crate::meta::{ClassName, ElementType, ToGodot};
+use crate::meta::{ClassId, ElementType, ToGodot};
 
 type Cause = Box<dyn Error + Send + Sync>;
 
@@ -318,7 +318,7 @@ pub(crate) enum FromVariantError {
     BadValue,
 
     WrongClass {
-        expected: ClassName,
+        expected: ClassId,
     },
 
     /// Variant holds an object which is no longer alive.

--- a/godot-core/src/meta/godot_convert/impls.rs
+++ b/godot-core/src/meta/godot_convert/impls.rs
@@ -11,8 +11,8 @@ use crate::builtin::{Array, Variant};
 use crate::meta;
 use crate::meta::error::{ConvertError, ErrorKind, FromFfiError, FromVariantError};
 use crate::meta::{
-    ArrayElement, ClassName, FromGodot, GodotConvert, GodotNullableFfi, GodotType,
-    PropertyHintInfo, PropertyInfo, ToGodot,
+    ArrayElement, ClassId, FromGodot, GodotConvert, GodotNullableFfi, GodotType, PropertyHintInfo,
+    PropertyInfo, ToGodot,
 };
 use crate::registry::method::MethodParamOrReturnInfo;
 
@@ -61,8 +61,8 @@ where
         T::param_metadata()
     }
 
-    fn class_name() -> ClassName {
-        T::class_name()
+    fn class_id() -> ClassId {
+        T::class_id()
     }
 
     fn property_info(property_name: &str) -> PropertyInfo {

--- a/godot-core/src/meta/method_info.rs
+++ b/godot-core/src/meta/method_info.rs
@@ -9,7 +9,7 @@ use godot_ffi::conv::u32_to_usize;
 
 use crate::builtin::{StringName, Variant};
 use crate::global::MethodFlags;
-use crate::meta::{ClassName, PropertyInfo};
+use crate::meta::{ClassId, PropertyInfo};
 use crate::sys;
 
 /// Describes a method in Godot.
@@ -21,7 +21,7 @@ use crate::sys;
 pub struct MethodInfo {
     pub id: i32,
     pub method_name: StringName,
-    pub class_name: ClassName,
+    pub class_name: ClassId,
     pub return_type: PropertyInfo,
     pub arguments: Vec<PropertyInfo>,
     pub default_arguments: Vec<Variant>,

--- a/godot-core/src/meta/mod.rs
+++ b/godot-core/src/meta/mod.rs
@@ -43,7 +43,7 @@
 //!   `&str` to a function expecting `GString`), but is generic to support object arguments like `Gd<T>` and array insertion.
 
 mod args;
-mod class_name;
+mod class_id;
 mod element_type;
 mod godot_convert;
 mod method_info;
@@ -61,7 +61,8 @@ pub(crate) mod signed_range;
 
 // Public re-exports
 pub use args::*;
-pub use class_name::ClassName;
+#[expect(deprecated)]
+pub use class_id::{ClassId, ClassName};
 pub use element_type::{ElementScript, ElementType};
 pub use godot_convert::{FromGodot, GodotConvert, ToGodot};
 pub use method_info::MethodInfo;
@@ -95,7 +96,7 @@ pub(crate) use reexport_crate::*;
 /// Clean up various resources at end of usage.
 ///
 /// # Safety
-/// Must not use meta facilities (e.g. `ClassName`) after this call.
+/// Must not use meta facilities (e.g. `ClassId`) after this call.
 pub(crate) unsafe fn cleanup() {
-    class_name::cleanup();
+    class_id::cleanup();
 }

--- a/godot-core/src/meta/signature.rs
+++ b/godot-core/src/meta/signature.rs
@@ -488,7 +488,7 @@ impl<'a> CallContext<'a> {
     /// Outbound call from Rust into the engine, via Gd methods.
     pub fn gd<T: GodotClass>(function_name: &'a str) -> Self {
         Self {
-            class_name: T::class_name().to_cow_str(),
+            class_name: T::class_id().to_cow_str(),
             function_name,
         }
     }

--- a/godot-core/src/meta/traits.rs
+++ b/godot-core/src/meta/traits.rs
@@ -12,7 +12,7 @@ use crate::builtin::{Variant, VariantType};
 use crate::global::PropertyUsageFlags;
 use crate::meta::error::ConvertError;
 use crate::meta::{
-    sealed, ClassName, FromGodot, GodotConvert, PropertyHintInfo, PropertyInfo, ToGodot,
+    sealed, ClassId, FromGodot, GodotConvert, PropertyHintInfo, PropertyInfo, ToGodot,
 };
 use crate::registry::method::MethodParamOrReturnInfo;
 use crate::registry::property::builtin_type_string;
@@ -85,16 +85,16 @@ pub trait GodotType: GodotConvert<Via = Self> + sealed::Sealed + Sized + 'static
     }
 
     #[doc(hidden)]
-    fn class_name() -> ClassName {
-        // If we use `ClassName::of::<()>()` then this type shows up as `(no base)` in documentation.
-        ClassName::none()
+    fn class_id() -> ClassId {
+        // If we use `ClassId::of::<()>`, then this type shows up as `(no base)` in documentation.
+        ClassId::none()
     }
 
     #[doc(hidden)]
     fn property_info(property_name: &str) -> PropertyInfo {
         PropertyInfo {
             variant_type: Self::Ffi::VARIANT_TYPE.variant_as_nil(),
-            class_name: Self::class_name(),
+            class_id: Self::class_id(),
             property_name: builtin::StringName::from(property_name),
             hint_info: Self::property_hint_info(),
             usage: PropertyUsageFlags::DEFAULT,

--- a/godot-core/src/obj/base.rs
+++ b/godot-core/src/obj/base.rs
@@ -223,7 +223,7 @@ impl<T: GodotClass> Base<T> {
             }
         });
 
-        let name = format!("Base<{}> deferred unref", T::class_name());
+        let name = format!("Base<{}> deferred unref", T::class_id());
         let callable = Callable::from_once_fn(&name, move |_args| {
             Self::drop_strong_ref(instance_id);
             Ok(Variant::nil())

--- a/godot-core/src/obj/bounds.rs
+++ b/godot-core/src/obj/bounds.rs
@@ -115,15 +115,15 @@ pub(super) mod private {
     /// ```no_run
     /// use godot::prelude::*;
     /// use godot::obj::bounds::implement_godot_bounds;
-    /// use godot::meta::ClassName;
+    /// use godot::meta::ClassId;
     ///
     /// struct MyClass {}
     ///
     /// impl GodotClass for MyClass {
     ///     type Base = Node;
     ///
-    ///     fn class_name() -> ClassName {
-    ///         ClassName::new_cached::<MyClass>(|| "MyClass".to_string())
+    ///     fn class_id() -> ClassId {
+    ///         ClassId::new_cached::<MyClass>(|| "MyClass".to_string())
     ///     }
     /// }
     ///

--- a/godot-core/src/obj/dyn_gd.rs
+++ b/godot-core/src/obj/dyn_gd.rs
@@ -9,7 +9,7 @@ use std::{fmt, ops};
 
 use crate::builtin::Variant;
 use crate::meta::error::ConvertError;
-use crate::meta::{ClassName, FromGodot, GodotConvert, PropertyHintInfo, ToGodot};
+use crate::meta::{ClassId, FromGodot, GodotConvert, PropertyHintInfo, ToGodot};
 use crate::obj::guards::DynGdRef;
 use crate::obj::{bounds, AsDyn, Bounds, DynGdMut, Gd, GodotClass, Inherits, OnEditor};
 use crate::registry::class::{get_dyn_property_hint_string, try_dynify_object};
@@ -371,8 +371,8 @@ where
         self.try_cast().unwrap_or_else(|from_obj| {
             panic!(
                 "downcast from {from} to {to} failed; instance {from_obj:?}",
-                from = T::class_name(),
-                to = Derived::class_name(),
+                from = T::class_id(),
+                to = Derived::class_id(),
             )
         })
     }
@@ -649,7 +649,7 @@ where
     }
 
     #[doc(hidden)]
-    fn as_node_class() -> Option<ClassName> {
+    fn as_node_class() -> Option<ClassId> {
         PropertyHintInfo::object_as_node_class::<T>()
     }
 }
@@ -699,7 +699,7 @@ where
     }
 
     #[doc(hidden)]
-    fn as_node_class() -> Option<ClassName> {
+    fn as_node_class() -> Option<ClassId> {
         PropertyHintInfo::object_as_node_class::<T>()
     }
 }

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -748,8 +748,8 @@ where
             sys::interface_fn!(object_destroy)(self.raw.obj_sys());
         }
 
-        // TODO: this might leak associated data in Gd<T>, e.g. ClassId.
-        std::mem::forget(self);
+        // Deallocate associated data in Gd, without destroying the object pointer itself (already done above).
+        self.drop_weak()
     }
 }
 

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -14,7 +14,7 @@ use sys::{static_assert_eq_size_align, SysPtr as _};
 use crate::builtin::{Callable, GString, NodePath, StringName, Variant};
 use crate::meta::error::{ConvertError, FromFfiError};
 use crate::meta::{
-    ArrayElement, AsArg, CallContext, ClassName, FromGodot, GodotConvert, GodotType,
+    ArrayElement, AsArg, CallContext, ClassId, FromGodot, GodotConvert, GodotType,
     PropertyHintInfo, RefArg, ToGodot,
 };
 use crate::obj::{
@@ -234,7 +234,7 @@ impl<T: GodotClass> Gd<T> {
             panic!(
                 "Instance ID {} does not belong to a valid object of class '{}': {}",
                 instance_id,
-                T::class_name(),
+                T::class_id(),
                 err
             )
         })
@@ -294,7 +294,7 @@ impl<T: GodotClass> Gd<T> {
 
     /// Returns the dynamic class name of the object as `StringName`.
     ///
-    /// This method retrieves the class name of the object at runtime, which can be different from [`T::class_name()`][GodotClass::class_name]
+    /// This method retrieves the class name of the object at runtime, which can be different from [`T::class_id()`][GodotClass::class_name]
     /// if derived classes are involved.
     ///
     /// Unlike [`Object::get_class()`][crate::classes::Object::get_class], this returns `StringName` instead of `GString` and needs no
@@ -505,8 +505,8 @@ impl<T: GodotClass> Gd<T> {
         self.owned_cast().unwrap_or_else(|from_obj| {
             panic!(
                 "downcast from {from} to {to} failed; instance {from_obj:?}",
-                from = T::class_name(),
-                to = Derived::class_name(),
+                from = T::class_id(),
+                to = Derived::class_id(),
             )
         })
     }
@@ -748,7 +748,7 @@ where
             sys::interface_fn!(object_destroy)(self.raw.obj_sys());
         }
 
-        // TODO: this might leak associated data in Gd<T>, e.g. ClassName.
+        // TODO: this might leak associated data in Gd<T>, e.g. ClassId.
         std::mem::forget(self);
     }
 }
@@ -923,12 +923,12 @@ impl<T: GodotClass> GodotType for Gd<T> {
         }
     }
 
-    fn class_name() -> ClassName {
-        T::class_name()
+    fn class_id() -> ClassId {
+        T::class_id()
     }
 
     fn godot_type_name() -> String {
-        T::class_name().to_string()
+        T::class_id().to_string()
     }
 
     fn qualifies_as_special_none(from_variant: &Variant) -> bool {
@@ -954,7 +954,7 @@ impl<T: GodotClass> GodotType for Gd<T> {
 impl<T: GodotClass> ArrayElement for Gd<T> {
     fn element_type_string() -> String {
         // See also impl Export for Gd<T>.
-        object_export_element_type_string::<T>(T::class_name())
+        object_export_element_type_string::<T>(T::class_id())
     }
 }
 
@@ -1010,7 +1010,7 @@ where
     }
 
     #[doc(hidden)]
-    fn as_node_class() -> Option<ClassName> {
+    fn as_node_class() -> Option<ClassId> {
         PropertyHintInfo::object_as_node_class::<T>()
     }
 }
@@ -1053,7 +1053,7 @@ where
     }
 
     #[doc(hidden)]
-    fn as_node_class() -> Option<ClassName> {
+    fn as_node_class() -> Option<ClassId> {
         PropertyHintInfo::object_as_node_class::<T>()
     }
 }

--- a/godot-core/src/obj/rtti.rs
+++ b/godot-core/src/obj/rtti.rs
@@ -22,11 +22,11 @@ pub struct ObjectRtti {
 
     /// Only in Debug mode: dynamic class.
     #[cfg(debug_assertions)]
-    class_name: crate::meta::ClassName,
+    class_name: crate::meta::ClassId,
     //
-    // TODO(bromeon): class_name is not always most-derived class; ObjectRtti is sometimes constructed from a base class, via RawGd::from_obj_sys_weak().
+    // TODO(bromeon): class_id is not always most-derived class; ObjectRtti is sometimes constructed from a base class, via RawGd::from_obj_sys_weak().
     // Examples: after upcast, when receiving Gd<Base> from Godot, etc.
-    // Thus, dynamic lookup via Godot get_class() is needed. However, this returns a String, and ClassName is 'static + Copy right now.
+    // Thus, dynamic lookup via Godot get_class() is needed. However, this returns a String, and ClassId is 'static + Copy right now.
 }
 
 impl ObjectRtti {
@@ -37,7 +37,7 @@ impl ObjectRtti {
             instance_id,
 
             #[cfg(debug_assertions)]
-            class_name: T::class_name(),
+            class_name: T::class_id(),
         }
     }
 
@@ -48,7 +48,7 @@ impl ObjectRtti {
     #[inline]
     pub fn check_type<T: GodotClass>(&self) -> InstanceId {
         #[cfg(debug_assertions)]
-        crate::classes::ensure_object_inherits(self.class_name, T::class_name(), self.instance_id);
+        crate::classes::ensure_object_inherits(self.class_name, T::class_id(), self.instance_id);
 
         self.instance_id
     }

--- a/godot-core/src/private.rs
+++ b/godot-core/src/private.rs
@@ -147,7 +147,7 @@ pub(crate) fn iterate_plugins(mut visitor: impl FnMut(&ClassPlugin)) {
 }
 
 #[cfg(feature = "codegen-full")] // Remove if used in other scenarios.
-pub(crate) fn find_inherent_impl(class_name: crate::meta::ClassName) -> Option<InherentImpl> {
+pub(crate) fn find_inherent_impl(class_name: crate::meta::ClassId) -> Option<InherentImpl> {
     // We do this manually instead of using `iterate_plugins()` because we want to break as soon as we find a match.
     let plugins = __GODOT_PLUGIN_REGISTRY.lock().unwrap();
 

--- a/godot-core/src/registry/callbacks.rs
+++ b/godot-core/src/registry/callbacks.rs
@@ -98,7 +98,7 @@ where
     T: GodotClass,
     F: FnOnce(Base<T::Base>) -> T,
 {
-    let base_class_name = T::Base::class_name();
+    let base_class_name = T::Base::class_id();
     let base_ptr = unsafe { sys::classdb_construct_object(base_class_name.string_sys()) };
 
     let postinit = |base_ptr| {
@@ -140,7 +140,7 @@ where
     F: FnOnce(Base<T::Base>) -> T,
     P: Fn(sys::GDExtensionObjectPtr),
 {
-    let class_name = T::class_name();
+    let class_name = T::class_id();
     //out!("create callback: {}", class_name.backing);
 
     let base = unsafe { Base::from_sys(base_ptr) };

--- a/godot-core/src/registry/constant.rs
+++ b/godot-core/src/registry/constant.rs
@@ -9,7 +9,7 @@ use godot_ffi as sys;
 use sys::interface_fn;
 
 use crate::builtin::StringName;
-use crate::meta::ClassName;
+use crate::meta::ClassId;
 
 /// A constant named `name` with the value `value`.
 pub struct IntegerConstant {
@@ -30,7 +30,7 @@ impl IntegerConstant {
         }
     }
 
-    fn register(&self, class_name: ClassName, enum_name: &StringName, is_bitfield: bool) {
+    fn register(&self, class_name: ClassId, enum_name: &StringName, is_bitfield: bool) {
         unsafe {
             interface_fn!(classdb_register_extension_class_integer_constant)(
                 sys::get_library(),
@@ -59,7 +59,7 @@ pub enum ConstantKind {
 }
 
 impl ConstantKind {
-    fn register(&self, class_name: ClassName) {
+    fn register(&self, class_name: ClassId) {
         match self {
             ConstantKind::Integer(integer) => {
                 integer.register(class_name, &StringName::default(), false)
@@ -80,12 +80,12 @@ impl ConstantKind {
 
 /// All the info needed to export a constant to Godot.
 pub struct ExportConstant {
-    class_name: ClassName,
+    class_name: ClassId,
     kind: ConstantKind,
 }
 
 impl ExportConstant {
-    pub fn new(class_name: ClassName, kind: ConstantKind) -> Self {
+    pub fn new(class_name: ClassId, kind: ConstantKind) -> Self {
         Self { class_name, kind }
     }
 

--- a/godot-core/src/registry/godot_register_wrappers.rs
+++ b/godot-core/src/registry/godot_register_wrappers.rs
@@ -11,7 +11,7 @@ use sys::GodotFfi;
 
 use crate::builtin::{GString, StringName};
 use crate::global::PropertyUsageFlags;
-use crate::meta::{ClassName, GodotConvert, GodotType, PropertyHintInfo, PropertyInfo};
+use crate::meta::{ClassId, GodotConvert, GodotType, PropertyHintInfo, PropertyInfo};
 use crate::obj::GodotClass;
 use crate::registry::property::{Export, Var};
 use crate::{classes, sys};
@@ -31,7 +31,7 @@ pub fn register_export<C: GodotClass, T: Export>(
             panic!(
                 "#[export] for Gd<{t}>: nodes can only be exported in Node-derived classes, but the current class is {c}.",
                 t = class,
-                c = C::class_name()
+                c = C::class_id()
             );
         }
     }
@@ -48,20 +48,20 @@ pub fn register_var<C: GodotClass, T: Var>(
 ) {
     let info = PropertyInfo {
         variant_type: <<T as GodotConvert>::Via as GodotType>::Ffi::VARIANT_TYPE.variant_as_nil(),
-        class_name: <T as GodotConvert>::Via::class_name(),
+        class_id: <T as GodotConvert>::Via::class_id(),
         property_name: StringName::from(property_name),
         hint_info,
         usage,
     };
 
-    let class_name = C::class_name();
+    let class_name = C::class_id();
 
     register_var_or_export_inner(info, class_name, getter_name, setter_name);
 }
 
 fn register_var_or_export_inner(
     info: PropertyInfo,
-    class_name: ClassName,
+    class_name: ClassId,
     getter_name: &str,
     setter_name: &str,
 ) {
@@ -84,7 +84,7 @@ fn register_var_or_export_inner(
 pub fn register_group<C: GodotClass>(group_name: &str, prefix: &str) {
     let group_name = GString::from(group_name);
     let prefix = GString::from(prefix);
-    let class_name = C::class_name();
+    let class_name = C::class_id();
 
     unsafe {
         sys::interface_fn!(classdb_register_extension_class_property_group)(
@@ -99,7 +99,7 @@ pub fn register_group<C: GodotClass>(group_name: &str, prefix: &str) {
 pub fn register_subgroup<C: GodotClass>(subgroup_name: &str, prefix: &str) {
     let subgroup_name = GString::from(subgroup_name);
     let prefix = GString::from(prefix);
-    let class_name = C::class_name();
+    let class_name = C::class_id();
 
     unsafe {
         sys::interface_fn!(classdb_register_extension_class_property_subgroup)(

--- a/godot-core/src/registry/method.rs
+++ b/godot-core/src/registry/method.rs
@@ -10,7 +10,7 @@ use sys::interface_fn;
 
 use crate::builtin::{StringName, Variant};
 use crate::global::MethodFlags;
-use crate::meta::{ClassName, GodotConvert, GodotType, ParamTuple, PropertyInfo, Signature};
+use crate::meta::{ClassId, GodotConvert, GodotType, ParamTuple, PropertyInfo, Signature};
 use crate::obj::GodotClass;
 
 /// Info relating to an argument or return type in a method.
@@ -27,7 +27,7 @@ impl MethodParamOrReturnInfo {
 
 /// All info needed to register a method for a class with Godot.
 pub struct ClassMethodInfo {
-    class_name: ClassName,
+    class_id: ClassId,
     method_name: StringName,
     call_func: sys::GDExtensionClassMethodCall,
     ptrcall_func: sys::GDExtensionClassMethodPtrCall,
@@ -71,7 +71,7 @@ impl ClassMethodInfo {
         );
 
         Self {
-            class_name: C::class_name(),
+            class_id: C::class_id(),
             method_name,
             call_func,
             ptrcall_func,
@@ -141,7 +141,7 @@ impl ClassMethodInfo {
         unsafe {
             interface_fn!(classdb_register_extension_class_method)(
                 sys::get_library(),
-                self.class_name.string_sys(),
+                self.class_id.string_sys(),
                 std::ptr::addr_of!(method_info_sys),
             )
         }
@@ -168,7 +168,7 @@ impl ClassMethodInfo {
         unsafe {
             interface_fn!(classdb_register_extension_class_virtual_method)(
                 sys::get_library(),
-                self.class_name.string_sys(),
+                self.class_id.string_sys(),
                 std::ptr::addr_of!(method_info_sys),
             )
         }

--- a/godot-core/src/registry/property/mod.rs
+++ b/godot-core/src/registry/property/mod.rs
@@ -14,7 +14,7 @@ use godot_ffi::{GodotNullableFfi, VariantType};
 
 use crate::classes;
 use crate::global::PropertyHint;
-use crate::meta::{ClassName, FromGodot, GodotConvert, GodotType, PropertyHintInfo, ToGodot};
+use crate::meta::{ClassId, FromGodot, GodotConvert, GodotType, PropertyHintInfo, ToGodot};
 use crate::obj::{EngineEnum, GodotClass};
 
 mod phantom_var;
@@ -77,12 +77,12 @@ pub trait Export: Var {
         <Self as Var>::var_hint()
     }
 
-    /// If this is a class inheriting `Node`, returns the `ClassName`; otherwise `None`.
+    /// If this is a class inheriting `Node`, returns the `ClassId`; otherwise `None`.
     ///
     /// Only overridden for `Gd<T>`, to detect erroneous exports of `Node` inside a `Resource` class.
     #[allow(clippy::wrong_self_convention)]
     #[doc(hidden)]
-    fn as_node_class() -> Option<ClassName> {
+    fn as_node_class() -> Option<ClassId> {
         None
     }
 }

--- a/godot-core/src/registry/property/phantom_var.rs
+++ b/godot-core/src/registry/property/phantom_var.rs
@@ -10,7 +10,7 @@ use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::marker::PhantomData;
 
-use crate::meta::{ClassName, GodotConvert, GodotType, PropertyHintInfo};
+use crate::meta::{ClassId, GodotConvert, GodotType, PropertyHintInfo};
 use crate::registry::property::{Export, Var};
 
 /// A zero-sized type for creating a property without a backing field, accessible only through custom getter/setter functions.
@@ -83,7 +83,7 @@ impl<T: GodotType + Var + Export> Export for PhantomVar<T> {
         <T as Export>::export_hint()
     }
 
-    fn as_node_class() -> Option<ClassName> {
+    fn as_node_class() -> Option<ClassId> {
         <T as Export>::as_node_class()
     }
 }

--- a/godot-core/src/tools/save_load.rs
+++ b/godot-core/src/tools/save_load.rs
@@ -146,19 +146,19 @@ where
 {
     let loaded = ResourceLoader::singleton()
         .load_ex(path)
-        .type_hint(&T::class_name().to_gstring())
+        .type_hint(&T::class_id().to_gstring())
         .done();
 
     match loaded {
         Some(res) => match res.try_cast::<T>() {
             Ok(obj) => Ok(obj),
             Err(_) => Err(IoError::loading_cast(
-                T::class_name().to_string(),
+                T::class_id().to_string(),
                 path.to_string(),
             )),
         },
         None => Err(IoError::loading(
-            T::class_name().to_string(),
+            T::class_id().to_string(),
             path.to_string(),
         )),
     }
@@ -175,7 +175,7 @@ where
     } else {
         Err(IoError::saving(
             res,
-            T::class_name().to_string(),
+            T::class_id().to_string(),
             path.to_string(),
         ))
     }

--- a/godot-macros/src/class/data_models/constant.rs
+++ b/godot-macros/src/class/data_models/constant.rs
@@ -48,7 +48,7 @@ pub fn make_constant_registration(
     let tokens = if !integer_constant_names.is_empty() {
         quote! {
             use ::godot::register::private::constant::*;
-            use ::godot::meta::ClassName;
+            use ::godot::meta::ClassId;
             use ::godot::builtin::StringName;
 
             #(

--- a/godot-macros/src/class/derive_godot_class.rs
+++ b/godot-macros/src/class/derive_godot_class.rs
@@ -60,9 +60,9 @@ pub fn derive_godot_class(item: venial::Item) -> ParseResult<TokenStream> {
     // so we can't cause a compile error if Unicode is used before Godot 4.4. However, this causes a runtime error at startup.
     let class_name_allocation = if class_name_str.is_ascii() {
         let c_str = util::c_str(&class_name_str);
-        quote! { ClassName::__alloc_next_ascii(#c_str) }
+        quote! { ClassId::__alloc_next_ascii(#c_str) }
     } else {
-        quote! { ClassName::__alloc_next_unicode(#class_name_str) }
+        quote! { ClassId::__alloc_next_unicode(#class_name_str) }
     };
 
     if struct_cfg.is_internal {
@@ -166,14 +166,14 @@ pub fn derive_godot_class(item: venial::Item) -> ParseResult<TokenStream> {
             type Base = #base_class;
 
             // Code duplicated in godot-codegen.
-            fn class_name() -> ::godot::meta::ClassName {
-                use ::godot::meta::ClassName;
+            fn class_id() -> ::godot::meta::ClassId {
+                use ::godot::meta::ClassId;
 
                 // Optimization note: instead of lazy init, could use separate static which is manually initialized during registration.
-                static CLASS_NAME: std::sync::OnceLock<ClassName> = std::sync::OnceLock::new();
+                static CLASS_ID: std::sync::OnceLock<ClassId> = std::sync::OnceLock::new();
 
-                let name: &'static ClassName = CLASS_NAME.get_or_init(|| #class_name_allocation);
-                *name
+                let id: &'static ClassId = CLASS_ID.get_or_init(|| #class_name_allocation);
+                *id
             }
         }
 

--- a/godot-macros/src/util/mod.rs
+++ b/godot-macros/src/util/mod.rs
@@ -31,7 +31,7 @@ pub fn c_str(string: &str) -> Literal {
 
 pub fn class_name_obj(class: &impl ToTokens) -> TokenStream {
     let class = class.to_token_stream();
-    quote! { <#class as ::godot::obj::GodotClass>::class_name() }
+    quote! { <#class as ::godot::obj::GodotClass>::class_id() }
 }
 
 pub fn bail_fn<R, T>(msg: impl AsRef<str>, tokens: T) -> ParseResult<R>

--- a/itest/rust/src/builtin_tests/containers/array_test.rs
+++ b/itest/rust/src/builtin_tests/containers/array_test.rs
@@ -641,7 +641,7 @@ fn array_element_type() {
         extension_class_array.element_type(),
         ElementType::Class(class_name),
     );
-    assert_eq!(class_name, ArrayTest::class_name());
+    assert_eq!(class_name, ArrayTest::class_id());
 }
 
 #[itest]

--- a/itest/rust/src/builtin_tests/script/script_instance_tests.rs
+++ b/itest/rust/src/builtin_tests/script/script_instance_tests.rs
@@ -13,7 +13,7 @@ use godot::classes::{
     ScriptLanguageExtension,
 };
 use godot::global::{Error, MethodFlags};
-use godot::meta::{ClassName, FromGodot, MethodInfo, PropertyInfo, ToGodot};
+use godot::meta::{ClassId, FromGodot, MethodInfo, PropertyInfo, ToGodot};
 use godot::obj::script::{create_script_instance, ScriptInstance, SiMut};
 use godot::obj::{Base, Gd, NewAlloc, WithBaseField};
 use godot::register::{godot_api, GodotClass};
@@ -107,7 +107,7 @@ impl TestScriptInstance {
             method_list: vec![MethodInfo {
                 id: 1,
                 method_name: StringName::from("script_method_a"),
-                class_name: ClassName::new_cached::<TestScript>(|| "TestScript".to_string()),
+                class_name: ClassId::new_cached::<TestScript>(|| "TestScript".to_string()),
                 return_type: PropertyInfo::new_var::<GString>(""),
                 arguments: vec![
                     PropertyInfo::new_var::<GString>("arg_a"),

--- a/itest/rust/src/object_tests/class_name_test.rs
+++ b/itest/rust/src/object_tests/class_name_test.rs
@@ -8,7 +8,7 @@
 use std::borrow::Cow;
 
 use godot::builtin::{GString, StringName};
-use godot::meta::ClassName;
+use godot::meta::ClassId;
 use godot::obj::bounds::implement_godot_bounds;
 use godot::obj::GodotClass;
 use godot::sys;
@@ -24,23 +24,23 @@ implement_godot_bounds!(U);
 impl GodotClass for A {
     type Base = godot::classes::Object;
 
-    fn class_name() -> ClassName {
-        ClassName::new_cached::<A>(|| "A".to_string())
+    fn class_id() -> ClassId {
+        ClassId::new_cached::<A>(|| "A".to_string())
     }
 }
 
 impl GodotClass for U {
     type Base = godot::classes::Object;
 
-    fn class_name() -> ClassName {
-        ClassName::new_cached::<U>(|| "统一码".to_string())
+    fn class_id() -> ClassId {
+        ClassId::new_cached::<U>(|| "统一码".to_string())
     }
 }
 
 #[itest]
 fn class_name_godotclass() {
-    let a = A::class_name();
-    let b = A::class_name();
+    let a = A::class_id();
+    let b = A::class_id();
 
     assert_eq!(a, b);
     assert_eq!(sys::hash_value(&a), sys::hash_value(&b));
@@ -54,8 +54,8 @@ fn class_name_godotclass() {
 #[cfg(since_api = "4.4")]
 #[itest]
 fn class_name_godotclass_unicode() {
-    let a = U::class_name();
-    let b = U::class_name();
+    let a = U::class_id();
+    let b = U::class_id();
 
     assert_eq!(a, b);
     assert_eq!(sys::hash_value(&a), sys::hash_value(&b));
@@ -68,25 +68,25 @@ fn class_name_godotclass_unicode() {
         Cow::<'static, str>::Owned("统一码".to_string())
     );
 
-    let b = ClassName::__dynamic("统一码");
+    let b = ClassId::__dynamic("统一码");
     assert_eq!(a, b);
 }
 
 #[itest]
 fn class_name_from_dynamic() {
     // Test that runtime-constructed class names are equal to compile-time ones.
-    let comptime = A::class_name();
-    let runtime = ClassName::__dynamic("A");
+    let comptime = A::class_id();
+    let runtime = ClassId::__dynamic("A");
     assert_eq!(comptime, runtime);
     assert_eq!(sys::hash_value(&comptime), sys::hash_value(&runtime));
     assert_eq!(comptime.to_string(), runtime.to_string());
 
     // Test that multiple runtime constructions of the same name are equal.
-    let runtime2 = ClassName::__dynamic("A");
+    let runtime2 = ClassId::__dynamic("A");
     assert_eq!(runtime, runtime2);
 
     // Test with a different name.
-    let different_runtime = ClassName::__dynamic("B");
+    let different_runtime = ClassId::__dynamic("B");
     assert_ne!(comptime, different_runtime);
     assert_eq!(different_runtime.to_string(), "B");
 }
@@ -94,12 +94,12 @@ fn class_name_from_dynamic() {
 #[itest]
 fn class_name_empty() {
     // Empty string and ClassName::none() should be the same.
-    let none_dynamic = ClassName::__dynamic("");
-    let none = ClassName::none();
+    let none_dynamic = ClassId::__dynamic("");
+    let none = ClassId::none();
 
     assert_eq!(none_dynamic, none);
-    assert_eq!(format!("{none_dynamic:?}"), "ClassName(none)");
-    assert_eq!(format!("{none:?}"), "ClassName(none)");
+    assert_eq!(format!("{none_dynamic:?}"), "ClassId(none)");
+    assert_eq!(format!("{none:?}"), "ClassId(none)");
 }
 
 // Test Unicode proc-macro support for ClassName.
@@ -113,13 +113,13 @@ fn class_name_dynamic_then_static() {
     struct A;
 
     // First, insert dynamic string, then static one.
-    let dynamic_name = ClassName::__dynamic("LocalA");
-    let static_name = ClassName::__cached::<A>(|| "LocalA".to_string());
+    let dynamic_name = ClassId::__dynamic("LocalA");
+    let static_name = ClassId::__cached::<A>(|| "LocalA".to_string());
 
     // They should be equal (same global_index), but current implementation may create duplicates
     assert_eq!(
         dynamic_name, static_name,
-        "Dynamic and static ClassName for same string should be equal"
+        "Dynamic and static ClassId for same string should be equal"
     );
 }
 
@@ -128,13 +128,13 @@ fn class_name_static_then_dynamic() {
     struct B;
 
     // First, insert static string, then dynamic one.
-    let static_name = ClassName::__cached::<B>(|| "LocalB".to_string());
-    let dynamic_name = ClassName::__dynamic("LocalB");
+    let static_name = ClassId::__cached::<B>(|| "LocalB".to_string());
+    let dynamic_name = ClassId::__dynamic("LocalB");
 
     // They should be equal (same global_index)
     assert_eq!(
         static_name, dynamic_name,
-        "Static and dynamic ClassName for same string should be equal"
+        "Static and dynamic ClassId for same string should be equal"
     );
 }
 
@@ -143,14 +143,14 @@ fn class_name_debug() {
     struct TestDebugClass;
 
     // Test debug output for various class names
-    let none_name = ClassName::none();
-    let dynamic_name = ClassName::__dynamic("MyDynamicClass");
-    let static_name = ClassName::__cached::<TestDebugClass>(|| "MyStaticClass".to_string());
+    let none_name = ClassId::none();
+    let dynamic_name = ClassId::__dynamic("MyDynamicClass");
+    let static_name = ClassId::__cached::<TestDebugClass>(|| "MyStaticClass".to_string());
 
     // Verify debug representations include the actual class names
-    assert_eq!(format!("{none_name:?}"), "ClassName(none)");
-    assert_eq!(format!("{dynamic_name:?}"), "ClassName(\"MyDynamicClass\")");
-    assert_eq!(format!("{static_name:?}"), "ClassName(\"MyStaticClass\")");
+    assert_eq!(format!("{none_name:?}"), "ClassId(none)");
+    assert_eq!(format!("{dynamic_name:?}"), "ClassId(\"MyDynamicClass\")");
+    assert_eq!(format!("{static_name:?}"), "ClassId(\"MyStaticClass\")");
 }
 
 #[cfg(debug_assertions)]
@@ -158,20 +158,20 @@ fn class_name_debug() {
 fn class_name_alloc_panic() {
     // ASCII.
     {
-        let _1st = ClassName::__alloc_next_ascii(c"DuplicateTestClass");
+        let _1st = ClassId::__alloc_next_ascii(c"DuplicateTestClass");
 
         expect_panic("2nd allocation with same ASCII string fails", || {
-            let _2nd = ClassName::__alloc_next_ascii(c"DuplicateTestClass");
+            let _2nd = ClassId::__alloc_next_ascii(c"DuplicateTestClass");
         });
     }
 
     // Unicode.
     #[cfg(since_api = "4.4")]
     {
-        let _1st = ClassName::__alloc_next_unicode("クラス名");
+        let _1st = ClassId::__alloc_next_unicode("クラス名");
 
         expect_panic("2nd allocation with same Unicode string fails", || {
-            let _2nd = ClassName::__alloc_next_unicode("クラス名");
+            let _2nd = ClassId::__alloc_next_unicode("クラス名");
         });
     }
 }

--- a/itest/rust/src/object_tests/class_rename_test.rs
+++ b/itest/rust/src/object_tests/class_rename_test.rs
@@ -28,9 +28,9 @@ pub mod rename {
 #[itest]
 fn renaming_changes_the_name() {
     assert_ne!(
-        dont_rename::RepeatMe::class_name(),
-        rename::RepeatMe::class_name()
+        dont_rename::RepeatMe::class_id(),
+        rename::RepeatMe::class_id()
     );
-    assert_eq!(dont_rename::RepeatMe::class_name().to_string(), "RepeatMe");
-    assert_eq!(rename::RepeatMe::class_name().to_string(), "NoRepeat");
+    assert_eq!(dont_rename::RepeatMe::class_id().to_string(), "RepeatMe");
+    assert_eq!(rename::RepeatMe::class_id().to_string(), "NoRepeat");
 }

--- a/itest/rust/src/object_tests/get_property_list_test.rs
+++ b/itest/rust/src/object_tests/get_property_list_test.rs
@@ -36,7 +36,7 @@ impl IObject for GetPropertyListTest {
 
 fn property_dict_eq_property_info(dict: &Dictionary, info: &PropertyInfo) -> bool {
     dict.get("name").unwrap().to::<GString>().to_string() == info.property_name.to_string()
-        && dict.get("class_name").unwrap().to::<StringName>() == info.class_name.to_string_name()
+        && dict.get("class_name").unwrap().to::<StringName>() == info.class_id.to_string_name()
         && dict.get("type").unwrap().to::<VariantType>() == info.variant_type
         && dict.get("hint").unwrap().to::<PropertyHint>() == info.hint_info.hint
         && dict.get("hint_string").unwrap().to::<GString>() == info.hint_info.hint_string

--- a/itest/rust/src/object_tests/validate_property_test.rs
+++ b/itest/rust/src/object_tests/validate_property_test.rs
@@ -30,8 +30,8 @@ impl IObject for ValidatePropertyTest {
             property.hint_info.hint_string = GString::from("SomePropertyHint");
             property.hint_info.hint = PropertyHint::TYPE_STRING;
 
-            // Makes no sense, but allows to check if given ClassName can be properly moved to GDExtensionPropertyInfo.
-            property.class_name = <ValidatePropertyTest as godot::obj::GodotClass>::class_name();
+            // Makes no sense, but allows to check if given ClassId can be properly moved to GDExtensionPropertyInfo.
+            property.class_id = <ValidatePropertyTest as godot::obj::GodotClass>::class_id();
         }
     }
 }

--- a/itest/rust/src/register_tests/constant_test.rs
+++ b/itest/rust/src/register_tests/constant_test.rs
@@ -68,7 +68,7 @@ impl HasConstants {
 
 /// Checks at runtime if a class has a given integer constant through [ClassDb].
 fn class_has_integer_constant<T: GodotClass>(name: &str) -> bool {
-    ClassDb::singleton().class_has_integer_constant(&T::class_name().to_string_name(), name)
+    ClassDb::singleton().class_has_integer_constant(&T::class_id().to_string_name(), name)
 }
 
 #[itest]
@@ -84,7 +84,7 @@ fn constants_correct_value() {
         ),
     ];
 
-    let class_name = HasConstants::class_name().to_string_name();
+    let class_name = HasConstants::class_id().to_string_name();
     let constants = ClassDb::singleton()
         .class_get_integer_constant_list_ex(&class_name)
         .no_inheritance(true)
@@ -137,7 +137,7 @@ impl godot::obj::cap::ImplementsGodotApi for HasOtherConstants {
         use ::godot::register::private::constant::*;
         // Try exporting an enum.
         ExportConstant::new(
-            HasOtherConstants::class_name(),
+            HasOtherConstants::class_id(),
             ConstantKind::Enum {
                 name: Self::ENUM_NAME.into(),
                 enumerators: vec![
@@ -151,7 +151,7 @@ impl godot::obj::cap::ImplementsGodotApi for HasOtherConstants {
 
         // Try exporting an enum.
         ExportConstant::new(
-            HasOtherConstants::class_name(),
+            HasOtherConstants::class_id(),
             ConstantKind::Bitfield {
                 name: Self::BITFIELD_NAME.into(),
                 flags: vec![
@@ -187,7 +187,7 @@ macro_rules! test_enum_export {
     ) => {
         #$attr
         fn $test_name() {
-            let class_name = <$class>::class_name().to_string_name();
+            let class_name = <$class>::class_id().to_string_name();
             let enum_name = StringName::from(<$class>::$enum_name);
             let variants = [
                 $((stringify!($enumerators), <$class>::$enumerators)),*

--- a/itest/rust/src/register_tests/func_test.rs
+++ b/itest/rust/src/register_tests/func_test.rs
@@ -346,12 +346,12 @@ fn cfg_removes_or_keeps_signals() {
 /// Checks at runtime if a class has a given method through [ClassDb].
 fn class_has_method<T: GodotClass>(name: &str) -> bool {
     ClassDb::singleton()
-        .class_has_method_ex(&T::class_name().to_string_name(), name)
+        .class_has_method_ex(&T::class_id().to_string_name(), name)
         .no_inheritance(true)
         .done()
 }
 
 /// Checks at runtime if a class has a given signal through [ClassDb].
 fn class_has_signal<T: GodotClass>(name: &str) -> bool {
-    ClassDb::singleton().class_has_signal(&T::class_name().to_string_name(), name)
+    ClassDb::singleton().class_has_signal(&T::class_id().to_string_name(), name)
 }


### PR DESCRIPTION
Since we moved instances to lightweight integers, the term "ID" fits better, also with respect to global uniqueness across all Godot classes.

No functional changes. Old symbols `ClassName` + `GodotClass::class_name()` remain deprecated for the time being.