### PR TITLE
`__are_oneditor_fields_initalized` needs explicit usage of Singleton trait

### DIFF
--- a/godot-macros/src/class/derive_godot_class.rs
+++ b/godot-macros/src/class/derive_godot_class.rs
@@ -369,7 +369,7 @@ fn make_onready_init(all_fields: &[Field]) -> TokenStream {
 
 fn make_oneditor_panic_inits(class_name: &Ident, all_fields: &[Field]) -> TokenStream {
     // Despite its name OnEditor shouldn't panic in the editor for tool classes.
-    let is_in_editor = quote! { ::godot::classes::Engine::singleton().is_editor_hint() };
+    let is_in_editor = quote! { <::godot::classes::Engine as ::godot::obj::Singleton>::singleton().is_editor_hint() };
 
     let are_all_oneditor_fields_valid = quote! { are_all_oneditor_fields_valid };
 

--- a/godot-macros/src/lib.rs
+++ b/godot-macros/src/lib.rs
@@ -231,12 +231,15 @@ use crate::util::{bail, ident, KvParser};
 /// [`Export`](../register/property/trait.Export.html):
 ///
 /// ```
-/// # use godot::prelude::*;
+/// # use godot::prelude::{GodotClass, Node3D, Gd, OnEditor};
 /// #[derive(GodotClass)]
 /// # #[class(init)]
 /// struct MyStruct {
 ///     #[export]
 ///     my_field: i64,
+///
+///     #[export]
+///     child: OnEditor<Gd<Node3D>>,
 /// }
 /// ```
 ///

--- a/itest/rust/src/object_tests/oneditor_test.rs
+++ b/itest/rust/src/object_tests/oneditor_test.rs
@@ -7,7 +7,7 @@
 
 use godot::classes::notify::NodeNotification;
 use godot::classes::{INode, Node, RefCounted};
-use godot::obj::{Gd, NewAlloc, OnEditor, Singleton};
+use godot::obj::{Gd, NewAlloc, OnEditor};
 use godot::register::{godot_api, GodotClass};
 
 use crate::framework::{expect_panic, itest};

--- a/itest/rust/src/object_tests/property_test.rs
+++ b/itest/rust/src/object_tests/property_test.rs
@@ -11,7 +11,7 @@ use godot::builtin::{
 use godot::classes::{INode, IRefCounted, Node, Object, RefCounted, Resource, Texture};
 use godot::global::{PropertyHint, PropertyUsageFlags};
 use godot::meta::{GodotConvert, PropertyHintInfo, ToGodot};
-use godot::obj::{Base, EngineBitfield, EngineEnum, Gd, NewAlloc, NewGd, OnEditor, Singleton};
+use godot::obj::{Base, EngineBitfield, EngineEnum, Gd, NewAlloc, NewGd, OnEditor};
 use godot::register::property::{Export, Var};
 use godot::register::{godot_api, Export, GodotClass, GodotConvert, Var};
 use godot::test::itest;


### PR DESCRIPTION
In `__are_oneditor_fields_initalized` that is generated by the `GodotClass` derive macro, we use `::godot::class::Engine::singleton()`. Since the introduction of the `Singleton` trait, we have to now explicitly mention the trait. Otherwise, users might run into compiler errors if they don't have the trait in scope:

> no function or associated item named `singleton` found for struct `godot::classes::Engine` in the current scope
items from traits can only be used if the trait is in scope.