### PR TITLE
itest: work around clippy errors when `quote!` generates one big line

### DIFF
--- a/itest/rust/build.rs
+++ b/itest/rust/build.rs
@@ -361,6 +361,7 @@ fn generate_rust_methods(inputs: &[Input]) -> Vec<TokenStream> {
         .collect::<Vec<_>>();
 
     let manual_methods = quote! {
+        #[allow(clippy::suspicious_else_formatting)] // `quote!` might output whole file as one big line.
         #[func]
         fn check_last_notrace(last_method_name: String, expected_callconv: String) -> bool {
             let last = godot::private::trace::pop();


### PR DESCRIPTION
add `#[allow(clippy::suspicious_else_formatting)]` in generated code in itest, since file can be generated as one big line.

See failing job: https://github.com/godot-rust/gdext/actions/runs/18001547399/job/51211796501?pr=1334

As explanation, such code:
```rs
    if a {
        println!("a");
        godot_error = true;
    }
    if b {
        println!("b");
        godot_error = true;
    }
```
is fine, while
```rs
    if a {
        println!("a");
        godot_error = true;
    } if b {
        println!("b");
        godot_error = true;
    }
```

triggers following warning:
```rs
warning: this looks like an `else if` but the `else` is missing
 --> src/main.rs:6:6
  |
6 |     } if b {
  |      ^
  |
  = note: to remove this lint, add the missing `else` or add a new line before the second `if`
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#suspicious_else_formatting
  = note: `#[warn(clippy::suspicious_else_formatting)]` on by default
```