### PR TITLE
Add `Array::functional_ops()`

### DIFF
--- a/godot-codegen/src/special_cases/special_cases.rs
+++ b/godot-codegen/src/special_cases/special_cases.rs
@@ -801,6 +801,7 @@ pub fn is_builtin_method_deleted(_class_name: &TyName, method: &JsonBuiltinMetho
 /// Returns some generic type – such as `GenericArray` representing `Array<T>` – if method is marked as generic, `None` otherwise.
 ///
 /// Usually required to initialize the return value and cache its type (see also https://github.com/godot-rust/gdext/pull/1357).
+#[rustfmt::skip]
 pub fn builtin_method_generic_ret(
     class_name: &TyName,
     method: &JsonBuiltinMethod,
@@ -809,9 +810,11 @@ pub fn builtin_method_generic_ret(
         class_name.rust_ty.to_string().as_str(),
         method.name.as_str(),
     ) {
-        ("Array", "duplicate") | ("Array", "slice") => {
-            Some(FnReturn::with_generic_builtin(RustTy::GenericArray))
-        }
+        | ("Array", "duplicate")
+        | ("Array", "slice")
+        | ("Array", "filter")
+
+        => Some(FnReturn::with_generic_builtin(RustTy::GenericArray)),
         _ => None,
     }
 }

--- a/godot-core/src/builtin/collections/array_functional_ops.rs
+++ b/godot-core/src/builtin/collections/array_functional_ops.rs
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use crate::builtin::{to_usize, Array, Callable, Variant, VariantArray};
+use crate::meta::{ArrayElement, AsArg};
+use crate::{meta, sys};
+
+/// Immutable, functional-programming operations for `Array`, based on Godot callables.
+///
+/// Returned by [`Array::functional_ops()`].
+///
+/// These methods exist to provide parity with Godot, e.g. when porting GDScript code to Rust. However, they come with several disadvantages
+/// compared to Rust's [iterator adapters](https://doc.rust-lang.org/stable/core/iter/index.html#adapters):
+/// - Not type-safe: callables are dynamically typed, so you need to double-check signatures. Godot may misinterpret returned values
+///   (e.g. predicates apply to any "truthy" values, not just booleans).
+/// - Slower: dispatching through callables is typically more costly than iterating over variants, especially since every call involves multiple
+///   variant conversions, too. Combining multiple operations like `filter().map()` is very expensive due to intermediate allocations.
+/// - Less composable/flexible: Godot's `map()` always returns an untyped array, even if the input is typed and unchanged by the mapping.
+///   Rust's `collect()` on the other hand gives you control over the output type. Chaining iterators can apply multiple transformations lazily.
+///
+/// In many cases, it is thus better to use [`Array::iter_shared()`] combined with iterator adapters. Check the individual method docs of
+/// this struct for concrete alternatives.
+pub struct ArrayFunctionalOps<'a, T: ArrayElement> {
+    array: &'a Array<T>,
+}
+
+impl<'a, T: ArrayElement> ArrayFunctionalOps<'a, T> {
+    pub(super) fn new(owner: &'a Array<T>) -> Self {
+        Self { array: owner }
+    }
+
+    /// Returns a new array containing only the elements for which the callable returns a truthy value.
+    ///
+    /// **Rust alternatives:** [`Iterator::filter()`].
+    ///
+    /// The callable has signature `fn(T) -> bool`.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use godot::prelude::*;
+    /// let array = array![1, 2, 3, 4, 5];
+    /// let even = array.functional_ops().filter(&Callable::from_fn("is_even", |args| {
+    ///     args[0].to::<i64>() % 2 == 0
+    /// }));
+    /// assert_eq!(even, array![2, 4]);
+    /// ```
+    #[must_use]
+    pub fn filter(&self, callable: &Callable) -> Array<T> {
+        // SAFETY: filter() returns array of same type as self.
+        unsafe { self.array.as_inner().filter(callable) }
+    }
+
+    /// Returns a new untyped array with each element transformed by the callable.
+    ///
+    /// **Rust alternatives:** [`Iterator::map()`].
+    ///
+    /// The callable has signature `fn(T) -> Variant`. Since the transformation can change the element type, this method returns
+    /// a `VariantArray` (untyped array).
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use godot::prelude::*;
+    /// let array = array![1.1, 1.5, 1.9];
+    /// let rounded = array.functional_ops().map(&Callable::from_fn("round", |args| {
+    ///     args[0].to::<f64>().round() as i64
+    /// }));
+    /// assert_eq!(rounded, varray![1, 2, 2]);
+    /// ```
+    #[must_use]
+    pub fn map(&self, callable: &Callable) -> VariantArray {
+        // SAFETY: map() returns an untyped array.
+        unsafe { self.array.as_inner().map(callable) }
+    }
+
+    /// Reduces the array to a single value by iteratively applying the callable.
+    ///
+    /// **Rust alternatives:** [`Iterator::fold()`] or [`Iterator::reduce()`].
+    ///
+    /// The callable takes two arguments: the accumulator and the current element.
+    /// It returns the new accumulator value. The process starts with `initial` as the accumulator.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use godot::prelude::*;
+    /// let array = array![1, 2, 3, 4];
+    /// let sum = array.functional_ops().reduce(
+    ///     &Callable::from_fn("sum", |args| {
+    ///         args[0].to::<i64>() + args[1].to::<i64>()
+    ///     }),
+    ///     &0.to_variant()
+    /// );
+    /// assert_eq!(sum, 10.to_variant());
+    /// ```
+    #[must_use]
+    pub fn reduce(&self, callable: &Callable, initial: &Variant) -> Variant {
+        self.array.as_inner().reduce(callable, initial)
+    }
+
+    /// Returns `true` if the callable returns a truthy value for at least one element.
+    ///
+    /// **Rust alternatives:** [`Iterator::any()`].
+    ///
+    /// The callable has signature `fn(element) -> bool`.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use godot::prelude::*;
+    /// let array = array![1, 2, 3, 4];
+    /// let any_even = array.functional_ops().any(&Callable::from_fn("is_even", |args| {
+    ///     args[0].to::<i64>() % 2 == 0
+    /// }));
+    /// assert!(any_even);
+    /// ```
+    pub fn any(&self, callable: &Callable) -> bool {
+        self.array.as_inner().any(callable)
+    }
+
+    /// Returns `true` if the callable returns a truthy value for all elements.
+    ///
+    /// **Rust alternatives:** [`Iterator::all()`].
+    ///
+    /// The callable has signature `fn(element) -> bool`.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use godot::prelude::*;
+    /// let array = array![2, 4, 6];
+    /// let all_even = array.functional_ops().all(&Callable::from_fn("is_even", |args| {
+    ///     args[0].to::<i64>() % 2 == 0
+    /// }));
+    /// assert!(all_even);
+    /// ```
+    pub fn all(&self, callable: &Callable) -> bool {
+        self.array.as_inner().all(callable)
+    }
+
+    /// Finds the index of the first element matching a custom predicate.
+    ///
+    /// **Rust alternatives:** [`Iterator::position()`].
+    ///
+    /// The callable has signature `fn(element) -> bool`.
+    ///
+    /// Returns the index of the first element for which the callable returns a truthy value, starting from `from`.
+    /// If no element matches, returns `None`.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use godot::prelude::*;
+    /// let array = array![1, 2, 3, 4, 5];
+    /// let is_even = Callable::from_fn("is_even", |args| {
+    ///     args[0].to::<i64>() % 2 == 0
+    /// });
+    /// assert_eq!(array.functional_ops().find_custom(&is_even, None), Some(1)); // value 2
+    /// assert_eq!(array.functional_ops().find_custom(&is_even, Some(2)), Some(3)); // value 4
+    /// ```
+    #[cfg(since_api = "4.4")]
+    pub fn find_custom(&self, callable: &Callable, from: Option<usize>) -> Option<usize> {
+        let from = from.map(|i| i as i64).unwrap_or(0);
+        let found_index = self.array.as_inner().find_custom(callable, from);
+
+        sys::found_to_option(found_index)
+    }
+
+    /// Finds the index of the last element matching a custom predicate, searching backwards.
+    ///
+    /// **Rust alternatives:** [`Iterator::rposition()`].
+    ///
+    /// The callable has signature `fn(element) -> bool`.
+    ///
+    /// Returns the index of the last element for which the callable returns a truthy value, searching backwards from `from`.
+    /// If no element matches, returns `None`.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use godot::prelude::*;
+    /// let array = array![1, 2, 3, 4, 5];
+    /// let is_even = Callable::from_fn("is_even", |args| {
+    ///     args[0].to::<i64>() % 2 == 0
+    /// });
+    /// assert_eq!(array.functional_ops().rfind_custom(&is_even, None), Some(3)); // value 4
+    /// assert_eq!(array.functional_ops().rfind_custom(&is_even, Some(2)), Some(1)); // value 2
+    /// ```
+    #[cfg(since_api = "4.4")]
+    pub fn rfind_custom(&self, callable: &Callable, from: Option<usize>) -> Option<usize> {
+        let from = from.map(|i| i as i64).unwrap_or(-1);
+        let found_index = self.array.as_inner().rfind_custom(callable, from);
+
+        sys::found_to_option(found_index)
+    }
+
+    /// Finds the index of a value in a sorted array using binary search, with `Callable` custom predicate.
+    ///
+    /// The callable `pred` takes two elements `(a, b)` and should return if `a < b` (strictly less).
+    /// For a type-safe version, check out [`Array::bsearch_by()`].
+    ///
+    /// If the value is not present in the array, returns the insertion index that would maintain sorting order.
+    ///
+    /// Calling `bsearch_custom()` on an unsorted array results in unspecified behavior. Consider using [`Array::sort_unstable_custom()`]
+    /// to ensure the sorting order is compatible with your callable's ordering.
+    pub fn bsearch_custom(&self, value: impl AsArg<T>, pred: &Callable) -> usize {
+        meta::arg_into_ref!(value: T);
+
+        to_usize(
+            self.array
+                .as_inner()
+                .bsearch_custom(&value.to_variant(), pred, true),
+        )
+    }
+}

--- a/godot-core/src/builtin/collections/mod.rs
+++ b/godot-core/src/builtin/collections/mod.rs
@@ -6,6 +6,7 @@
  */
 
 mod array;
+mod array_functional_ops;
 mod dictionary;
 mod extend_buffer;
 mod packed_array;
@@ -21,6 +22,7 @@ pub(crate) mod containers {
 // Re-export in godot::builtin::iter.
 #[rustfmt::skip] // Individual lines.
 pub(crate) mod iterators {
+    pub use super::array_functional_ops::ArrayFunctionalOps;
     pub use super::array::Iter as ArrayIter;
     pub use super::dictionary::Iter as DictIter;
     pub use super::dictionary::Keys as DictKeys;

--- a/godot-core/src/builtin/mod.rs
+++ b/godot-core/src/builtin/mod.rs
@@ -65,6 +65,7 @@ pub use __prelude_reexport::*;
 pub mod math;
 
 /// Iterator types for arrays and dictionaries.
+// Might rename this to `collections` or so.
 pub mod iter {
     pub use super::collections::iterators::*;
 }

--- a/godot-core/src/builtin/string/mod.rs
+++ b/godot-core/src/builtin/string/mod.rs
@@ -66,25 +66,13 @@ pub enum Encoding {
 }
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
+// Utilities
 
 fn populated_or_none(s: GString) -> Option<GString> {
     if s.is_empty() {
         None
     } else {
         Some(s)
-    }
-}
-
-fn found_to_option(index: i64) -> Option<usize> {
-    if index == -1 {
-        None
-    } else {
-        // If this fails, then likely because we overlooked a negative value.
-        let index_usize = index
-            .try_into()
-            .unwrap_or_else(|_| panic!("unexpected index {index} returned from Godot function"));
-
-        Some(index_usize)
     }
 }
 

--- a/godot-core/src/builtin/string/string_macros.rs
+++ b/godot-core/src/builtin/string/string_macros.rs
@@ -399,7 +399,7 @@ macro_rules! impl_shared_string_api {
                     }
                 };
 
-                super::found_to_option(godot_found)
+                sys::found_to_option(godot_found)
             }
         }
 

--- a/godot-ffi/src/toolbox.rs
+++ b/godot-ffi/src/toolbox.rs
@@ -195,6 +195,20 @@ pub fn i64_to_ordering(value: i64) -> std::cmp::Ordering {
     }
 }
 
+/// Converts a Godot "found" index `Option<usize>`, where -1 is mapped to `None`.
+pub fn found_to_option(index: i64) -> Option<usize> {
+    if index == -1 {
+        None
+    } else {
+        // If this fails, then likely because we overlooked a negative value.
+        let index_usize = index
+            .try_into()
+            .unwrap_or_else(|_| panic!("unexpected index {index} returned from Godot function"));
+
+        Some(index_usize)
+    }
+}
+
 /*
 pub fn unqualified_type_name<T>() -> &'static str {
     let type_name = std::any::type_name::<T>();


### PR DESCRIPTION
Created a new "namespaced" type accessible from `Array`, which provides FP immutable operations on the array. Usage is deliberately more verbose, since the main reason for using those APIs is Godot parity (e.g. to match existing GDScript code), but they are slower and less type-safe than Rust `Iterator` alternatives.

Added APIs:
- `map`
- `filter`
- `reduce`
- `all`
- `any`
- `find_custom`
- `rfind_custom`
- `bsearch_custom` (moved from `Array`)