### PR TITLE
Provide error context for typed array clone check

### DIFF
--- a/godot-core/src/builtin/collections/array.rs
+++ b/godot-core/src/builtin/collections/array.rs
@@ -1245,8 +1245,9 @@ impl<T: ArrayElement> Clone for Array<T> {
 
         // Double-check copy's runtime type in Debug mode.
         if cfg!(debug_assertions) {
-            copy.with_checked_type()
-                .expect("copied array should have same type as original array")
+            copy.with_checked_type().unwrap_or_else(|e| {
+                panic!("copied array should have same type as original array: {e}")
+            })
         } else {
             copy
         }


### PR DESCRIPTION
This patch adds output of `ConvertError`'s `Display` to debug-only check's panic message which provides additional context when type mismatch happens.

Panic message would include the intended type name and what was given instead of it.

The output would look roughly like this:
```
copied array should have same type as original array:
expected array of type Builtin(DICTIONARY), got Untyped: []
```