### PR TITLE
Backport Godot fix for incorrect `Glyph` native-struct

### DIFF
--- a/godot-codegen/src/models/domain_mapping.rs
+++ b/godot-codegen/src/models/domain_mapping.rs
@@ -803,9 +803,14 @@ fn validate_enum_replacements(
 
 impl NativeStructure {
     pub fn from_json(json: &JsonNativeStructure) -> Self {
+        // Some native-struct definitions are incorrect in earlier Godot versions; this backports corrections.
+        let format = special_cases::get_native_struct_definition(&json.name)
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| json.format.clone());
+
         Self {
             name: json.name.clone(),
-            format: json.format.clone(),
+            format,
         }
     }
 }

--- a/godot-codegen/src/special_cases/special_cases.rs
+++ b/godot-codegen/src/special_cases/special_cases.rs
@@ -97,6 +97,22 @@ pub fn is_native_struct_excluded(ty: &str) -> bool {
     codegen_special_cases::is_native_struct_excluded(ty)
 }
 
+/// Overrides the definition string for native structures, if they have incorrect definitions in the JSON.
+#[rustfmt::skip]
+pub fn get_native_struct_definition(struct_name: &str) -> Option<&'static str> {
+    match struct_name {
+        // Glyph struct definition was corrected in Godot 4.6 to include missing `span_index` field.
+        // See https://github.com/godotengine/godot/pull/108369.
+        // #[cfg(before_api = "4.6")] // TODO(v0.5): enable this once upstream PR is merged.
+        "Glyph" => Some(
+            "int start = -1;int end = -1;uint8_t count = 0;uint8_t repeat = 1;uint16_t flags = 0;float x_off = 0.f;float y_off = 0.f;\
+            float advance = 0.f;RID font_rid;int font_size = 0;int32_t index = 0;int span_index = -1"
+        ),
+
+        _ => None,
+    }
+}
+
 #[rustfmt::skip]
 pub fn is_godot_type_deleted(godot_ty: &str) -> bool {
     // Note: parameter can be a class or builtin name, but also something like "enum::AESContext.Mode".

--- a/itest/rust/src/engine_tests/native_structures_test.rs
+++ b/itest/rust/src/engine_tests/native_structures_test.rs
@@ -26,6 +26,7 @@ pub fn sample_glyph(start: i32) -> Glyph {
         font_rid: Rid::new(1024),
         font_size: 1025,
         index: 1026,
+        span_index: -1,
     }
 }
 
@@ -48,6 +49,7 @@ fn native_structure_codegen() {
         font_rid: Rid::new(0),
         font_size: 0,
         index: 0,
+        span_index: -1,
     };
 }
 


### PR DESCRIPTION
Upstream PR: https://github.com/godotengine/godot/pull/108369