### PR TITLE
Add `GodotImmutable` to constrain `#[opt(default)]` types

### DIFF
--- a/godot-core/src/meta/mod.rs
+++ b/godot-core/src/meta/mod.rs
@@ -76,7 +76,7 @@ pub use signature::trace;
 #[doc(hidden)]
 pub use signature::*;
 pub use signed_range::{wrapped, SignedRange};
-pub use traits::{ArrayElement, GodotType, PackedArrayElement};
+pub use traits::{ArrayElement, GodotImmutable, GodotType, PackedArrayElement};
 pub use uniform_object_deref::UniformObjectDeref;
 
 // Public due to signals emit() needing it. Should be made pub(crate) again if that changes.

--- a/godot-macros/src/class/data_models/func.rs
+++ b/godot-macros/src/class/data_models/func.rs
@@ -217,9 +217,7 @@ fn make_default_argument_vec(
         .zip(optional_param_types)
         .map(|(value, param_type)| {
             quote! {
-                ::godot::builtin::Variant::from(
-                    ::godot::meta::AsArg::<#param_type>::into_arg(#value)
-                )
+                ::godot::private::opt_default_value::<#param_type>(#value)
             }
         });
 


### PR DESCRIPTION
Addresses some of the open questions from #1396 regarding mutable default values.
Conservatively disallows many types, we can probably open them up over time.

One future approach would be to allow immutable _values_ where types support them, e.g.:
```rs
#[opt] object: Option<Gd<RefCounted>>,
// We can safely use None here.

#[opt] v: Variant,
// We can safely use Variant::nil() here. Recreated each time.
```

Or, have an override like:
```rs
#[opt(default = allow_mut(...))] object: Gd<RefCounted>,
```