### PR TITLE
Limit `api-4-*` features to minor versions

### DIFF
--- a/.github/composite/godot-itest/action.yml
+++ b/.github/composite/godot-itest/action.yml
@@ -34,7 +34,7 @@ inputs:
   godot-prebuilt-patch:
     required: false
     default: ''
-    description: "If specified, sets the branch name of the godot4-prebuilt crate to this value"
+    description: "If specified, sets the branch name of the godot4-prebuilt crate to this value. Example '4.2' or '4.2.2' (latter being currently disabled, https://github.com/godot-rust/gdext/pull/1505)"
 
   rust-toolchain:
     required: false

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -409,7 +409,7 @@ jobs:
             os: ubuntu-22.04
             artifact-name: linux-4.2
             godot-binary: godot.linuxbsd.editor.dev.x86_64
-            godot-prebuilt-patch: '4.2.2'
+            godot-prebuilt-patch: '4.2'
             hot-reload: api-4-2
 
           # Memory checks: special Godot binaries compiled with AddressSanitizer/LeakSanitizer to detect UB/leaks. Always Linux.

--- a/.github/workflows/minimal-ci.yml
+++ b/.github/workflows/minimal-ci.yml
@@ -258,7 +258,7 @@ jobs:
             os: ubuntu-22.04
             artifact-name: linux-4.2
             godot-binary: godot.linuxbsd.editor.dev.x86_64
-            godot-prebuilt-patch: '4.2.2'
+            godot-prebuilt-patch: '4.2'
 
           # Memory checkers (always Linux).
 

--- a/godot-bindings/Cargo.toml
+++ b/godot-bindings/Cargo.toml
@@ -20,8 +20,6 @@ experimental-wasm-nothreads = []
 # [version-sync] [[
 #  [line] api-$kebabVersion = []
 api-4-2 = []
-api-4-2-1 = []
-api-4-2-2 = []
 api-4-3 = []
 api-4-4 = []
 api-4-5 = []

--- a/godot-bindings/build.rs
+++ b/godot-bindings/build.rs
@@ -18,8 +18,6 @@ fn main() {
     // [version-sync] [[
     //  [line] \tif cfg!(feature = "api-$kebabVersion") { count += 1; }
     if cfg!(feature = "api-4-2") { count += 1; }
-    if cfg!(feature = "api-4-2-1") { count += 1; }
-    if cfg!(feature = "api-4-2-2") { count += 1; }
     if cfg!(feature = "api-4-3") { count += 1; }
     if cfg!(feature = "api-4-4") { count += 1; }
     if cfg!(feature = "api-4-5") { count += 1; }

--- a/godot-bindings/src/import.rs
+++ b/godot-bindings/src/import.rs
@@ -16,8 +16,6 @@ pub const ALL_VERSIONS: &[(u8, u8, u8)] = &[
     //  [include] past+current+future
     //  [line] \t$triple,
     (4, 2, 0),
-    (4, 2, 1),
-    (4, 2, 2),
     (4, 3, 0),
     (4, 4, 0),
     (4, 5, 0),
@@ -30,10 +28,6 @@ pub const ALL_VERSIONS: &[(u8, u8, u8)] = &[
 //  [line] #[cfg(feature = "api-$kebabVersion")]\npub use gdextension_api::version_$snakeVersion as prebuilt;
 #[cfg(feature = "api-4-2")]
 pub use gdextension_api::version_4_2 as prebuilt;
-#[cfg(feature = "api-4-2-1")]
-pub use gdextension_api::version_4_2_1 as prebuilt;
-#[cfg(feature = "api-4-2-2")]
-pub use gdextension_api::version_4_2_2 as prebuilt;
 #[cfg(feature = "api-4-3")]
 pub use gdextension_api::version_4_3 as prebuilt;
 #[cfg(feature = "api-4-4")]
@@ -52,8 +46,6 @@ pub use gdextension_api::version_4_6 as prebuilt;
 //  [post] \tfeature = "api-custom",\n\tfeature = "api-custom-json",\n)))]
 #[cfg(not(any(
     feature = "api-4-2",
-    feature = "api-4-2-1",
-    feature = "api-4-2-2",
     feature = "api-4-3",
     feature = "api-4-4",
     feature = "api-4-5",

--- a/godot-core/Cargo.toml
+++ b/godot-core/Cargo.toml
@@ -31,8 +31,6 @@ api-custom-json = ["godot-codegen/api-custom-json"]
 # [version-sync] [[
 #  [line] api-$kebabVersion = ["godot-ffi/api-$kebabVersion"]
 api-4-2 = ["godot-ffi/api-4-2"]
-api-4-2-1 = ["godot-ffi/api-4-2-1"]
-api-4-2-2 = ["godot-ffi/api-4-2-2"]
 api-4-3 = ["godot-ffi/api-4-3"]
 api-4-4 = ["godot-ffi/api-4-4"]
 api-4-5 = ["godot-ffi/api-4-5"]

--- a/godot-ffi/Cargo.toml
+++ b/godot-ffi/Cargo.toml
@@ -23,8 +23,6 @@ api-custom-json = ["godot-bindings/api-custom-json"]
 # [version-sync] [[
 #  [line] api-$kebabVersion = ["godot-bindings/api-$kebabVersion"]
 api-4-2 = ["godot-bindings/api-4-2"]
-api-4-2-1 = ["godot-bindings/api-4-2-1"]
-api-4-2-2 = ["godot-bindings/api-4-2-2"]
 api-4-3 = ["godot-bindings/api-4-3"]
 api-4-4 = ["godot-bindings/api-4-4"]
 api-4-5 = ["godot-bindings/api-4-5"]

--- a/godot/Cargo.toml
+++ b/godot/Cargo.toml
@@ -32,8 +32,6 @@ api-custom-json = ["godot-core/api-custom-json"]
 # [version-sync] [[
 #  [line] api-$kebabVersion = ["godot-core/api-$kebabVersion"]
 api-4-2 = ["godot-core/api-4-2"]
-api-4-2-1 = ["godot-core/api-4-2-1"]
-api-4-2-2 = ["godot-core/api-4-2-2"]
 api-4-3 = ["godot-core/api-4-3"]
 api-4-4 = ["godot-core/api-4-4"]
 api-4-5 = ["godot-core/api-4-5"]

--- a/godot/src/lib.rs
+++ b/godot/src/lib.rs
@@ -108,7 +108,6 @@
 //! _Godot version and configuration:_
 //!
 //! * **`api-4-{minor}`**
-//! * **`api-4-{minor}-{patch}`**
 //! * **`api-custom`**
 //! * **`api-custom-json`**
 //!

--- a/itest/repo-tweak/src/main.rs
+++ b/itest/repo-tweak/src/main.rs
@@ -14,18 +14,21 @@ use std::fs::File;
 use std::io::Write;
 use std::path::Path;
 
-// Manual input.
-#[rustfmt::skip]
+// Manual input. Disabled for now, limiting `api-*` features to minor levels.
+/*#[rustfmt::skip]
 pub const GODOT_LATEST_PATCH_VERSIONS: &[&str] = &[
     // 4.0.4 no longer supported.
     // 4.1.4 no longer supported.
     "4.2.2",
     "4.3.0",
-    "4.4.0",
-    "4.5.0",
-    "4.6.0",
+    "4.4.1",
+    "4.5.1",
+    "4.6.1",
     "4.7.0", // Upcoming.
-];
+];*/
+
+/// `(Min supported version, next version)`. Read as `4.x`.
+pub const GODOT_VERSION_RANGE: (u8, u8) = (2, 7);
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -187,6 +190,13 @@ fn apply_char_substitutions(s: &str) -> String {
         .replace("\\n", "\n")
 }
 
+// Limit to minor versions.
+fn latest_patch_versions() -> Vec<(u8, u8)> {
+    let (min, next) = GODOT_VERSION_RANGE;
+    (min..=next).map(|minor| (minor, 0)).collect()
+}
+
+/* Old disabled implementation that allowed patch versions.
 fn latest_patch_versions() -> Vec<(u8, u8)> {
     GODOT_LATEST_PATCH_VERSIONS
         .iter()
@@ -198,4 +208,4 @@ fn latest_patch_versions() -> Vec<(u8, u8)> {
             (minor, patch)
         })
         .collect()
-}
+}*/


### PR DESCRIPTION
We didn't provide Cargo features `api-4-4-1` and `api-4-5-1`. Godot 4.4.1 was released 1 year ago already, but no one has asked for them.

This PR limits `api-4-*` features to **minor versions**, abandoning the patch. While there are occasionally API additions in patches, they're rather rare, and not supporting patch versions would allow us to ship a smaller `gdextension-api` crate in the future.

If there is demand for patch versions supported by good use cases, we can also add them again. For now I won't change the infra behind yet, so there's some time to see how things go.