### PR TITLE
Aabb refactor/cleanup

### DIFF
--- a/itest/rust/src/builtin_tests/geometry/aabb_test.rs
+++ b/itest/rust/src/builtin_tests/geometry/aabb_test.rs
@@ -53,10 +53,13 @@ fn aabb_equiv() {
     for i in 0..8 {
         assert_eq_approx!(
             inner.get_endpoint(i as i64),
-            outer.get_endpoint(i),
+            outer.get_corner(i),
             "index: {i}\n"
         );
     }
+
+    let intersecting_segment = (Vector3::new(-2.6, -1.0, 2.0), Vector3::new(3.0, 2.0, 2.0));
+    let non_intersecting_segment = (Vector3::new(-4.5, 0.0, 2.0), Vector3::new(-2.5, 0.0, 2.0));
 
     #[rustfmt::skip]
     let mappings_vector3 = [
@@ -79,6 +82,11 @@ fn aabb_equiv() {
             "support",
             inner.get_support(Vector3::UP),
             outer.get_support(Vector3::UP),
+        ),
+        (
+            "intersect_segment",
+            inner.intersects_segment(intersecting_segment.0, intersecting_segment.1).try_to().expect("Failed to intersect segment!"),
+            outer.intersect_segment(intersecting_segment.0, intersecting_segment.1).expect(" Failed to intersect segment!"),
         ),
     ];
 
@@ -115,6 +123,16 @@ fn aabb_equiv() {
             "intersects_plane",
             inner.intersects_plane(test_plane),
             outer.intersects_plane(test_plane),
+        ),
+        (
+            "intersects_segment",
+            !inner.intersects_segment(intersecting_segment.0, intersecting_segment.1).is_nil(),
+            outer.intersects_segment(intersecting_segment.0, intersecting_segment.1),
+        ),
+        (
+            "intersect_segment",
+            inner.intersects_segment(non_intersecting_segment.0, non_intersecting_segment.1).is_nil(),
+            outer.intersect_segment(non_intersecting_segment.0, non_intersecting_segment.1).is_none(),
         ),
         (
             "is_finite",


### PR DESCRIPTION
### Fix `intersect_segment` (account for cases when one of the axis is 0. and doesn't intersect).

The results differed from Godot ones, and were wrong when one axis of the segment direction was 0. I checked Godot implementation and MathGeoLib one, which uses the same algorithm (and just makes it twice as much readable) https://github.com/juj/MathGeoLib/blob/55053da5e3e55a83043af7324944407b174c3724/src/Geometry/AABB.cpp#L725

### Rename `from_corners` to `from_position_end`, `get_endpoint` -> `get_corner`, `endpoints` -> `corners`.

More explicit and less confusing. I checked and in most cases Axis Aligned Bounding Box vertices are being refereed to as `vertices` or `corners`, _sometimes_ `points`, and then Godot calls them [`endpoints`](https://docs.godotengine.org/en/stable/classes/class_aabb.html#class-aabb-method-get-endpoint) ever since it was known as Rect3.

Arguably `corners` should be called `get_corners`. Up to you :innocent:.


### Remove mention of `InnerAabb`.
Aabb should be, finally, feature complete!


# Questions

I kept doubled methods for intersections (`intersects` which returns bool and `intersect` which, well, returns Optional result of intersection) – they might differ a bit. I'm not sure if it is good approach and if we shouldn't keep only the one returning Option, while praying to compiler for correct optimization.