### PR TITLE
Allow to register user defined engine singletons.

### DIFF
--- a/godot/src/prelude.rs
+++ b/godot/src/prelude.rs
@@ -18,7 +18,7 @@ pub use super::meta::error::{ConvertError, IoError};
 pub use super::meta::{FromGodot, GodotConvert, ToGodot};
 pub use super::obj::{
     AsDyn, Base, DynGd, DynGdMut, DynGdRef, Gd, GdMut, GdRef, GodotClass, Inherits, InstanceId,
-    OnEditor, OnReady,
+    OnEditor, OnReady, UserSingleton,
 };
 pub use super::register::property::{Export, PhantomVar, Var};
 // Re-export macros.

--- a/itest/rust/src/object_tests/singleton_test.rs
+++ b/itest/rust/src/object_tests/singleton_test.rs
@@ -8,6 +8,7 @@
 use godot::builtin::GString;
 use godot::classes::{Input, Os};
 use godot::obj::{Gd, Singleton};
+use godot::register::{godot_api, GodotClass};
 
 use crate::framework::itest;
 
@@ -43,4 +44,24 @@ fn singleton_is_operational() {
 
     let read_value = os.get_environment(&key);
     assert_eq!(read_value, value);
+}
+
+#[itest]
+fn user_singleton() {
+    // Must be registered with the library and accessible at this point.
+    let value = SomeUserSingleton::singleton().bind().some_method();
+    assert_eq!(value, 42);
+}
+
+#[derive(GodotClass)]
+// `#[class(tool, base = Object)]` is implied by `#[class(singleton)]`.
+#[class(init, singleton)]
+struct SomeUserSingleton {}
+
+#[godot_api]
+impl SomeUserSingleton {
+    #[func]
+    fn some_method(&self) -> u32 {
+        42
+    }
 }


### PR DESCRIPTION
Allows to register user-defined engine singletons via #[class(singleton)]`.

```rs
#[derive(GodotClass)]
// Can not inherit RefCounted - guaranteed by trait.
#[class(init, singleton, base = Object)]
struct MyEngineSingleton {...}

...

// Same access as for built-in Engine Singletons via Class:singleton():
let var = MyEngineSingleton::singleton().bind().my_var;
```

For now it has same API as engine singletons and follows the same logic – `T::singleton()` returns some instance.
GDScript will prohibit creating a new instance of the singleton (both in the Godot Editor and on runtime):

```
 ERROR: res://node.tscn::GDScript_nxiqb:7 - Parse Error: Cannot construct native class "ClassInEditor" because it is an engine singleton.
  ERROR: res://node.tscn::GDScript_nxiqb:8 - Parse Error: Cannot construct native class "MyEngineSingleton" because it is an engine singleton.
```

One can register their own user singleton without the proc-macro like so:
```rs
#[derive(GodotClass)]
#[class(init, base = Object)]
struct MyEngineSingleton {}

// Provides blanket implementation allowing to use MyEngineSingleton::singleton().
// Makes sure that `MyEngineSingleton` is valid singleton (i.e. is non-refcounted GodotClass).
impl UserSingleton for MyEngineSingleton {}

#[gdextension]
unsafe impl ExtensionLibrary for MyExtension {
    fn on_stage_init(stage: InitStage) {
        if matches!(stage, InitStage::MainLoop) {
            let obj = MyEngineSingleton::new_alloc();
            // Name of the registered singleton **must** be the same as a class one (i.e. use `class_id().to_string_name()`)
            // otherwise other Godot components (for example GDScript before 4.4) will have troubles handling it 
            // and editor might crash while using `T::singleton()`.
            Engine::singleton()
                .register_singleton(&MyEngineSingleton::class_id().to_string_name(), &obj);
        }
    }

    fn on_stage_deinit(stage: InitStage) {
        if matches!(stage, InitStage::MainLoop) {
            let obj = MyEngineSingleton::singleton();
            Engine::singleton()
                .unregister_singleton(&MyEngineSingleton::class_id().to_string_name());
            obj.free();
        }
    }
}
```

## Creating new instance

`init` is required to properly register given singleton – mostly for Editor purposes (I decided to not mess with it so far). GDScript won't allow to create new instances of class registered as engine singleton, and in the future it might be good idea to block doing so from godot-rust side as well.

## Caching

Unimplemented for now. Godot keeps engine singletons on its side in big hashmap; While implementing caching we must make sure it is not redundant :sweat_smile:.