### PR TITLE
Update `runtime_version` to use non-deprecated get_godot_version pointer.

### DIFF
--- a/godot-ffi/src/interface_init.rs
+++ b/godot-ffi/src/interface_init.rs
@@ -71,7 +71,7 @@ pub fn ensure_static_runtime_compatibility(
         let minor = unsafe { data_ptr.offset(1).read() };
         if minor == 0 {
             // SAFETY: at this point it's reasonably safe to say that we are indeed dealing with that version struct; read the whole.
-            let data_ptr = get_proc_address as *const sys::GDExtensionGodotVersion;
+            let data_ptr = get_proc_address as *const sys::GodotSysVersion;
             let runtime_version_str = unsafe { read_version_string(&data_ptr.read()) };
 
             panic!(
@@ -114,7 +114,7 @@ pub fn ensure_static_runtime_compatibility(
 
 pub unsafe fn runtime_version(
     get_proc_address: sys::GDExtensionInterfaceGetProcAddress,
-) -> sys::GDExtensionGodotVersion {
+) -> sys::GodotSysVersion {
     let get_proc_address = get_proc_address.expect("get_proc_address unexpectedly null");
 
     runtime_version_inner(get_proc_address)
@@ -125,17 +125,17 @@ unsafe fn runtime_version_inner(
     get_proc_address: unsafe extern "C" fn(
         *const std::ffi::c_char,
     ) -> sys::GDExtensionInterfaceFunctionPtr,
-) -> sys::GDExtensionGodotVersion {
+) -> sys::GodotSysVersion {
     // SAFETY: `self.0` is a valid `get_proc_address` pointer.
-    let get_godot_version = unsafe { get_proc_address(sys::c_str(b"get_godot_version\0")) }; //.expect("get_godot_version unexpectedly null");
+    let get_godot_version = unsafe { get_proc_address(sys::c_str(sys::GET_GODOT_VERSION_SYS_STR)) }; //.expect("get_godot_version unexpectedly null");
 
-    // SAFETY: `sys::GDExtensionInterfaceGetGodotVersion` is an `Option` of an `unsafe extern "C"` function pointer.
+    // SAFETY: `GDExtensionInterfaceGetGodotVersion` is an `Option` of an `unsafe extern "C"` function pointer.
     let get_godot_version =
-        crate::unsafe_cast_fn_ptr!(get_godot_version as sys::GDExtensionInterfaceGetGodotVersion);
+        crate::unsafe_cast_fn_ptr!(get_godot_version as sys::GetGodotSysVersion);
 
-    let mut version = std::mem::MaybeUninit::<sys::GDExtensionGodotVersion>::zeroed();
+    let mut version = std::mem::MaybeUninit::<sys::GodotSysVersion>::zeroed();
 
-    // SAFETY: `get_proc_address` with "get_godot_version" does return a valid `sys::GDExtensionInterfaceGetGodotVersion` pointer, and since we have a valid
+    // SAFETY: `get_proc_address` with "get_godot_version" does return a valid `GDExtensionInterfaceGetGodotVersion` pointer, and since we have a valid
     // `get_proc_address` pointer then it must be callable.
     unsafe { get_godot_version(version.as_mut_ptr()) };
 

--- a/godot-ffi/src/lib.rs
+++ b/godot-ffi/src/lib.rs
@@ -111,10 +111,28 @@ use binding::{
 #[cfg(not(wasm_nothreads))]
 static MAIN_THREAD_ID: ManualInitCell<std::thread::ThreadId> = ManualInitCell::new();
 
+#[cfg(before_api = "4.5")]
+mod version_symbols {
+
+    pub type GodotSysVersion = super::GDExtensionGodotVersion;
+    pub type GetGodotSysVersion = super::GDExtensionInterfaceGetGodotVersion;
+    pub const GET_GODOT_VERSION_SYS_STR: &[u8] = b"get_godot_version\0";
+}
+
+#[cfg(since_api = "4.5")]
+mod version_symbols {
+    pub type GodotSysVersion = super::GDExtensionGodotVersion2;
+
+    pub type GetGodotSysVersion = super::GDExtensionInterfaceGetGodotVersion2;
+    pub const GET_GODOT_VERSION_SYS_STR: &[u8] = b"get_godot_version2\0";
+}
+
+use version_symbols::*;
+
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 
 pub struct GdextRuntimeMetadata {
-    godot_version: GDExtensionGodotVersion,
+    godot_version: GodotSysVersion,
 }
 
 impl GdextRuntimeMetadata {
@@ -122,7 +140,7 @@ impl GdextRuntimeMetadata {
     ///
     /// - The `string` field of `godot_version` must not be written to while this struct exists.
     /// - The `string` field of `godot_version` must be safe to read from while this struct exists.
-    pub unsafe fn new(godot_version: GDExtensionGodotVersion) -> Self {
+    pub unsafe fn new(godot_version: GodotSysVersion) -> Self {
         Self { godot_version }
     }
 }
@@ -264,7 +282,7 @@ fn safeguards_level_string() -> &'static str {
     }
 }
 
-fn print_preamble(version: GDExtensionGodotVersion) {
+fn print_preamble(version: GodotSysVersion) {
     let api_version: &'static str = GdextBuild::godot_static_version_string();
     let runtime_version = read_version_string(&version);
     let safeguards_level = safeguards_level_string();

--- a/godot-ffi/src/toolbox.rs
+++ b/godot-ffi/src/toolbox.rs
@@ -402,7 +402,7 @@ pub(crate) fn load_utility_function(
     })
 }
 
-pub(crate) fn read_version_string(version_ptr: &sys::GDExtensionGodotVersion) -> String {
+pub(crate) fn read_version_string(version_ptr: &sys::GodotSysVersion) -> String {
     let char_ptr = version_ptr.string;
 
     // SAFETY: GDExtensionGodotVersion has the (manually upheld) invariant of a valid string field.


### PR DESCRIPTION
`get_godot_version` has been deprecated in favor of `get_godot_version2`: https://github.com/godotengine/godot/blob/master/core/extension/gdextension_interface.h#L854. 


I could leave it as good first issue, oh well :grimacing:.