### PR TITLE
`Node::get_tree()` returns non-null

### DIFF
--- a/godot-codegen/src/special_cases/special_cases.rs
+++ b/godot-codegen/src/special_cases/special_cases.rs
@@ -396,6 +396,9 @@ pub fn is_named_accessor_in_table(class_or_builtin_ty: &TyName, godot_method_nam
 ///
 /// Builtin class methods are all private by default, due to being declared in an `Inner*` struct. A separate mechanism is used
 /// to make them public, see [`is_builtin_method_exposed`].
+///
+/// This does not rename the method. For methods that are replaced with type-safe equivalents, use
+/// [`is_class_method_replaced_with_type_safe()`] instead.
 #[rustfmt::skip]
 pub fn is_method_private(class_or_builtin_ty: &TyName, godot_method_name: &str) -> bool {
     if is_class_method_replaced_with_type_safe(class_or_builtin_ty, godot_method_name) {
@@ -426,6 +429,9 @@ fn is_class_method_replaced_with_type_safe(class_ty: &TyName, godot_method_name:
 
         // u32 -> ConnectFlags
         | ("Object", "connect")
+
+        // godot-rust provides optional + required APIs.
+        | ("Node", "get_tree")
 
         // i32 -> CallGroupFlags
         // Some of those (not the notifications) could be handled by automated enum replacement, but keeping them together is simpler.

--- a/godot-core/src/classes/type_safe_replacements.rs
+++ b/godot-core/src/classes/type_safe_replacements.rs
@@ -15,7 +15,7 @@ use crate::builtin::{Callable, GString, StringName, Variant};
 use crate::classes::notify::NodeNotification;
 use crate::classes::object::ConnectFlags;
 use crate::classes::scene_tree::GroupCallFlags;
-use crate::classes::{Object, SceneTree, Script};
+use crate::classes::{Node, Object, SceneTree, Script};
 use crate::global::Error;
 use crate::meta::{arg_into_ref, AsArg, ToGodot};
 use crate::obj::{EngineBitfield, Gd};
@@ -49,6 +49,24 @@ impl Object {
         self.raw_connect_ex(signal, callable)
             .flags(flags.ord() as u32)
             .done()
+    }
+}
+
+impl Node {
+    /// ⚠️ Assuming the node is inside a scene tree, obtains the latter.
+    ///
+    /// # Panics
+    /// If the node is not inside the scene tree. If you're unsure, use [`get_tree_or_null()`][Self::get_tree_or_null].
+    pub fn get_tree(&self) -> Gd<SceneTree> {
+        // Don't call get_tree_or_null() to avoid extra FFI call.
+        // If the invariant is wrong, this panics and Godot additionally prints its own error.
+        self.raw_get_tree()
+            .unwrap_or_else(|| panic!("node outside scene tree; use get_tree_or_null() instead"))
+    }
+
+    /// Fallibly obtains the scene tree containing the node, or `None`.
+    pub fn get_tree_or_null(&self) -> Option<Gd<SceneTree>> {
+        self.is_inside_tree().then(|| self.get_tree())
     }
 }
 

--- a/itest/rust/src/engine_tests/async_test.rs
+++ b/itest/rust/src/engine_tests/async_test.rs
@@ -81,7 +81,7 @@ fn async_task_array() -> TaskHandle {
 
 #[itest]
 fn cancel_async_task(ctx: &TestContext) {
-    let tree = ctx.scene_tree.get_tree().unwrap();
+    let tree = ctx.scene_tree.get_tree();
     let signal = Signal::from_object_signal(&tree, "process_frame");
 
     let handle = task::spawn(async move {

--- a/itest/rust/src/engine_tests/node_test.rs
+++ b/itest/rust/src/engine_tests/node_test.rs
@@ -64,7 +64,7 @@ fn node_path_from_str(ctx: &TestContext) {
 #[itest]
 fn node_call_group(ctx: &TestContext) {
     let mut node = ctx.scene_tree.clone();
-    let mut tree = node.get_tree().unwrap();
+    let mut tree = node.get_tree();
 
     node.add_to_group("group");
 

--- a/itest/rust/src/framework/runner.rs
+++ b/itest/rust/src/framework/runner.rs
@@ -487,7 +487,6 @@ fn check_async_test_task(
 
     ctx.scene_tree
         .get_tree()
-        .expect("The itest scene tree node is part of a Godot SceneTree")
         .connect_flags("process_frame", &deferred, ConnectFlags::ONE_SHOT);
 }
 


### PR DESCRIPTION
Changes `Node` API:
```rs
fn get_tree(&self) -> Option<Gd<SceneTree>>;
```
to:
```rs
fn get_tree(&self) -> Gd<SceneTree>;
fn get_tree_or_null(&self) -> Option<Gd<SceneTree>>;
```

Following _required_ object APIs (#1383), we can classify `Node::get_tree()` in a similar way -- it's supposed to be called inside the tree. Calling it outside the tree [is explicitly an error](https://docs.godotengine.org/en/stable/classes/class_node.html#class-node-method-get-tree):

> **`SceneTree get_tree() const`**
>
> Returns the [SceneTree](https://docs.godotengine.org/en/stable/classes/class_scenetree.html#class-scenetree) that contains this node. If this node is not inside the tree, generates an error and returns null. See also [is_inside_tree()](https://docs.godotengine.org/en/stable/classes/class_node.html#class-node-method-is-inside-tree).

This differentiates it from other methods like [`get_window`](https://github.com/godotengine/godot/blob/bf332b7e2ba9e56499c7912b960b0d024ca37363/scene/main/node.cpp#L2113-L2120), `get_parent`, `get_owner` etc. which have explicit non-error branches for the `nullptr` return type, and thus continue to return `Option`.

The fallible method is now available under `get_tree_or_null`. Unlike before, it no longer prints an error in the `None` case.