### PR TITLE
Preserve doc comments for signal.

### DIFF
--- a/godot-macros/src/util/mod.rs
+++ b/godot-macros/src/util/mod.rs
@@ -275,6 +275,15 @@ pub(crate) fn extract_cfg_attrs(
     attrs.iter().filter(|attr| is_cfg_or_cfg_attr(attr))
 }
 
+pub(crate) fn extract_doc_attrs(
+    attrs: &[venial::Attribute],
+) -> impl IntoIterator<Item = &venial::Attribute> {
+    attrs.iter().filter(|attr| {
+        attr.get_single_path_segment()
+            .is_some_and(|attr_name| attr_name == "doc")
+    })
+}
+
 #[cfg(before_api = "4.3")]
 pub fn make_virtual_tool_check() -> TokenStream {
     quote! {

--- a/itest/rust/src/register_tests/func_test.rs
+++ b/itest/rust/src/register_tests/func_test.rs
@@ -192,6 +192,17 @@ impl GdSelfObj {
     #[cfg(any())]
     fn cfg_removes_signal();
 
+    /// Sample docstring.
+    ///
+    /// Impossible to check by other means than manually, but it is still nice to have some documentation.
+    #[signal]
+    fn docstring_is_preserved_in_signal();
+
+    /// Sample docstring, to watch if it causes any issues with `#[cfg(...)]`.
+    #[signal]
+    #[cfg(any())]
+    fn cfg_removes_signal_with_docstring();
+
     #[func]
     fn fail_to_update_internal_value_due_to_conflicting_borrow(
         &mut self,


### PR DESCRIPTION
User-defined doc comments for signals can be now preserved:

<details>
<summary> How it looks like in IDEs </summary>

<img width="860" height="297" alt="image" src="https://github.com/user-attachments/assets/9fcca97c-2a8a-4eb3-898c-21d0cbeced80" />

<img width="908" height="181" alt="image" src="https://github.com/user-attachments/assets/7f8465f7-fdaa-43e4-91af-61aff650c236" />

</details>

Small, silly change but I've found docstrings fairly useful in few cases. It also preserves `#[doc(hidden)]` which is… okay I guess? 