### PR TITLE
Implement `AnyArray`, a covariant typed/untyped array

### DIFF
--- a/godot-codegen/src/generator/builtins.rs
+++ b/godot-codegen/src/generator/builtins.rs
@@ -15,8 +15,8 @@ use crate::generator::functions_common::{FnCode, FnDefinition, FnDefinitions};
 use crate::generator::method_tables::MethodTableKey;
 use crate::generator::{enums, functions_common};
 use crate::models::domain::{
-    BuiltinClass, BuiltinMethod, ClassLike, ExtensionApi, FnDirection, Function, ModName, RustTy,
-    TyName,
+    BuiltinClass, BuiltinMethod, ClassLike, ExtensionApi, FlowDirection, FnDirection, Function,
+    ModName, RustTy, TyName,
 };
 use crate::{conv, util, SubmitFn};
 
@@ -97,9 +97,12 @@ fn make_builtin_class(
 ) -> GeneratedBuiltin {
     let godot_name = &class.name().godot_ty;
 
+    // Meta direction irrelevant, since we're just interested in the builtin "outer" name.
+    // Flow mostly irrelevant too, but we'd like to have VariantArray as the outer class, so choose Godot->Rust.
+    let flow = FlowDirection::GodotToRust;
     let RustTy::BuiltinIdent {
         ty: outer_class, ..
-    } = conv::to_rust_type(godot_name, None, ctx)
+    } = conv::to_rust_type(godot_name, None, Some(flow), ctx)
     else {
         panic!("Rust type `{godot_name}` categorized wrong")
     };

--- a/godot-codegen/src/generator/central_files.rs
+++ b/godot-codegen/src/generator/central_files.rs
@@ -12,7 +12,7 @@ use crate::context::Context;
 use crate::conv;
 use crate::generator::sys_pointer_types::make_godotconvert_for_systypes;
 use crate::generator::{enums, gdext_build_struct};
-use crate::models::domain::ExtensionApi;
+use crate::models::domain::{ExtensionApi, FlowDirection};
 use crate::util::ident;
 
 pub fn make_sys_central_code(api: &ExtensionApi) -> TokenStream {
@@ -175,11 +175,14 @@ fn make_variant_enums(api: &ExtensionApi, ctx: &mut Context) -> VariantEnums {
         variant_ty_enumerators_rust: Vec::with_capacity(len),
     };
 
+    // When extracting variant, data moves Godot->Rust. Means `VariantArray` for `Array`.
+    let flow = FlowDirection::GodotToRust;
+
     // Note: NIL is not part of this iteration, it will be added manually.
     for builtin in api.builtins.iter() {
         let original_name = builtin.godot_original_name();
         let shout_case = builtin.godot_shout_name();
-        let rust_ty = conv::to_rust_type(original_name, None, ctx);
+        let rust_ty = conv::to_rust_type(original_name, None, Some(flow), ctx);
         let pascal_case = conv::to_pascal_case(original_name);
 
         result

--- a/godot-codegen/src/generator/functions_common.rs
+++ b/godot-codegen/src/generator/functions_common.rs
@@ -389,7 +389,7 @@ pub(crate) enum FnArgExpr {
     StoreInDefaultField,
 }
 
-/// How parameters are declared in a function signature.
+/// Whether parameters need to be declared in a special way (e.g. with `impl AsArg`).
 #[derive(Copy, Clone)]
 pub(crate) enum FnParamDecl {
     /// Public-facing, i.e. `T`, `&T`, `impl AsArg<T>`.
@@ -493,6 +493,11 @@ pub(crate) fn make_param_or_field_type(
         | RustTy::EngineArray { .. } => {
             let lft = lifetimes.next();
             special_ty = Some(quote! { RefArg<#lft, #ty> });
+
+            // Transform VariantArray -> AnyArray for outbound parameters.
+            // FIXME virtual params
+            // let ty = if matches!(decl, FnParamDecl::)
+            //     ty.try_to_any_array().unwrap_or_else(|| ty.clone());
 
             match decl {
                 FnParamDecl::FnPublic => quote! { & #ty },

--- a/godot-codegen/src/special_cases/codegen_special_cases.rs
+++ b/godot-codegen/src/special_cases/codegen_special_cases.rs
@@ -62,7 +62,9 @@ fn is_type_excluded(ty: &str, ctx: &mut Context) -> bool {
             RustTy::ExtenderReceiver { .. } => false,
         }
     }
-    is_rust_type_excluded(&conv::to_rust_type(ty, None, ctx))
+
+    // Both meta + flow direction are irrelevant here.
+    is_rust_type_excluded(&conv::to_rust_temporary_type(ty, ctx))
 }
 
 #[cfg(feature = "codegen-full")]

--- a/godot-core/src/builtin/callable.rs
+++ b/godot-core/src/builtin/callable.rs
@@ -11,7 +11,7 @@ use std::{fmt, ptr};
 use godot_ffi as sys;
 use sys::{ffi_methods, ExtVariantType, GodotFfi};
 
-use crate::builtin::{inner, GString, StringName, VarArray, Variant};
+use crate::builtin::{inner, AnyArray, GString, StringName, Variant};
 use crate::meta::{GodotType, ToGodot};
 use crate::obj::bounds::DynMemory;
 use crate::obj::{Bounds, Gd, GodotClass, InstanceId, Singleton};
@@ -381,14 +381,14 @@ impl Callable {
     /// - If called on an invalid Callable then no error is printed, and `NIL` is returned.
     ///
     /// _Godot equivalent: `callv`_
-    pub fn callv(&self, arguments: &VarArray) -> Variant {
+    pub fn callv(&self, arguments: &AnyArray) -> Variant {
         self.as_inner().callv(arguments)
     }
 
     /// Returns a copy of this Callable with one or more arguments bound, reading them from an array.
     ///
     /// _Godot equivalent: `bindv`_
-    pub fn bindv(&self, arguments: &VarArray) -> Self {
+    pub fn bindv(&self, arguments: &AnyArray) -> Self {
         self.as_inner().bindv(arguments)
     }
 

--- a/godot-core/src/builtin/collections/any_array.rs
+++ b/godot-core/src/builtin/collections/any_array.rs
@@ -1,0 +1,578 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use std::fmt;
+
+use godot_ffi as sys;
+use sys::{ffi_methods, GodotFfi};
+
+use crate::builtin::iter::ArrayFunctionalOps;
+use crate::builtin::*;
+use crate::meta;
+use crate::meta::error::{ArrayMismatch, ConvertError, ErrorKind};
+use crate::meta::{
+    ArrayElement, ElementType, FromGodot, GodotConvert, GodotFfiVariant, GodotType, ToGodot,
+};
+
+/// Covariant `Array` that can be either typed or untyped.
+///
+/// Unlike [`Array<T>`], which carries compile-time type information, `AnyArray` is a type-erased version of arrays.
+/// It can point to any `Array<T>`, for both typed and untyped arrays. See [`Array`: Element type](struct.Array.html#element-type) section.
+///
+/// # Covariance
+/// In GDScript, the subtyping relationship is modeled incorrectly for arrays:
+/// ```gdscript
+/// var typed: Array[int] = [1, 2, 3]
+/// var untyped: Array = typed   # Implicit "upcast" to Array[Variant].
+///
+/// untyped.append("hello")      # Not detected by GDScript parser (no-op at runtime).
+/// ```
+///
+/// godot-rust on the other hand introduces a new type `AnyArray`, which can store _any_ array, typed or untyped.
+/// `AnyArray` thus provides operations that are valid regardless of the type, e.g. `len()`, `clear()` or `shuffle()`.
+/// Methods, which can be more concrete on `Array<T>` by using `T` (e.g. `pick_random() -> Option<T>`), exist on both types.
+///
+/// `AnyArray` does not provide any operations where data flows _in_ to the array, such as `push()` or `insert()`.
+///
+/// # Conversions
+/// Engine APIs accept `&AnyArray` parameters. Due to [deref coercion], you can pass any `&Array<T>` implicitly, even for `T=Variant`.
+///
+/// If you need to upcast `Array<T>` _values_ to `AnyArray`, use [`Array::into_any()`].
+///
+/// [deref coercion]: struct.Array.html#deref-methods-AnyArray
+///
+/// You can explicitly downcast an `AnyArray` using [`try_into_typed()`][Self::try_into_typed] and
+/// [`try_into_untyped()`][Self::try_into_untyped].
+#[derive(PartialEq, PartialOrd)]
+#[repr(transparent)] // Guarantees same layout as VarArray, enabling Deref from Array<T>.
+pub struct AnyArray {
+    array: VarArray,
+}
+
+impl AnyArray {
+    pub(super) fn from_typed_or_untyped<T: ArrayElement>(array: Array<T>) -> Self {
+        // SAFETY: Array<Variant> is not accessed as such, but immediately wrapped in AnyArray.
+        let inner = unsafe { array.assume_type::<Variant>() };
+
+        Self { array: inner }
+    }
+
+    /// Creates an empty untyped `AnyArray`.
+    pub(crate) fn new_untyped() -> Self {
+        Self {
+            array: VarArray::default(),
+        }
+    }
+
+    fn from_opaque(opaque: sys::types::OpaqueArray) -> Self {
+        Self {
+            array: VarArray::from_opaque(opaque),
+        }
+    }
+
+    /// Returns the value at the specified index.
+    ///
+    /// This replaces the `Index` trait, which cannot be implemented for `Array`, as it stores variants and not references.
+    ///
+    /// # Panics
+    /// If `index` is out of bounds. To handle out-of-bounds access fallibly, use [`get()`](Self::get) instead.
+    pub fn at(&self, index: usize) -> Variant {
+        self.array.at(index)
+    }
+
+    /// Returns the value at the specified index, or `None` if the index is out-of-bounds.
+    ///
+    /// If you know the index is correct, use [`at()`](Self::at) instead.
+    pub fn get(&self, index: usize) -> Option<Variant> {
+        self.array.get(index)
+    }
+
+    /// Returns `true` if the array contains the given value. Equivalent of `has` in GDScript.
+    pub fn contains(&self, value: &Variant) -> bool {
+        self.array.contains(value)
+    }
+
+    /// Returns the number of times a value is in the array.
+    pub fn count(&self, value: &Variant) -> usize {
+        self.array.count(value)
+    }
+
+    /// Returns the number of elements in the array. Equivalent of `size()` in Godot.
+    ///
+    /// Retrieving the size incurs an FFI call. If you know the size hasn't changed, you may consider storing
+    /// it in a variable. For loops, prefer iterators.
+    #[doc(alias = "size")]
+    pub fn len(&self) -> usize {
+        to_usize(self.array.as_inner().size())
+    }
+
+    /// Returns `true` if the array is empty.
+    ///
+    /// Checking for emptiness incurs an FFI call. If you know the size hasn't changed, you may consider storing
+    /// it in a variable. For loops, prefer iterators.
+    pub fn is_empty(&self) -> bool {
+        self.array.as_inner().is_empty()
+    }
+
+    /// Returns a 32-bit integer hash value representing the array and its contents.
+    ///
+    /// Arrays with equal content will always produce identical hash values. However, the reverse is not true:
+    /// Different arrays can have identical hash values due to hash collisions.
+    pub fn hash_u32(&self) -> u32 {
+        self.array
+            .as_inner()
+            .hash()
+            .try_into()
+            .expect("Godot hashes are uint32_t")
+    }
+
+    /// Returns the first element in the array, or `None` if the array is empty.
+    #[doc(alias = "first")]
+    pub fn front(&self) -> Option<Variant> {
+        self.array.front()
+    }
+
+    /// Returns the last element in the array, or `None` if the array is empty.
+    #[doc(alias = "last")]
+    pub fn back(&self) -> Option<Variant> {
+        self.array.back()
+    }
+
+    /// Clears the array, removing all elements.
+    pub fn clear(&mut self) {
+        self.balanced_ensure_mutable();
+
+        // SAFETY: No new values are written to the array, we only remove values from the array.
+        unsafe { self.as_inner_mut() }.clear();
+    }
+
+    /// Removes and returns the last element of the array. Returns `None` if the array is empty.
+    ///
+    /// _Godot equivalent: `pop_back`_
+    #[doc(alias = "pop_back")]
+    pub fn pop(&mut self) -> Option<Variant> {
+        self.array.pop()
+    }
+
+    /// Removes and returns the first element of the array, in O(n). Returns `None` if the array is empty.
+    ///
+    /// Note: On large arrays, this method is much slower than `pop()` as it will move all the
+    /// array's elements. The larger the array, the slower `pop_front()` will be.
+    pub fn pop_front(&mut self) -> Option<Variant> {
+        self.array.pop_front()
+    }
+
+    /// ⚠️ Removes and returns the element at the specified index. Equivalent of `pop_at` in GDScript.
+    ///
+    /// On large arrays, this method is much slower than [`pop()`][Self::pop] as it will move all the array's
+    /// elements after the removed element. The larger the array, the slower `remove()` will be.
+    ///
+    /// # Panics
+    ///
+    /// If `index` is out of bounds.
+    #[doc(alias = "pop_at")]
+    pub fn remove(&mut self, index: usize) -> Variant {
+        self.array.remove(index)
+    }
+
+    /// Removes the first occurrence of a value from the array.
+    ///
+    /// If the value does not exist in the array, nothing happens. To remove an element by index, use [`remove()`][Self::remove] instead.
+    ///
+    /// On large arrays, this method is much slower than [`pop()`][Self::pop], as it will move all the array's
+    /// elements after the removed element.
+    pub fn erase(&mut self, value: &Variant) {
+        self.array.erase(value)
+    }
+
+    /// Shrinks the array down to `new_size`.
+    ///
+    /// This will only change the size of the array if `new_size` is smaller than the current size. Returns `true` if the array was shrunk.
+    ///
+    /// If you want to increase the size of the array, use [`resize`](Array::resize) instead.
+    #[doc(alias = "resize")]
+    pub fn shrink(&mut self, new_size: usize) -> bool {
+        self.balanced_ensure_mutable();
+
+        if new_size >= self.len() {
+            return false;
+        }
+
+        // SAFETY: Since `new_size` is less than the current size, we'll only be removing elements from the array.
+        unsafe { self.as_inner_mut() }.resize(to_i64(new_size));
+
+        true
+    }
+
+    /// Returns a shallow copy, sharing reference types (`Array`, `Dictionary`, `Object`...) with the original array.
+    ///
+    /// This operation retains the dynamic [element type][Self::element_type]: copying `Array<T>` will yield another `Array<T>`.
+    ///
+    /// To create a deep copy, use [`duplicate_deep()`][Self::duplicate_deep] instead.
+    /// To create a new reference to the same array data, use [`clone()`][Clone::clone].
+    pub fn duplicate_shallow(&self) -> AnyArray {
+        self.array.duplicate_shallow().into_any()
+    }
+
+    /// Returns a deep copy, duplicating nested `Array`/`Dictionary` elements but keeping `Object` elements shared.
+    ///
+    /// This operation retains the dynamic [element type][Self::element_type]: copying `Array<T>` will yield another `Array<T>`.
+    ///
+    /// To create a shallow copy, use [`duplicate_shallow()`][Self::duplicate_shallow] instead.
+    /// To create a new reference to the same array data, use [`clone()`][Clone::clone].
+    pub fn duplicate_deep(&self) -> Self {
+        self.array.duplicate_deep().into_any()
+    }
+
+    /// Returns a sub-range as a new array.
+    ///
+    /// Array elements are copied to the slice, but any reference types (such as `Array`,
+    /// `Dictionary` and `Object`) will still refer to the same value. To create a deep copy, use
+    /// [`subarray_deep()`][Self::subarray_deep] instead.
+    ///
+    /// _Godot equivalent: `slice`_
+    #[doc(alias = "slice")]
+    pub fn subarray_shallow(&self, range: impl meta::SignedRange, step: Option<i32>) -> Self {
+        let sliced = self.array.subarray_shallow(range, step);
+        sliced.into_any()
+    }
+
+    /// Returns a sub-range as a new `Array`.
+    ///
+    /// All nested arrays and dictionaries are duplicated and will not be shared with the original
+    /// array. Note that any `Object`-derived elements will still be shallow copied. To create a
+    /// shallow copy, use [`subarray_shallow()`][Self::subarray_shallow] instead.
+    ///
+    /// _Godot equivalent: `slice` with `deep: true`_
+    #[doc(alias = "slice")]
+    pub fn subarray_deep(&self, range: impl meta::SignedRange, step: Option<i32>) -> Self {
+        let sliced = self.array.subarray_deep(range, step);
+        sliced.into_any()
+    }
+
+    /// Returns an non-exclusive iterator over the elements of the `Array`.
+    ///
+    /// Takes the array by reference but returns its elements by value, since they are internally converted from `Variant`.
+    ///
+    /// Notice that it's possible to modify the `Array` through another reference while iterating over it. This will not result
+    /// in unsoundness or crashes, but will cause the iterator to behave in an unspecified way.
+    pub fn iter_shared(&self) -> Iter<'_> {
+        Iter {
+            inner: self.array.iter_shared(),
+        }
+    }
+
+    /// Returns the minimum value contained in the array if all elements are of comparable types.
+    ///
+    /// If the elements can't be compared or the array is empty, `None` is returned.
+    pub fn min(&self) -> Option<Variant> {
+        self.array.min()
+    }
+
+    /// Returns the maximum value contained in the array if all elements are of comparable types.
+    ///
+    /// If the elements can't be compared or the array is empty, `None` is returned.
+    pub fn max(&self) -> Option<Variant> {
+        self.array.max()
+    }
+
+    /// Returns a random element from the array, or `None` if it is empty.
+    pub fn pick_random(&self) -> Option<Variant> {
+        self.array.pick_random()
+    }
+
+    /// Searches the array for the first occurrence of a value and returns its index, or `None` if
+    /// not found. Starts searching at index `from`; pass `None` to search the entire array.
+    // TODO test if method works.
+    pub fn find(&self, value: &Variant, from: Option<usize>) -> Option<usize> {
+        self.array.find(value, from)
+    }
+
+    /// Searches the array backwards for the last occurrence of a value and returns its index, or
+    /// `None` if not found. Starts searching at index `from`; pass `None` to search the entire array.
+    // TODO test if method works.
+    pub fn rfind(&self, value: &Variant, from: Option<usize>) -> Option<usize> {
+        self.array.rfind(value, from)
+    }
+
+    /// Finds the index of an existing value in a sorted array using binary search.
+    /// Equivalent of `bsearch` in GDScript.
+    ///
+    /// If the value is not present in the array, returns the insertion index that
+    /// would maintain sorting order.
+    ///
+    /// Calling `bsearch` on an unsorted array results in unspecified behavior.
+    pub fn bsearch(&self, value: &Variant) -> usize {
+        self.array.bsearch(value)
+    }
+
+    /// Reverses the order of the elements in the array.
+    pub fn reverse(&mut self) {
+        self.balanced_ensure_mutable();
+
+        // SAFETY: We do not write any values that don't already exist in the array, so all values have the correct type.
+        unsafe { self.as_inner_mut() }.reverse();
+    }
+
+    /// Sorts the array.
+    ///
+    /// The sorting algorithm used is not [stable](https://en.wikipedia.org/wiki/Sorting_algorithm#Stability).
+    /// This means that values considered equal may have their order changed when using `sort_unstable()`. For most variant types,
+    /// this distinction should not matter though.
+    ///
+    /// See also: [`Array::sort_unstable_by()`][Array::sort_unstable_by], [`sort_unstable_custom()`][Self::sort_unstable_custom].
+    ///
+    /// _Godot equivalent: `Array.sort()`_
+    #[doc(alias = "sort")]
+    pub fn sort_unstable(&mut self) {
+        self.balanced_ensure_mutable();
+
+        // SAFETY: We do not write any values that don't already exist in the array, so all values have the correct type.
+        unsafe { self.as_inner_mut() }.sort();
+    }
+
+    /// Sorts the array, using type-unsafe `Callable` comparator.
+    ///
+    /// The callable expects two parameters `(lhs, rhs)` and should return a bool `lhs < rhs`.
+    ///
+    /// The sorting algorithm used is not [stable](https://en.wikipedia.org/wiki/Sorting_algorithm#Stability).
+    /// This means that values considered equal may have their order changed when using `sort_unstable_custom()`. For most variant types,
+    /// this distinction should not matter though.
+    ///
+    /// Type-safe alternatives: [`Array::sort_unstable_by()`][Array::sort_unstable_by], [`sort_unstable()`][Self::sort_unstable].
+    ///
+    /// _Godot equivalent: `Array.sort_custom()`_
+    #[doc(alias = "sort_custom")]
+    pub fn sort_unstable_custom(&mut self, func: &Callable) {
+        self.balanced_ensure_mutable();
+
+        // SAFETY: We do not write any values that don't already exist in the array, so all values have the correct type.
+        unsafe { self.as_inner_mut() }.sort_custom(func);
+    }
+
+    /// Shuffles the array such that the items will have a random order.
+    ///
+    /// This method uses the global random number generator common to methods such as `randi`. Call `randomize` to
+    /// ensure that a new seed will be used each time, if you want non-reproducible shuffling.
+    pub fn shuffle(&mut self) {
+        self.balanced_ensure_mutable();
+
+        // SAFETY: We do not write any values that don't already exist in the array, so all values have the correct type.
+        unsafe { self.as_inner_mut() }.shuffle();
+    }
+
+    /// Accesses Godot's functional-programming APIs (filter, map, reduce, etc.).
+    pub fn functional_ops(&self) -> ArrayFunctionalOps<'_, Variant> {
+        self.array.functional_ops()
+    }
+
+    /// Returns the runtime element type information for this array.
+    ///
+    /// The result is generally cached, so feel free to call this method repeatedly.
+    pub fn element_type(&self) -> ElementType {
+        ElementType::get_or_compute_cached(
+            &self.array.cached_element_type,
+            || self.array.as_inner().get_typed_builtin(),
+            || self.array.as_inner().get_typed_class_name(),
+            || self.array.as_inner().get_typed_script(),
+        )
+    }
+
+    /// Returns `true` if the array is read-only. See [`make_read_only`][crate::builtin::Array::make_read_only].
+    pub fn is_read_only(&self) -> bool {
+        self.array.as_inner().is_read_only()
+    }
+
+    /// Best-effort mutability check.
+    ///
+    /// # Panics
+    /// In debug builds, panics if the array is read-only.
+    fn balanced_ensure_mutable(&self) {
+        sys::balanced_assert!(
+            !self.is_read_only(),
+            "mutating operation on read-only array"
+        );
+    }
+
+    /// # Safety
+    /// Must not be used for any "input" operations, moving elements into the array -- this would break covariance.
+    #[doc(hidden)]
+    pub unsafe fn as_inner_mut(&self) -> inner::InnerArray<'_> {
+        inner::InnerArray::from_outer_typed(&self.array)
+    }
+
+    /// Converts to `Array<T>` if the runtime type matches.
+    ///
+    /// Returns `Err` if the array's dynamic type differs from `T`. Check [`element_type()`][Self::element_type]
+    /// before calling to determine what type the array actually holds.
+    pub fn try_into_typed<T: ArrayElement>(self) -> Result<Array<T>, ConvertError> {
+        let from_type = self.array.element_type();
+        let to_type = ElementType::of::<T>();
+
+        if from_type == to_type {
+            // SAFETY: just checked type.
+            let array = unsafe { self.array.assume_type::<T>() };
+            Ok(array)
+        } else {
+            let mismatch = ArrayMismatch {
+                expected: to_type,
+                actual: from_type,
+            };
+            Err(ConvertError::with_kind(ErrorKind::FromOutArray(mismatch)))
+        }
+    }
+
+    /// Converts to `VarArray` if the array is untyped.
+    ///
+    /// This is a shorthand for [`try_into_typed::<Variant>()`][Self::try_into_typed].
+    pub fn try_into_untyped(self) -> Result<VarArray, ConvertError> {
+        self.try_into_typed::<Variant>()
+    }
+
+    // If we add direct-conversion methods that panic, we can use meta::element_godot_type_name::<T>() to mention type in case of mismatch.
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// Traits
+
+// SAFETY: See VarArray.
+//
+// We cannot provide GodotConvert with Via=VarArray, because ToGodot::to_godot() would otherwise enable a safe conversion from AnyArray to
+// VarArray, which is not sound.
+unsafe impl GodotFfi for AnyArray {
+    const VARIANT_TYPE: sys::ExtVariantType = sys::ExtVariantType::Concrete(VariantType::ARRAY);
+
+    // No Default trait, thus manually defining this and ffi_methods!.
+    unsafe fn new_with_init(init_fn: impl FnOnce(sys::GDExtensionTypePtr)) -> Self {
+        let mut result = Self::new_untyped();
+        init_fn(result.sys_mut());
+        result
+    }
+
+    // Manually forwarding these, since no Opaque.
+    fn sys(&self) -> sys::GDExtensionConstTypePtr {
+        self.array.sys()
+    }
+
+    fn sys_mut(&mut self) -> sys::GDExtensionTypePtr {
+        self.array.sys_mut()
+    }
+
+    unsafe fn move_return_ptr(self, dst: sys::GDExtensionTypePtr, call_type: sys::PtrcallType) {
+        self.array.move_return_ptr(dst, call_type)
+    }
+
+    ffi_methods! { type sys::GDExtensionTypePtr = *mut Opaque;
+        fn new_from_sys;
+        fn new_with_uninit;
+        fn from_arg_ptr;
+    }
+}
+
+impl Clone for AnyArray {
+    fn clone(&self) -> Self {
+        // SAFETY: we don't want to check that static type (Variant) matches dynamic type (anything), because all types are valid in AnyArray.
+        let inner = unsafe { VarArray::clone_unchecked(&self.array) };
+
+        Self { array: inner }
+    }
+}
+
+// Only implement for untyped arrays; typed arrays cannot be nested in Godot.
+impl meta::sealed::Sealed for AnyArray {}
+
+impl ArrayElement for AnyArray {}
+
+impl GodotConvert for AnyArray {
+    type Via = Self;
+}
+
+impl ToGodot for AnyArray {
+    type Pass = meta::ByValue;
+
+    fn to_godot(&self) -> meta::ToArg<'_, Self::Via, Self::Pass> {
+        self.clone()
+    }
+
+    fn to_variant(&self) -> Variant {
+        self.ffi_to_variant()
+    }
+}
+
+impl FromGodot for AnyArray {
+    fn try_from_godot(via: Self::Via) -> Result<Self, ConvertError> {
+        Ok(via)
+    }
+}
+
+impl fmt::Debug for AnyArray {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.array.fmt(f)
+    }
+}
+
+impl fmt::Display for AnyArray {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.array.fmt(f)
+    }
+}
+
+impl GodotType for AnyArray {
+    type Ffi = Self;
+
+    type ToFfi<'f>
+        = meta::RefArg<'f, AnyArray>
+    where
+        Self: 'f;
+
+    fn to_ffi(&self) -> Self::ToFfi<'_> {
+        meta::RefArg::new(self)
+    }
+
+    fn into_ffi(self) -> Self::Ffi {
+        self
+    }
+
+    fn try_from_ffi(ffi: Self::Ffi) -> Result<Self, ConvertError> {
+        Ok(ffi)
+    }
+
+    fn godot_type_name() -> String {
+        VarArray::godot_type_name()
+    }
+}
+
+impl GodotFfiVariant for AnyArray {
+    fn ffi_to_variant(&self) -> Variant {
+        VarArray::ffi_to_variant(&self.array)
+    }
+
+    fn ffi_from_variant(variant: &Variant) -> Result<Self, ConvertError> {
+        // SAFETY: All element types are valid for AnyArray.
+        let result = unsafe { VarArray::unchecked_from_variant(variant) };
+        result.map(|inner| Self { array: inner })
+    }
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+
+/// An iterator over elements of an [`AnyArray`].
+pub struct Iter<'a> {
+    inner: super::array::Iter<'a, Variant>,
+}
+
+impl<'a> Iterator for Iter<'a> {
+    type Item = Variant;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+}

--- a/godot-core/src/builtin/collections/array_functional_ops.rs
+++ b/godot-core/src/builtin/collections/array_functional_ops.rs
@@ -72,7 +72,7 @@ impl<'a, T: ArrayElement> ArrayFunctionalOps<'a, T> {
     /// ```
     #[must_use]
     pub fn map(&self, callable: &Callable) -> VarArray {
-        // SAFETY: map() returns an untyped array.
+        // SAFETY: map() returns an untyped array (element type Variant).
         unsafe { self.array.as_inner().map(callable) }
     }
 
@@ -199,7 +199,8 @@ impl<'a, T: ArrayElement> ArrayFunctionalOps<'a, T> {
     ///
     /// If the value is not present in the array, returns the insertion index that would maintain sorting order.
     ///
-    /// Calling `bsearch_custom()` on an unsorted array results in unspecified behavior. Consider using [`Array::sort_unstable_custom()`]
+    /// Calling `bsearch_custom()` on an unsorted array results in unspecified behavior. Consider using
+    /// [`AnyArray::sort_unstable_custom()`][crate::builtin::AnyArray::sort_unstable_custom()] beforehand.
     /// to ensure the sorting order is compatible with your callable's ordering.
     pub fn bsearch_custom(&self, value: impl AsArg<T>, pred: &Callable) -> usize {
         meta::arg_into_ref!(value: T);

--- a/godot-core/src/builtin/collections/dictionary.rs
+++ b/godot-core/src/builtin/collections/dictionary.rs
@@ -303,7 +303,9 @@ impl VarDictionary {
     /// _Godot equivalent: `keys`_
     #[doc(alias = "keys")]
     pub fn keys_array(&self) -> VarArray {
-        self.as_inner().keys()
+        // SAFETY: keys() returns an untyped array with element type Variant.
+        let out_array = self.as_inner().keys();
+        unsafe { out_array.assume_type() }
     }
 
     /// Creates a new `Array` containing all the values currently in the dictionary.
@@ -311,7 +313,9 @@ impl VarDictionary {
     /// _Godot equivalent: `values`_
     #[doc(alias = "values")]
     pub fn values_array(&self) -> VarArray {
-        self.as_inner().values()
+        // SAFETY: values() returns an untyped array with element type Variant.
+        let out_array = self.as_inner().values();
+        unsafe { out_array.assume_type() }
     }
 
     /// Copies all keys and values from `other` into `self`.

--- a/godot-core/src/builtin/collections/mod.rs
+++ b/godot-core/src/builtin/collections/mod.rs
@@ -5,6 +5,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+mod any_array;
 mod array;
 mod array_functional_ops;
 mod dictionary;
@@ -14,6 +15,7 @@ mod packed_array_element;
 
 // Re-export in godot::builtin.
 pub(crate) mod containers {
+    pub use super::any_array::AnyArray;
     #[allow(deprecated)]
     pub use super::array::VariantArray;
     pub use super::array::{Array, VarArray};

--- a/godot-core/src/builtin/variant/mod.rs
+++ b/godot-core/src/builtin/variant/mod.rs
@@ -587,7 +587,7 @@ impl fmt::Debug for Variant {
         match self.get_type() {
             // Special case for arrays: avoids converting to VarArray (the only Array type in VariantDispatch),
             // which fails for typed arrays and causes a panic. This can cause an infinite loop with Debug, or abort.
-            // Can be removed if there's ever a "possibly typed" Array type (e.g. OutArray) in the library.
+            // Can be removed if there's ever a "possibly typed" Array type (e.g. AnyArray) in the library.
             VariantType::ARRAY => {
                 // SAFETY: type is checked, and only operation is print (out data flow, no covariant in access).
                 let array = unsafe { VarArray::from_variant_unchecked(self) };

--- a/godot-core/src/meta/element_type.rs
+++ b/godot-core/src/meta/element_type.rs
@@ -15,10 +15,12 @@ use crate::obj::{Gd, InstanceId};
 
 /// Dynamic type information of Godot arrays and dictionaries.
 ///
-/// Used by [`Array::element_type()`][crate::builtin::Array::element_type], dictionary key/value type methods,
-/// and other type introspection functionality.
+/// Used in the following APIs:
+/// - [`AnyArray::element_type()`][crate::builtin::AnyArray::element_type]
+/// - [`Dictionary::key_element_type()`][crate::builtin::Dictionary::key_element_type]
+/// - [`Dictionary::value_element_type()`][crate::builtin::Dictionary::value_element_type]
 ///
-/// While Rust's type parameters provide compile-time type information, this method can give additional RTTI (runtime type information).
+/// While Rust's type parameters provide compile-time type information, this method supplies additional RTTI (runtime type information).
 /// For example, `Array<Gd<RefCounted>>` may store classes or scripts derived from `RefCounted`.
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub enum ElementType {

--- a/itest/rust/src/builtin_tests/script/script_instance_tests.rs
+++ b/itest/rust/src/builtin_tests/script/script_instance_tests.rs
@@ -7,7 +7,7 @@
 
 use std::ffi::c_void;
 
-use godot::builtin::{Array, GString, StringName, VarDictionary, Variant, VariantType};
+use godot::builtin::{Array, GString, StringName, VarArray, VarDictionary, Variant, VariantType};
 use godot::classes::{
     IScriptExtension, IScriptLanguageExtension, Object, Script, ScriptExtension, ScriptLanguage,
     ScriptLanguageExtension,
@@ -329,7 +329,7 @@ impl IScriptLanguageExtension for TestScriptLanguage {
     #[cfg(since_api = "4.3")]
     fn preferred_file_name_casing(&self) -> godot::classes::script_language::ScriptNameCasing { unreachable!() }
     #[cfg(since_api = "4.4")]
-    fn reload_scripts(&mut self, _scripts: Array<Variant>, _soft: bool) { unreachable!() }
+    fn reload_scripts(&mut self, _scripts: VarArray, _soft: bool) { unreachable!() }
 }
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------

--- a/itest/rust/src/engine_tests/codegen_test.rs
+++ b/itest/rust/src/engine_tests/codegen_test.rs
@@ -9,6 +9,7 @@
 // Functionality is only tested on a superficial level (to make sure general FFI mechanisms work).
 
 use godot::builtin::inner::InnerColor;
+use godot::classes::rendering_server::PrimitiveType;
 use godot::classes::{FileAccess, HttpRequest, IHttpRequest, RenderingServer};
 use godot::prelude::*;
 
@@ -64,6 +65,32 @@ fn cfg_test() {
     // Makes sure that since_api and before_api are mutually exclusive.
     assert_ne!(cfg!(since_api = "4.3"), cfg!(before_api = "4.3"));
     assert_ne!(cfg!(since_api = "4.4"), cfg!(before_api = "4.4"));
+}
+
+// Test that generated builtin/class methods return untyped arrays, not any-arrays.
+fn __array_return_types() {
+    let c = Callable::invalid();
+    let _args: VarArray = c.get_bound_arguments();
+
+    let server = RenderingServer::singleton();
+    let _arrays: VarArray = server.mesh_surface_get_arrays(Rid::Invalid, 12);
+
+    // Nested arrays still work.
+    let _arrays: Array<VarArray> = server.mesh_surface_get_blend_shape_arrays(Rid::Invalid, 12);
+}
+
+// Test that generated builtin/class methods accept OutArray.
+fn __array_param_types() {
+    let mut server = RenderingServer::singleton();
+
+    let arrays: AnyArray = varray![].into_any();
+    server.mesh_add_surface_from_arrays(Rid::Invalid, PrimitiveType::LINES, &arrays);
+
+    let arrays: Array<GString> = array![];
+    server.mesh_add_surface_from_arrays(Rid::Invalid, PrimitiveType::LINES, &arrays);
+
+    let arrays: VarArray = varray![];
+    server.mesh_add_surface_from_arrays(Rid::Invalid, PrimitiveType::LINES, &arrays);
 }
 
 #[derive(GodotClass)]

--- a/itest/rust/src/object_tests/virtual_methods_test.rs
+++ b/itest/rust/src/object_tests/virtual_methods_test.rs
@@ -6,9 +6,9 @@
  */
 
 use godot::builtin::{
-    real, varray, vslice, Color, GString, PackedByteArray, PackedColorArray, PackedFloat32Array,
-    PackedInt32Array, PackedVector2Array, PackedVector3Array, RealConv, StringName, VarArray,
-    Variant, Vector2, Vector3,
+    real, varray, vslice, AnyArray, Color, GString, PackedByteArray, PackedColorArray,
+    PackedFloat32Array, PackedInt32Array, PackedVector2Array, PackedVector3Array, RealConv,
+    StringName, Variant, Vector2, Vector3,
 };
 use godot::classes::notify::NodeNotification;
 #[cfg(feature = "codegen-full")]
@@ -123,7 +123,7 @@ struct VirtualReturnTest {
 #[rustfmt::skip]
 #[godot_api]
 impl IPrimitiveMesh for VirtualReturnTest {
-    fn create_mesh_array(&self) -> VarArray {
+    fn create_mesh_array(&self) -> AnyArray {
         varray![
             PackedVector3Array::from_iter([Vector3::LEFT]),
             PackedVector3Array::from_iter([Vector3::LEFT]),
@@ -138,14 +138,14 @@ impl IPrimitiveMesh for VirtualReturnTest {
             PackedInt32Array::from_iter([0, 1, 2, 3]),
             PackedFloat32Array::from_iter([0.0, 1.0, 2.0, 3.0]),
             PackedInt32Array::from_iter([0]),
-        ]
+        ].into_any()
     }
 
     fn get_surface_count(&self) -> i32 { unreachable!() }
     fn surface_get_array_len(&self, _index: i32) -> i32 { unreachable!() }
     fn surface_get_array_index_len(&self, _index: i32) -> i32 { unreachable!() }
-    fn surface_get_arrays(&self, _index: i32) -> VarArray { unreachable!() }
-    fn surface_get_blend_shape_arrays(&self, _index: i32) -> godot::prelude::Array<VarArray> { unreachable!() }
+    fn surface_get_arrays(&self, _index: i32) -> AnyArray { unreachable!() }
+    fn surface_get_blend_shape_arrays(&self, _index: i32) -> godot::prelude::Array<AnyArray> { unreachable!() }
     fn surface_get_lods(&self, _index: i32) -> godot::prelude::VarDictionary { unreachable!() }
     fn surface_get_format(&self, _index: i32) -> u32 { unreachable!() }
     fn surface_get_primitive_type(&self, _index: i32) -> u32 { unreachable!() }


### PR DESCRIPTION
This is a second attempt at addressing the "`OutArray` problem" from #806.
Closes #727.

## The problem

In GDScript, the subtyping relationship is modeled incorrectly for arrays:
```gdscript
var typed: Array[int] = [1, 2, 3]
var untyped: Array = typed   # Implicit "upcast" to Array[Variant].
untyped.append("hello")      # Not detected by GDScript parser (no-op at runtime).
```


## The solution: `AnyArray`

This PR introduces a new type `AnyArray`, which can store _any_ array, typed or untyped.
`AnyArray` thus provides operations that are valid regardless of the type, e.g. `len()`, `clear()` or `shuffle()`.
Methods, which can be more concrete on `Array<T>` by using `T` (e.g. `pick_random() -> Option<T>`), exist on both types.

`AnyArray` does not provide any operations where data flows _in_ to the array, such as `push()` or `insert()`.


### Conversions
Deref coercion allows every `&Array<T>` to be treated as `&AnyArray`. This is true even for `T=Variant`.

To upcast `Array<T>` _values_ to `AnyArray`, use `Array::into_any()`. You can explicitly downcast an `AnyArray` using `try_into_typed()` and `try_into_untyped()`.


### Compatibility

I've put a lot of emphasis on keeping existing code working as much as possible:

* :heavy_check_mark: `engine_method(&variant_array)` keeps working due to `Deref` coercion.
* :heavy_check_mark: `let a: VariantArray = engine_method()` also keeps working. Methods return untyped arrays.
* :heavy_check_mark: `virtual_method(a: VariantArray)` signature stays as well.
* :x: `virtual_method() -> VariantArray` now returns `AnyArray`. This is breaking but now allows returning both typed and untyped arrays, using `into_any()` conversion.
* :heavy_check_mark: `array!`, `varray!` expressions keep working as-is and as expected.

New features:
* You can now pass _typed_ arrays (`Array<T>` for `T != Variant`) for engine parameters that previously only accepted `VariantArray`.
* You can now operate on element-agnostic arrays, without knowing whether they're typed or not. This opens some use cases that weren't previously possible.
* Some internal patterns can be represented more nicely, e.g. the `InnerArray` methods that return a possibly-typed array, and currently need a combination of generics + `unsafe` to be used correctly.

## Open points

### Naming

- `AnyArray` means "it can represent any array, either typed or untyped". The type erasure is somewhat expressed through "any". Not 100% happy with it though...
- I originally considered `OutArray` due to data only being allowed to flow _out_ of the array. Kotlin uses `out` variance. Important, this is **not** read-only. `clear()`, `shuffle()` etc. are perfectly fine, as they don't need to insert an unknown element type.
- Another option would be `CovArray` for "covariant array", but this gets a bit more towards type theory and may not be obvious at all.

### Complexity

It does introduce a new concept that doesn't exist in GDScript, but allows for more robust code when dealing with untyped or maybe-typed arrays. There are no more no-ops or panics when accidentally inserting into arrays.

An alternative would be to just allow `Array<T>` to deref to `VariantArray` (maybe needs separate type?) and thus model GDScript's (broken) relations. It would mean we have to introduce panics or no-ops when the `VariantArray` is in reality pointing to a typed array.