### PR TITLE
Prevent procedural macro hygiene issue with eager macros

### DIFF
--- a/godot-macros/src/class/data_models/func.rs
+++ b/godot-macros/src/class/data_models/func.rs
@@ -386,7 +386,9 @@ fn make_forwarding_closure(
             };
 
             quote! {
-                |instance_ptr, params| {
+                // Identifiers need to share the span to avoid proc macro hygiene issues
+                // similar to https://github.com/godot-rust/gdext/pull/1397.
+                |instance_ptr, #param_ident| {
                     let #params_tuple #sig_tuple_annotation = #param_ident;
 
                     let storage =
@@ -409,7 +411,9 @@ fn make_forwarding_closure(
             };
 
             quote! {
-                |instance_ptr, params| {
+                // Identifiers need to share the span to avoid proc macro hygiene issues
+                // similar to https://github.com/godot-rust/gdext/pull/1397.
+                |instance_ptr, #param_ident| {
                     // Not using `virtual_sig`, since virtual methods with `#[func(gd_self)]` are being moved out of the trait to inherent impl.
                     let #params_tuple #sig_tuple_annotation = #param_ident;
 
@@ -423,8 +427,11 @@ fn make_forwarding_closure(
         }
         ReceiverType::Static => {
             // No before-call needed, since static methods are not virtual.
+            //
+            // Identifiers need to share the span to avoid proc macro hygiene issues
+            // similar to https://github.com/godot-rust/gdext/pull/1397.
             quote! {
-                |_, params| {
+                |_, #param_ident| {
                     let #params_tuple = #param_ident;
                     #class_name::#method_name(#(#params),*)
                 }


### PR DESCRIPTION
This PR adds a change which links together identifiers in `quote!` expansion. While in normal context, there's no issues with expansion of procedural macro `#[func]` attribute, Rust macro hygiene rules start to apply within the context of `eager2` crate.

## Context/use case

I'm using `eager2` [crate](https://crates.io/crates/eager2) to implement makeshift mixin pattern for exported GDExtension classes. This allows to define 'interface' as macro once, and then apply the same `#[func]`/`#[signal]`/`#[property]` 'signature' to multiple exported classes, embedding it as tokens (so `#[godot_api]` is able to catch the `#[func]` attribute).

``` rust
#[eager_macro]
macro_rules! common_method {
    () => {
        #[func]
        fn common_method(&self) { self.common_trait_method() }
    };
}

eager! {
    #[godot_api]
    impl Foo {
        common_method!()
    }
    #[godot_api]
    impl Bar {
        common_method!()
    }
}
```

Even beyond this use case, `eager2` macro is overall infinitely useful and powerful, as it allows to define and perform eager macro expansion (similar to built-in ones, such as `concat`) - there's a chance that similar functionality will make it into 'declarative macros 2.0' proposal in Rust language some time later.

However, recent changes to the `#[func]` attribute expansion started causing this type of error:
```
error[E0425]: cannot find value `params` in this scope
  --> [...]:34:1
   |
34 | / eager! {
35 | |     #[godot_api]
36 | |     impl Foo {
37 | |         common_method!()
...  |
40 | | }
   | |_^ not found in this scope
   |
   = note: this error originates in the macro `interface_equipment` which comes from the expansion of the macr
o `eager` (in Nightly builds, run with -Z macro-backtrace for more info)
```
So during the expansion of `#[godot_api]` within `eager` context, hygiene rule for `params` trigger, preventing the compiler from matching the identifier referenced with `#param_ident` to `params`. Use of consistent identifier reference (`#param_ident` in both argument list and function body, with same `span`) prevents this issue and allows to keep using the eager expansion.