### PR TITLE
`Callable::from_linked_fn` now returns `R: ToGodot` instead of Variant.

### DIFF
--- a/godot-core/src/builtin/callable.rs
+++ b/godot-core/src/builtin/callable.rs
@@ -178,15 +178,16 @@ impl Callable {
     /// Prefer using [`Gd::linked_callable()`] instead.
     ///
     /// If you need a callable which can live indefinitely use [`Callable::from_local_fn()`].
-    pub fn from_linked_fn<F, T, S>(name: S, linked_object: &Gd<T>, rust_function: F) -> Self
+    pub fn from_linked_fn<R, F, T, S>(name: S, linked_object: &Gd<T>, rust_function: F) -> Self
     where
+        R: ToGodot,
         T: GodotClass,
-        F: 'static + FnMut(&[&Variant]) -> Variant,
+        F: 'static + FnMut(&[&Variant]) -> R,
         S: meta::AsArg<GString>,
     {
         meta::arg_into_owned!(name);
 
-        Self::from_fn_wrapper::<F, Variant>(FnWrapper {
+        Self::from_fn_wrapper::<F, R>(FnWrapper {
             rust_function,
             name,
             thread_id: Some(std::thread::current().id()),

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -584,9 +584,14 @@ impl<T: GodotClass> Gd<T> {
     ///
     /// Such a callable will be automatically invalidated by Godot when a linked Object is freed.
     /// If you need a Callable which can live indefinitely use [`Callable::from_local_fn()`].
-    pub fn linked_callable<F>(&self, method_name: impl AsArg<GString>, rust_function: F) -> Callable
+    pub fn linked_callable<R, F>(
+        &self,
+        method_name: impl AsArg<GString>,
+        rust_function: F,
+    ) -> Callable
     where
-        F: 'static + FnMut(&[&Variant]) -> Variant,
+        R: ToGodot,
+        F: 'static + FnMut(&[&Variant]) -> R,
     {
         Callable::from_linked_fn(method_name, self, rust_function)
     }


### PR DESCRIPTION
Followup to #1332. `Callable::from_linked_fn` should obey the same rules.

```rs
Callable::from_linked_fn(&obj, "sort backwards", |args| {
    let res = args[0].to::<i32>() > args[1].to::<i32>();
    res.to_variant()
})

// becomes:
Callable::from_linked_fn(&obj, "sort backwards", |args| {
    args[0].to::<i32>() > args[1].to::<i32>()
})

self.to_gd().linked_callable("deactivate", move |_args| {
                RenderingServer::singleton().canvas_item_set_visible(cell, false);
                Variant::nil()
            });

// becomes:
self.to_gd().linked_callable("deactivate", move |_args| {
                RenderingServer::singleton().canvas_item_set_visible(cell, false);
            });
```