### PR TITLE
Codegen: support sys types in engine APIs (I)

### DIFF
--- a/godot-codegen/src/conv/type_conversions.rs
+++ b/godot-codegen/src/conv/type_conversions.rs
@@ -172,6 +172,15 @@ fn to_rust_type_uncached(full_ty: &GodotTy, ctx: &mut Context) -> RustTy {
 
         // .trim() is necessary here, as Godot places a space between a type and the stars when representing a double pointer.
         // Example: "int*" but "int **".
+        if ctx.is_sys(ty.trim()) {
+            let ty = rustify_ty(&ty);
+            return RustTy::RawPointer {
+                inner: Box::new(RustTy::SysIdent {
+                    tokens: quote! { sys::#ty },
+                }),
+                is_const,
+            };
+        }
         let inner_type = to_rust_type(ty.trim(), None, ctx);
         return RustTy::RawPointer {
             inner: Box::new(inner_type),

--- a/godot-codegen/src/generator/central_files.rs
+++ b/godot-codegen/src/generator/central_files.rs
@@ -10,6 +10,7 @@ use quote::{format_ident, quote, ToTokens};
 
 use crate::context::Context;
 use crate::conv;
+use crate::generator::sys::make_godotconvert_for_systypes;
 use crate::generator::{enums, gdext_build_struct};
 use crate::models::domain::ExtensionApi;
 use crate::util::ident;
@@ -60,6 +61,7 @@ pub fn make_core_central_code(api: &ExtensionApi, ctx: &mut Context) -> TokenStr
 
     let (global_enum_defs, global_reexported_enum_defs) = make_global_enums(api);
     let variant_type_traits = make_variant_type_enum(api, false);
+    let sys_types_godotconvert_impl = make_godotconvert_for_systypes();
 
     // TODO impl Clone, Debug, PartialEq, PartialOrd, Hash for VariantDispatch
     // TODO could use try_to().unwrap_unchecked(), since type is already verified. Also directly overload from_variant().
@@ -121,6 +123,8 @@ pub fn make_core_central_code(api: &ExtensionApi, ctx: &mut Context) -> TokenStr
             use crate::sys;
             #( #global_reexported_enum_defs )*
         }
+
+        #( #sys_types_godotconvert_impl )*
     }
 }
 

--- a/godot-codegen/src/generator/mod.rs
+++ b/godot-codegen/src/generator/mod.rs
@@ -28,6 +28,7 @@ pub mod method_tables;
 pub mod native_structures;
 pub mod notifications;
 pub mod signals;
+pub mod sys;
 pub mod utility_functions;
 pub mod virtual_definition_consts;
 pub mod virtual_traits;

--- a/godot-codegen/src/generator/sys.rs
+++ b/godot-codegen/src/generator/sys.rs
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use proc_macro2::{Ident, TokenStream};
+use quote::{quote, ToTokens};
+
+use crate::util::ident;
+
+#[allow(unused)]
+pub enum SysTypeParam {
+    /// `* mut SysType`
+    Mut(&'static str),
+    /// `* const SysType`
+    Const(&'static str),
+}
+
+impl SysTypeParam {
+    pub fn type_(&self) -> &'static str {
+        match self {
+            SysTypeParam::Mut(s) | SysTypeParam::Const(s) => s,
+        }
+    }
+
+    fn to_ident(&self) -> Ident {
+        match self {
+            SysTypeParam::Mut(s) | SysTypeParam::Const(s) => ident(s),
+        }
+    }
+}
+
+impl ToTokens for SysTypeParam {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let type_ident = self.to_ident();
+        match self {
+            SysTypeParam::Mut(_) => quote! { * mut crate::sys::#type_ident },
+            SysTypeParam::Const(_) => quote! { * const crate::sys::#type_ident },
+        }
+        .to_tokens(tokens);
+    }
+}
+
+/// SysTypes used as parameters in various APIs defined in `extension_api.json`.
+// Currently hardcoded and it probably will stay this way – extracting types from gdextension_interface is way too messy.
+// Must be different abstraction to avoid clashes with other types passed as pointers (e.g. *Glyph).
+pub static SYS_PARAMS: &[SysTypeParam] = &[
+    #[cfg(since_api = "4.6")]
+    SysTypeParam::Const("GDExtensionInitializationFunction"),
+];
+
+/// Creates `GodotConvert`, `ToGodot` and `FromGodot` impl
+/// for SysTypes – various pointer types declared in `gdextension_interface`.
+pub fn make_godotconvert_for_systypes() -> Vec<TokenStream> {
+    let mut tokens = vec![];
+    for sys_type_param in SYS_PARAMS {
+        tokens.push(
+            quote! {
+                    impl crate::meta::GodotConvert for #sys_type_param {
+                        type Via = i64;
+
+                    }
+
+                    impl crate::meta::ToGodot for #sys_type_param {
+                        type Pass = crate::meta::ByValue;
+                        fn to_godot(&self) -> Self::Via {
+                            * self as i64
+                        }
+                    }
+
+                    impl crate::meta::FromGodot for #sys_type_param {
+                        fn try_from_godot(via: Self::Via) -> Result < Self, crate::meta::error::ConvertError > {
+                            Ok(via as Self)
+                        }
+                    }
+            }
+        )
+    }
+    tokens
+}

--- a/godot-codegen/src/models/domain.rs
+++ b/godot-codegen/src/models/domain.rs
@@ -699,6 +699,9 @@ pub struct GodotTy {
 pub enum RustTy {
     /// `bool`, `Vector3i`, `Array`, `GString`
     BuiltinIdent { ty: Ident, arg_passing: ArgPassing },
+    /// Pointers declared in `gdextension_interface` such as `sys::GDExtensionInitializationFunction`
+    /// used as parameters in some APIs.
+    SysIdent { tokens: TokenStream },
 
     /// `Array<i32>`
     ///
@@ -789,6 +792,7 @@ impl ToTokens for RustTy {
             RustTy::EngineEnum { tokens: path, .. } => path.to_tokens(tokens),
             RustTy::EngineClass { tokens: path, .. } => path.to_tokens(tokens),
             RustTy::ExtenderReceiver { tokens: path } => path.to_tokens(tokens),
+            RustTy::SysIdent { tokens: path } => path.to_tokens(tokens),
         }
     }
 }

--- a/godot-codegen/src/special_cases/codegen_special_cases.rs
+++ b/godot-codegen/src/special_cases/codegen_special_cases.rs
@@ -49,6 +49,7 @@ fn is_type_excluded(ty: &str, ctx: &mut Context) -> bool {
             RustTy::BuiltinIdent { .. } => false,
             RustTy::BuiltinArray { .. } => false,
             RustTy::RawPointer { inner, .. } => is_rust_type_excluded(inner),
+            RustTy::SysIdent { .. } => true,
             RustTy::EngineArray { elem_class, .. } => is_class_excluded(elem_class.as_str()),
             RustTy::EngineEnum {
                 surrounding_class, ..


### PR DESCRIPTION
# What problem does this PR solve?

Adds supports for pointer types defined by Godot (ones defined in `gdextension_interface.h`) to our codegen, which has been broken by the new method defined in `extension_api.json`:

```json
				{
					"name": "load_extension_from_function",
					"is_const": false,
					"is_vararg": false,
					"is_static": false,
					"is_virtual": false,
					"hash": 1565094761,
					"return_value": {
						"type": "enum::GDExtensionManager.LoadStatus"
					},
					"arguments": [
						{
							"name": "path",
							"type": "String"
						},
						{
							"name": "init_func",
							"type": "const GDExtensionInitializationFunction*"
						}
					]
				},
```

Currently all Godot pointer types (named sys types since it was the first thing that come to my head) used as params by available Godot APIs are hardcoded – in the future it might be nice to parse them somehow out of `gdextension_interface.h`. Assuming their type by other means is a little too error prone.


closes: #1362

