### PR TITLE
Getters/setters now only accessible in Rust with `#[var(pub)]`

### DIFF
--- a/godot-macros/src/lib.rs
+++ b/godot-macros/src/lib.rs
@@ -152,10 +152,26 @@ use crate::util::{bail, ident, KvParser};
 /// }
 /// ```
 ///
-/// This makes the field accessible in GDScript using `my_struct.my_field` syntax. Additionally, it
-/// generates a trivial getter and setter named `get_my_field` and `set_my_field`, respectively.
-/// These are `pub` in Rust, since they're exposed from GDScript anyway.
+/// This makes the field accessible in GDScript using `obj.my_field` syntax. In addition to direct property access, GDScript can use
+/// explicit getter and setter notation: `obj.get_my_field()` and `obj.set_my_field()`.
 ///
+/// If you want to access those getters/setters from Rust, you can use `#[var(pub)]`:
+///
+/// ```no_run
+/// # use godot::prelude::*;
+/// #[derive(GodotClass)]
+/// #[class(init)]
+/// struct MyStruct {
+///     #[var(pub)]
+///     my_field: i64,
+/// }
+///
+/// fn use_accessors(obj: &MyStruct) {
+///     let f: i64 = obj.get_my_field();
+/// }
+/// ```
+///
+/// You can also customize getters and setters.
 /// The `get` and `set` options are **orthogonal** as of godot-rust v0.5: specifying one does not affect the other.
 /// By default, both a getter and setter are generated, but you can customize either independently:
 ///

--- a/godot-macros/src/util/mod.rs
+++ b/godot-macros/src/util/mod.rs
@@ -388,14 +388,14 @@ pub fn make_funcs_collection_constants(
 /// a constant is used as indirection.
 pub fn make_funcs_collection_constant(
     class_name: &Ident,
-    func_name: &Ident,
+    rust_function_name: &Ident,
     registered_name: Option<&String>,
     attributes: &[&venial::Attribute],
 ) -> TokenStream {
-    let const_name = format_funcs_collection_constant(class_name, func_name);
-    let const_value = match &registered_name {
+    let const_name = format_funcs_collection_constant(class_name, rust_function_name);
+    let const_value = match registered_name {
         Some(renamed) => renamed.to_string(),
-        None => func_name.to_string(),
+        None => rust_function_name.to_string(),
     };
 
     quote! {

--- a/itest/rust/src/engine_tests/save_load_test.rs
+++ b/itest/rust/src/engine_tests/save_load_test.rs
@@ -23,6 +23,7 @@ fn remove_test_file(file_name: &str) {
 #[derive(GodotClass)]
 #[class(base=Resource, init)]
 struct SavedGame {
+    #[var(pub)]
     #[export]
     level: u32,
 }

--- a/itest/rust/src/object_tests/property_test.rs
+++ b/itest/rust/src/object_tests/property_test.rs
@@ -34,7 +34,7 @@ struct HasProperty {
     #[var]
     packed_int_array: PackedInt32Array,
 
-    #[var(rename = renamed_variable)]
+    #[var(pub, rename = renamed_variable)]
     unused_name: GString,
 }
 
@@ -84,7 +84,7 @@ impl INode for HasProperty {
 }
 
 #[itest]
-fn test_renamed_var() {
+fn test_renamed_variable_reflection() {
     let mut obj = HasProperty::new_alloc();
 
     let prop_list = obj.get_property_list();
@@ -108,14 +108,16 @@ fn test_renamed_var() {
 }
 
 #[itest]
-fn test_renamed_var_getter_setter() {
-    let obj = HasProperty::new_alloc();
+fn test_renamed_variable_getter_setter() {
+    let mut obj = HasProperty::new_alloc();
+    obj.bind_mut()
+        .set_renamed_variable(GString::from("changed"));
 
     assert!(obj.has_method("get_renamed_variable"));
     assert!(obj.has_method("set_renamed_variable"));
     assert!(!obj.has_method("get_unused_name"));
     assert!(!obj.has_method("get_unused_name"));
-    assert_eq!(obj.bind().get_renamed_variable(), GString::new());
+    assert_eq!(obj.bind().get_renamed_variable(), "changed");
 
     obj.free();
 }
@@ -322,7 +324,7 @@ pub enum StrBehavior {
 #[derive(GodotClass)]
 #[class(no_init)]
 pub struct DeriveProperty {
-    #[var]
+    #[var(pub)]
     pub my_enum: TestEnum,
 }
 


### PR DESCRIPTION
In the past, every property automatically created `get_*` and `set_*` methods **accessible from Rust**.
```rs
#[var]
field: i64,

// later:
obj.bind_mut().set_field(1234);
let i = obj.bind().get_field();
```

After this PR, the **Rust**-side getter/setter will no longer be generated. The GDScript getter/setter are still accessible as `get_field`/`set_field`, in addition to `field` property syntax.

To use the old behavior, `#[var(pub)]` can be used:
```rs
#[var(pub)]
field: i64,
```
The `pub` emphasizes that this property is public (in Rust). Either way it's always possible to access it through the Godot engine -- slightly more involved via scripts or reflection. This change cuts down on a potentially large number of uselessly generated methods (i.e. compile time[^methods]) and can improve encapsulation, while still allowing people who need public accessors to opt in. 

Furthermore, this is not a hard breakage: the old methods continue to be generated until v0.6 and will issue a deprecation warning when accessed without `#[var(pub)]`, including migration instructions.

Came up during https://github.com/godot-rust/gdext/pull/1454.

[^methods]: in the current implementation, methods are still generated but hidden. However, them not being public allows us to transparently find optimized representations without affecting user code.