### PR TITLE
`Callable`: rename `from_local_fn` -> `from_fn`, keep deprecated `from_local_fn` with old signature

### DIFF
--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -583,7 +583,7 @@ impl<T: GodotClass> Gd<T> {
     /// `name` is used for the string representation of the closure, which helps with debugging.
     ///
     /// Such a callable will be automatically invalidated by Godot when a linked Object is freed.
-    /// If you need a Callable which can live indefinitely use [`Callable::from_local_fn()`].
+    /// If you need a Callable which can live indefinitely, use [`Callable::from_fn()`].
     pub fn linked_callable<R, F>(
         &self,
         method_name: impl AsArg<GString>,

--- a/godot-core/src/task/async_runtime.rs
+++ b/godot-core/src/task/async_runtime.rs
@@ -506,7 +506,7 @@ impl Wake for GodotWaker {
         }
 
         #[cfg(not(feature = "experimental-threads"))]
-        let create_callable = Callable::from_local_fn;
+        let create_callable = Callable::from_fn;
 
         #[cfg(feature = "experimental-threads")]
         let create_callable = Callable::from_sync_fn;

--- a/itest/rust/src/builtin_tests/containers/array_test.rs
+++ b/itest/rust/src/builtin_tests/containers/array_test.rs
@@ -563,7 +563,7 @@ fn array_bsearch_custom() {
 
 fn backwards_sort_callable() -> Callable {
     // No &[&Variant] explicit type in arguments.
-    Callable::from_local_fn("sort backwards", |args| {
+    Callable::from_fn("sort backwards", |args| {
         args[0].to::<i32>() > args[1].to::<i32>()
     })
 }

--- a/itest/rust/src/builtin_tests/containers/signal_test.rs
+++ b/itest/rust/src/builtin_tests/containers/signal_test.rs
@@ -821,7 +821,7 @@ mod custom_callable {
     fn connect_signal_panic_from_fn(received: Arc<AtomicU32>) -> Callable {
         // Explicit `Variant` return type to avoid following warning becoming a hard error in edition 2024.
         // warning: this function depends on never type fallback being `()`
-        Callable::from_local_fn("test", move |_args| -> Variant {
+        Callable::from_fn("test", move |_args| -> Variant {
             panic!("TEST: {}", received.fetch_add(1, Ordering::SeqCst))
         })
     }

--- a/itest/rust/src/engine_tests/async_test.rs
+++ b/itest/rust/src/engine_tests/async_test.rs
@@ -211,7 +211,7 @@ fn resolver_callabable_equality() {
 
     let callable = Callable::from_custom(resolver.clone());
     let cloned_callable = Callable::from_custom(resolver.clone());
-    let unrelated_callable = Callable::from_local_fn("unrelated", |_| {});
+    let unrelated_callable = Callable::from_fn("unrelated", |_| {});
 
     assert_eq!(callable, cloned_callable);
     assert_ne!(callable, unrelated_callable);

--- a/itest/rust/src/framework/runner.rs
+++ b/itest/rust/src/framework/runner.rs
@@ -473,7 +473,7 @@ fn check_async_test_task(
     let mut callback = Some(on_test_finished);
     let mut probably_task_handle = Some(task_handle);
 
-    let deferred = Callable::from_local_fn("run_async_rust_test", move |_| {
+    let deferred = Callable::from_fn("run_async_rust_test", move |_| {
         check_async_test_task(
             probably_task_handle
                 .take()


### PR DESCRIPTION
@Yarwin pointed out that the error message for this breaking change (#1332) is not very helpful:
```rs
error[E0277]: passing type `std::result::Result<godot::prelude::Variant, _>` to Godot requires `ToGodot` trait, which is usually provided by the library
   --> src/path/to/code.rs:123:4
    |
486 | /         Callable::from_local_fn("name", move |_| {
...   |
492 | |             Ok(Variant::nil())
493 | |         })
    | |__________^ the trait `godot::prelude::ToGodot` is not implemented for `std::result::Result<godot::prelude::Variant, _>`
``` 

To make the migration period smoother, this PR reintroduces the `from_local_fn()` constructor with its old signature, which can be used throughout v0.4 before it's going to be removed. This also affects `from_linked_fn()`, but that function being relatively new and more niche makes it much less likely to be widely used.

Regarding naming, "local" indicated "thread-local" as opposed to "sync" (multi-threaded). This was for explicitness, however `Callable::from_local_fn` the last API still using this term. Notably:
- `from_local_static` was renamed to `from_class_static` in [#1332](https://github.com/godot-rust/gdext/pull/1332).
- `from_linked_fn` is implicitly local but doesn't have this naming.
- All signals are implicitly single-threaded and need opt-in to multithreaded via [`ConnectBuilder::connect_sync()`](https://godot-rust.github.io/docs/gdext/master/godot/register/struct.ConnectBuilder.html#method.connect_sync).
- `Gd` is also single-threaded, hopefully in the future we'll have a multi-threaded variant ([#18](https://github.com/godot-rust/gdext/issues/18)).

As such, `from_fn` is probably OK for the time being. We might need to create general awareness that godot-rust constructs are single-threaded unless explicitly noted otherwise.