### PR TITLE
Make `base_mut` not clone `Gd` and work in init and predelete

### DIFF
--- a/godot-core/src/classes/class_runtime.rs
+++ b/godot-core/src/classes/class_runtime.rs
@@ -226,30 +226,6 @@ pub(crate) fn ensure_object_inherits(derived: ClassId, base: ClassId, instance_i
     )
 }
 
-#[cfg(debug_assertions)]
-pub(crate) fn ensure_binding_not_null<T>(binding: sys::GDExtensionClassInstancePtr)
-where
-    T: GodotClass + Bounds<Declarer = bounds::DeclUser>,
-{
-    if !binding.is_null() {
-        return;
-    }
-
-    // Non-tool classes can't be instantiated in the editor.
-    if crate::classes::Engine::singleton().is_editor_hint() {
-        panic!(
-            "Class {} -- null instance; does the class have a Godot creator function? \
-            Ensure that the given class is a tool class with #[class(tool)], if it is being accessed in the editor.",
-            std::any::type_name::<T>()
-        )
-    } else {
-        panic!(
-            "Class {} -- null instance; does the class have a Godot creator function?",
-            std::any::type_name::<T>()
-        );
-    }
-}
-
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Implementation of this file
 

--- a/godot-core/src/obj/base.rs
+++ b/godot-core/src/obj/base.rs
@@ -320,7 +320,7 @@ impl<T: GodotClass> Base<T> {
 
     /// Returns `true` if this `Base<T>` is currently in the initializing state.
     #[cfg(debug_assertions)]
-    fn is_initializing(&self) -> bool {
+    pub(crate) fn is_initializing(&self) -> bool {
         self.init_state.get() == InitState::ObjectConstructing
     }
 
@@ -344,12 +344,6 @@ impl<T: GodotClass> Base<T> {
     /// # Safety
     /// Caller must ensure that the underlying object remains valid for the entire lifetime of the returned `PassiveGd`.
     pub(crate) unsafe fn constructed_passive(&self) -> PassiveGd<T> {
-        #[cfg(debug_assertions)] // debug_assert! still checks existence of symbols.
-        assert!(
-            !self.is_initializing(),
-            "WithBaseField::base(), base_mut() can only be called on fully-constructed objects, after I*::init() or Gd::from_init_fn()"
-        );
-
         // SAFETY: object pointer is valid and remains valid as long as self is alive (per safety precondition of this fn).
         unsafe { PassiveGd::from_obj_sys(self.obj.obj_sys()) }
     }

--- a/godot-core/src/obj/bounds.rs
+++ b/godot-core/src/obj/bounds.rs
@@ -221,7 +221,9 @@ impl DynMemory for MemRefCounted {
         }
         obj.with_ref_counted(|refc| {
             let success = refc.init_ref();
-            assert!(success, "init_ref() failed");
+            if !success {
+                crate::godot_error!("init_ref() failed, make sure you don't create a `Gd` pointer to base/self in predelete or drop()");
+            };
         });
 
         /*
@@ -249,6 +251,10 @@ impl DynMemory for MemRefCounted {
             return false;
         }
         obj.with_ref_counted(|refc| {
+            if refc.get_reference_count() == 0 {
+	            crate::godot_error!("Trying to unreference a RefCounted whose reference count is already zero, make sure you don't create a `Gd` pointer to base/self in predelete or drop()");
+				return false;
+            }
             let is_last = refc.unreference();
             out!("  +-- was last={is_last}");
             is_last

--- a/godot-core/src/obj/guards.rs
+++ b/godot-core/src/obj/guards.rs
@@ -232,13 +232,14 @@ macro_rules! make_base_mut {
         #[doc = concat!("See [`", stringify!($doc_type), "::base_mut()`](", stringify!($doc_path), "::base_mut()) for usage.\n")]
         pub struct $ident<'a, T: $bound> {
             passive_gd: PassiveGd<T::Base>,
-            _inaccessible_guard: InaccessibleGuard<'a, T>,
+       		// Option because we can't make a guard yet since the instance storage is null during initializing.
+    	    _inaccessible_guard: Option<InaccessibleGuard<'a, T>>,
         }
 
         impl<'a, T: $bound> $ident<'a, T> {
             pub(crate) fn new(
                 passive_gd: PassiveGd<T::Base>,
-                inaccessible_guard: InaccessibleGuard<'a, T>,
+                inaccessible_guard: Option<InaccessibleGuard<'a, T>>,
             ) -> Self {
                 Self {
                     passive_gd,

--- a/godot-core/src/obj/script.rs
+++ b/godot-core/src/obj/script.rs
@@ -503,7 +503,7 @@ impl<'a, T: ScriptInstance> SiMut<'a, T> {
         let guard = self.cell.make_inaccessible(self.mut_ref).unwrap();
         let passive_gd = self.base_ref.to_script_passive();
 
-        ScriptBaseMut::new(passive_gd, guard)
+        ScriptBaseMut::new(passive_gd, Some(guard))
     }
 }
 


### PR DESCRIPTION
Don't call `self.to_gd` in `base_mut` to make it work in init and predelete.

`BaseMut` has no runtime inaccessible guard during initialization because the instance binding is not set yet, but Rust compiler's borrow checking for `base` and `base_mut` are still enforced.