### PR TITLE
Blocklist `max_align_t` from bindings generation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ serde_json = "1"
 # Related to tooling/build setup.
 # * regex: not used for unicode parsing -> features unicode-bool + unicode-gencat are enabled instead of unicode-perl.
 #          'unicode-gencat' needed for \d, see https://docs.rs/regex/latest/regex/#unicode-features.
-bindgen = { version = "0.71", default-features = false, features = ["runtime"] }
+bindgen = { version = "0.72.1", default-features = false, features = ["runtime"] }
 libc = "0.2.172"
 regex = { version = "1.11", default-features = false, features = ["std", "unicode-bool", "unicode-gencat"] }
 which = "7"


### PR DESCRIPTION
- blocklist max_align_t from binding generation
- update bindgen.

----

Bindgen can generate wrong size checks for types defined as `__attribute__((aligned(__alignof__(struct {...}))))`, which is, for example, how clang defines max_align_t: https://clang.llvm.org/doxygen/____stddef__max__align__t_8h_source.html. Size checks seems to be fine on all the targets but `wasm32-unknown-emscripten`, disallowing web builds. 

Outside the size check, the generated max_align_t seemed to be OK - llvm defines long double as 128 bits long (u128/f128) for wasm32.

We don't use `max_align_t` anywhere, so blacklisting it until upstream fixes the problem seems to be the most sane solution. 

The `max_align_t` is being included because of `#include <cstddef>` in gdextension_interface.h: https://github.com/godotengine/godot/blob/master/core/extension/gdextension_interface.h#L44

Upstream issue: https://github.com/rust-lang/rust-bindgen/issues/3295

---

Before 0.70 bindgen wasn't generating compile-time checks and relied on tests instead (which were never ran):

<details>

<summary> Generated binding to max_align_t with bindgen 0.69 </summary>

```rs
#[repr(C)]
#[derive(Debug, Copy, Clone)]
pub struct max_align_t {
    pub __clang_max_align_nonce1: ::std::os::raw::c_longlong,
    pub __clang_max_align_nonce2: u128,
}
#[test]
fn bindgen_test_layout_max_align_t() {
    const UNINIT: ::std::mem::MaybeUninit<max_align_t> = ::std::mem::MaybeUninit::uninit();
    let ptr = UNINIT.as_ptr();
    assert_eq!(
        ::std::mem::size_of::<max_align_t>(),
        24usize,
        concat!("Size of: ", stringify!(max_align_t))
    );
    assert_eq!(
        ::std::mem::align_of::<max_align_t>(),
        8usize,
        concat!("Alignment of ", stringify!(max_align_t))
    );
    assert_eq!(
        unsafe { ::std::ptr::addr_of!((*ptr).__clang_max_align_nonce1) as usize - ptr as usize },
        0usize,
        concat!(
            "Offset of field: ",
            stringify!(max_align_t),
            "::",
            stringify!(__clang_max_align_nonce1)
        )
    );
    assert_eq!(
        unsafe { ::std::ptr::addr_of!((*ptr).__clang_max_align_nonce2) as usize - ptr as usize },
        8usize,
        concat!(
            "Offset of field: ",
            stringify!(max_align_t),
            "::",
            stringify!(__clang_max_align_nonce2)
        )
    );
}
```
</details>

<details>

<summary> Same for bindgen >= 0.7 </summary>

```rs
#[repr(C)]
#[derive(Debug, Copy, Clone)]
pub struct max_align_t {
    pub __clang_max_align_nonce1: ::std::os::raw::c_longlong,
    pub __clang_max_align_nonce2: u128,
}
#[allow(clippy::unnecessary_operation, clippy::identity_op)]
const _: () = {
    ["Size of max_align_t"][::std::mem::size_of::<max_align_t>() - 24usize];
    ["Alignment of max_align_t"][::std::mem::align_of::<max_align_t>() - 8usize];
    ["Offset of field: max_align_t::__clang_max_align_nonce1"]
        [::std::mem::offset_of!(max_align_t, __clang_max_align_nonce1) - 0usize];
    ["Offset of field: max_align_t::__clang_max_align_nonce2"]
        [::std::mem::offset_of!(max_align_t, __clang_max_align_nonce2) - 8usize];
};
```

</details>

---

I also updated bindgen – I was already poking their code, so I would (hopefully) notice any regression or change in their API.