### PR TITLE
Codegen excludes classes only on certain targets 

### DIFF
--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -26,8 +26,8 @@ env:
   # * report_objects: list individual leaked objects when running LeakSanitizer
   LSAN_OPTIONS: report_objects=1
 
-  CARGO_DENY_VERSION: "0.16.1"
-  CARGO_MACHETE_VERSION: "0.7.0"
+  CARGO_DENY_VERSION: "0.18.5"
+  CARGO_MACHETE_VERSION: "0.9.1"
 
 
 defaults:

--- a/godot-codegen/src/special_cases/special_cases.rs
+++ b/godot-codegen/src/special_cases/special_cases.rs
@@ -97,6 +97,7 @@ pub fn is_native_struct_excluded(ty: &str) -> bool {
     codegen_special_cases::is_native_struct_excluded(ty)
 }
 
+#[rustfmt::skip]
 pub fn is_godot_type_deleted(godot_ty: &str) -> bool {
     // Note: parameter can be a class or builtin name, but also something like "enum::AESContext.Mode".
 
@@ -117,15 +118,20 @@ pub fn is_godot_type_deleted(godot_ty: &str) -> bool {
         }
     }
 
+    // cfg!(target_os = "...") are relatively new and need more testing. If causing problems, revert to `true` (deleted) for now.
+    // TODO(v0.5): for doc generation, consider moving the target-filters to the generated code, so that API docs still show the classes.
     match godot_ty {
-        // Hardcoded cases that are not accessible.
         // Only on Android.
-        | "JavaClassWrapper"
-        | "JNISingleton"
         | "JavaClass"
+        | "JavaClassWrapper"
+        | "JavaObject"
+        | "JNISingleton"
+        => !cfg!(target_os = "android"),
+
         // Only on Wasm.
         | "JavaScriptBridge"
         | "JavaScriptObject"
+        => !cfg!(target_os = "emscripten"),
 
         // Thread APIs.
         | "Thread"


### PR DESCRIPTION
Newly exclude `JavaObject`, which now caused CI failures.

Previously, classes like `JavaClass` etc. were not available at all, because Desktop Godot targets did not support them. Now, they are conditionally included for Wasm/Android.