### PR TITLE
Use rust str instead of cstr in `ClassIdSource`

### DIFF
--- a/godot-codegen/src/generator/classes.rs
+++ b/godot-codegen/src/generator/classes.rs
@@ -91,7 +91,6 @@ fn make_class(class: &Class, ctx: &mut Context, view: &ApiView) -> GeneratedClas
 
     // Strings
     let godot_class_str = &class_name.godot_ty;
-    let class_name_cstr = util::c_str(godot_class_str);
 
     // Idents and tokens
     let (base_ty, base_ident_opt) = match class.base_class.as_ref() {
@@ -248,7 +247,7 @@ fn make_class(class: &Class, ctx: &mut Context, view: &ApiView) -> GeneratedClas
                     // Optimization note: instead of lazy init, could use separate static which is manually initialized during registration.
                     static CLASS_ID: std::sync::OnceLock<ClassId> = std::sync::OnceLock::new();
 
-                    let name: &'static ClassId = CLASS_ID.get_or_init(|| ClassId::__alloc_next_ascii(#class_name_cstr));
+                    let name: &'static ClassId = CLASS_ID.get_or_init(|| ClassId::__alloc_next_unicode(#godot_class_str));
                     *name
                 }
 

--- a/godot-core/src/meta/signature.rs
+++ b/godot-core/src/meta/signature.rs
@@ -470,7 +470,7 @@ impl<'a> CallContext<'a> {
     }
 
     /// Call from Godot into a custom Callable.
-    pub fn custom_callable(function_name: &'a str) -> Self {
+    pub const fn custom_callable(function_name: &'a str) -> Self {
         Self {
             class_name: Cow::Borrowed("<Callable>"),
             function_name,

--- a/godot-macros/src/class/derive_godot_class.rs
+++ b/godot-macros/src/class/derive_godot_class.rs
@@ -55,15 +55,7 @@ pub fn derive_godot_class(item: venial::Item) -> ParseResult<TokenStream> {
         .map_or_else(|| class.name.clone(), |rename| rename)
         .to_string();
 
-    // Determine if we can use ASCII for the class name (in most cases).
-    // Crate godot-macros does not have knowledge of `api-*` features (and neither does user crate where macros are generated),
-    // so we can't cause a compile error if Unicode is used before Godot 4.4. However, this causes a runtime error at startup.
-    let class_name_allocation = if class_name_str.is_ascii() {
-        let c_str = util::c_str(&class_name_str);
-        quote! { ClassId::__alloc_next_ascii(#c_str) }
-    } else {
-        quote! { ClassId::__alloc_next_unicode(#class_name_str) }
-    };
+    let class_name_allocation = quote! { ClassId::__alloc_next_unicode(#class_name_str) };
 
     if struct_cfg.is_internal {
         modifiers.push(quote! { with_internal })

--- a/itest/rust/src/object_tests/class_name_test.rs
+++ b/itest/rust/src/object_tests/class_name_test.rs
@@ -158,10 +158,10 @@ fn class_name_debug() {
 fn class_name_alloc_panic() {
     // ASCII.
     {
-        let _1st = ClassId::__alloc_next_ascii(c"DuplicateTestClass");
+        let _1st = ClassId::__alloc_next_unicode("DuplicateTestClass");
 
         expect_panic("2nd allocation with same ASCII string fails", || {
-            let _2nd = ClassId::__alloc_next_ascii(c"DuplicateTestClass");
+            let _2nd = ClassId::__alloc_next_unicode("DuplicateTestClass");
         });
     }
 


### PR DESCRIPTION
This simplifies things and improves performance of `ClassId::to_cow_str`, which is overhead in `CallContext::gd` and `check_rtti`.

```rust
#[bench(repeat = 10000)]
fn class_id_str() -> std::borrow::Cow<'static, str> {
    godot::classes::Object::class_id().to_cow_str()
}

// In debug build
// before:
//    -- class_id_str               ...      0.148μs      0.156μs
// after:
//    -- class_id_str               ...      0.119μs      0.125μs
```
I think the only reason for using cstr might be initializing StringName from it is slightly faster than rust str, but this is not a hot path since initialization only happens once.