### PR TITLE
Add regression test for auto-generated setters/getters to a field named `instance`.

### DIFF
--- a/itest/rust/src/register_tests/var_test.rs
+++ b/itest/rust/src/register_tests/var_test.rs
@@ -75,6 +75,11 @@ struct VarAccessors {
     // Custom getter, public generated setter.
     #[var(pub, get = my_l_get)]
     l_pub_get: GString,
+
+    // A field named `instance` caused compilation error in versions before 0.5.
+    // See: https://github.com/godot-rust/gdext/pull/1481.
+    #[var]
+    instance: i32,
 }
 
 #[godot_api]


### PR DESCRIPTION
Ultra silly, but I want to have it documented – we have seen people on discord running into this problem three times already :sweat_smile:.

on 4.5. auto-generated setter/getter for a field called `instance` causes compilation errors:
 
```rs
error[E0308]: mismatched types
  --> itest/rust/src/register_tests/var_test.rs:25:5
   |
10 | #[derive(GodotClass)]
   |          ---------- arguments to this method are incorrect
...
25 |     instance: GString,
   |     ^^^^^^^^ expected `GString`, found `MutGuard<'_, WithInitDefaults>`
   |
   = note: expected struct `godot::prelude::GString`
              found struct `godot_cell::guards::MutGuard<'_, WithInitDefaults>`
note: method defined here
  --> itest/rust/src/register_tests/var_test.rs:10:10
   |
10 | #[derive(GodotClass)]
   |          ^^^^^^^^^^
   = note: this error originates in the derive macro `GodotClass` (in Nightly builds, run with -Z macro-backtrace for more info)

```

Fixed in: #1413  (`let mut instance` => `let __gdext_self` (ironically we have seen first cases of people running into bug AFTER the fix))