### PR TITLE
`#[godot_api(secondary)]` in other files

### DIFF
--- a/godot-macros/src/class/derive_godot_class.rs
+++ b/godot-macros/src/class/derive_godot_class.rs
@@ -156,13 +156,15 @@ pub fn derive_godot_class(item: venial::Item) -> ParseResult<TokenStream> {
         modifiers.push(quote! { with_tool })
     }
 
-    // Declares a "funcs collection" struct that, for holds a constant for each #[func].
+    // Declares a "funcs collection" struct that holds a constant for each #[func].
     // That constant maps the Rust name (constant ident) to the Godot registered name (string value).
+    // Adopt visibility of class (could be relevant if ever #[godot_api(secondary)] support is added).
     let funcs_collection_struct_name = format_funcs_collection_struct(class_name);
+    let class_vis = class.vis_marker.as_ref();
     let funcs_collection_struct = quote! {
         #[doc(hidden)]
         #[allow(non_camel_case_types)]
-        pub struct #funcs_collection_struct_name {}
+        #class_vis struct #funcs_collection_struct_name {}
     };
 
     // Note: one limitation is that macros don't work for `impl nested::MyClass` blocks.

--- a/godot-macros/src/lib.rs
+++ b/godot-macros/src/lib.rs
@@ -1110,6 +1110,7 @@ pub fn derive_godot_class(input: TokenStream) -> TokenStream {
 /// ```
 ///
 /// `#[signal]` and `#[rpc]` attributes are not currently supported in secondary `impl` blocks.
+/// Additionally, `#[var(get = ..., set = ...)]` on fields cannot reference `#[func]` methods defined in secondary blocks.
 ///
 ///```compile_fail
 /// # use godot::prelude::*;

--- a/godot-macros/src/util/mod.rs
+++ b/godot-macros/src/util/mod.rs
@@ -422,6 +422,8 @@ pub fn make_funcs_collection_constant(
 }
 
 /// Converts `path::class` to `path::new_class`.
+///
+/// Used to derive the funcs collection path from the class path (e.g. `nested::__godot_MyClass_Funcs`).
 pub fn replace_class_in_path(path: venial::Path, new_class: Ident) -> venial::Path {
     match path.segments.as_slice() {
         // Can't happen, you have at least one segment (the class name).

--- a/itest/rust/src/register_tests/mod.rs
+++ b/itest/rust/src/register_tests/mod.rs
@@ -10,6 +10,7 @@ mod conversion_test;
 mod derive_godotconvert_test;
 mod func_test;
 mod gdscript_ffi_test;
+mod multiple_impl_blocks_secondary;
 mod multiple_impl_blocks_test;
 mod naming_tests;
 mod option_ffi_test;

--- a/itest/rust/src/register_tests/multiple_impl_blocks_secondary.rs
+++ b/itest/rust/src/register_tests/multiple_impl_blocks_secondary.rs
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use godot::prelude::*;
+
+use super::multiple_impl_blocks_test::MultipleImplBlocks;
+
+#[godot_api(secondary)]
+impl MultipleImplBlocks {
+    #[func]
+    fn third(&self) -> String {
+        "3rd result".to_string()
+    }
+}

--- a/itest/rust/src/register_tests/multiple_impl_blocks_test.rs
+++ b/itest/rust/src/register_tests/multiple_impl_blocks_test.rs
@@ -15,7 +15,7 @@ use crate::framework::itest;
 
 #[derive(GodotClass)]
 #[class(base=Object)]
-struct MultipleImplBlocks {}
+pub struct MultipleImplBlocks {}
 
 #[godot_api]
 impl IObject for MultipleImplBlocks {
@@ -37,14 +37,6 @@ impl MultipleImplBlocks {
     #[func]
     fn second(&self) -> String {
         "2nd result".to_string()
-    }
-}
-
-#[godot_api(secondary)]
-impl MultipleImplBlocks {
-    #[func]
-    fn third(&self) -> String {
-        "3rd result".to_string()
     }
 }
 
@@ -73,5 +65,3 @@ fn godot_api_multiple_impl_blocks() {
 
     obj.free();
 }
-
-// ----------------------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1498.