### PR TITLE
Separate public and internal `ToGodot` + `FromGodot` traits

### DIFF
--- a/godot-codegen/src/generator/enums.rs
+++ b/godot-codegen/src/generator/enums.rs
@@ -127,8 +127,10 @@ pub fn make_enum_definition_with(
 
             impl crate::meta::FromGodot for #name {
                 fn try_from_godot(via: Self::Via) -> std::result::Result<Self, crate::meta::error::ConvertError> {
+                    // Pass i32/u64 enum/bitfield as i64 on the FFI layer. Only necessary for bitfields (u64).
+                    // Bitfields are cast to i64 for FFI, then reinterpreted in C++ as uint64_t.
                     <Self as #engine_trait>::try_from_ord(via)
-                        .ok_or_else(|| crate::meta::error::FromGodotError::InvalidEnum.into_error(via))
+                        .ok_or_else(|| crate::meta::error::FromGodotError::InvalidEnum.into_error(via as i64))
                 }
             }
         }

--- a/godot-core/src/meta/error/convert_error.rs
+++ b/godot-core/src/meta/error/convert_error.rs
@@ -292,7 +292,6 @@ pub(crate) enum FromFfiError {
     U16,
     I32,
     U32,
-    U64,
 }
 
 impl FromFfiError {
@@ -317,7 +316,6 @@ impl fmt::Display for FromFfiError {
             Self::U16 => "u16",
             Self::I32 => "i32",
             Self::U32 => "u32",
-            Self::U64 => "u64",
         };
 
         write!(f, "`{target}` cannot store the given value")
@@ -332,15 +330,15 @@ pub(crate) enum FromVariantError {
         actual: VariantType,
     },
 
-    /// Value cannot be represented in target type's domain.
-    BadValue,
-
     WrongClass {
         expected: ClassId,
     },
 
     /// Variant holds an object which is no longer alive.
     DeadObject,
+    //
+    // BadValue: Value cannot be represented in target type's domain.
+    // Used in the past for types like u64, with fallible FromVariant.
 }
 
 impl FromVariantError {
@@ -359,7 +357,6 @@ impl fmt::Display for FromVariantError {
                 // Note: wording is the same as in CallError::failed_param_conversion_engine()
                 write!(f, "cannot convert from {actual:?} to {expected:?}")
             }
-            Self::BadValue => write!(f, "value cannot be represented in target type's domain"),
             Self::WrongClass { expected } => {
                 write!(f, "cannot convert to class {expected}")
             }

--- a/godot-core/src/meta/mod.rs
+++ b/godot-core/src/meta/mod.rs
@@ -66,7 +66,7 @@ pub use args::*;
 #[expect(deprecated)]
 pub use class_id::{ClassId, ClassName};
 pub use element_type::{ElementScript, ElementType};
-pub use godot_convert::{FromGodot, GodotConvert, ToGodot};
+pub use godot_convert::{EngineFromGodot, EngineToGodot, FromGodot, GodotConvert, ToGodot};
 pub use method_info::MethodInfo;
 pub use object_to_owned::ObjectToOwned;
 pub use param_tuple::{InParamTuple, OutParamTuple, ParamTuple};

--- a/godot-macros/src/class/data_models/func.rs
+++ b/godot-macros/src/class/data_models/func.rs
@@ -318,10 +318,10 @@ fn make_forwarding_closure(
 
     let instance_decl = match &signature_info.receiver_type {
         ReceiverType::Ref => quote! {
-            let instance = ::godot::private::Storage::get(storage);
+            let __gdext_self = ::godot::private::Storage::get(storage);
         },
         ReceiverType::Mut => quote! {
-            let mut instance = ::godot::private::Storage::get_mut(storage);
+            let mut __gdext_self = ::godot::private::Storage::get_mut(storage);
         },
         _ => quote! {},
     };
@@ -333,7 +333,7 @@ fn make_forwarding_closure(
                 // In case of GdSelf receiver use instance only to call the before_method.
                 quote! { ::godot::private::Storage::get_mut(storage).#before_method(); }
             } else {
-                quote! { instance.#before_method(); }
+                quote! { __gdext_self.#before_method(); }
             }
         }
         BeforeKind::Without => TokenStream::new(),
@@ -354,8 +354,8 @@ fn make_forwarding_closure(
                 // Virtual methods.
 
                 let instance_ref = match signature_info.receiver_type {
-                    ReceiverType::Ref => quote! { &instance },
-                    ReceiverType::Mut => quote! { &mut instance },
+                    ReceiverType::Ref => quote! { &__gdext_self },
+                    ReceiverType::Mut => quote! { &mut __gdext_self },
                     _ => unreachable!("unexpected receiver type"), // checked above.
                 };
 
@@ -379,7 +379,7 @@ fn make_forwarding_closure(
 
                 sig_tuple_annotation = TokenStream::new();
                 method_call = quote! {
-                    instance.#method_name( #(#params),* )
+                    __gdext_self.#method_name( #(#params),* )
                 };
             };
 

--- a/itest/rust/src/builtin_tests/containers/variant_test.rs
+++ b/itest/rust/src/builtin_tests/containers/variant_test.rs
@@ -212,7 +212,8 @@ fn variant_bad_integer_conversions() {
     truncate_bad::<u32>(4294967296);
     truncate_bad::<u32>(-1);
 
-    truncate_bad::<u64>(-1);
+    // u64 no longer implements FromGodot, so this test is not applicable.
+    // truncate_bad::<u64>(-1);
 }
 
 #[itest]
@@ -233,15 +234,12 @@ fn variant_bad_conversions() {
     assert_convert_err::<_, String>(false);
     assert_convert_err::<_, StringName>(VarArray::default());
 
-    // Special case: ToVariant is not yet fallible, so u64 -> i64 conversion error panics.
-    expect_panic("u64 -> i64 conversion error", || {
-        u64::MAX.to_variant();
-    });
-
+    // u64 no longer implements ToGodot: u64::MAX.to_variant() would fail to compile.
     //assert_eq!(
     //    VarDictionary::default().to_variant().try_to::<Array>(),
     //    Err(VariantConversionError)
     //);
+
     Variant::nil()
         .to_variant()
         .try_to::<VarDictionary>()

--- a/itest/rust/src/object_tests/virtual_methods_test.rs
+++ b/itest/rust/src/object_tests/virtual_methods_test.rs
@@ -735,8 +735,7 @@ impl GetSetTest {
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 
-// There isn't a good way to test editor plugins, but we can at least declare one to ensure that the macro
-// compiles.
+// There isn't a good way to test editor plugins, but we can at least declare one to ensure that the macro compiles.
 #[derive(GodotClass)]
 #[class(init, base = EditorPlugin, tool)]
 struct CustomEditorPlugin;
@@ -752,5 +751,26 @@ impl IEditorPlugin for CustomEditorPlugin {
     // This parameter is non-null.
     fn handles(&self, _object: Gd<Object>) -> bool {
         true
+    }
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+
+/// Test that virtual methods with u64 parameters work correctly.
+///
+/// `u64` doesn't have ToGodot/FromGodot implementations (not natively supported in GDScript),
+/// but engine virtual methods may use it via EngineToGodot/EngineFromGodot.
+#[cfg(feature = "codegen-full")]
+#[derive(GodotClass)]
+#[class(init, tool, base=OpenXrExtensionWrapper)]
+struct VirtualU64Test {
+    base: Base<godot::classes::OpenXrExtensionWrapper>,
+}
+
+#[cfg(feature = "codegen-full")]
+#[godot_api]
+impl godot::classes::IOpenXrExtensionWrapper for VirtualU64Test {
+    fn on_instance_created(&mut self, _instance: u64) {
+        // No need to do anything, this must just compile with u64.
     }
 }


### PR DESCRIPTION
Introduces new _internal_ traits `EngineToGodot` + `EngineFromGodot`. These are used by functions in generated code for engine APIs. Where available, they delegate to `ToGodot` + `FromGodot` traits via blanket impl. In addition, they have implementations for types that make sense on an engine level, but not for user-defined `#[func]` functions or `Variant` conversions.

This addresses multiple problems:

1. Type `u64` currently implements `ToGodot`/`FromGodot` out of necessity: 
   - It's required for engine-provided APIs, which are backed by C++ `std::uint64_t` and thus safe.
   - However, `#[func]` interacts with GDScript, which does **not** have an unsigned 64-bit type. The current implementation panics, which is the only instance of such behavior in otherwise infallible `ToGodot::to_godot()`. Silently changing value would be even worse.
   - **This PR removes `impl To/FromGodot for u64`.**

2. Similar: raw pointers like native-struct `*const AudioFrame`, or `*const c_void` used in virtual methods.
   - While not technically unsound (?), there's hardly a way to use those correctly in variant conversions or `#[func]`. You can just do `123.to_variant().to::<*mut Glyph>()` and obtain a bad pointer.
   - Again, engine methods need them but `#[func]` doesn't.
   - Removing such impls also declutters the [`impl` docs for `ToGodot`](https://godot-rust.github.io/docs/gdext/master/godot/meta/trait.ToGodot.html#foreign-impls) and `FromGodot`.

3. There is currently a bug: API calls cause runtime panics for some `u64` values.
   - If highest bit is set, i.e. `value > i64::MAX`, the `ToGodot` validation kicks in and causes panic.
   - Itest `u64_fileaccess_roundtrip` tests that this works after the changes.

4. Relatedly, bitfields are represented as `u64`.
   - According to my brief research, there are no bitfields that currently use the highest bit, but this is possible. If that happens, then a panic could also occur.
   - A private `EngineToGodot` trait can handle this case without exposing error-prone conversions for public use.