### PR TITLE
Add rustfmt to clippy job in CI to format files generated by itest.

### DIFF
--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -101,7 +101,8 @@ jobs:
       - name: "Install Rust"
         uses: ./.github/composite/rust
         with:
-          components: clippy
+          # Rustfmt is needed to format generated code in itest.
+          components: clippy,rustfmt
 
       # Note: could use `-- --no-deps` to not lint dependencies, however it doesn't really speed up and also skips deps in workspace.
       - name: "Check clippy"

--- a/.github/workflows/minimal-ci.yml
+++ b/.github/workflows/minimal-ci.yml
@@ -94,7 +94,8 @@ jobs:
       - name: "Install Rust"
         uses: ./.github/composite/rust
         with:
-          components: clippy
+          # Rustfmt is needed to format generated code in itest.
+          components: clippy,rustfmt
 
       - name: "Check clippy"
         run: |

--- a/itest/rust/build.rs
+++ b/itest/rust/build.rs
@@ -361,7 +361,6 @@ fn generate_rust_methods(inputs: &[Input]) -> Vec<TokenStream> {
         .collect::<Vec<_>>();
 
     let manual_methods = quote! {
-        #[allow(clippy::suspicious_else_formatting)] // `quote!` might output whole file as one big line.
         #[func]
         fn check_last_notrace(last_method_name: String, expected_callconv: String) -> bool {
             let last = godot::private::trace::pop();


### PR DESCRIPTION
closes: #1341

Fixes bugs and false-positives related to failing clippy check (due to unformatted code).

-----

Example of failed check (whole file generated as one big line):

<https://github.com/godot-rust/gdext/actions/runs/17991625944/job/51205406657> 

```rs
error: this looks like an `else if` but the `else` is missing
 --> /home/runner/work/gdext/gdext/target/debug/build/itest-5a45487132c19198/out/gen_ffi.rs:1:36016
  |
1 | ... ("Expected class GenFfi, got {}" , last . class) ; ok = false ; } if last . method != last_method_name { godot_error ! ("Expected met...
  |                                                                      ^
  |
  = note: to remove this lint, add the missing `else` or add a new line before the second `if`
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#suspicious_else_formatting
  = note: `-D clippy::suspicious-else-formatting` implied by `-D clippy::suspicious`
  = help: to override `-D clippy::suspicious` add `#[allow(clippy::suspicious_else_formatting)]`

error: this looks like an `else if` but the `else` is missing
 --> /home/runner/work/gdext/gdext/target/debug/build/itest-5a45487132c19198/out/gen_ffi.rs:1:36152
  |
1 | ...d {}, got {}" , last_method_name , last . method) ; ok = false ; } if ! last . is_inbound { godot_error ! ("Expected inbound call, got...
  |                                                                      ^
  |
  = note: to remove this lint, add the missing `else` or add a new line before the second `if`
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#suspicious_else_formatting
``` 