### PR TITLE
Support `read_as_gstring_entire` in Godot versions newer than 4.5.

### DIFF
--- a/godot-core/src/tools/gfile.rs
+++ b/godot-core/src/tools/gfile.rs
@@ -332,9 +332,26 @@ impl GFile {
     ///
     /// Underlying Godot method:
     /// [`FileAccess::get_as_text`](https://docs.godotengine.org/en/stable/classes/class_fileaccess.html#class-fileaccess-method-get-as-text).
+    // For Godot versions before `skip_cr` has been removed, see: https://github.com/godotengine/godot/pull/110867.
     #[doc(alias = "get_as_text")]
+    #[cfg(before_api = "4.6")]
     pub fn read_as_gstring_entire(&mut self, skip_cr: bool) -> std::io::Result<GString> {
         let val = self.fa.get_as_text_ex().skip_cr(skip_cr).done();
+        self.check_error()?;
+        Ok(val)
+    }
+
+    /// Reads the whole file as UTF-8 [`GString`].
+    ///
+    /// To retrieve the file as [`String`] instead, use the [`Read`] trait method
+    /// [`read_to_string()`](https://doc.rust-lang.org/std/io/trait.Read.html#method.read_to_string).
+    ///
+    /// Underlying Godot method:
+    /// [`FileAccess::get_as_text`](https://docs.godotengine.org/en/stable/classes/class_fileaccess.html#class-fileaccess-method-get-as-text).
+    #[doc(alias = "get_as_text")]
+    #[cfg(since_api = "4.6")]
+    pub fn read_as_gstring_entire(&mut self) -> std::io::Result<GString> {
+        let val = self.fa.get_as_text();
         self.check_error()?;
         Ok(val)
     }


### PR DESCRIPTION
`skip_cr` argument has been removed, see: https://github.com/godotengine/godot/pull/110867.

EDIT: Nothing changes for 4.5 API, generated code compatibility is never guaranteed (i.e. generated signatures for API version `4.x` might be different for `4.x+1`), so after consultation we decided that SemVer bump is not required (from sanity point of view as well – APIs before beta/RCs can be wildly unstable)