### PR TITLE
Fix `get_godot_version2` unavailable on older builds

### DIFF
--- a/godot-codegen/src/generator/gdext_build_struct.rs
+++ b/godot-codegen/src/generator/gdext_build_struct.rs
@@ -24,34 +24,29 @@ pub fn make_gdext_build_struct(header: &GodotApiVersion) -> TokenStream {
         pub struct GdextBuild;
 
         impl GdextBuild {
-            /// Godot version against which gdext was compiled.
+            /// Godot version against which godot-rust was compiled.
             ///
             /// Example format: `v4.0.stable.official`
             pub const fn godot_static_version_string() -> &'static str {
                 #version_string
             }
 
-            /// Godot version against which gdext was compiled, as `(major, minor, patch)` triple.
+            /// Godot version against which godot-rust was compiled, as `(major, minor, patch)` triple.
             pub const fn godot_static_version_triple() -> (u8, u8, u8) {
                 (#major, #minor, #patch)
             }
 
-            /// Version of the Godot engine which loaded gdext via GDExtension binding.
+            /// Version of the Godot engine which loaded godot-rust via GDExtension binding.
             pub fn godot_runtime_version_string() -> String {
-                unsafe {
-                    let char_ptr = crate::runtime_metadata().godot_version.string;
-                    let c_str = std::ffi::CStr::from_ptr(char_ptr);
-                    String::from_utf8_lossy(c_str.to_bytes()).to_string()
-                }
+                let rt = unsafe { crate::runtime_metadata() };
+                rt.version_string().to_string()
             }
 
-            /// Version of the Godot engine which loaded gdext via GDExtension binding, as
+            /// Version of the Godot engine which loaded godot-rust via GDExtension binding, as
             /// `(major, minor, patch)` triple.
             pub fn godot_runtime_version_triple() -> (u8, u8, u8) {
-                let version = unsafe {
-                    crate::runtime_metadata().godot_version
-                };
-                (version.major as u8, version.minor as u8, version.patch as u8)
+                let rt = unsafe { crate::runtime_metadata() };
+                rt.version_triple()
             }
 
             // Duplicates code from `before_api` in `godot-bindings/lib.rs`.

--- a/godot-ffi/src/toolbox.rs
+++ b/godot-ffi/src/toolbox.rs
@@ -386,10 +386,14 @@ pub(crate) fn load_utility_function(
     })
 }
 
-pub(crate) fn read_version_string(version_ptr: &sys::GodotSysVersion) -> String {
-    let char_ptr = version_ptr.string;
-
-    // SAFETY: GDExtensionGodotVersion has the (manually upheld) invariant of a valid string field.
+/// Extracts the version string from a Godot version struct.
+///
+/// Works transparently with both `GDExtensionGodotVersion` and `GDExtensionGodotVersion2`.
+///
+/// # Safety
+/// The `char_ptr` must point to a valid C string.
+pub(crate) unsafe fn read_version_string(char_ptr: *const std::ffi::c_char) -> String {
+    // SAFETY: Caller guarantees the pointer is valid.
     let c_str = unsafe { std::ffi::CStr::from_ptr(char_ptr) };
 
     let full_version = c_str.to_str().unwrap_or("(invalid UTF-8 in version)");


### PR DESCRIPTION
Checks for availability of both `get_godot_version` and `get_godot_version2` function pointers to obtain runtime version. This works for versions < 4.5 and >= 4.5, and both normal and no-deprecated-symbol builds of Godot.

Also fixes a bug during init logic where `GDExtensionGodotVersion2` was used in some cases, although this one would *always* be `GDExtensionGodotVersion` for Godot 4.0.

Fixes #1398.