### PR TITLE
Remove deprecated symbols, other small cleanups

### DIFF
--- a/godot-codegen/src/conv/type_conversions.rs
+++ b/godot-codegen/src/conv/type_conversions.rs
@@ -308,9 +308,7 @@ fn to_rust_expr_inner(expr: &str, ty: &RustTy, is_inner: bool) -> TokenStream {
                 _ => panic!("null not representable in target type {ty:?}"),
             }
         }
-        // empty string appears only for Callable/Rid in 4.0; default ctor syntax in 4.1+
-        // TODO(v0.4): check if we can remove ""
-        "" | "RID()" | "Callable()" if !is_inner => {
+        "RID()" | "Callable()" if !is_inner => {
             return match ty {
                 RustTy::BuiltinIdent { ty: ident, .. } if ident == "Rid" => quote! { Rid::Invalid },
                 RustTy::BuiltinIdent { ty: ident, .. } if ident == "Callable" => {

--- a/godot-codegen/src/generator/extension_interface.rs
+++ b/godot-codegen/src/generator/extension_interface.rs
@@ -12,7 +12,7 @@ use proc_macro2::{Ident, Literal, TokenStream};
 use quote::quote;
 use regex::Regex;
 
-use crate::util::ident;
+use crate::util::{ident, make_load_safety_doc};
 use crate::SubmitFn;
 
 pub fn generate_sys_interface_file(
@@ -77,15 +77,14 @@ fn generate_proc_address_funcs(h_path: &Path) -> TokenStream {
     }
 
     // Do not derive Copy -- even though the struct is bitwise-copyable, this is rarely needed and may point to an error.
+    let safety_doc = make_load_safety_doc();
     let code = quote! {
         pub struct GDExtensionInterface {
             #( #fptr_decls )*
         }
 
         impl GDExtensionInterface {
-            // TODO: Figure out the right safety preconditions. This currently does not have any because incomplete safety docs
-            // can cause issues with people assuming they are sufficient.
-            #[allow(clippy::missing_safety_doc)]
+            #safety_doc
             pub(crate) unsafe fn load(
                 get_proc_address: crate::GDExtensionInterfaceGetProcAddress,
             ) -> Self {

--- a/godot-codegen/src/generator/method_tables.rs
+++ b/godot-codegen/src/generator/method_tables.rs
@@ -16,7 +16,7 @@ use crate::models::domain::{
     BuiltinClass, BuiltinMethod, BuiltinVariant, Class, ClassCodegenLevel, ClassLike, ClassMethod,
     ExtensionApi, FnDirection, Function, TyName,
 };
-use crate::util::ident;
+use crate::util::{ident, make_load_safety_doc};
 use crate::{conv, generator, special_cases, util};
 
 pub fn make_builtin_lifecycle_table(api: &ExtensionApi) -> TokenStream {
@@ -276,6 +276,7 @@ fn make_named_method_table(info: NamedMethodTable) -> TokenStream {
 
     // Assumes that both decls and inits already have a trailing comma.
     // This is necessary because some generators emit multiple lines (statements) per element.
+    let safety_doc = make_load_safety_doc();
     quote! {
         #imports
 
@@ -288,9 +289,7 @@ fn make_named_method_table(info: NamedMethodTable) -> TokenStream {
             pub const CLASS_COUNT: usize = #class_count;
             pub const METHOD_COUNT: usize = #method_count;
 
-            // TODO: Figure out the right safety preconditions. This currently does not have any because incomplete safety docs
-            // can cause issues with people assuming they are sufficient.
-            #[allow(clippy::missing_safety_doc)]
+            #safety_doc
             pub unsafe fn load(
                 #ctor_parameters
             ) -> Self {
@@ -374,6 +373,7 @@ fn make_method_table(info: IndexedMethodTable) -> TokenStream {
 
     // Assumes that inits already have a trailing comma.
     // This is necessary because some generators emit multiple lines (statements) per element.
+    let safety_doc = make_load_safety_doc();
     quote! {
         #imports
 
@@ -387,9 +387,7 @@ fn make_method_table(info: IndexedMethodTable) -> TokenStream {
             pub const CLASS_COUNT: usize = #class_count;
             pub const METHOD_COUNT: usize = #method_count;
 
-            // TODO: Figure out the right safety preconditions. This currently does not have any because incomplete safety docs
-            // can cause issues with people assuming they are sufficient.
-            #[allow(clippy::missing_safety_doc)]
+            #safety_doc
             #unused_attr
             pub unsafe fn load(
                 #ctor_parameters
@@ -440,6 +438,7 @@ fn make_method_table(info: IndexedMethodTable) -> TokenStream {
 
     // Assumes that inits already have a trailing comma.
     // This is necessary because some generators emit multiple lines (statements) per element.
+    let safety_doc = make_load_safety_doc();
     quote! {
         #imports
         use crate::StringCache;
@@ -462,9 +461,7 @@ fn make_method_table(info: IndexedMethodTable) -> TokenStream {
             pub const CLASS_COUNT: usize = #class_count;
             pub const METHOD_COUNT: usize = #method_count;
 
-            // TODO: Figure out the right safety preconditions. This currently does not have any because incomplete safety docs
-            // can cause issues with people assuming they are sufficient.
-            #[allow(clippy::missing_safety_doc)]
+            #safety_doc
             #unused_attr
             pub unsafe fn load() -> Self {
                 // SAFETY: interface and lifecycle tables are initialized at this point, so we can get 'static references to them.

--- a/godot-codegen/src/util.rs
+++ b/godot-codegen/src/util.rs
@@ -85,6 +85,14 @@ pub fn lifetime(s: &str) -> TokenStream {
     TokenStream::from_iter([tk_apostrophe, tk_lifetime])
 }
 
+pub fn make_load_safety_doc() -> TokenStream {
+    quote! {
+        /// # Safety
+        /// - Must be called exactly once during library initialization.
+        /// - All parameters (dependencies) must have been initialized and valid.
+    }
+}
+
 // This function is duplicated in godot-macros\src\util\mod.rs
 #[rustfmt::skip]
 pub fn safe_ident(s: &str) -> Ident {

--- a/godot-core/src/builtin/aabb.rs
+++ b/godot-core/src/builtin/aabb.rs
@@ -28,8 +28,11 @@ use crate::builtin::{real, Plane, Vector3, Vector3Axis};
 /// [`Rect2`]: crate::builtin::Rect2
 /// [`Rect2i`]: crate::builtin::Rect2i
 ///
-/// # Godot docs
+/// # Soft invariants
+/// `Aabb` requires non-negative size for certain operations, which is validated only on a best-effort basis. Violations may
+/// cause panics in Debug mode. See also [_Builtin API design_](../__docs/index.html#6-public-fields-and-soft-invariants).
 ///
+/// # Godot docs
 /// [`AABB`](https://docs.godotengine.org/en/stable/classes/class_aabb.html)
 #[derive(Default, Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -421,8 +424,7 @@ impl Aabb {
     ///
     /// Most functions will fail to give a correct result if the size is negative.
     #[inline]
-    /// TODO(v0.3): make private, change to debug_assert().
-    pub fn assert_nonnegative(self) {
+    fn assert_nonnegative(self) {
         assert!(
             self.size.x >= 0.0 && self.size.y >= 0.0 && self.size.z >= 0.0,
             "size {:?} is negative",

--- a/godot-core/src/builtin/callable.rs
+++ b/godot-core/src/builtin/callable.rs
@@ -615,7 +615,7 @@ mod custom_callable {
         #[allow(clippy::result_unit_err)] // TODO remove once there's a clear error type here.
         fn invoke(&mut self, args: &[&Variant]) -> Variant;
 
-        // TODO(v0.3): add object_id().
+        // TODO(v0.5): add object_id().
 
         /// Returns whether the callable is considered valid.
         ///

--- a/godot-core/src/builtin/collections/packed_array.rs
+++ b/godot-core/src/builtin/collections/packed_array.rs
@@ -771,8 +771,6 @@ impl<T: PackedArrayElement + fmt::Display> fmt::Display for PackedArray<T> {
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Specific API for PackedByteArray
 
-impl_builtin_froms!(PackedByteArray; VariantArray => packed_byte_array_from_array);
-
 macro_rules! declare_encode_decode {
     // $Via could be inferred, but ensures we have the correct type expectations.
     ($Ty:ty, $bytes:literal, $encode_fn:ident, $decode_fn:ident, $Via:ty) => {

--- a/godot-core/src/builtin/plane.rs
+++ b/godot-core/src/builtin/plane.rs
@@ -23,8 +23,11 @@ use crate::builtin::{real, Vector3};
 /// unit length and will panic if this invariant is violated. This is not separately
 /// annotated for each method.
 ///
-/// # Godot docs
+/// # Soft invariants
+/// `Plane` requires that the normal vector has unit length for most operations, which is validated only on a best-effort basis. Violations may
+/// cause panics in Debug mode. See also [_Builtin API design_](../__docs/index.html#6-public-fields-and-soft-invariants).
 ///
+/// # Godot docs
 /// [Plane (stable)](https://docs.godotengine.org/en/stable/classes/class_plane.html)
 #[derive(Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/godot-core/src/builtin/rect2.rs
+++ b/godot-core/src/builtin/rect2.rs
@@ -27,8 +27,11 @@ use crate::builtin::{real, Rect2i, Side, Vector2};
 ///
 /// [`Aabb`]: crate::builtin::Aabb
 ///
-/// # Godot docs
+/// # Soft invariants
+/// `Rect2` requires non-negative size for certain operations, which is validated only on a best-effort basis. Violations may
+/// cause panics in Debug mode. See also [_Builtin API design_](../__docs/index.html#6-public-fields-and-soft-invariants).
 ///
+/// # Godot docs
 /// [`Rect2` (stable)](https://docs.godotengine.org/en/stable/classes/class_rect2.html)
 #[derive(Default, Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/godot-core/src/builtin/rect2i.rs
+++ b/godot-core/src/builtin/rect2i.rs
@@ -28,8 +28,11 @@ use crate::builtin::{Rect2, Side, Vector2i};
 ///
 /// [`Aabb`]: crate::builtin::Aabb
 ///
-/// # Godot docs
+/// # Soft invariants
+/// `Rect2i` requires non-negative size for certain operations, which is validated only on a best-effort basis. Violations may
+/// cause panics in Debug mode. See also [_Builtin API design_](../__docs/index.html#6-public-fields-and-soft-invariants).
 ///
+/// # Godot docs
 /// [`Rect2i` (stable)](https://docs.godotengine.org/en/stable/classes/class_rect2i.html)
 #[derive(Default, Copy, Clone, Eq, PartialEq, Hash, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/godot-core/src/builtin/variant/impls.rs
+++ b/godot-core/src/builtin/variant/impls.rs
@@ -22,12 +22,10 @@ use crate::task::{impl_dynamic_send, DynamicSend, IntoDynamicSend, ThreadConfine
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Macro definitions
 
-// Certain types need to be passed as initialized pointers in their from_variant implementations in 4.0. Because
-// 4.0 uses `*ptr = value` to return the type, and some types in C++ override `operator=` in C++ in a way
-// that requires the pointer to be initialized. But some other types will cause a memory leak in 4.1 if initialized.
-//
-// Therefore, we can use `init` to indicate when it must be initialized in 4.0.
-// TODO(v0.4): see if above comment is still relevant for 4.2+.
+// Historical note: In Godot 4.0, certain types needed to be passed as initialized pointers in their from_variant implementations, because
+// 4.0 used `*ptr = value` to return the type, and some types in C++ override `operator=` in a way that requires the pointer to be initialized.
+// However, those same types would cause memory leaks in Godot 4.1 if pre-initialized. A compat layer `new_with_uninit_or_init()` addressed this.
+// As these Godot versions are no longer supported, the current implementation uses `new_with_uninit()` uniformly for all versions.
 macro_rules! impl_ffi_variant {
     (ref $T:ty, $from_fn:ident, $to_fn:ident $(; $GodotTy:ident)?) => {
         impl_ffi_variant!(@impls by_ref; $T, $from_fn, $to_fn $(; $GodotTy)?);

--- a/godot-core/src/builtin/vectors/vector_axis.rs
+++ b/godot-core/src/builtin/vectors/vector_axis.rs
@@ -47,14 +47,6 @@ macro_rules! impl_vector_axis_enum {
                 }
             }
 
-            fn godot_name(&self) -> &'static str {
-                match *self {
-                    $(
-                        Self::$axis => concat!("AXIS_", stringify!($axis)),
-                    )+
-                }
-            }
-
             fn values() -> &'static [Self] {
                 // For vector axis enums, all values are distinct, so both are the same
                 &[

--- a/godot-core/src/deprecated.rs
+++ b/godot-core/src/deprecated.rs
@@ -38,10 +38,6 @@ pub use crate::emit_deprecated_warning;
 // Library-side deprecations -- see usage description above.
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
-// Godot-side deprecations
+// Godot-side deprecations (we may mark them deprecated but keep support).
 
-// This is a Godot-side deprecation. Since it's the only way in Godot 4.1, we keep compatibility for now.
-// TODO(v0.4): remove with error.
-#[deprecated = "\nUse #[export(range = (radians_as_degrees))] and not #[export(range = (radians))].\n\
-	More information on https://github.com/godotengine/godot/pull/82195."]
-pub const fn export_range_radians() {}
+// Past removals: `radians` in #[export(range)].

--- a/godot-core/src/meta/args/as_arg.rs
+++ b/godot-core/src/meta/args/as_arg.rs
@@ -133,8 +133,6 @@ where
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Object (Gd + DynGd) impls
 
-// TODO(v0.4): all objects + optional objects should be pass-by-ref.
-
 // Convert `Gd` -> `Gd` (with upcast).
 impl<T, Base> AsArg<Gd<Base>> for &Gd<T>
 where

--- a/godot-core/src/meta/mod.rs
+++ b/godot-core/src/meta/mod.rs
@@ -37,10 +37,11 @@
 //! ## Argument conversions
 //!
 //! Rust does not support implicit conversions, however it has something very close: the `impl Into<T>` idiom, which can be used to convert
-//! "T-compatible" arguments into `T`. This library specializes this idea with two traits:
+//! "T-compatible" arguments into `T`.
 //!
-//! - [`AsArg<T>`] allows argument conversions from arguments into `T`. This is most interesting in the context of strings (so you can pass
-//!   `&str` to a function expecting `GString`), but is generic to support object arguments like `Gd<T>` and array insertion.
+//! This library specializes this idea with the trait [`AsArg<T>`]. `AsArg` allows argument conversions from arguments into `T`.
+//! This is most interesting in the context of strings (so you can pass `&str` to a function expecting `GString`) and objects (pass
+//! `&Gd<Node2D>` to a function expecting `Node2D` objects).
 
 mod args;
 mod class_id;

--- a/godot-core/src/meta/mod.rs
+++ b/godot-core/src/meta/mod.rs
@@ -48,6 +48,7 @@ mod class_id;
 mod element_type;
 mod godot_convert;
 mod method_info;
+mod object_to_owned;
 mod param_tuple;
 mod property_info;
 mod signature;
@@ -67,6 +68,7 @@ pub use class_id::{ClassId, ClassName};
 pub use element_type::{ElementScript, ElementType};
 pub use godot_convert::{FromGodot, GodotConvert, ToGodot};
 pub use method_info::MethodInfo;
+pub use object_to_owned::ObjectToOwned;
 pub use param_tuple::{InParamTuple, OutParamTuple, ParamTuple};
 pub use property_info::{PropertyHintInfo, PropertyInfo};
 #[cfg(feature = "trace")]

--- a/godot-core/src/meta/object_to_owned.rs
+++ b/godot-core/src/meta/object_to_owned.rs
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use crate::obj::{Gd, GodotClass, WithBaseField};
+
+/// Obtain owned `Gd` from either `&self` or `&Gd`.
+///
+/// This trait allows passing either `Gd<T>` or `C` (where `C: WithBaseField`) to functions that need an owned `Gd<T>`.
+///
+/// This is primarily used for signal connection methods in [`TypedSignal`][crate::registry::signal::TypedSignal] and
+/// [`ConnectBuilder`][crate::registry::signal::ConnectBuilder], where you can pass either a `&Gd` (outside) or `&SomeClass`
+/// (from within `impl` block) as the receiver object.
+///
+/// # Similar traits
+/// - [`UniformObjectDeref`][crate::meta::UniformObjectDeref] provides unified dereferencing of user and engine classes.
+/// - [`AsArg`][crate::meta::AsArg] enables general argument conversions for Godot APIs.
+pub trait ObjectToOwned<T: GodotClass> {
+    /// Converts the object reference to an owned `Gd<T>`.
+    fn object_to_owned(&self) -> Gd<T>;
+}
+
+impl<T: GodotClass> ObjectToOwned<T> for Gd<T> {
+    fn object_to_owned(&self) -> Gd<T> {
+        self.clone()
+    }
+}
+
+impl<C: WithBaseField> ObjectToOwned<C> for C {
+    fn object_to_owned(&self) -> Gd<C> {
+        WithBaseField::to_gd(self)
+    }
+}

--- a/godot-core/src/meta/uniform_object_deref.rs
+++ b/godot-core/src/meta/uniform_object_deref.rs
@@ -60,6 +60,9 @@ use crate::obj::{Gd, GdMut, GdRef, GodotClass, WithBaseField};
 ///     abstract_over_objects(&user_obj);
 /// }
 /// ```
+///
+/// # Similar traits
+/// - [`ObjectToOwned`][crate::meta::ObjectToOwned] provides conversion from `&self` or `&Gd<T>` to owned `Gd<T>`.
 //
 // The crate `https://crates.io/crates/disjoint_impls` handles this in a more user-friendly way, we should
 // consider using it if disjoint impls are going to be frequently used.

--- a/godot-core/src/obj/base.rs
+++ b/godot-core/src/obj/base.rs
@@ -156,16 +156,6 @@ impl<T: GodotClass> Base<T> {
         }
     }
 
-    /// Returns a [`Gd`] referencing the same object as this reference.
-    ///
-    /// Using this method to call methods on the base field of a Rust object is discouraged, instead use the
-    /// methods from [`WithBaseField`](super::WithBaseField) when possible.
-    #[doc(hidden)]
-    #[deprecated = "Private API. Use `Base::to_init_gd()` or `WithBaseField::to_gd()` instead."] // TODO(v0.4): remove.
-    pub fn to_gd(&self) -> Gd<T> {
-        (*self.obj).clone()
-    }
-
     /// Returns a [`Gd`] referencing the base object, for exclusive use during object initialization and `NOTIFICATION_POSTINITIALIZE`.
     ///
     /// Can be used during an initialization function [`I*::init()`][crate::classes::IObject::init] or [`Gd::from_init_fn()`], or [`POSTINITIALIZE`][crate::classes::notify::ObjectNotification::POSTINITIALIZE].

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -714,6 +714,15 @@ impl<T: GodotClass> Gd<T> {
         });
         callable.call_deferred(&[]);
     }
+
+    #[deprecated = "Split into `run_deferred()` + `run_deferred_gd()`."]
+    pub fn apply_deferred<F>(&mut self, rust_function: F)
+    where
+        T: WithBaseField,
+        F: FnOnce(&mut T) + 'static,
+    {
+        self.run_deferred(rust_function)
+    }
 }
 
 /// _The methods in this impl block are only available for objects `T` that are manually managed,

--- a/godot-core/src/obj/traits.rs
+++ b/godot-core/src/obj/traits.rs
@@ -550,6 +550,14 @@ pub trait WithBaseField: GodotClass + Bounds<Declarer = bounds::DeclUser> {
     {
         self.to_gd().run_deferred_gd(gd_function)
     }
+
+    #[deprecated = "Split into `run_deferred()` + `run_deferred_gd()`."]
+    fn apply_deferred<F>(&mut self, rust_function: F)
+    where
+        F: FnOnce(&mut Self) + 'static,
+    {
+        self.run_deferred(rust_function)
+    }
 }
 
 /// Implemented for all classes with registered signals, both engine- and user-declared.

--- a/godot-core/src/obj/traits.rs
+++ b/godot-core/src/obj/traits.rs
@@ -211,30 +211,6 @@ pub trait EngineEnum: Copy {
     /// If the value does not match one of the known enumerators, the empty string is returned.
     fn as_str(&self) -> &'static str;
 
-    /// The equivalent name of the enumerator, as specified in Godot.
-    ///
-    /// If the value does not match one of the known enumerators, the empty string is returned.
-    ///
-    /// # Deprecation
-    /// Design change is due to the fact that Godot enums may have multiple constants with the same ordinal value, and `godot_name()` cannot
-    /// always return a unique name for it. So there are cases where this method returns unexpected results.
-    ///
-    /// To keep the old -- possibly incorrect -- behavior, you can write the following function. However, it runs in linear rather than constant
-    /// time (which is often OK, given that there are very few constants per enum).
-    /// ```
-    /// use godot::obj::EngineEnum;
-    ///
-    /// fn godot_name<T: EngineEnum + Eq + PartialEq + 'static>(value: T) -> &'static str {
-    ///     T::all_constants()
-    ///         .iter()
-    ///         .find(|c| c.value() == value)
-    ///         .map(|c| c.godot_name())
-    ///         .unwrap_or("") // Previous behavior.
-    /// }
-    /// ```
-    #[deprecated = "Moved to introspection API, see `EngineEnum::all_constants()` and `EnumConstant::godot_name()`"]
-    fn godot_name(&self) -> &'static str;
-
     /// Returns a slice of distinct enum values.
     ///
     /// This excludes `MAX` constants at the end (existing only to express the number of enumerators) and deduplicates aliases,

--- a/itest/rust/src/object_tests/base_test.rs
+++ b/itest/rust/src/object_tests/base_test.rs
@@ -70,23 +70,6 @@ fn base_debug() {
     obj.free();
 }
 
-// Compatibility check until v0.4 Base::to_gd() is removed.
-#[itest]
-fn base_with_init() {
-    let obj = Gd::<Based>::from_init_fn(|base| {
-        #[allow(deprecated)]
-        base.to_gd().set_rotation(11.0);
-        Based { base, i: 732 }
-    });
-
-    {
-        let guard = obj.bind();
-        assert_eq!(guard.i, 732);
-        assert_eq!(guard.base().get_rotation(), 11.0);
-    }
-    obj.free();
-}
-
 #[itest]
 fn base_gd_self() {
     let obj = Based::new_alloc();

--- a/itest/rust/src/object_tests/enum_test.rs
+++ b/itest/rust/src/object_tests/enum_test.rs
@@ -114,29 +114,6 @@ fn enum_godot_name() {
     assert_eq!(godot_name(Key::from_ord(1234)), "");
 }
 
-#[itest]
-#[expect(deprecated)]
-fn enum_godot_name_deprecated() {
-    use godot::obj::EngineEnum;
-    assert_eq!(
-        Orientation::VERTICAL.godot_name(),
-        Orientation::VERTICAL.as_str()
-    );
-    assert_eq!(
-        Orientation::HORIZONTAL.godot_name(),
-        Orientation::HORIZONTAL.as_str()
-    );
-
-    assert_eq!(Key::NONE.godot_name(), "KEY_NONE");
-    assert_eq!(Key::SPECIAL.godot_name(), "KEY_SPECIAL");
-    assert_eq!(Key::ESCAPE.godot_name(), "KEY_ESCAPE");
-    assert_eq!(Key::TAB.godot_name(), "KEY_TAB");
-    assert_eq!(Key::A.godot_name(), "KEY_A");
-
-    // Unknown enumerators (might come from the future).
-    assert_eq!(Key::from_ord(1234).godot_name(), "");
-}
-
 fn godot_name<T: EngineEnum + Eq + PartialEq + 'static>(value: T) -> &'static str {
     T::all_constants()
         .iter()


### PR DESCRIPTION
Closes #1186.

Addresses TODOs destined for v0.3 and v0.4, and phases out deprecated APIs introduced during v0.3 cycle.

Removes support for following APIs:
- `From` conversion `VariantArray` -> `PackedArray<T>` (unsound)
- `EngineEnum::godot_name()`  
   - replaced with [`all_constants()`](https://godot-rust.github.io/docs/gdext/master/godot/obj/trait.EngineEnum.html#tymethod.all_constants)
- `Base::to_gd()`
    - replaced with `to_init_gd()`
- `ToSignalObject`
   - renamed to `ObjectToOwned`
- `#[export(range = (radians))]`
   - deprecated in Godot, migrate to `radians_as_degrees`