### PR TITLE
Fix codegen regression: `Array<Option<Gd>>` -> `Array<Gd>`

### DIFF
--- a/godot-codegen/src/conv/type_conversions.rs
+++ b/godot-codegen/src/conv/type_conversions.rs
@@ -232,8 +232,11 @@ fn to_rust_type_uncached(full_ty: &GodotTy, ctx: &mut Context) -> RustTy {
                 elem_type: quote! { Array<#rust_elem_ty> },
             }
         } else {
+            // In Array, store Gd and not Option<Gd> elements.
+            let without_option = rust_elem_ty.tokens_non_null();
+
             RustTy::EngineArray {
-                tokens: quote! { Array<#rust_elem_ty> },
+                tokens: quote! { Array<#without_option> },
                 elem_class: elem_ty.to_string(),
             }
         };

--- a/itest/rust/src/object_tests/object_test.rs
+++ b/itest/rust/src/object_tests/object_test.rs
@@ -11,12 +11,11 @@
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 
-use godot::builtin::{GString, StringName, Variant, Vector3};
+use godot::builtin::{Array, GString, StringName, Variant, Vector3};
 use godot::classes::{
     file_access, Engine, FileAccess, IRefCounted, Node, Node2D, Node3D, Object, RefCounted,
 };
 use godot::global::godot_str;
-#[allow(deprecated)]
 use godot::meta::{FromGodot, GodotType, ToGodot};
 use godot::obj::{Base, Gd, Inherits, InstanceId, NewAlloc, NewGd, RawGd, Singleton};
 use godot::register::{godot_api, GodotClass};
@@ -878,6 +877,10 @@ fn object_get_scene_tree(ctx: &TestContext) {
 
     let count = tree.get_child_count();
     assert_eq!(count, 1);
+
+    // Explicit type as regression test: https://github.com/godot-rust/gdext/pull/1385
+    let nodes: Array<Gd<Node>> = tree.get_children();
+    assert_eq!(nodes.len(), 1);
 } // implicitly tested: node does not leak
 
 #[itest]


### PR DESCRIPTION
Regression introduced by #1383. Thanks to @Yarwin for noticing.

Also added regression test. 