### PR TITLE
Format bitfields in `Debug` impl

### DIFF
--- a/godot-codegen/src/generator/enums.rs
+++ b/godot-codegen/src/generator/enums.rs
@@ -242,6 +242,11 @@ fn make_enum_debug_impl(enum_: &Enum, use_as_str: bool) -> TokenStream {
             if enumerator.is_empty() {
                 #enumerator_not_found
             }
+            f.write_str(enumerator)
+        }
+    } else if enum_.is_bitfield {
+        quote! {
+            crate::classes::debug_bitfield(*self, f)
         }
     } else {
         let enumerators = make_enum_to_str_cases(enum_);
@@ -256,6 +261,7 @@ fn make_enum_debug_impl(enum_: &Enum, use_as_str: bool) -> TokenStream {
                     #enumerator_not_found
                 }
             };
+            f.write_str(enumerator)
         }
     };
 
@@ -263,7 +269,6 @@ fn make_enum_debug_impl(enum_: &Enum, use_as_str: bool) -> TokenStream {
         impl std::fmt::Debug for #enum_name {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 #function_body
-                f.write_str(enumerator)
             }
         }
     }

--- a/godot-core/src/meta/inspect.rs
+++ b/godot-core/src/meta/inspect.rs
@@ -12,7 +12,7 @@
 /// Returned by [`EngineEnum::all_constants()`][crate::obj::EngineEnum::all_constants] and
 /// [`EngineBitfield::all_constants()`][crate::obj::EngineBitfield::all_constants].
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
-pub struct EnumConstant<T: Copy + 'static> {
+pub struct EnumConstant<T> {
     rust_name: &'static str,
     godot_name: &'static str,
     value: T,
@@ -20,7 +20,7 @@ pub struct EnumConstant<T: Copy + 'static> {
 
 impl<T> EnumConstant<T>
 where
-    T: Copy + Eq + PartialEq + 'static,
+    T: Copy,
 {
     /// Creates a new enum constant metadata entry.
     pub(crate) const fn new(rust_name: &'static str, godot_name: &'static str, value: T) -> Self {

--- a/godot-core/src/obj/traits.rs
+++ b/godot-core/src/obj/traits.rs
@@ -184,7 +184,7 @@ pub trait UserClass: Bounds<Declarer = bounds::DeclUser> {
 }
 
 /// Auto-implemented for all engine-provided enums.
-pub trait EngineEnum: Copy {
+pub trait EngineEnum: Copy + 'static {
     fn try_from_ord(ord: i32) -> Option<Self>;
 
     /// Ordinal value of the enumerator, as specified in Godot.
@@ -244,7 +244,7 @@ pub trait EngineEnum: Copy {
 }
 
 /// Auto-implemented for all engine-provided bitfields.
-pub trait EngineBitfield: Copy {
+pub trait EngineBitfield: Copy + 'static {
     fn try_from_ord(ord: u64) -> Option<Self>;
 
     /// Ordinal value of the bit flag, as specified in Godot.

--- a/itest/rust/src/engine_tests/engine_enum_test.rs
+++ b/itest/rust/src/engine_tests/engine_enum_test.rs
@@ -6,7 +6,7 @@
  */
 
 use godot::classes::{mesh, window};
-use godot::global::{InlineAlignment, Key, KeyModifierMask, Orientation};
+use godot::global::{InlineAlignment, Key, KeyModifierMask, Orientation, PropertyUsageFlags};
 use godot::obj::{EngineBitfield, EngineEnum};
 
 use crate::framework::itest;
@@ -190,4 +190,44 @@ fn bitfield_all_constants() {
     assert_eq!(shift_constant.godot_name(), "KEY_MASK_SHIFT");
     assert_eq!(shift_constant.value(), KeyModifierMask::SHIFT);
     assert_eq!(shift_constant.value().ord(), 1 << 25);
+}
+
+#[itest]
+fn bitfield_debug() {
+    let flags = KeyModifierMask::CTRL | KeyModifierMask::ALT | KeyModifierMask::SHIFT;
+    assert_eq!(
+        format!("{flags:?}"),
+        "KeyModifierMask { SHIFT | ALT | CTRL }"
+    );
+
+    let flags = PropertyUsageFlags::EDITOR | PropertyUsageFlags::READ_ONLY;
+    assert_eq!(
+        format!("{flags:?}"),
+        "PropertyUsageFlags { EDITOR | READ_ONLY }"
+    );
+
+    // Zero bits (here NONE) are only included if no other bits are found.
+    let flags = PropertyUsageFlags::NONE;
+    assert_eq!(format!("{flags:?}"), "PropertyUsageFlags { NONE }");
+
+    // Multi-bit constants (DEFAULT) are included individually and with all expanded bits.
+    let flags = PropertyUsageFlags::DEFAULT;
+    assert_eq!(
+        format!("{flags:?}"),
+        "PropertyUsageFlags { STORAGE | EDITOR | DEFAULT | NO_EDITOR }"
+    );
+}
+
+#[itest]
+fn bitfield_debug_unknown() {
+    let flags = KeyModifierMask::from_ord(77);
+    assert_eq!(format!("{flags:?}"), "KeyModifierMask { Unknown(0x4D) }");
+
+    let flags = PropertyUsageFlags::EDITOR
+        | PropertyUsageFlags::READ_ONLY
+        | PropertyUsageFlags::from_ord(1 << 31);
+    assert_eq!(
+        format!("{flags:?}"),
+        "PropertyUsageFlags { EDITOR | READ_ONLY | Unknown(0x80000000) }"
+    );
 }

--- a/itest/rust/src/object_tests/enum_test.rs
+++ b/itest/rust/src/object_tests/enum_test.rs
@@ -68,10 +68,10 @@ fn enum_hash() {
     assert_eq!(months.len(), 12, "hash collisions in constants");
 }
 
-// Testing https://github.com/godot-rust/gdext/issues/335
+// Tests https://github.com/godot-rust/gdext/issues/335.
 // This fails upon calling the function, we don't actually need to make a good call.
 #[itest]
-fn add_surface_from_arrays() {
+fn enum_add_surface_from_arrays() {
     let mut mesh = ArrayMesh::new_gd();
     mesh.add_surface_from_arrays(PrimitiveType::TRIANGLES, &varray![]);
 }


### PR DESCRIPTION
Makes the `Debug` impl for bitfields more useful.

Godot often uses a combination of patterns in bitfields:
- Individual bits
- Masks covering multiple bits
- Constants representing zero (no bit set)
- Values outside known range (or from future Godot versions)

The algorithm tries to be smart about printing the most relevant information.
Example outputs:
```js
// Individual bits
KeyModifierMask { SHIFT | ALT | CTRL }
PropertyUsageFlags { EDITOR | READ_ONLY }

// Zero bits
PropertyUsageFlags { NONE }

// Multiple bits
PropertyUsageFlags { STORAGE | EDITOR | DEFAULT | NO_EDITOR }

// Bits not covered by constants
PropertyUsageFlags { EDITOR | READ_ONLY | Unknown(0x80000000) }
```