### PR TITLE
Add `StringName == &str` equality operator

### DIFF
--- a/godot-core/src/builtin/strings/string_name.rs
+++ b/godot-core/src/builtin/strings/string_name.rs
@@ -347,6 +347,23 @@ impl_shared_string_api! {
     builtin_mod: string_name,
 }
 
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// Comparison with Rust strings
+
+// API design: see PartialEq for GString.
+impl PartialEq<&str> for StringName {
+    #[cfg(since_api = "4.5")]
+    fn eq(&self, other: &&str) -> bool {
+        self.chars().iter().copied().eq(other.chars())
+    }
+
+    // Polyfill for older Godot versions -- StringName->GString conversion still requires allocation in older versions.
+    #[cfg(before_api = "4.5")]
+    fn eq(&self, other: &&str) -> bool {
+        GString::from(self) == *other
+    }
+}
+
 impl fmt::Display for StringName {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let s = GString::from(self);

--- a/godot-core/src/obj/on_ready.rs
+++ b/godot-core/src/obj/on_ready.rs
@@ -104,7 +104,7 @@ use crate::registry::property::Var;
 /// impl INode for MyClass {
 ///     fn ready(&mut self) {
 ///        // self.node is now ready with the node found at path `ChildPath`.
-///        assert_eq!(self.auto.get_name(), "ChildPath".into());
+///        assert_eq!(self.auto.get_name(), "ChildPath");
 ///
 ///        // self.manual needs to be initialized manually.
 ///        self.manual.init(22);

--- a/itest/rust/build.rs
+++ b/itest/rust/build.rs
@@ -121,8 +121,8 @@ fn collect_inputs() -> Vec<Input> {
     push!(inputs; bool, bool, true);
     push!(inputs; Color, Color, Color(0.7, 0.5, 0.3, 0.2), Color::from_rgba(0.7, 0.5, 0.3, 0.2));
     push!(inputs; String, GString, "hello", GString::from("hello"));
-    push!(inputs; StringName, StringName, &"hello", "hello".into());
-    pushs!(inputs; NodePath, NodePath, r#"^"hello""#, "hello".into(), true, true, None);
+    push!(inputs; StringName, StringName, &"hello", StringName::from("hello"));
+    pushs!(inputs; NodePath, NodePath, r#"^"hello""#, NodePath::from("hello"), true, true, None);
     push!(inputs; Vector2, Vector2, Vector2(12.5, -3.5), Vector2::new(12.5, -3.5));
     push!(inputs; Vector3, Vector3, Vector3(117.5, 100.0, -323.25), Vector3::new(117.5, 100.0, -323.25));
     push!(inputs; Vector4, Vector4, Vector4(-18.5, 24.75, -1.25, 777.875), Vector4::new(-18.5, 24.75, -1.25, 777.875));
@@ -171,8 +171,8 @@ fn collect_inputs() -> Vec<Input> {
     push_newtype!(inputs; bool, NewBool(bool), true);
     push_newtype!(inputs; Color, NewColor(Color), Color(0.7, 0.5, 0.3, 0.2), NewColor(Color::from_rgba(0.7, 0.5, 0.3, 0.2)));
     push_newtype!(inputs; String, NewString(GString), "hello", NewString(GString::from("hello")));
-    push_newtype!(inputs; StringName, NewStringName(StringName), &"hello", NewStringName("hello".into()));
-    push_newtype!(@s inputs; NodePath, NewNodePath(NodePath), r#"^"hello""#, NewNodePath("hello".into()));
+    push_newtype!(inputs; StringName, NewStringName(StringName), &"hello", NewStringName(StringName::from("hello")));
+    push_newtype!(@s inputs; NodePath, NewNodePath(NodePath), r#"^"hello""#, NewNodePath(NodePath::from("hello")));
     push_newtype!(inputs; Vector2, NewVector2(Vector2), Vector2(12.5, -3.5), NewVector2(Vector2::new(12.5, -3.5)));
     push_newtype!(inputs; Vector3, NewVector3(Vector3), Vector3(117.5, 100.0, -323.25), NewVector3(Vector3::new(117.5, 100.0, -323.25)));
     push_newtype!(inputs; Vector4, NewVector4(Vector4), Vector4(-18.5, 24.75, -1.25, 777.875), NewVector4(Vector4::new(-18.5, 24.75, -1.25, 777.875)));

--- a/itest/rust/src/builtin_tests/containers/array_test.rs
+++ b/itest/rust/src/builtin_tests/containers/array_test.rs
@@ -712,10 +712,10 @@ func make_array() -> Array[CustomScriptForArrays]:
     let script = script.script().expect("script object should be alive");
     assert_eq!(script, gdscript.upcast());
     assert_eq!(script.get_name(), GString::new()); // Resource name.
-    assert_eq!(script.get_instance_base_type(), "RefCounted".into());
+    assert_eq!(script.get_instance_base_type(), "RefCounted");
 
     #[cfg(since_api = "4.3")]
-    assert_eq!(script.get_global_name(), "CustomScriptForArrays".into());
+    assert_eq!(script.get_global_name(), "CustomScriptForArrays");
 }
 
 // Test that proper type has been set&cached while creating new Array.

--- a/itest/rust/src/builtin_tests/containers/dictionary_test.rs
+++ b/itest/rust/src/builtin_tests/containers/dictionary_test.rs
@@ -829,8 +829,5 @@ func variant_script_dict() -> Dictionary[Variant, CustomScriptForDictionaries]:
     assert_match!(dict.value_element_type(), ElementType::ScriptClass(script));
     let script = script.script().expect("script object should be alive");
     assert_eq!(script, gdscript.upcast());
-    assert_eq!(
-        script.get_global_name(),
-        "CustomScriptForDictionaries".into()
-    );
+    assert_eq!(script.get_global_name(), "CustomScriptForDictionaries");
 }

--- a/itest/rust/src/builtin_tests/script/script_instance_tests.rs
+++ b/itest/rust/src/builtin_tests/script/script_instance_tests.rs
@@ -138,7 +138,7 @@ impl ScriptInstance for TestScriptInstance {
     }
 
     fn set_property(mut this: SiMut<Self>, name: StringName, value: &Variant) -> bool {
-        if name.to_string() == "script_property_b" {
+        if name == "script_property_b" {
             this.script_property_b = FromGodot::from_variant(value);
             true
         } else {

--- a/itest/rust/src/builtin_tests/string/node_path_test.rs
+++ b/itest/rust/src/builtin_tests/string/node_path_test.rs
@@ -109,23 +109,23 @@ fn node_path_subpath() {
 #[itest]
 fn node_path_get_name() {
     let path = NodePath::from("../RigidBody2D/Sprite2D");
-    assert_eq!(path.get_name(0), "..".into());
-    assert_eq!(path.get_name(1), "RigidBody2D".into());
-    assert_eq!(path.get_name(2), "Sprite2D".into());
+    assert_eq!(path.get_name(0), "..");
+    assert_eq!(path.get_name(1), "RigidBody2D");
+    assert_eq!(path.get_name(2), "Sprite2D");
 
     expect_panic_or_nothing("NodePath::get_name() out of bounds", || {
-        assert_eq!(path.get_name(3), "".into());
+        assert_eq!(path.get_name(3), "");
     })
 }
 
 #[itest]
 fn node_path_get_subname() {
     let path = NodePath::from("Sprite2D:texture:resource_name");
-    assert_eq!(path.get_subname(0), "texture".into());
-    assert_eq!(path.get_subname(1), "resource_name".into());
+    assert_eq!(path.get_subname(0), "texture");
+    assert_eq!(path.get_subname(1), "resource_name");
 
     expect_panic_or_nothing("NodePath::get_subname() out of bounds", || {
-        assert_eq!(path.get_subname(2), "".into());
+        assert_eq!(path.get_subname(2), "");
     })
 }
 

--- a/itest/rust/src/builtin_tests/string/string_name_test.rs
+++ b/itest/rust/src/builtin_tests/string/string_name_test.rs
@@ -52,6 +52,13 @@ fn string_name_equality() {
 }
 
 #[itest]
+fn string_name_eq_str() {
+    let apple = StringName::from("apple");
+    assert_eq!(apple, "apple");
+    assert_ne!(apple, "orange");
+}
+
+#[itest]
 #[allow(clippy::eq_op)]
 fn string_name_transient_ord() {
     // We can't deterministically know the ordering, so this test only ensures consistency between different operators.

--- a/itest/rust/src/object_tests/dyn_gd_test.rs
+++ b/itest/rust/src/object_tests/dyn_gd_test.rs
@@ -282,7 +282,7 @@ fn dyn_gd_call_godot_method() {
     let mut node = foreign::NodeHealth::new_alloc().into_dyn::<dyn Health>();
 
     node.set_name("dyn-name!");
-    assert_eq!(node.get_name(), "dyn-name!".into());
+    assert_eq!(node.get_name(), "dyn-name!");
 
     node.free();
 }

--- a/itest/rust/src/object_tests/object_arg_test.rs
+++ b/itest/rust/src/object_tests/object_arg_test.rs
@@ -228,7 +228,7 @@ where
 
     assert_eq!(a, global::Error::OK);
     assert_eq!(b, global::Error::OK);
-    assert_eq!(manual2.get_name(), "hello".into());
+    assert_eq!(manual2.get_name(), "hello");
     assert_eq!(refc2.bind().value, -123);
 
     manual2.free();

--- a/itest/rust/src/object_tests/onready_test.rs
+++ b/itest/rust/src/object_tests/onready_test.rs
@@ -218,7 +218,7 @@ fn init_attribute_node_key_lifecycle() {
 
     {
         let obj = obj.bind();
-        assert_eq!(obj.node.get_name(), "child".into());
+        assert_eq!(obj.node.get_name(), "child");
         assert_eq!(obj.self_name.as_str(), "CustomNodeName");
     }
 
@@ -374,7 +374,7 @@ struct InitWithNodeOrBase {
 #[godot_api]
 impl INode for InitWithNodeOrBase {
     fn ready(&mut self) {
-        assert_eq!(self.node.get_name(), "child".into());
+        assert_eq!(self.node.get_name(), "child");
         assert_eq!(self.self_name.as_str(), "CustomNodeName");
     }
 }

--- a/itest/rust/src/object_tests/validate_property_test.rs
+++ b/itest/rust/src/object_tests/validate_property_test.rs
@@ -24,7 +24,7 @@ pub struct ValidatePropertyTest {
 #[godot_api]
 impl IObject for ValidatePropertyTest {
     fn validate_property(&self, property: &mut PropertyInfo) {
-        if property.property_name.to_string() == "my_var" {
+        if property.property_name == "my_var" {
             property.usage = PropertyUsageFlags::NO_EDITOR;
             property.property_name = StringName::from("SuperNewTestPropertyName");
             property.hint_info.hint_string = GString::from("SomePropertyHint");

--- a/itest/rust/src/register_tests/func_virtual_test.rs
+++ b/itest/rust/src/register_tests/func_virtual_test.rs
@@ -152,7 +152,7 @@ func _get_thing():
         .collect::<VarArray>();
 
     // Ensure script has been parsed + compiled correctly.
-    assert_eq!(script.get_instance_base_type(), "VirtualScriptCalls".into());
+    assert_eq!(script.get_instance_base_type(), "VirtualScriptCalls");
     assert_eq!(
         methods,
         varray![


### PR DESCRIPTION
Now that `StringName::chars()` has been merged in #1419, we can add `PartialEq<str> for StringName`.

Bases on #1415, which does the same thing for `GString`.
Breaking because `"str".into()` becomes ambiguous.