### PR TITLE
Allow to use other GDExtensions as dependencies.

### DIFF
--- a/.github/composite/godot-itest/action.yml
+++ b/.github/composite/godot-itest/action.yml
@@ -51,6 +51,11 @@ inputs:
     default: ''
     description: "Extra values for the RUSTFLAGS env var"
 
+  rust-extra-env:
+    required: false
+    default: ''
+    description: "Extra env values to be passed during cargo build"
+
   rust-target:
     required: false
     default: ''
@@ -164,7 +169,7 @@ runs:
         fi
         
         # Keep `--no-default-features` even if it's currently redundant. Features may change.
-        cargo build -p itest --no-default-features ${{ inputs.rust-extra-args }} $targetArgs
+        ${{ inputs.rust-extra-env }} cargo build -p itest --no-default-features ${{ inputs.rust-extra-args }} $targetArgs
         
         # Instead of modifying .gdextension, rename the output directory.
         if [[ -n "$TARGET" ]]; then

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -337,7 +337,8 @@ jobs:
             os: ubuntu-22.04
             artifact-name: linux-nightly
             godot-binary: godot.linuxbsd.editor.dev.x86_64
-            rust-extra-args: --features itest/codegen-full
+            rust-extra-args: --features itest/codegen-full,itest/test-gdextension-dependency
+            rust-extra-env: GODOT_RUST_MAIN_EXTENSION=IntegrationTests
             hot-reload: api-custom
 
           # Combines now a lot of features, but should be OK. lazy-function-tables doesn't work with experimental-threads.
@@ -472,6 +473,7 @@ jobs:
           rust-extra-args: ${{ matrix.rust-extra-args }}
           rust-toolchain: ${{ matrix.rust-toolchain || 'stable' }}
           rust-env-rustflags: ${{ matrix.rust-env-rustflags }}
+          rust-extra-env: ${{ matrix.rust-extra-env }}
           rust-target: ${{ matrix.rust-target }}
           rust-target-dir: ${{ matrix.rust-target-dir }}
           rust-cache-key: ${{ matrix.rust-cache-key }}

--- a/.github/workflows/minimal-ci.yml
+++ b/.github/workflows/minimal-ci.yml
@@ -201,7 +201,8 @@ jobs:
             os: ubuntu-22.04
             artifact-name: linux-nightly
             godot-binary: godot.linuxbsd.editor.dev.x86_64
-            rust-extra-args: --features itest/codegen-full
+            rust-extra-args: --features itest/codegen-full,itest/test-gdextension-dependency
+            rust-extra-env: GODOT_RUST_MAIN_EXTENSION=IntegrationTests
             hot-reload: stable
 
           - name: linux-custom-api-json
@@ -305,6 +306,7 @@ jobs:
           rust-extra-args: ${{ matrix.rust-extra-args }}
           rust-toolchain: ${{ matrix.rust-toolchain || 'stable' }}
           rust-env-rustflags: ${{ matrix.rust-env-rustflags }}
+          rust-extra-env: ${{ matrix.rust-extra-env }}
           rust-target: ${{ matrix.rust-target }}
           rust-target-dir: ${{ matrix.rust-target-dir }}
           with-llvm: ${{ contains(matrix.name, 'macos') && contains(matrix.rust-extra-args, 'api-custom') }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "itest/rust",
     "itest/repo-tweak",
     "itest/hot-reload/rust",
+    "itest/itest-dependency"
 ]
 
 # All dependencies except own crates of this project should be specified here, independently of whether they're dev, build or

--- a/godot-macros/src/util/mod.rs
+++ b/godot-macros/src/util/mod.rs
@@ -165,7 +165,10 @@ fn delimiter_opening_char(delimiter: Delimiter) -> char {
 /// declaration of the form `impl MyTrait for SomeType`. The type `SomeType` is irrelevant in this example.
 pub(crate) fn is_impl_named(original_impl: &venial::Impl, name: &str) -> bool {
     let trait_name = original_impl.trait_ty.as_ref().unwrap(); // unwrap: already checked outside
-    extract_typename(trait_name).is_some_and(|seg| seg.ident == name)
+    let implementor =
+        extract_typename(trait_name).expect("`impl ExtensionLibrary` must have a typename");
+
+    implementor.ident == name
 }
 
 /// Validates either:

--- a/itest/itest-dependency/Cargo.toml
+++ b/itest/itest-dependency/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "itest-dependency"
+version = "0.0.0"
+edition = "2021"
+rust-version = "1.87"
+license = "MPL-2.0"
+publish = false
+
+[dependencies]
+godot = { path = "../../godot", default-features = false }

--- a/itest/itest-dependency/src/lib.rs
+++ b/itest/itest-dependency/src/lib.rs
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use godot::prelude::*;
+
+#[derive(GodotClass)]
+#[class(init)]
+pub struct DependencyObj {
+    #[var]
+    #[init(val = 42)]
+    some_property: i64,
+}
+
+#[godot_api]
+impl DependencyObj {
+    #[func]
+    fn method_from_dependency(&self) -> u32 {
+        42
+    }
+}
+
+#[allow(unused)]
+struct OtherGDExtension;
+
+#[gdextension]
+unsafe impl ExtensionLibrary for OtherGDExtension {}

--- a/itest/rust/Cargo.toml
+++ b/itest/rust/Cargo.toml
@@ -17,6 +17,7 @@ codegen-full-experimental = ["codegen-full", "godot/experimental-godot-api"]
 experimental-threads = ["godot/experimental-threads"]
 register-docs = ["godot/register-docs"]
 serde = ["dep:serde", "dep:serde_json", "godot/serde"]
+test-gdextension-dependency = ["dep:itest-dependency"]
 
 # Do not add features here that are 1:1 forwarded to the `godot` crate, unless they are needed by itest itself.
 # Instead, compile itest with `--features godot/my-feature`.
@@ -26,6 +27,9 @@ godot = { path = "../../godot", default-features = false, features = ["__trace"]
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 pin-project-lite = { workspace = true }
+# Required to test using another GDExtension as a dependency.
+# Requires compiling with `GODOT_RUST_MAIN_EXTENSION="IntegrationTests` env variable set.
+itest-dependency = { path = "../itest-dependency", optional = true }
 
 [build-dependencies]
 godot-bindings = { path = "../../godot-bindings" } # emit_godot_version_cfg

--- a/itest/rust/src/register_tests/dependency_test.rs
+++ b/itest/rust/src/register_tests/dependency_test.rs
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use godot::prelude::*;
+use itest_dependency::DependencyObj;
+
+use crate::framework::itest;
+
+#[itest]
+fn test_dependent_object_method() {
+    let mut obj = DependencyObj::new_gd();
+    // Route call through Godot to see if method has been registered properly.
+    let num: i64 = obj.call("method_from_dependency", &[]).to();
+    assert_eq!(num, 42);
+}
+
+#[itest]
+fn test_dependent_object_property() {
+    let obj = DependencyObj::new_gd();
+    // Get property through Godot to see if it has been registered properly.
+    let num: i64 = obj.get("some_property").to();
+    assert_eq!(num, 42);
+}

--- a/itest/rust/src/register_tests/mod.rs
+++ b/itest/rust/src/register_tests/mod.rs
@@ -18,6 +18,8 @@ mod register_docs_test;
 mod rpc_test;
 mod var_test;
 
+#[cfg(feature = "test-gdextension-dependency")]
+mod dependency_test;
 #[cfg(since_api = "4.3")]
 mod func_virtual_test;
 


### PR DESCRIPTION
closes: #951

Solves specified problem in the very same fashion, i.e. allows to specify name of the "main", user-forwarding crate (via the ENV var) which will be used as a GDExtension library and doesn't generate register-specific code for other ExtensionLibraries.

## Other stuff I tried
- Conditional compilation (not possible)
- Crate name shenanigans && auto-discovery (very brittle and error-prone)
- Extra attributes for `#[gdextension]` macro (doesn't work because it requires editing code of the dependencies)


# Example:

<details> <summary> Basic example </summary>

```rs
use test_extension_2::*;

struct MyExtension;

#[gdextension]
unsafe impl ExtensionLibrary for MyExtension {}

/// Docs for my other class.
#[derive(GodotClass)]
#[class(init, base = Node)]
struct MyClass1 {
    #[export]
    other_node: OnEditor<Gd<MyClass2>>,
    base: Base<Node>
}
```

```rs
struct MyExtension2;

#[gdextension]
unsafe impl ExtensionLibrary for MyExtension2 {}


/// Docs for my class blah blah blah.
#[derive(GodotClass)]
#[class(init, base = Node)]
pub struct MyClass2 {
    base: Base<Node>
}
```

We will need to take care of said warning:

```bash
$ MAIN_EXTENSION="MyExtension" cargo build
warning: struct `MyExtension2` is never constructed
 --> .../test_extension_2/src/lib.rs:4:8
  |
4 | struct MyExtension2;
  |        ^^^^^^^^^^^^
  |
  = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default

warning: `test_extension_2` (lib) generated 1 warning
   Compiling docstest v0.1.0 (.../testground)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 16.91s
```

<img width="1907" height="463" alt="image" src="https://github.com/user-attachments/assets/0bdd1e06-7b3c-44b2-a319-f238ef5f9e8e" />



</details>

CC: @greenfox1505