### PR TITLE
WIP: Prevent `Gd::default_instance` bypassing placeholder instances.

### DIFF
--- a/godot-core/src/obj/base.rs
+++ b/godot-core/src/obj/base.rs
@@ -80,7 +80,7 @@ pub struct Base<T: GodotClass> {
     // 2.
     obj: ManuallyDrop<Gd<T>>,
 
-    /// Tracks the initialization state of this `Base<T>` in Debug mode.
+    /// Tracks the initialization state of this `Base<T>` if safeguards are enabled.
     ///
     /// Rc allows to "copy-construct" the base from an existing one, while still affecting the user-instance through the original `Base<T>`.
     #[cfg(safeguards_balanced)]

--- a/godot-core/src/obj/bounds.rs
+++ b/godot-core/src/obj/bounds.rs
@@ -420,7 +420,7 @@ impl Declarer for DeclUser {
     where
         T: GodotDefault + Bounds<Declarer = Self>,
     {
-        Gd::default_instance()
+        Gd::default_user_instance()
     }
 }
 

--- a/godot-core/src/obj/traits.rs
+++ b/godot-core/src/obj/traits.rs
@@ -773,7 +773,7 @@ pub mod cap {
     use super::*;
     use crate::builtin::{StringName, Variant};
     use crate::meta::PropertyInfo;
-    use crate::obj::{Base, Bounds, Gd};
+    use crate::obj::{Base, Gd};
     use crate::storage::{IntoVirtualMethodReceiver, VirtualMethodReceiver};
 
     /// Trait for all classes that are default-constructible from the Godot engine.
@@ -804,19 +804,7 @@ pub mod cap {
         /// - For user-defined classes, this calls `T::init()` or the generated init-constructor.
         /// - For engine classes, this calls `T::new()`.
         #[doc(hidden)]
-        fn __godot_default() -> Gd<Self> {
-            // This is a bit hackish, but the alternatives are:
-            // 1. Separate trait `GodotUserDefault` for user classes, which then proliferates through all APIs and makes abstraction harder.
-            // 2. Repeatedly implementing __godot_default() that forwards to something like Gd::default_user_instance(). Possible, but this
-            //    will make the step toward builder APIs more difficult, as users would need to re-implement this as well.
-            sys::strict_assert_eq!(
-                std::any::TypeId::of::<<Self as Bounds>::Declarer>(),
-                std::any::TypeId::of::<bounds::DeclUser>(),
-                "__godot_default() called on engine class; must be overridden for engine classes"
-            );
-
-            Gd::default_instance()
-        }
+        fn __godot_default() -> Gd<Self>;
 
         /// Only provided for user classes.
         #[doc(hidden)]

--- a/godot-macros/src/class/data_models/interface_trait_impl.rs
+++ b/godot-macros/src/class/data_models/interface_trait_impl.rs
@@ -289,6 +289,10 @@ fn handle_init<'a>(
 
         #(#cfg_attrs)*
         impl ::godot::obj::cap::GodotDefault for #class_name {
+            fn __godot_default() -> ::godot::obj::Gd<Self> {
+                ::godot::obj::Gd::default_user_instance()
+            }
+
             fn __godot_user_init(base: ::godot::obj::Base<Self::Base>) -> Self {
                 <Self as #trait_path>::init(base)
             }

--- a/godot-macros/src/class/derive_godot_class.rs
+++ b/godot-macros/src/class/derive_godot_class.rs
@@ -362,6 +362,10 @@ fn make_godot_init_impl(class_name: &Ident, fields: &Fields) -> TokenStream {
 
     quote! {
         impl ::godot::obj::cap::GodotDefault for #class_name {
+            fn __godot_default() -> ::godot::obj::Gd<Self> {
+                ::godot::obj::Gd::default_user_instance()
+            }
+
             fn __godot_user_init(base: ::godot::obj::Base<<#class_name as ::godot::obj::GodotClass>::Base>) -> Self {
                 Self {
                     #( #rest_init )*


### PR DESCRIPTION
Closes: https://github.com/godot-rust/gdext/issues/1404#issuecomment-3558431763

Forwards instance creation from godot-rust through Godot – making sure that Godot-specific logic (creating placeholders and whatnot) is being run & preserved.

I'm marking it as a breaking change – API is the same (at least the exposed one) but it is breaking change in behavior which must be properly announced.


**WIP** – I want to give it solid beating after merging https://github.com/godot-rust/gdext/pull/1399 (+ Godot before 4.4 is not properly covered I think).