### PR TITLE
Qol: Preserve span of arguments for better compile errors.

### DIFF
--- a/godot-macros/src/util/mod.rs
+++ b/godot-macros/src/util/mod.rs
@@ -269,6 +269,16 @@ pub fn is_cfg_or_cfg_attr(attr: &venial::Attribute) -> bool {
     false
 }
 
+/// Returns group representing properly spanned tuple (e.g. `(arg1, arg2, arg3)`).
+///
+/// Use it to preserve span in case if tuple in question is empty (will create properly spanned `()` in such a case).
+pub fn to_spanned_tuple(items: &[impl ToTokens], span: Span) -> Group {
+    let mut group = Group::new(Delimiter::Parenthesis, quote! { #(#items,)* });
+    group.set_span(span);
+
+    group
+}
+
 pub(crate) fn extract_cfg_attrs(
     attrs: &[venial::Attribute],
 ) -> impl IntoIterator<Item = &venial::Attribute> {


### PR DESCRIPTION
Followup to: https://github.com/godot-rust/gdext/pull/1370

For declaration such as

```rs
#[godot_api]
impl INode for MyClass {
    fn on_notification(&mut self, what: ObjectNotification) {

    }

    fn physics_process(&mut self) {

    }

    fn process(&mut self, _delta: i32) {}
}
```

Following errors were emitted: 

<details>
<summary> bunch of errors leading to #[godot_api] </summary>

```rs
error[E0050]: method `physics_process` has 1 parameter but the declaration in trait `godot::prelude::INode::physics_process` has 2
  --> src/lib.rs:18:24
   |
18 |     fn physics_process(&mut self) {
   |                        ^^^^^^^^^ expected 2 parameters, found 1
   |
   = note: `physics_process` from trait: `fn(&mut Self, f64)`

error[E0053]: method `process` has an incompatible type for trait
  --> src/lib.rs:22:35
   |
22 |     fn process(&mut self, _delta: i32) {}
   |                                   ^^^ expected `f64`, found `i32`
   |
   = note: expected signature `fn(&mut MyClass, f64)`
              found signature `fn(&mut MyClass, i32)`
help: change the parameter type to match the trait
   |
22 -     fn process(&mut self, _delta: i32) {}
22 +     fn process(&mut self, _delta: f64) {}
   |

error[E0308]: mismatched types
  --> src/lib.rs:16:1
   |
16 | #[godot_api]
   | ^^^^^^^^^^^^
   | |
   | expected `(f64,)`, found `()`
   | expected due to this
   |
   = note:  expected tuple `(f64,)`
           found unit type `()`
   = note: this error originates in the attribute macro `godot_api` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0061]: this function takes 2 arguments but 1 argument was supplied
   --> src/lib.rs:16:1
    |
 16 | #[godot_api]
    | ^^^^^^^^^^^^ argument #2 of type `f64` is missing
    |
note: method defined here
   --> /home/irwin/apps/godot/opensource-contr/missing_docs/bug-repro-godot-rust-docs-master/testground/target/debug/build/godot-core-b05936b7ac85ab80/out/classes/node.rs:121:12
    |
121 |         fn physics_process(&mut self, delta: f64,) {
    |            ^^^^^^^^^^^^^^^
    = note: this error originates in the attribute macro `godot_api` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0308]: mismatched types
  --> src/lib.rs:16:1
   |
16 | #[godot_api]
   | ^^^^^^^^^^^^
   | |
   | expected `(f64,)`, found `(i32,)`
   | expected due to this
   |
   = note: expected tuple `(f64,)`
              found tuple `(i32,)`
   = note: this error originates in the attribute macro `godot_api` (in Nightly builds, run with -Z macro-backtrace for more info)

```

</details>

After changes:

<details>
<summary> Same errors, pointing at user code </summary>

```rs
error[E0050]: method `physics_process` has 1 parameter but the declaration in trait `godot::prelude::INode::physics_process` has 2
  --> src/lib.rs:18:24
   |
18 |     fn physics_process(&mut self) {
   |                        ^^^^^^^^^ expected 2 parameters, found 1
   |
   = note: `physics_process` from trait: `fn(&mut Self, f64)`

error[E0053]: method `process` has an incompatible type for trait
  --> src/lib.rs:22:35
   |
22 |     fn process(&mut self, _delta: i32) {}
   |                                   ^^^ expected `f64`, found `i32`
   |
   = note: expected signature `fn(&mut MyClass, f64)`
              found signature `fn(&mut MyClass, i32)`
help: change the parameter type to match the trait
   |
22 -     fn process(&mut self, _delta: i32) {}
22 +     fn process(&mut self, _delta: f64) {}
   |

error[E0308]: mismatched types
  --> src/lib.rs:18:5
   |
16 | #[godot_api]
   | ------------ expected due to this
17 | impl INode for MyClass {
18 |     fn physics_process(&mut self) {
   |     ^^ expected `(f64,)`, found `()`
   |
   = note:  expected tuple `(f64,)`
           found unit type `()`

error[E0061]: this function takes 2 arguments but 1 argument was supplied
   --> src/lib.rs:18:5
    |
 16 | #[godot_api]
    | ------------ argument #2 of type `f64` is missing
 17 | impl INode for MyClass {
 18 |     fn physics_process(&mut self) {
    |     ^^
    |
note: method defined here
   --> /home/irwin/apps/godot/opensource-contr/missing_docs/bug-repro-godot-rust-docs-master/testground/target/debug/build/godot-core-b05936b7ac85ab80/out/classes/node.rs:121:12
    |
121 |         fn physics_process(&mut self, delta: f64,) {
    |            ^^^^^^^^^^^^^^^
help: provide the argument
    |
 18 |     fn(#[godot_api], /* f64 */) physics_process(&mut self) {
    |       +++++++++++++++++++++++++

error[E0308]: mismatched types
  --> src/lib.rs:22:5
   |
16 | #[godot_api]
   | ------------ expected due to this
...
22 |     fn process(&mut self, _delta: i32) {}
   |     ^^ expected `(f64,)`, found `(i32,)`
   |
   = note: expected tuple `(f64,)`
              found tuple `(i32,)`
```
</details>

----

Side note: It seems that 
```rs
                let method_invocation = TokenStream::from_iter(
                    quote! {<#class_name as #interface_trait>::#method_name}
                        .into_iter()
                        .map(|mut token| {
                            token.set_span(signature_info.params_span);
                            token
                        }),
                );
```

is the sanest way to deal with spans when it comes to various declaration (including `impl ::godot::...::AsArg<...>`).

I also wanted to deal with signals, but I gave up :sweat_smile:. Potential candidate for `Good first issue (hard)`?