### PR TITLE
Set proper initialization level for `OpenXrExtensionWrapper`

### DIFF
--- a/godot-codegen/src/special_cases/special_cases.rs
+++ b/godot-codegen/src/special_cases/special_cases.rs
@@ -1163,9 +1163,13 @@ pub fn classify_codegen_level(class_name: &str) -> Option<ClassCodegenLevel> {
         | "ProjectSettings" | "Engine" | "OS" | "Time"
         => ClassCodegenLevel::Core,
 
+        // See initialize_openxr_module() in https://github.com/godotengine/godot/blob/master/modules/openxr/register_types.cpp
+        | "OpenXRExtensionWrapper"
+        => ClassCodegenLevel::Core,
+
         // Symbols from another extension could be available in Core, but since GDExtension can currently not guarantee
         // the order of different extensions being loaded, we prevent implicit dependencies and require Server.
-        | "OpenXRExtensionWrapperExtension" 
+        | "OpenXRExtensionWrapperExtension"
         => ClassCodegenLevel::Servers,
 
         // See register_server_types() in https://github.com/godotengine/godot/blob/master/servers/register_server_types.cpp


### PR DESCRIPTION
As doc mentions: https://docs.godotengine.org/en/stable/classes/class_openxrextensionwrapper.html OpenXrExtensionWrapper should be initialized at core init level – this is how they do so in official C++ extension https://github.com/GodotVR/godot_openxr_vendors/blob/e25282cdf00d3ca1485c29aee9aa066efba75f67/plugin/src/main/cpp/register_types.cpp#L158. As for class itself – see `initialize_openxr_module` in https://github.com/godotengine/godot/blob/master/modules/openxr/register_types.cpp.