### PR TITLE
Rename untyped collections to `VarArray` + `VarDictionary`

### DIFF
--- a/godot-codegen/src/conv/type_conversions.rs
+++ b/godot-codegen/src/conv/type_conversions.rs
@@ -53,7 +53,8 @@ fn to_hardcoded_rust_ident(full_ty: &GodotTy) -> Option<&str> {
         // Others
         ("bool", None) => "bool",
         ("String", None) => "GString",
-        ("Array", None) => "VariantArray",
+        ("Array", None) => "VarArray",
+        ("Dictionary", None) => "VarDictionary",
 
         // Types needed for native structures mapping
         ("uint8_t", None) => "u8",
@@ -331,8 +332,8 @@ fn to_rust_expr_inner(expr: &str, ty: &RustTy, is_inner: bool) -> TokenStream {
         "true" => return quote! { true },
         "false" => return quote! { false },
         "[]" | "{}" if is_inner => return quote! {},
-        "[]" => return quote! { Array::new() }, // VariantArray or Array<T>
-        "{}" => return quote! { Dictionary::new() },
+        "[]" => return quote! { Array::new() }, // VarArray or Array<T>
+        "{}" => return quote! { VarDictionary::new() },
         "null" => {
             return match ty {
                 RustTy::BuiltinIdent { ty: ident, .. } if ident == "Variant" => {
@@ -614,7 +615,7 @@ fn gdscript_to_rust_expr() {
         // Special literals
         ("true",                                           None,               quote! { true }),
         ("false",                                          None,               quote! { false }),
-        ("{}",                                             None,               quote! { Dictionary::new() }),
+        ("{}",                                             None,               quote! { VarDictionary::new() }),
         ("[]",                                             None,               quote! { Array::new() }),
 
         ("null",                                           ty_variant,         quote! { Variant::nil() }),

--- a/godot-codegen/src/generator/builtins.rs
+++ b/godot-codegen/src/generator/builtins.rs
@@ -211,7 +211,7 @@ fn method_safety_doc(class_name: &TyName, method: &BuiltinMethod) -> Option<Toke
                ///
                /// In the current implementation, both cases will produce a panic rather than undefined behavior, but this should not be relied upon.
             });
-        } else if &method.return_value().type_tokens().to_string() == "VariantArray" {
+        } else if &method.return_value().type_tokens().to_string() == "VarArray" {
             return Some(quote! {
                 /// # Safety
                 ///

--- a/godot-core/src/builtin/callable.rs
+++ b/godot-core/src/builtin/callable.rs
@@ -11,7 +11,7 @@ use std::{fmt, ptr};
 use godot_ffi as sys;
 use sys::{ffi_methods, ExtVariantType, GodotFfi};
 
-use crate::builtin::{inner, GString, StringName, Variant, VariantArray};
+use crate::builtin::{inner, GString, StringName, VarArray, Variant};
 use crate::meta::{GodotType, ToGodot};
 use crate::obj::bounds::DynMemory;
 use crate::obj::{Bounds, Gd, GodotClass, InstanceId, Singleton};
@@ -381,14 +381,14 @@ impl Callable {
     /// - If called on an invalid Callable then no error is printed, and `NIL` is returned.
     ///
     /// _Godot equivalent: `callv`_
-    pub fn callv(&self, arguments: &VariantArray) -> Variant {
+    pub fn callv(&self, arguments: &VarArray) -> Variant {
         self.as_inner().callv(arguments)
     }
 
     /// Returns a copy of this Callable with one or more arguments bound, reading them from an array.
     ///
     /// _Godot equivalent: `bindv`_
-    pub fn bindv(&self, arguments: &VariantArray) -> Self {
+    pub fn bindv(&self, arguments: &VarArray) -> Self {
         self.as_inner().bindv(arguments)
     }
 

--- a/godot-core/src/builtin/collections/array_functional_ops.rs
+++ b/godot-core/src/builtin/collections/array_functional_ops.rs
@@ -5,7 +5,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use crate::builtin::{to_usize, Array, Callable, Variant, VariantArray};
+use crate::builtin::{to_usize, Array, Callable, VarArray, Variant};
 use crate::meta::{ArrayElement, AsArg};
 use crate::{meta, sys};
 
@@ -59,7 +59,7 @@ impl<'a, T: ArrayElement> ArrayFunctionalOps<'a, T> {
     /// **Rust alternatives:** [`Iterator::map()`].
     ///
     /// The callable has signature `fn(T) -> Variant`. Since the transformation can change the element type, this method returns
-    /// a `VariantArray` (untyped array).
+    /// a `VarArray` (untyped array).
     ///
     /// # Example
     /// ```no_run
@@ -71,7 +71,7 @@ impl<'a, T: ArrayElement> ArrayFunctionalOps<'a, T> {
     /// assert_eq!(rounded, varray![1, 2, 2]);
     /// ```
     #[must_use]
-    pub fn map(&self, callable: &Callable) -> VariantArray {
+    pub fn map(&self, callable: &Callable) -> VarArray {
         // SAFETY: map() returns an untyped array.
         unsafe { self.array.as_inner().map(callable) }
     }

--- a/godot-core/src/builtin/collections/mod.rs
+++ b/godot-core/src/builtin/collections/mod.rs
@@ -14,8 +14,12 @@ mod packed_array_element;
 
 // Re-export in godot::builtin.
 pub(crate) mod containers {
-    pub use super::array::{Array, VariantArray};
+    #[allow(deprecated)]
+    pub use super::array::VariantArray;
+    pub use super::array::{Array, VarArray};
+    #[allow(deprecated)]
     pub use super::dictionary::Dictionary;
+    pub use super::dictionary::VarDictionary;
     pub use super::packed_array::*;
 }
 

--- a/godot-core/src/builtin/signal.rs
+++ b/godot-core/src/builtin/signal.rs
@@ -10,7 +10,7 @@ use std::{fmt, ptr};
 use godot_ffi as sys;
 use sys::{ffi_methods, ExtVariantType, GodotFfi};
 
-use crate::builtin::{inner, Array, Callable, Dictionary, StringName, Variant};
+use crate::builtin::{inner, Array, Callable, StringName, VarDictionary, Variant};
 use crate::classes::object::ConnectFlags;
 use crate::classes::Object;
 use crate::global::Error;
@@ -117,7 +117,7 @@ impl Signal {
     ///  - `flags` is a combination of [`ConnectFlags`](ConnectFlags).
     ///
     /// _Godot equivalent: `get_connections`_
-    pub fn connections(&self) -> Array<Dictionary> {
+    pub fn connections(&self) -> Array<VarDictionary> {
         self.as_inner()
             .get_connections()
             .iter_shared()

--- a/godot-core/src/builtin/variant/impls.rs
+++ b/godot-core/src/builtin/variant/impls.rs
@@ -150,7 +150,7 @@ mod impls {
     impl_ffi_variant!(ref GString, string_to_variant, string_from_variant; String);
     impl_ffi_variant!(ref StringName, string_name_to_variant, string_name_from_variant);
     impl_ffi_variant!(ref NodePath, node_path_to_variant, node_path_from_variant);
-    impl_ffi_variant!(ref Dictionary, dictionary_to_variant, dictionary_from_variant);
+    impl_ffi_variant!(ref VarDictionary, dictionary_to_variant, dictionary_from_variant; Dictionary);
     impl_ffi_variant!(ref Signal, signal_to_variant, signal_from_variant);
     impl_ffi_variant!(ref Callable, callable_to_variant, callable_from_variant);
 }
@@ -192,7 +192,7 @@ impl_dynamic_send!(
 
 impl_dynamic_send!(
     !Send;
-    Variant, NodePath, GString, Dictionary, Callable, Signal,
+    Variant, NodePath, GString, VarDictionary, Callable, Signal,
     PackedByteArray, PackedInt32Array, PackedInt64Array, PackedFloat32Array, PackedFloat64Array, PackedStringArray,
     PackedVector2Array, PackedVector3Array, PackedColorArray
 );
@@ -261,8 +261,8 @@ const _: () = {
     const OBJECT: VariantType = variant_type::<Gd<Object>>();
     const CALLABLE: VariantType = variant_type::<Callable>();
     const SIGNAL: VariantType = variant_type::<Signal>();
-    const DICTIONARY: VariantType = variant_type::<Dictionary>();
-    const ARRAY: VariantType = variant_type::<VariantArray>();
+    const DICTIONARY: VariantType = variant_type::<VarDictionary>();
+    const ARRAY: VariantType = variant_type::<VarArray>();
     const PACKED_BYTE_ARRAY: VariantType = variant_type::<PackedByteArray>();
     const PACKED_INT32_ARRAY: VariantType = variant_type::<PackedInt32Array>();
     const PACKED_INT64_ARRAY: VariantType = variant_type::<PackedInt64Array>();

--- a/godot-core/src/builtin/variant/mod.rs
+++ b/godot-core/src/builtin/variant/mod.rs
@@ -11,7 +11,7 @@ use godot_ffi as sys;
 use sys::{ffi_methods, interface_fn, GodotFfi};
 
 use crate::builtin::{
-    GString, StringName, VariantArray, VariantDispatch, VariantOperator, VariantType,
+    GString, StringName, VarArray, VariantDispatch, VariantOperator, VariantType,
 };
 use crate::classes;
 use crate::meta::error::{ConvertError, FromVariantError};
@@ -585,12 +585,12 @@ impl fmt::Display for Variant {
 impl fmt::Debug for Variant {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.get_type() {
-            // Special case for arrays: avoids converting to VariantArray (the only Array type in VariantDispatch),
+            // Special case for arrays: avoids converting to VarArray (the only Array type in VariantDispatch),
             // which fails for typed arrays and causes a panic. This can cause an infinite loop with Debug, or abort.
             // Can be removed if there's ever a "possibly typed" Array type (e.g. OutArray) in the library.
             VariantType::ARRAY => {
                 // SAFETY: type is checked, and only operation is print (out data flow, no covariant in access).
-                let array = unsafe { VariantArray::from_variant_unchecked(self) };
+                let array = unsafe { VarArray::from_variant_unchecked(self) };
                 array.fmt(f)
             }
 

--- a/godot-core/src/meta/sealed.rs
+++ b/godot-core/src/meta/sealed.rs
@@ -44,7 +44,7 @@ impl Sealed for Rect2i {}
 impl Sealed for Signal {}
 impl Sealed for Transform2D {}
 impl Sealed for Transform3D {}
-impl Sealed for Dictionary {}
+impl Sealed for VarDictionary {}
 impl Sealed for bool {}
 impl Sealed for i64 {}
 impl Sealed for i32 {}

--- a/godot-core/src/meta/traits.rs
+++ b/godot-core/src/meta/traits.rs
@@ -165,7 +165,7 @@ pub trait GodotType: GodotConvert<Via = Self> + sealed::Sealed + Sized + 'static
 /// The types, for which this trait is implemented, overlap mostly with [`GodotType`].
 ///
 /// Notable differences are:
-/// - Only `VariantArray`, not `Array<T>` is allowed (typed arrays cannot be nested).
+/// - Only `VarArray`, not `Array<T>` is allowed (typed arrays cannot be nested).
 /// - `Option` is only supported for `Option<Gd<T>>`, but not e.g. `Option<i32>`.
 ///
 /// # Integer and float types

--- a/godot-core/src/registry/property/mod.rs
+++ b/godot-core/src/registry/property/mod.rs
@@ -607,7 +607,7 @@ mod export_impls {
     impl_property_by_godot_convert!(Color);
 
     // Dictionary: will need to be done manually once they become typed.
-    impl_property_by_godot_convert!(Dictionary);
+    impl_property_by_godot_convert!(VarDictionary);
     impl_property_by_godot_convert!(Variant);
 
     // Primitives

--- a/godot-core/src/registry/rpc_config.rs
+++ b/godot-core/src/registry/rpc_config.rs
@@ -5,7 +5,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use crate::builtin::{Dictionary, StringName};
+use crate::builtin::{StringName, VarDictionary};
 use crate::classes::multiplayer_api::RpcMode;
 use crate::classes::multiplayer_peer::TransferMode;
 use crate::classes::Node;
@@ -43,8 +43,8 @@ impl RpcConfig {
         node.rpc_config(method_name, &self.to_dictionary().to_variant());
     }
 
-    /// Returns a [`Dictionary`] populated with the values required for a call to [`Node::rpc_config()`].
-    pub fn to_dictionary(&self) -> Dictionary {
+    /// Returns an untyped `Dictionary` populated with the values required for a call to [`Node::rpc_config()`].
+    pub fn to_dictionary(&self) -> VarDictionary {
         vdict! {
             "rpc_mode": self.rpc_mode,
             "transfer_mode": self.transfer_mode,

--- a/godot/src/__docs.rs
+++ b/godot/src/__docs.rs
@@ -40,7 +40,7 @@
 //!    is entirely hidden from the API and you don't normally need to worry about it. <br><br>
 //!
 //! 3. **Reference-counted types**: [`Array`][crate::builtin::Array],
-//!    [`Dictionary`][crate::builtin::Dictionary], and [`Gd<T>`][crate::obj::Gd] where `T` inherits
+//!    [`VarDictionary`][crate::builtin::VarDictionary], and [`Gd<T>`][crate::obj::Gd] where `T` inherits
 //!    from [`RefCounted`][crate::classes::RefCounted].
 //!
 //!    These types may share their underlying data between multiple instances: changes to one

--- a/itest/rust/build.rs
+++ b/itest/rust/build.rs
@@ -188,11 +188,11 @@ fn collect_inputs() -> Vec<Input> {
         array![-7, 12, 40]
     );*/
 
-    push!(inputs; Array, VariantArray,
+    push!(inputs; Array, VarArray,
         [-7, "godot", false, Vector2i(-77, 88)],
         varray![-7, "godot", false, Vector2i::new(-77, 88)]);
 
-    pushs!(inputs; Dictionary, Dictionary,
+    pushs!(inputs; Dictionary, VarDictionary,
         r#"{"key": 83, -3: Vector2(1, 2), 0.03: true}"#,
         vdict! { "key": 83, (-3): Vector2::new(1.0, 2.0), 0.03: true },
         true, true, None

--- a/itest/rust/src/builtin_tests/containers/array_test.rs
+++ b/itest/rust/src/builtin_tests/containers/array_test.rs
@@ -12,12 +12,12 @@ use crate::framework::{assert_match, create_gdscript, expect_panic, itest};
 
 #[itest]
 fn array_default() {
-    assert_eq!(VariantArray::default().len(), 0);
+    assert_eq!(VarArray::default().len(), 0);
 }
 
 #[itest]
 fn array_new() {
-    assert_eq!(VariantArray::new().len(), 0);
+    assert_eq!(VarArray::new().len(), 0);
 }
 
 #[itest]
@@ -43,14 +43,14 @@ fn untyped_array_from_to_variant() {
     let array = varray![1, 2];
     let variant = array.to_variant();
     let result =
-        VariantArray::try_from_variant(&variant).expect("untyped array conversion should succeed");
+        VarArray::try_from_variant(&variant).expect("untyped array conversion should succeed");
     assert_eq!(result, array);
 }
 
 #[itest]
 fn array_from_packed_array() {
     let packed_array = PackedInt32Array::from(&[42]);
-    let mut array = VariantArray::from(&packed_array);
+    let mut array = VarArray::from(&packed_array);
 
     // This tests that the resulting array doesn't secretly have a runtime type assigned to it,
     // which is not reflected in our static type. It would make sense if it did, but Godot decided
@@ -226,7 +226,7 @@ fn array_first_last() {
     assert_eq!(array.front(), Some(1));
     assert_eq!(array.back(), Some(2));
 
-    let empty_array = VariantArray::new();
+    let empty_array = VarArray::new();
 
     assert_eq!(empty_array.front(), None);
     assert_eq!(empty_array.back(), None);
@@ -262,7 +262,7 @@ fn array_min_max() {
     assert_eq!(uncomparable_array.min(), None);
     assert_eq!(uncomparable_array.max(), None);
 
-    let empty_array = VariantArray::new();
+    let empty_array = VarArray::new();
 
     assert_eq!(empty_array.min(), None);
     assert_eq!(empty_array.max(), None);
@@ -270,7 +270,7 @@ fn array_min_max() {
 
 #[itest]
 fn array_pick_random() {
-    assert_eq!(VariantArray::new().pick_random(), None);
+    assert_eq!(VarArray::new().pick_random(), None);
     assert_eq!(array![1].pick_random(), Some(1));
 }
 
@@ -436,7 +436,7 @@ fn untyped_array_return_from_godot_func() {
 
 // Conditional, so we don't need Texture2DArray > ImageTextureLayered > TextureLayered > Texture in minimal codegen.
 // Potential alternatives (search for "typedarray::" in extension_api.json):
-// - ClassDB::class_get_signal_list() -> Array<Dictionary>
+// - ClassDB::class_get_signal_list() -> Array<VarDictionary>
 // - Compositor::set_compositor_effects( Array<Gd<Compositor>> )
 #[cfg(feature = "codegen-full-experimental")]
 #[itest]
@@ -476,7 +476,7 @@ fn typed_array_return_from_godot_func() {
 #[itest]
 fn typed_array_try_from_untyped() {
     let node = Node::new_alloc();
-    let array = VariantArray::from(&[node.clone().to_variant()]);
+    let array = VarArray::from(&[node.clone().to_variant()]);
 
     array
         .to_variant()
@@ -493,7 +493,7 @@ fn untyped_array_try_from_typed() {
 
     array
         .to_variant()
-        .try_to::<VariantArray>()
+        .try_to::<VarArray>()
         .expect_err("typed array should not coerce to untyped array");
 
     node.free();
@@ -607,10 +607,10 @@ fn __array_type_inference() {
 #[itest]
 fn array_element_type() {
     // Untyped array.
-    let untyped = VariantArray::new();
+    let untyped = VarArray::new();
     assert!(
         matches!(untyped.element_type(), ElementType::Untyped),
-        "expected untyped array for VariantArray"
+        "expected untyped array for VarArray"
     );
 
     let builtin_int = Array::<i64>::new();
@@ -674,7 +674,7 @@ func make_array() -> Array[CustomScriptForArrays]:
 // https://github.com/godot-rust/gdext/pull/1357
 #[itest]
 fn array_inner_type() {
-    let primary = Array::<Dictionary>::new();
+    let primary = Array::<VarDictionary>::new();
 
     let secondary = primary.duplicate_shallow();
     assert_eq!(secondary.element_type(), primary.element_type());

--- a/itest/rust/src/builtin_tests/containers/callable_test.rs
+++ b/itest/rust/src/builtin_tests/containers/callable_test.rs
@@ -9,8 +9,8 @@ use std::hash::Hasher;
 use std::sync::atomic::{AtomicU32, Ordering};
 
 use godot::builtin::{
-    array, varray, vdict, vslice, Array, Callable, Color, GString, NodePath, StringName, Variant,
-    VariantArray, Vector2,
+    array, varray, vdict, vslice, Array, Callable, Color, GString, NodePath, StringName, VarArray,
+    Variant, Vector2,
 };
 use godot::classes::{Node2D, Object, RefCounted};
 use godot::init::GdextBuild;
@@ -39,7 +39,7 @@ impl CallableTestObj {
     }
 
     #[func] // static
-    fn concat_array(a: i32, b: GString, c: Array<NodePath>, d: Gd<RefCounted>) -> VariantArray {
+    fn concat_array(a: i32, b: GString, c: Array<NodePath>, d: Gd<RefCounted>) -> VarArray {
         varray![a, b, c, d]
     }
 }
@@ -103,7 +103,7 @@ fn callable_object_method() {
 #[itest]
 #[cfg(since_api = "4.3")]
 fn callable_variant_method() {
-    // Dictionary
+    // VarDictionary
     let dict = vdict! { "one": 1, "value": 2 };
     let dict_get = Callable::from_variant_method(&dict.to_variant(), "get");
     assert_eq!(dict_get.call(vslice!["one"]), 1.to_variant());
@@ -158,7 +158,7 @@ fn callable_static() {
         RefCounted::new_gd()
     ]);
 
-    let result = result.to::<VariantArray>();
+    let result = result.to::<VarArray>();
     assert_eq!(result.len(), 4);
     assert_eq!(result.at(0), 10.to_variant());
 
@@ -188,7 +188,7 @@ fn callable_static_bind() {
 
     assert!(!bindv_result.is_nil());
 
-    let bind_result_data: VariantArray = bindv_result.to();
+    let bind_result_data: VarArray = bindv_result.to();
     assert_eq!(4, bind_result_data.len());
 }
 
@@ -373,7 +373,7 @@ pub mod custom_callable {
     use std::hash::Hash;
     use std::sync::{Arc, Mutex};
 
-    use godot::builtin::{Dictionary, RustCallable};
+    use godot::builtin::{RustCallable, VarDictionary};
     use godot::prelude::Signal;
     use godot::sys;
     use godot::sys::GdextBuild;
@@ -558,7 +558,7 @@ pub mod custom_callable {
         let a = Callable::from_custom(Adder::new_tracked(3, at.clone()));
         let b = Callable::from_custom(Adder::new_tracked(3, bt.clone()));
 
-        let mut dict = Dictionary::new();
+        let mut dict = VarDictionary::new();
 
         dict.set(a, "hello");
         assert_eq!(hash_count(&at), 1, "hash needed for a dict key");

--- a/itest/rust/src/builtin_tests/containers/dictionary_test.rs
+++ b/itest/rust/src/builtin_tests/containers/dictionary_test.rs
@@ -7,7 +7,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use godot::builtin::{varray, vdict, Dictionary, Variant, VariantType};
+use godot::builtin::{varray, vdict, VarDictionary, Variant, VariantType};
 use godot::classes::RefCounted;
 use godot::meta::{ElementType, FromGodot, ToGodot};
 use godot::obj::NewGd;
@@ -18,23 +18,23 @@ use crate::framework::{
 
 #[itest]
 fn dictionary_default() {
-    assert_eq!(Dictionary::default().len(), 0);
+    assert_eq!(VarDictionary::default().len(), 0);
 }
 
 #[itest]
 fn dictionary_new() {
-    assert_eq!(Dictionary::new().len(), 0);
+    assert_eq!(VarDictionary::new().len(), 0);
 }
 
 #[itest]
 fn dictionary_from_iterator() {
-    let dictionary = Dictionary::from_iter([("foo", 1), ("bar", 2)]);
+    let dictionary = VarDictionary::from_iter([("foo", 1), ("bar", 2)]);
 
     assert_eq!(dictionary.len(), 2);
     assert_eq!(dictionary.get("foo"), Some(1.to_variant()), "key = \"foo\"");
     assert_eq!(dictionary.get("bar"), Some(2.to_variant()), "key = \"bar\"");
 
-    let dictionary = Dictionary::from_iter([(1, "foo"), (2, "bar")]);
+    let dictionary = VarDictionary::from_iter([(1, "foo"), (2, "bar")]);
 
     assert_eq!(dictionary.len(), 2);
     assert_eq!(dictionary.get(1), Some("foo".to_variant()), "key = 1");
@@ -43,13 +43,13 @@ fn dictionary_from_iterator() {
 
 #[itest]
 fn dictionary_from() {
-    let dictionary = Dictionary::from(&HashMap::from([("foo", 1), ("bar", 2)]));
+    let dictionary = VarDictionary::from(&HashMap::from([("foo", 1), ("bar", 2)]));
 
     assert_eq!(dictionary.len(), 2);
     assert_eq!(dictionary.get("foo"), Some(1.to_variant()), "key = \"foo\"");
     assert_eq!(dictionary.get("bar"), Some(2.to_variant()), "key = \"bar\"");
 
-    let dictionary = Dictionary::from(&HashMap::from([(1, "foo"), (2, "bar")]));
+    let dictionary = VarDictionary::from(&HashMap::from([(1, "foo"), (2, "bar")]));
 
     assert_eq!(dictionary.len(), 2);
     assert_eq!(dictionary.get(1), Some("foo".to_variant()), "key = \"foo\"");
@@ -104,7 +104,7 @@ fn dictionary_clone() {
 
     #[allow(clippy::redundant_clone)]
     let clone = dictionary.clone();
-    Dictionary::from_variant(&clone.get("bar").unwrap()).set("final", 4);
+    VarDictionary::from_variant(&clone.get("bar").unwrap()).set("final", 4);
     assert_eq!(subdictionary.get("final"), Some(4.to_variant()));
 }
 
@@ -157,7 +157,7 @@ fn dictionary_duplicate_deep() {
         "bar": subdictionary.clone()
     };
     let clone = dictionary.duplicate_deep();
-    Dictionary::from_variant(&clone.get("bar").unwrap()).set("baz", 4);
+    VarDictionary::from_variant(&clone.get("bar").unwrap()).set("baz", 4);
     assert_eq!(
         subdictionary.get("baz"),
         Some(true.to_variant()),
@@ -177,7 +177,7 @@ fn dictionary_duplicate_shallow() {
     };
 
     let mut clone = dictionary.duplicate_shallow();
-    Dictionary::from_variant(&clone.get("bar").unwrap()).set("baz", 4);
+    VarDictionary::from_variant(&clone.get("bar").unwrap()).set("baz", 4);
     assert_eq!(
         subdictionary.get("baz"),
         Some(4.to_variant()),
@@ -464,7 +464,7 @@ fn dictionary_iter() {
 #[itest]
 fn dictionary_iter_size_hint() {
     // Test a completely empty dict.
-    let dictionary = Dictionary::new();
+    let dictionary = VarDictionary::new();
     let iter = dictionary.iter_shared();
     assert_eq!(iter.size_hint(), (0, Some(0)));
 
@@ -502,11 +502,11 @@ fn dictionary_iter_size_hint() {
 
 #[itest]
 fn dictionary_iter_equals_big() {
-    let dictionary: Dictionary = (0..1000).zip(0..1000).collect();
+    let dictionary: VarDictionary = (0..1000).zip(0..1000).collect();
     let map: HashMap<i64, i64> = (0..1000).zip(0..1000).collect();
     let collected_map: HashMap<i64, i64> = dictionary.iter_shared().typed::<i64, i64>().collect();
     assert_eq!(map, collected_map);
-    let collected_dictionary: Dictionary = collected_map.into_iter().collect();
+    let collected_dictionary: VarDictionary = collected_map.into_iter().collect();
     assert_eq!(dictionary, collected_dictionary);
 }
 
@@ -559,7 +559,7 @@ fn dictionary_iter_insert_after_completion() {
 
 #[itest]
 fn dictionary_iter_big() {
-    let dictionary: Dictionary = (0..256).zip(0..256).collect();
+    let dictionary: VarDictionary = (0..256).zip(0..256).collect();
     let mut dictionary2 = dictionary.clone();
     let mut iter = dictionary.iter_shared();
 
@@ -627,18 +627,19 @@ fn dictionary_iter_simultaneous() {
 #[itest]
 fn dictionary_iter_panics() {
     expect_panic(
-        "Dictionary containing integer keys should not be convertible to a HashSet<String>",
+        "VarDictionary containing integer keys should not be convertible to a HashSet<String>",
         || {
-            let dictionary: Dictionary = (0..10).zip(0..).collect();
+            let dictionary: VarDictionary = (0..10).zip(0..).collect();
             let _set: HashSet<String> = dictionary.keys_shared().typed::<String>().collect();
         },
     );
 
     expect_panic(
-        "Dictionary containing integer entries should not be convertible to a HashMap<String,String>",
+        "VarDictionary containing integer entries should not be convertible to a HashMap<String,String>",
         || {
-            let dictionary: Dictionary = (0..10).zip(0..).collect();
-            let _set: HashMap<String,String> = dictionary.iter_shared().typed::<String,String>().collect();
+            let dictionary: VarDictionary = (0..10).zip(0..).collect();
+            let _set: HashMap<String, String> =
+                dictionary.iter_shared().typed::<String, String>().collect();
         },
     );
 }
@@ -737,7 +738,7 @@ fn dictionary_iter_erase() {
 
 #[itest]
 fn dictionary_should_format_with_display() {
-    let d = Dictionary::new();
+    let d = VarDictionary::new();
     assert_eq!(format!("{d}"), "{  }");
 
     let d = vdict! {
@@ -754,14 +755,14 @@ fn dictionary_element_type() {
     use godot::meta::ElementType;
 
     // Test untyped dictionary
-    let untyped = Dictionary::new();
+    let untyped = VarDictionary::new();
     assert!(
         matches!(untyped.key_element_type(), ElementType::Untyped),
-        "expected untyped key for Dictionary"
+        "expected untyped key for VarDictionary"
     );
     assert!(
         matches!(untyped.value_element_type(), ElementType::Untyped),
-        "expected untyped value for Dictionary"
+        "expected untyped value for VarDictionary"
     );
 }
 
@@ -795,12 +796,16 @@ func variant_script_dict() -> Dictionary[Variant, CustomScriptForDictionaries]:
     // Test all 4 ElementType variants in alternating key/value pattern.
 
     // 1) Dictionary.
-    let dict = object.call("variant_variant_dict", &[]).to::<Dictionary>();
+    let dict = object
+        .call("variant_variant_dict", &[])
+        .to::<VarDictionary>();
     assert_match!(dict.key_element_type(), ElementType::Untyped);
     assert_match!(dict.value_element_type(), ElementType::Untyped);
 
     // 2) Dictionary[String, Variant].
-    let dict = object.call("builtin_variant_dict", &[]).to::<Dictionary>();
+    let dict = object
+        .call("builtin_variant_dict", &[])
+        .to::<VarDictionary>();
     assert_match!(
         dict.key_element_type(),
         ElementType::Builtin(VariantType::STRING)
@@ -808,7 +813,7 @@ func variant_script_dict() -> Dictionary[Variant, CustomScriptForDictionaries]:
     assert_match!(dict.value_element_type(), ElementType::Untyped);
 
     // 3) Dictionary[Color, RefCounted].
-    let dict = object.call("builtin_class_dict", &[]).to::<Dictionary>();
+    let dict = object.call("builtin_class_dict", &[]).to::<VarDictionary>();
     assert_match!(
         dict.key_element_type(),
         ElementType::Builtin(VariantType::COLOR)
@@ -817,7 +822,9 @@ func variant_script_dict() -> Dictionary[Variant, CustomScriptForDictionaries]:
     assert_eq!(class_name.to_string(), "RefCounted");
 
     // 4) Dictionary[Variant, CustomScriptForDictionaries].
-    let dict = object.call("variant_script_dict", &[]).to::<Dictionary>();
+    let dict = object
+        .call("variant_script_dict", &[])
+        .to::<VarDictionary>();
     assert_match!(dict.key_element_type(), ElementType::Untyped);
     assert_match!(dict.value_element_type(), ElementType::ScriptClass(script));
     let script = script.script().expect("script object should be alive");

--- a/itest/rust/src/builtin_tests/containers/variant_test.rs
+++ b/itest/rust/src/builtin_tests/containers/variant_test.rs
@@ -10,9 +10,9 @@ use std::fmt;
 use std::fmt::Display;
 
 use godot::builtin::{
-    array, varray, vdict, vslice, Array, Basis, Color, Dictionary, GString, NodePath,
-    PackedInt32Array, PackedStringArray, Projection, Quaternion, Signal, StringName, Transform2D,
-    Transform3D, Variant, VariantArray, VariantOperator, VariantType, Vector2, Vector2i, Vector3,
+    array, varray, vdict, vslice, Array, Basis, Color, GString, NodePath, PackedInt32Array,
+    PackedStringArray, Projection, Quaternion, Signal, StringName, Transform2D, Transform3D,
+    VarArray, VarDictionary, Variant, VariantOperator, VariantType, Vector2, Vector2i, Vector3,
     Vector3i,
 };
 use godot::classes::{Node, Node2D, Resource};
@@ -124,8 +124,8 @@ fn variant_relaxed_conversions() {
     convert_relaxed_fail::<i64>(Variant::nil());
     convert_relaxed_fail::<GString>(Variant::nil());
     convert_relaxed_fail::<Gd<Node>>(Variant::nil());
-    convert_relaxed_fail::<VariantArray>(Variant::nil());
-    convert_relaxed_fail::<Dictionary>(Variant::nil());
+    convert_relaxed_fail::<VarArray>(Variant::nil());
+    convert_relaxed_fail::<VarDictionary>(Variant::nil());
 
     // anything -> Variant
     convert_relaxed_to(123, Variant::from(123));
@@ -231,7 +231,7 @@ fn variant_bad_conversions() {
     assert_convert_err::<f32, i32>(1.23);
     assert_convert_err::<i32, bool>(10);
     assert_convert_err::<_, String>(false);
-    assert_convert_err::<_, StringName>(VariantArray::default());
+    assert_convert_err::<_, StringName>(VarArray::default());
 
     // Special case: ToVariant is not yet fallible, so u64 -> i64 conversion error panics.
     expect_panic("u64 -> i64 conversion error", || {
@@ -239,13 +239,13 @@ fn variant_bad_conversions() {
     });
 
     //assert_eq!(
-    //    Dictionary::default().to_variant().try_to::<Array>(),
+    //    VarDictionary::default().to_variant().try_to::<Array>(),
     //    Err(VariantConversionError)
     //);
     Variant::nil()
         .to_variant()
-        .try_to::<Dictionary>()
-        .expect_err("`nil` should not convert to `Dictionary`");
+        .try_to::<VarDictionary>()
+        .expect_err("`nil` should not convert to `VarDictionary`");
 }
 
 #[itest]
@@ -337,9 +337,9 @@ fn variant_array_to_untyped_conversions() {
     // Even empty arrays are typed and cannot be converted.
     let node_array: Array<Gd<Node>> = array![];
     let node_variant = node_array.to_variant();
-    let untyped_array = node_variant.try_to::<VariantArray>();
+    let untyped_array = node_variant.try_to::<VarArray>();
 
-    let err = untyped_array.expect_err("Array<Gd<Node>> -> VariantArray conversion should fail");
+    let err = untyped_array.expect_err("Array<Gd<Node>> -> VarArray conversion should fail");
     assert_eq!(
         err.to_string(),
         "expected array of type Untyped, got Class(Node): []"
@@ -350,11 +350,11 @@ fn variant_array_to_untyped_conversions() {
 #[itest]
 fn variant_array_from_untyped_conversions() {
     // Even empty arrays are typed and cannot be converted.
-    let untyped_array: VariantArray = varray![1, 2];
+    let untyped_array: VarArray = varray![1, 2];
     let untyped_variant = untyped_array.to_variant();
     let int_array = untyped_variant.try_to::<Array<i64>>();
 
-    let err = int_array.expect_err("VariantArray -> Array<i64> conversion should fail");
+    let err = int_array.expect_err("VarArray -> Array<i64> conversion should fail");
     assert_eq!(
         err.to_string(),
         "expected array of type Builtin(INT), got Untyped: [1, 2]"
@@ -691,7 +691,7 @@ fn variant_booleanize() {
     assert!(varray![""].to_variant().booleanize());
     assert!(vdict! { "Key": 50 }.to_variant().booleanize());
 
-    assert!(!Dictionary::new().to_variant().booleanize());
+    assert!(!VarDictionary::new().to_variant().booleanize());
     assert!(!varray![].to_variant().booleanize());
     assert!(!0.to_variant().booleanize());
     assert!(!Variant::nil().booleanize());

--- a/itest/rust/src/builtin_tests/convert_test.rs
+++ b/itest/rust/src/builtin_tests/convert_test.rs
@@ -6,7 +6,7 @@
  */
 
 use godot::builtin::{
-    array, vdict, Array, Dictionary, GString, NodePath, StringName, Variant, VariantArray, Vector2,
+    array, vdict, Array, GString, NodePath, StringName, VarArray, VarDictionary, Variant, Vector2,
     Vector2Axis,
 };
 use godot::classes::{Node, Resource};
@@ -27,18 +27,18 @@ fn error_has_value_and_no_cause() {
             "`nil` -> `i64`",
         ),
         (
-            VariantArray::new()
+            VarArray::new()
                 .to_variant()
                 .try_to::<GString>()
                 .unwrap_err(),
-            "`VariantArray` -> `GString`",
+            "`VarArray` -> `GString`",
         ),
         (
-            VariantArray::new()
+            VarArray::new()
                 .to_variant()
                 .try_to::<Array<i64>>()
                 .unwrap_err(),
-            "`VariantArray` -> `Array<i64>`",
+            "`VarArray` -> `Array<i64>`",
         ),
         (
             Array::<Gd<Node>>::new()
@@ -104,7 +104,7 @@ impl ConvertedStruct {
 }
 
 impl GodotConvert for ConvertedStruct {
-    type Via = Dictionary;
+    type Via = VarDictionary;
 }
 
 impl ToGodot for ConvertedStruct {

--- a/itest/rust/src/builtin_tests/script/script_instance_tests.rs
+++ b/itest/rust/src/builtin_tests/script/script_instance_tests.rs
@@ -7,7 +7,7 @@
 
 use std::ffi::c_void;
 
-use godot::builtin::{Array, Dictionary, GString, StringName, Variant, VariantType};
+use godot::builtin::{Array, GString, StringName, VarDictionary, Variant, VariantType};
 use godot::classes::{
     IScriptExtension, IScriptLanguageExtension, Object, Script, ScriptExtension, ScriptLanguage,
     ScriptLanguageExtension,
@@ -60,21 +60,21 @@ impl IScriptExtension for TestScript {
     fn get_source_code(&self) -> GString { unreachable!() }
     fn set_source_code(&mut self, _code: GString) { unreachable!() }
     fn reload(&mut self, _keep_state: bool) -> Error { unreachable!() }
-    fn get_documentation(&self) -> Array<Dictionary> { unreachable!() }
+    fn get_documentation(&self) -> Array<VarDictionary> { unreachable!() }
     fn has_method(&self, _method: StringName) -> bool { unreachable!() }
     fn has_static_method(&self, _method: StringName) -> bool { unreachable!() }
-    fn get_method_info(&self, _method: StringName) -> Dictionary { unreachable!() }
+    fn get_method_info(&self, _method: StringName) -> VarDictionary { unreachable!() }
     fn is_tool(&self) -> bool { unreachable!() }
     fn is_valid(&self) -> bool { unreachable!() }
     fn has_script_signal(&self, _signall: StringName) -> bool { unreachable!() }
-    fn get_script_signal_list(&self) -> Array<Dictionary> { unreachable!() }
+    fn get_script_signal_list(&self) -> Array<VarDictionary> { unreachable!() }
     fn has_property_default_value(&self, _property: StringName) -> bool { unreachable!() }
     fn get_property_default_value(&self, _property: StringName) -> Variant { unreachable!() }
     fn update_exports(&mut self) { unreachable!() }
-    fn get_script_method_list(&self) -> Array<Dictionary> { unreachable!() }
-    fn get_script_property_list(&self) -> Array<Dictionary> { unreachable!() }
+    fn get_script_method_list(&self) -> Array<VarDictionary> { unreachable!() }
+    fn get_script_property_list(&self) -> Array<VarDictionary> { unreachable!() }
     fn get_member_line(&self, _member: StringName) -> i32 { unreachable!() }
-    fn get_constants(&self) -> Dictionary { unreachable!() }
+    fn get_constants(&self) -> VarDictionary { unreachable!() }
     fn get_members(&self) -> Array<StringName> { unreachable!() }
     fn is_placeholder_fallback_enabled(&self) -> bool { unreachable!() }
     fn get_rpc_config(&self) -> Variant { unreachable!() }
@@ -276,9 +276,9 @@ impl IScriptLanguageExtension for TestScriptLanguage {
     fn get_comment_delimiters(&self) -> godot::prelude::PackedStringArray { unreachable!() }
     fn get_string_delimiters(&self) -> godot::prelude::PackedStringArray { unreachable!() }
     fn make_template(&self, _template: GString, _class_name: GString, _base_class_name: GString) -> Option<Gd<Script>> { unreachable!() }
-    fn get_built_in_templates(&self, _object: StringName) -> Array<Dictionary> { unreachable!() }
+    fn get_built_in_templates(&self, _object: StringName) -> Array<VarDictionary> { unreachable!() }
     fn is_using_templates(&mut self) -> bool { unreachable!() }
-    fn validate(&self, _script: GString, _path: GString, _validate_functions: bool, _validate_errors: bool, _validate_warnings: bool, _validate_safe_lines: bool) -> Dictionary { unreachable!() }
+    fn validate(&self, _script: GString, _path: GString, _validate_functions: bool, _validate_errors: bool, _validate_warnings: bool, _validate_safe_lines: bool) -> VarDictionary { unreachable!() }
     fn validate_path(&self, _path: GString) -> GString { unreachable!() }
     fn create_script(&self) -> Option<Gd<Object>> { unreachable!() }
     fn has_named_classes(&self) -> bool { unreachable!() }
@@ -289,8 +289,8 @@ impl IScriptLanguageExtension for TestScriptLanguage {
     fn make_function(&self, _class_name: GString, _function_name: GString, _function_args: godot::prelude::PackedStringArray) -> GString { unreachable!() }
     fn open_in_external_editor(&mut self, _script: Option<Gd<Script>>, _line: i32, _column: i32) -> godot::global::Error { unreachable!() }
     fn overrides_external_editor(&mut self) -> bool { unreachable!() }
-    fn complete_code(&self, _code: GString,_pathh: GString, _ownerer: Option<Gd<Object>>) -> Dictionary { unreachable!() }
-    fn lookup_code(&self, _code: GString, _symbol: GString, _path: GString, _owner: Option<Gd<Object>>) -> Dictionary { unreachable!() }
+    fn complete_code(&self, _code: GString,_pathh: GString, _ownerer: Option<Gd<Object>>) -> VarDictionary { unreachable!() }
+    fn lookup_code(&self, _code: GString, _symbol: GString, _path: GString, _owner: Option<Gd<Object>>) -> VarDictionary { unreachable!() }
     fn auto_indent_code(&self, _code: GString, _from_linee: i32, _to_line: i32) -> GString { unreachable!() }
     fn add_global_constant(&mut self, _name: StringName,_valuee: Variant) { unreachable!() }
     fn add_named_global_constant(&mut self, _name: StringName,_valuee: Variant) { unreachable!() }
@@ -301,25 +301,25 @@ impl IScriptLanguageExtension for TestScriptLanguage {
     fn debug_get_stack_level_count(&self) -> i32 { unreachable!() }
     fn debug_get_stack_level_line(&self, _level: i32) -> i32 { unreachable!() }
     fn debug_get_stack_level_function(&self, _level: i32) -> GString { unreachable!() }
-    fn debug_get_stack_level_locals(&mut self, _level: i32, _max_subitems: i32, _max_depth: i32) -> Dictionary { unreachable!() }
-    fn debug_get_stack_level_members(&mut self, _level: i32, _max_subitems: i32, _max_depth: i32) -> Dictionary { unreachable!() }
+    fn debug_get_stack_level_locals(&mut self, _level: i32, _max_subitems: i32, _max_depth: i32) -> VarDictionary { unreachable!() }
+    fn debug_get_stack_level_members(&mut self, _level: i32, _max_subitems: i32, _max_depth: i32) -> VarDictionary { unreachable!() }
     unsafe fn debug_get_stack_level_instance_rawptr(&mut self, _level: i32) -> *mut c_void { unreachable!() }
-    fn debug_get_globals(&mut self, _max_subitems: i32,_max_depthh: i32) -> Dictionary { unreachable!() }
+    fn debug_get_globals(&mut self, _max_subitems: i32,_max_depthh: i32) -> VarDictionary { unreachable!() }
     fn debug_parse_stack_level_expression(&mut self, _level: i32, _expression: GString, _max_subitems: i32, _max_depth: i32) -> GString { unreachable!() }
-    fn debug_get_current_stack_info(&mut self) -> Array<Dictionary> { unreachable!() }
+    fn debug_get_current_stack_info(&mut self) -> Array<VarDictionary> { unreachable!() }
     fn reload_all_scripts(&mut self) { unreachable!() }
     fn reload_tool_script(&mut self, _script: Option<Gd<Script>>,_soft_reloadd: bool) { unreachable!() }
     fn get_recognized_extensions(&self) -> godot::prelude::PackedStringArray { unreachable!() }
-    fn get_public_functions(&self) -> Array<Dictionary> { unreachable!() }
-    fn get_public_constants(&self) -> Dictionary { unreachable!() }
-    fn get_public_annotations(&self) -> Array<Dictionary> { unreachable!() }
+    fn get_public_functions(&self) -> Array<VarDictionary> { unreachable!() }
+    fn get_public_constants(&self) -> VarDictionary { unreachable!() }
+    fn get_public_annotations(&self) -> Array<VarDictionary> { unreachable!() }
     fn profiling_start(&mut self) { unreachable!() }
     fn profiling_stop(&mut self) { unreachable!() }
     unsafe fn profiling_get_accumulated_data_rawptr(&mut self, _info_array: *mut godot::classes::native::ScriptLanguageExtensionProfilingInfo, _info_max: i32) -> i32 { unreachable!() }
     unsafe fn profiling_get_frame_data_rawptr(&mut self, _info_array: *mut godot::classes::native::ScriptLanguageExtensionProfilingInfo, _info_max: i32) -> i32 { unreachable!() }
     fn frame(&mut self) { unreachable!() }
     fn handles_global_class_type(&self, _type_: GString) -> bool { unreachable!() }
-    fn get_global_class_name(&self, _path: GString) -> Dictionary { unreachable!() }
+    fn get_global_class_name(&self, _path: GString) -> VarDictionary { unreachable!() }
     #[cfg(since_api = "4.3")]
     fn profiling_set_save_native_calls(&mut self, _enable: bool) { unreachable!() }
     #[cfg(since_api = "4.3")]

--- a/itest/rust/src/engine_tests/native_st_niche_pointer_test.rs
+++ b/itest/rust/src/engine_tests/native_st_niche_pointer_test.rs
@@ -11,7 +11,7 @@
 
 use std::ptr;
 
-use godot::builtin::{vslice, Dictionary, Rect2, Rid};
+use godot::builtin::{vslice, Rect2, Rid, VarDictionary};
 use godot::classes::native::{CaretInfo, Glyph, ObjectId, PhysicsServer2DExtensionShapeResult};
 use godot::classes::text_server::Direction;
 use godot::classes::{IRefCounted, Node3D, RefCounted};
@@ -42,7 +42,7 @@ impl IRefCounted for NativeStructTests {
 #[godot_api]
 impl NativeStructTests {
     #[func]
-    fn pass_native_struct(&self, caret_info: *const CaretInfo) -> Dictionary {
+    fn pass_native_struct(&self, caret_info: *const CaretInfo) -> VarDictionary {
         let CaretInfo {
             leading_caret,
             trailing_caret,
@@ -50,7 +50,7 @@ impl NativeStructTests {
             trailing_direction,
         } = unsafe { &*caret_info };
 
-        let mut result = Dictionary::new();
+        let mut result = VarDictionary::new();
 
         result.set("leading_caret", *leading_caret);
         result.set("trailing_caret", *trailing_caret);
@@ -79,7 +79,7 @@ fn native_structure_parameter() {
 
     let ptr = ptr::addr_of!(caret);
     let mut object = NativeStructTests::new_gd();
-    let result: Dictionary = object.call("pass_native_struct", vslice![ptr]).to();
+    let result: VarDictionary = object.call("pass_native_struct", vslice![ptr]).to();
 
     assert_eq!(
         result.at("leading_caret").to::<Rect2>(),

--- a/itest/rust/src/framework/runner.rs
+++ b/itest/rust/src/framework/runner.rs
@@ -7,7 +7,7 @@
 
 use std::time::{Duration, Instant};
 
-use godot::builtin::{vslice, Array, Callable, GString, Variant, VariantArray};
+use godot::builtin::{vslice, Array, Callable, GString, VarArray, Variant};
 use godot::classes::{Engine, Node, Os};
 use godot::global::godot_error;
 use godot::obj::{Gd, Singleton};
@@ -40,11 +40,11 @@ impl IntegrationTests {
     #[func]
     fn run_all_tests(
         &mut self,
-        gdscript_tests: VariantArray,
+        gdscript_tests: VarArray,
         gdscript_file_count: i64,
         allow_focus: bool,
         scene_tree: Gd<Node>,
-        filters: VariantArray,
+        filters: VarArray,
         property_tests: Gd<Node>,
         on_finished: Callable,
     ) {
@@ -247,7 +247,7 @@ impl IntegrationTests {
         });
     }
 
-    fn run_gdscript_tests(&mut self, tests: VariantArray) -> Duration {
+    fn run_gdscript_tests(&mut self, tests: VarArray) -> Duration {
         let mut last_file = None;
         let mut extra_duration = Duration::new(0, 0);
 

--- a/itest/rust/src/object_tests/get_property_list_test.rs
+++ b/itest/rust/src/object_tests/get_property_list_test.rs
@@ -7,7 +7,7 @@
 
 use std::collections::HashMap;
 
-use godot::builtin::{Dictionary, GString, StringName, VariantType, Vector2, Vector3};
+use godot::builtin::{GString, StringName, VarDictionary, VariantType, Vector2, Vector3};
 use godot::classes::{IObject, Node};
 use godot::global::{PropertyHint, PropertyUsageFlags};
 use godot::meta::PropertyInfo;
@@ -34,7 +34,7 @@ impl IObject for GetPropertyListTest {
     }
 }
 
-fn property_dict_eq_property_info(dict: &Dictionary, info: &PropertyInfo) -> bool {
+fn property_dict_eq_property_info(dict: &VarDictionary, info: &PropertyInfo) -> bool {
     dict.get("name").unwrap().to::<GString>().to_string() == info.property_name.to_string()
         && dict.get("class_name").unwrap().to::<StringName>() == info.class_id.to_string_name()
         && dict.get("type").unwrap().to::<VariantType>() == info.variant_type

--- a/itest/rust/src/object_tests/property_template_test.rs
+++ b/itest/rust/src/object_tests/property_template_test.rs
@@ -26,7 +26,7 @@ fn property_template_test(ctx: &TestContext) {
 
     // Accumulate errors so we can catch all of them in one go.
     let mut errors: Vec<String> = Vec::new();
-    let mut properties: HashMap<String, Dictionary> = HashMap::new();
+    let mut properties: HashMap<String, VarDictionary> = HashMap::new();
 
     for property in rust_properties.get_property_list().iter_shared() {
         let name = property.get("name").unwrap().to::<String>();

--- a/itest/rust/src/object_tests/property_test.rs
+++ b/itest/rust/src/object_tests/property_test.rs
@@ -6,7 +6,7 @@
  */
 
 use godot::builtin::{
-    vdict, vslice, Color, Dictionary, GString, PackedInt32Array, Variant, VariantType,
+    vdict, vslice, Color, GString, PackedInt32Array, VarDictionary, Variant, VariantType,
 };
 use godot::classes::{INode, IRefCounted, Node, Object, RefCounted, Resource, Texture};
 use godot::global::{PropertyHint, PropertyUsageFlags};
@@ -236,7 +236,7 @@ struct NotExportable {
 }
 
 impl GodotConvert for NotExportable {
-    type Via = Dictionary;
+    type Via = VarDictionary;
 }
 
 impl Var for NotExportable {
@@ -556,7 +556,7 @@ fn override_export() {
     check_property(&property, "usage", PropertyUsageFlags::GROUP);
 }
 
-fn check_property(property: &Dictionary, key: &str, expected: impl ToGodot) {
+fn check_property(property: &VarDictionary, key: &str, expected: impl ToGodot) {
     assert_eq!(property.get_or_nil(key), expected.to_variant());
 }
 

--- a/itest/rust/src/object_tests/validate_property_test.rs
+++ b/itest/rust/src/object_tests/validate_property_test.rs
@@ -5,7 +5,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use godot::builtin::{Array, Dictionary, GString, StringName};
+use godot::builtin::{Array, GString, StringName, VarDictionary};
 use godot::classes::IObject;
 use godot::global::{PropertyHint, PropertyUsageFlags};
 use godot::meta::PropertyInfo;
@@ -39,7 +39,7 @@ impl IObject for ValidatePropertyTest {
 #[itest]
 fn validate_property_test() {
     let obj = ValidatePropertyTest::new_alloc();
-    let properties: Array<Dictionary> = obj.get_property_list();
+    let properties: Array<VarDictionary> = obj.get_property_list();
 
     let property = properties
         .iter_shared()

--- a/itest/rust/src/object_tests/virtual_methods_test.rs
+++ b/itest/rust/src/object_tests/virtual_methods_test.rs
@@ -7,8 +7,8 @@
 
 use godot::builtin::{
     real, varray, vslice, Color, GString, PackedByteArray, PackedColorArray, PackedFloat32Array,
-    PackedInt32Array, PackedVector2Array, PackedVector3Array, RealConv, StringName, Variant,
-    VariantArray, Vector2, Vector3,
+    PackedInt32Array, PackedVector2Array, PackedVector3Array, RealConv, StringName, VarArray,
+    Variant, Vector2, Vector3,
 };
 use godot::classes::notify::NodeNotification;
 #[cfg(feature = "codegen-full")]
@@ -123,7 +123,7 @@ struct VirtualReturnTest {
 #[rustfmt::skip]
 #[godot_api]
 impl IPrimitiveMesh for VirtualReturnTest {
-    fn create_mesh_array(&self) -> VariantArray {
+    fn create_mesh_array(&self) -> VarArray {
         varray![
             PackedVector3Array::from_iter([Vector3::LEFT]),
             PackedVector3Array::from_iter([Vector3::LEFT]),
@@ -144,9 +144,9 @@ impl IPrimitiveMesh for VirtualReturnTest {
     fn get_surface_count(&self) -> i32 { unreachable!() }
     fn surface_get_array_len(&self, _index: i32) -> i32 { unreachable!() }
     fn surface_get_array_index_len(&self, _index: i32) -> i32 { unreachable!() }
-    fn surface_get_arrays(&self, _index: i32) -> VariantArray { unreachable!() }
-    fn surface_get_blend_shape_arrays(&self, _index: i32) -> godot::prelude::Array<VariantArray> { unreachable!() }
-    fn surface_get_lods(&self, _index: i32) -> godot::prelude::Dictionary { unreachable!() }
+    fn surface_get_arrays(&self, _index: i32) -> VarArray { unreachable!() }
+    fn surface_get_blend_shape_arrays(&self, _index: i32) -> godot::prelude::Array<VarArray> { unreachable!() }
+    fn surface_get_lods(&self, _index: i32) -> godot::prelude::VarDictionary { unreachable!() }
     fn surface_get_format(&self, _index: i32) -> u32 { unreachable!() }
     fn surface_get_primitive_type(&self, _index: i32) -> u32 { unreachable!() }
     #[cfg(feature = "codegen-full")]

--- a/itest/rust/src/register_tests/func_test.rs
+++ b/itest/rust/src/register_tests/func_test.rs
@@ -62,7 +62,7 @@ impl FuncObj {
         required: i32,
         #[opt(default = "Default str")] string: GString,
         #[opt(default = 100)] integer: i32,
-    ) -> VariantArray {
+    ) -> VarArray {
         varray![required, string, integer]
     }
 
@@ -347,13 +347,13 @@ fn func_default_parameters() {
     let mut obj = FuncObj::new_gd();
 
     let a = obj.call("method_with_defaults", vslice![0]);
-    assert_eq!(a.to::<VariantArray>(), varray![0, "Default str", 100]);
+    assert_eq!(a.to::<VarArray>(), varray![0, "Default str", 100]);
 
     let b = obj.call("method_with_defaults", vslice![1, "My string"]);
-    assert_eq!(b.to::<VariantArray>(), varray![1, "My string", 100]);
+    assert_eq!(b.to::<VarArray>(), varray![1, "My string", 100]);
 
     let c = obj.call("method_with_defaults", vslice![2, "Another string", 456]);
-    assert_eq!(c.to::<VariantArray>(), varray![2, "Another string", 456]);
+    assert_eq!(c.to::<VarArray>(), varray![2, "Another string", 456]);
 
     /* For now, Gd<T> defaults are disabled due to immutability.
     // Test that object is passed through, and that Option<Gd> with default Gd::null_arg() works.

--- a/itest/rust/src/register_tests/func_virtual_test.rs
+++ b/itest/rust/src/register_tests/func_virtual_test.rs
@@ -149,7 +149,7 @@ func _get_thing():
         .get_script_method_list()
         .iter_shared()
         .map(|dict| dict.get("name").unwrap())
-        .collect::<VariantArray>();
+        .collect::<VarArray>();
 
     // Ensure script has been parsed + compiled correctly.
     assert_eq!(script.get_instance_base_type(), "VirtualScriptCalls".into());


### PR DESCRIPTION
As we plan to introduce typed dictionaries in the future, we need to revise our naming for untyped ones. `VariantDictionary` is possible, but rather long for such a ubiquitous type -- dictionaries are much more often untyped than arrays, since their elements often have heterogenous types by their nature.

To be forward-compatible to such additions, we add deprecations already now.

| Before         | After                                                | Literal        |
|----------------|------------------------------------------------------|----------------|
| `Array<T>`     | `Array<T>`                                           | `array![...]`  |
| `VariantArray` | `VarArray` == <br> `Array<Variant>`                    | `varray![...]` |
| `&[Variant]`   | `&[Variant]`                                         | `vslice![...]` |
| _n/a_          | `Dictionary<K, V>`                                   | `dict![...]`   |
| `Dictionary`   | `VarDictionary` == <br> `Dictionary<Variant, Variant>` | `vdict![...]`  |


So we would have, with #1422:

- `Array<T>`, `VarArray`, `AnyArray`
- `Dictionary<K, V>`, `VarDictionary`, `AnyDictionary`

The nice thing about that is that `Var*` + `Any*` have the same length, and `VarArray` is slightly more readable than `VArray`. At the same time, `VarDict` isn't as excessively long as `VariantDictionary`.


## Earlier proposals

A first version of this suggested the following (956835c4b9af284559bf5039860b7a397c51bc40):

- `Array<T>`, `VArray`, `AnyArray`
- `Dictionary<K, V>`, `VDictionary`, `AnyDictionary`

A potential alternative:

- `Array<T>`, `VarArray`, `AnyArray`
- `Dict<K, V>`, `VarDict`, `AnyDict`

This would also allow a longer migration period, since we're not repurposing the `Dictionary` identifier. However, seems that `Dict` isn't that popular as it departs quite a bit from the Godot name.