### PR TITLE
`Array<T>` + `AnyArray` cast API consistency

### DIFF
--- a/godot-core/src/builtin/collections/packed_array.rs
+++ b/godot-core/src/builtin/collections/packed_array.rs
@@ -87,6 +87,9 @@ pub type PackedColorArray = PackedArray<Color>;
 /// but any writes must be externally synchronized. The Rust compiler will enforce this as
 /// long as you use only Rust threads, but it cannot protect against concurrent modification
 /// on other threads (e.g. created through GDScript).
+///
+/// # Element type and conversions
+/// See the [corresponding section in `Array`](struct.Array.html#conversions-between-arrays).
 pub struct PackedArray<T: PackedArrayElement> {
     // All packed arrays have same memory layout.
     opaque: sys::types::OpaquePackedByteArray,

--- a/godot-core/src/meta/error/convert_error.rs
+++ b/godot-core/src/meta/error/convert_error.rs
@@ -36,6 +36,7 @@ impl ConvertError {
     }
 
     /// Create a new custom error for a conversion, without associated value.
+    #[allow(dead_code)] // Needed a few times already, stays to prevent churn on refactorings.
     pub(crate) fn with_kind(kind: ErrorKind) -> Self {
         Self { kind, value: None }
     }
@@ -162,7 +163,7 @@ pub(crate) enum ErrorKind {
     FromGodot(FromGodotError),
     FromFfi(FromFfiError),
     FromVariant(FromVariantError),
-    FromOutArray(ArrayMismatch),
+    // FromAnyArray(ArrayMismatch), -- needed if AnyArray downcasts return ConvertError one day.
     Custom(Option<Cause>),
 }
 
@@ -172,7 +173,6 @@ impl fmt::Display for ErrorKind {
             Self::FromGodot(from_godot) => write!(f, "{from_godot}"),
             Self::FromVariant(from_variant) => write!(f, "{from_variant}"),
             Self::FromFfi(from_ffi) => write!(f, "{from_ffi}"),
-            Self::FromOutArray(array_mismatch) => write!(f, "{array_mismatch}"),
             Self::Custom(cause) => match cause {
                 Some(c) => write!(f, "{c}"),
                 None => write!(f, "custom error"),

--- a/godot-core/src/obj/traits.rs
+++ b/godot-core/src/obj/traits.rs
@@ -773,7 +773,7 @@ pub mod cap {
     use super::*;
     use crate::builtin::{StringName, Variant};
     use crate::meta::PropertyInfo;
-    use crate::obj::{Base, Bounds, Gd};
+    use crate::obj::{Base, Gd};
     use crate::storage::{IntoVirtualMethodReceiver, VirtualMethodReceiver};
 
     /// Trait for all classes that are default-constructible from the Godot engine.

--- a/itest/rust/src/engine_tests/codegen_test.rs
+++ b/itest/rust/src/engine_tests/codegen_test.rs
@@ -80,7 +80,7 @@ fn __array_return_types() {
     let _arrays: Array<VarArray> = server.mesh_surface_get_blend_shape_arrays(Rid::Invalid, 12);
 }
 
-// Test that generated builtin/class methods accept OutArray.
+// Test that generated builtin/class methods accept AnyArray.
 fn __array_param_types() {
     let mut server = RenderingServer::singleton();
 

--- a/itest/rust/src/object_tests/virtual_methods_test.rs
+++ b/itest/rust/src/object_tests/virtual_methods_test.rs
@@ -138,7 +138,7 @@ impl IPrimitiveMesh for VirtualReturnTest {
             PackedInt32Array::from_iter([0, 1, 2, 3]),
             PackedFloat32Array::from_iter([0.0, 1.0, 2.0, 3.0]),
             PackedInt32Array::from_iter([0]),
-        ].into_any()
+        ].upcast_any_array()
     }
 
     fn get_surface_count(&self) -> i32 { unreachable!() }


### PR DESCRIPTION
Conversion methods between `Array<T>` and `AnyArray` values now follow the precedent of `Gd::try_cast()` + `Gd::upcast()`, meaning:
* Upcast: `upcast_any_array`
* Downcast: `cast_array<T>`, `cast_var_array`

Also returns `self` instead of `ConvertError` on failure. This may need to be revisited in the future, it's also possible (but more expensive?) to return a pair of both.

---

# Covariance on arrays

It's currently **not** possible to upcast `Array<Gd<Derived>>` to `Array<Gd<Base>>`.

 `Array<T>` is not covariant over the `T` parameter. Otherwise it would be possible to insert `Base` values that aren't `Derived`. This is precisely the GDScript problem that `AnyArray` tries to avoid, just with `Variant` and `T`.

During this PR, I was however wondering if there would be value in supporting class covariance -- maybe once we have inheritance? It would however open quite a can of worms, for the varying subtyping systems we have in godot-rust:

1. `Variant` -> `T`
2. `Gd<Base>` -> `Gd<Derived>`
3. `Gd<Class>` -> `DynGd<Class, Trait>`

One way would be to make a `CovArray<T>` as an replacement for `AnyArray`, which is generic and covariant over `T`. You could then do (maybe some indirectly):
- Array downgrade: `Array<T>` -> `CovArray<T>`
- To variant: `CovArray<T>` -> `CovArray<Variant>`
- Class upcast: `CovArray<Gd<Derived>>` -> `CovArray<Gd<Base>>`
- Dyn decay: `CovArray<DynGd<Class, Trait>>` -> `CovArray<Gd<Class>>`