### PR TITLE
Heuristic to const-qualify Godot getters

### DIFF
--- a/itest/rust/src/register_tests/func_virtual_test.rs
+++ b/itest/rust/src/register_tests/func_virtual_test.rs
@@ -143,7 +143,7 @@ func _get_thing():
     return thing
 "#;
 
-    let mut script = create_gdscript(code);
+    let script = create_gdscript(code);
 
     let methods = script
         .get_script_method_list()


### PR DESCRIPTION
Several methods starting with `get_`, `is_` or `has_` are wrongly declared mutable in the GDExtension API. Instead of chasing individual methods, we assume those to generally be const, and only mark the exceptions as mutable.

Some similar changes in the past:
- #1456
- #1274


Virtual methods are currently excluded; we may inspect them separately in the future.