### PR TITLE
Bugfix: Ease `AsArg<Option<Gd<T>>>` bounds to make it usable with signals.

### DIFF
--- a/godot-core/src/meta/args/as_arg.rs
+++ b/godot-core/src/meta/args/as_arg.rs
@@ -9,7 +9,7 @@ use crate::builtin::{GString, NodePath, StringName, Variant};
 use crate::meta::sealed::Sealed;
 use crate::meta::traits::{GodotFfiVariant, GodotNullableFfi};
 use crate::meta::{CowArg, FfiArg, GodotType, ObjectArg, ToGodot};
-use crate::obj::{bounds, Bounds, DynGd, Gd, GodotClass, Inherits};
+use crate::obj::{DynGd, Gd, GodotClass, Inherits};
 
 /// Implicit conversions for arguments passed to Godot APIs.
 ///
@@ -263,7 +263,7 @@ where
 impl<T, Base> AsArg<Option<Gd<Base>>> for &Gd<T>
 where
     T: Inherits<Base>,
-    Base: GodotClass + Bounds<Declarer = bounds::DeclEngine>,
+    Base: GodotClass,
 {
     fn into_arg<'arg>(self) -> CowArg<'arg, Option<Gd<Base>>>
     where
@@ -286,7 +286,7 @@ where
 impl<T, Base> AsArg<Option<Gd<Base>>> for Option<&Gd<T>>
 where
     T: Inherits<Base>,
-    Base: GodotClass + Bounds<Declarer = bounds::DeclEngine>,
+    Base: GodotClass,
 {
     fn into_arg<'arg>(self) -> CowArg<'arg, Option<Gd<Base>>>
     where
@@ -313,7 +313,7 @@ impl<T, D, Base> AsArg<Option<DynGd<Base, D>>> for &DynGd<T, D>
 where
     T: Inherits<Base>,
     D: ?Sized,
-    Base: GodotClass + Bounds<Declarer = bounds::DeclEngine>,
+    Base: GodotClass,
 {
     fn into_arg<'arg>(self) -> CowArg<'arg, Option<DynGd<Base, D>>>
     where
@@ -337,7 +337,7 @@ impl<T, D, Base> AsArg<Option<Gd<Base>>> for &DynGd<T, D>
 where
     T: Inherits<Base>,
     D: ?Sized,
-    Base: GodotClass + Bounds<Declarer = bounds::DeclEngine>,
+    Base: GodotClass,
 {
     fn into_arg<'arg>(self) -> CowArg<'arg, Option<Gd<Base>>>
     where
@@ -361,7 +361,7 @@ impl<T, D, Base> AsArg<Option<DynGd<Base, D>>> for Option<&DynGd<T, D>>
 where
     T: Inherits<Base>,
     D: ?Sized,
-    Base: GodotClass + Bounds<Declarer = bounds::DeclEngine>,
+    Base: GodotClass,
 {
     fn into_arg<'arg>(self) -> CowArg<'arg, Option<DynGd<Base, D>>>
     where
@@ -764,3 +764,35 @@ where
 
 #[doc(hidden)] // Easier for internal use.
 pub type ToArg<'r, Via, Pass> = <Pass as ArgPassing>::Output<'r, Via>;
+
+/// This type exists only as a place to add doctests for `AsArg`, which do not need to be in the public documentation.
+///
+/// `AsArg<Option<Gd<UserClass>>` can be used with signals correctly:
+///
+/// ```no_run
+/// # use godot::prelude::*;
+/// #[derive(GodotClass)]
+/// #[class(init, base = Node)]
+/// struct MyClass {
+///     base: Base<Node>
+/// }
+///
+/// #[godot_api]
+/// impl MyClass {
+///     #[signal]
+///     fn signal_optional_user_obj(arg1: Option<Gd<MyClass>>);
+///
+///     fn foo(&mut self) {
+///         let arg = self.to_gd();
+///         // Directly:
+///         self.signals().signal_optional_user_obj().emit(&arg);
+///         // Via Some:
+///         self.signals().signal_optional_user_obj().emit(Some(&arg));
+///         // With None (Note: Gd::null_arg() is restricted to engine classes):
+///         self.signals().signal_optional_user_obj().emit(None::<Gd<MyClass>>.as_ref());
+///     }
+/// }
+/// ```
+///
+#[allow(dead_code)]
+struct PhantomAsArgDoctests;


### PR DESCRIPTION
Long story short `AsArg<Option<Gd<T>>` bounds were too restrictive which made it unusable with user-defined classes (despite `Option<Gd<MyClass>>` being totally valid).

In other words, this did not compile:

```rs
#[derive(GodotClass)]
#[class(init, base = Node)]
struct MyClass {
    base: Base<Node>
}

#[godot_api]
impl MyClass {
    #[signal]
    fn my_signal(arg: Option<Gd<MyClass>>);

    #[func]
    fn foo(&mut self) {
        let obj = self.to_gd();
        self.signals().my_signal().emit(&obj);
        let smth: Option<Gd<MyClass>> = None;
        self.signals().my_signal().emit(smth.as_ref());
    }
}
```

<details>
<summary> compile error </summary>

```
error[E0271]: type mismatch resolving `<MyClass as Bounds>::Declarer == DeclEngine`
  --> src/lib.rs:27:41
   |
27 |         self.signals().my_signal().emit(&obj);
   |                                    ---- ^^^^ type mismatch resolving `<MyClass as Bounds>::Declarer == DeclEngine`
   |                                    |
   |                                    required by a bound introduced by this call
   |
note: expected this to be `DeclEngine`
  --> src/lib.rs:8:10
   |
 8 | #[derive(GodotClass)]
   |          ^^^^^^^^^^
   = note: required for `&godot::prelude::Gd<MyClass>` to implement `AsArg<Option<godot::prelude::Gd<MyClass>>>`
note: required by a bound in `__godot_Signal_MyClass_my_signal::<'_, C>::emit`
  --> src/lib.rs:14:1
   |
14 | #[godot_api]
   | ^^^^^^^^^^^^ required by this bound in `__godot_Signal_MyClass_my_signal::<'_, C>::emit`
   = note: this error originates in the derive macro `GodotClass` which comes from the expansion of the attribute macro `godot_api` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0271]: type mismatch resolving `<MyClass as Bounds>::Declarer == DeclEngine`
  --> src/lib.rs:29:41
   |
29 |         self.signals().my_signal().emit(smth.as_ref());
   |                                    ---- ^^^^^^^^^^^^^ type mismatch resolving `<MyClass as Bounds>::Declarer == DeclEngine`
   |                                    |
   |                                    required by a bound introduced by this call
   |
note: expected this to be `DeclEngine`
  --> src/lib.rs:8:10
   |
 8 | #[derive(GodotClass)]
   |          ^^^^^^^^^^
   = note: required for `Option<&godot::prelude::Gd<MyClass>>` to implement `AsArg<Option<godot::prelude::Gd<MyClass>>>`
note: required by a bound in `__godot_Signal_MyClass_my_signal::<'_, C>::emit`
  --> src/lib.rs:14:1
   |
14 | #[godot_api]
   | ^^^^^^^^^^^^ required by this bound in `__godot_Signal_MyClass_my_signal::<'_, C>::emit`
   = note: this error originates in the derive macro `GodotClass` which comes from the expansion of the attribute macro `godot_api` (in Nightly builds, run with -Z macro-backtrace for more info)
```

</details>

Since it is compilation error only I covered it with doctests (I'm pretty sure doctest works because it failed on me three times due to typos and whatnot). 

`Gd:null_arg` remains unchanged (idk what to think about it - `let arg: Option<Gd<MyClass> = None;` ain't that bad).

------------------

Reported by Iride Lombardi on discord (thanks!): https://discord.com/channels/723850269347283004/1429013604258025554/1429013604258025554