### PR TITLE
Misleading docs: `UserSingleton` must be registered before `MainLoop` stage

### DIFF
--- a/godot-core/src/obj/traits.rs
+++ b/godot-core/src/obj/traits.rs
@@ -703,7 +703,8 @@ pub trait Singleton: GodotClass {
 /// #[gdextension]
 /// unsafe impl ExtensionLibrary for MyExtension {
 ///     fn on_stage_init(stage: InitStage) {
-///         if stage == InitStage::MainLoop {
+///         // Singleton should be registered before the MainLoop startup – otherwise it won't be recognized by the GDScriptParser.
+///         if stage == InitStage::Scene {
 ///             let obj = MyEngineSingleton::new_alloc();
 ///             Engine::singleton()
 ///                 .register_singleton(&MyEngineSingleton::class_id().to_string_name(), &obj);
@@ -711,7 +712,7 @@ pub trait Singleton: GodotClass {
 ///     }
 ///
 ///     fn on_stage_deinit(stage: InitStage) {
-///         if stage == InitStage::MainLoop {
+///         if stage == InitStage::Scene {
 ///             let obj = MyEngineSingleton::singleton();
 ///             Engine::singleton()
 ///                 .unregister_singleton(&MyEngineSingleton::class_id().to_string_name());


### PR DESCRIPTION
Long story short GDScriptParser was loading list of EngineSingletons at the end of the startup sequence – i.e. before mainloop (https://github.com/godotengine/godot/tree/master/main/main.cpp#L3726). 

I tested it extensively in the editor but I forget to restart the Editor before writing the docs :upside_down_face: while all my "manual" implementations where registering singletons on "Scenes" level.