### PR TITLE
`InnerArray`: remove generic + unsafe methods in favor of `AnyArray`

### DIFF
--- a/godot-codegen/src/generator/classes.rs
+++ b/godot-codegen/src/generator/classes.rs
@@ -635,7 +635,6 @@ fn make_class_method_definition(
             is_virtual_required: false,
             is_varcall_fallible: true,
         },
-        None,
         cfg_attributes,
     )
 }

--- a/godot-codegen/src/generator/utility_functions.rs
+++ b/godot-codegen/src/generator/utility_functions.rs
@@ -75,7 +75,6 @@ pub(crate) fn make_utility_function_definition(function: &UtilityFunction) -> To
             is_virtual_required: false,
             is_varcall_fallible: false,
         },
-        None,
         &TokenStream::new(),
     );
 

--- a/godot-codegen/src/generator/virtual_traits.rs
+++ b/godot-codegen/src/generator/virtual_traits.rs
@@ -204,7 +204,6 @@ fn make_virtual_method(
             is_virtual_required,
             is_varcall_fallible: true,
         },
-        None,
         &TokenStream::new(),
     );
 

--- a/godot-codegen/src/special_cases/codegen_special_cases.rs
+++ b/godot-codegen/src/special_cases/codegen_special_cases.rs
@@ -48,7 +48,6 @@ fn is_type_excluded(ty: &str, ctx: &mut Context) -> bool {
         match ty {
             RustTy::BuiltinIdent { .. } => false,
             RustTy::BuiltinArray { .. } => false,
-            RustTy::GenericArray => false,
             RustTy::RawPointer { inner, .. } => is_rust_type_excluded(inner),
             RustTy::SysPointerType { .. } => true,
             RustTy::EngineArray { elem_class, .. } => is_class_excluded(elem_class.as_str()),

--- a/godot-codegen/src/special_cases/special_cases.rs
+++ b/godot-codegen/src/special_cases/special_cases.rs
@@ -34,7 +34,7 @@ use proc_macro2::Ident;
 use crate::Context;
 use crate::conv::to_enum_type_uncached;
 use crate::models::domain::{
-    ClassCodegenLevel, Enum, EnumReplacements, FnReturn, RustTy, TyName, VirtualMethodPresence,
+    ClassCodegenLevel, Enum, EnumReplacements, RustTy, TyName, VirtualMethodPresence,
 };
 use crate::models::json::{JsonBuiltinMethod, JsonClassMethod, JsonSignal, JsonUtilityFunction};
 use crate::special_cases::codegen_special_cases;
@@ -821,27 +821,6 @@ pub fn is_class_method_param_required(
 /// True if builtin method is excluded. Does NOT check for type exclusion; use [`is_builtin_type_deleted`] for that.
 pub fn is_builtin_method_deleted(_class_name: &TyName, method: &JsonBuiltinMethod) -> bool {
     codegen_special_cases::is_builtin_method_excluded(method)
-}
-
-/// Returns some generic type – such as `GenericArray` representing `Array<T>` – if method is marked as generic, `None` otherwise.
-///
-/// Usually required to initialize the return value and cache its type (see also https://github.com/godot-rust/gdext/pull/1357).
-#[rustfmt::skip]
-pub fn builtin_method_generic_ret(
-    class_name: &TyName,
-    method: &JsonBuiltinMethod,
-) -> Option<FnReturn> {
-    match (
-        class_name.rust_ty.to_string().as_str(),
-        method.name.as_str(),
-    ) {
-        | ("Array", "duplicate")
-        | ("Array", "slice")
-        | ("Array", "filter")
-
-        => Some(FnReturn::with_generic_builtin(RustTy::GenericArray)),
-        _ => None,
-    }
 }
 
 /// True if signal is absent from codegen (only when surrounding class is excluded).

--- a/godot-core/src/builtin/collections/array_functional_ops.rs
+++ b/godot-core/src/builtin/collections/array_functional_ops.rs
@@ -50,8 +50,7 @@ impl<'a, T: ArrayElement> ArrayFunctionalOps<'a, T> {
     /// ```
     #[must_use]
     pub fn filter(&self, callable: &Callable) -> Array<T> {
-        // SAFETY: filter() returns array of same type as self.
-        unsafe { self.array.as_inner().filter(callable) }
+        self.array.as_inner().filter(callable).cast_array::<T>()
     }
 
     /// Returns a new untyped array with each element transformed by the callable.
@@ -72,8 +71,7 @@ impl<'a, T: ArrayElement> ArrayFunctionalOps<'a, T> {
     /// ```
     #[must_use]
     pub fn map(&self, callable: &Callable) -> VarArray {
-        // SAFETY: map() returns an untyped array (element type Variant).
-        unsafe { self.array.as_inner().map(callable) }
+        self.array.as_inner().map(callable).cast_array()
     }
 
     /// Reduces the array to a single value by iteratively applying the callable.

--- a/itest/rust/src/builtin_tests/containers/array_test.rs
+++ b/itest/rust/src/builtin_tests/containers/array_test.rs
@@ -94,7 +94,7 @@ fn array_hash() {
 }
 
 #[itest]
-fn array_share() {
+fn array_clone() {
     let mut array = array![1, 2];
     let shared = array.clone();
     array.set(0, 3);
@@ -104,23 +104,48 @@ fn array_share() {
 #[itest]
 fn array_duplicate_shallow() {
     let subarray = array![2, 3];
+    assert_eq!(
+        subarray.duplicate_shallow().element_type(),
+        ElementType::Builtin(VariantType::INT)
+    );
+
     let array = varray![1, subarray];
     let duplicate = array.duplicate_shallow();
-    Array::<i64>::try_from_variant(&duplicate.at(1))
-        .unwrap()
-        .set(0, 4);
+    assert_eq!(duplicate.element_type(), ElementType::Untyped);
+
+    Array::<i64>::from_variant(&duplicate.at(1)).set(0, 4);
     assert_eq!(subarray.at(0), 4);
 }
 
 #[itest]
 fn array_duplicate_deep() {
     let subarray = array![2, 3];
+    assert_eq!(
+        subarray.duplicate_deep().element_type(),
+        ElementType::Builtin(VariantType::INT)
+    );
+
     let array = varray![1, subarray];
     let duplicate = array.duplicate_deep();
-    Array::<i64>::try_from_variant(&duplicate.at(1))
-        .unwrap()
-        .set(0, 4);
+    assert_eq!(duplicate.element_type(), ElementType::Untyped);
+
+    Array::<i64>::from_variant(&duplicate.at(1)).set(0, 4);
     assert_eq!(subarray.at(0), 2);
+}
+
+#[itest]
+fn array_any_duplicate_deep() {
+    let typed = array![2, 3].upcast_any_array();
+    assert_eq!(
+        typed.duplicate_deep().element_type(),
+        ElementType::Builtin(VariantType::INT)
+    );
+
+    let untyped = varray![1, typed].upcast_any_array();
+    assert_eq!(
+        untyped.duplicate_deep().element_type(),
+        ElementType::Untyped
+    );
 }
 
 #[itest]

--- a/itest/rust/src/builtin_tests/containers/dictionary_test.rs
+++ b/itest/rust/src/builtin_tests/containers/dictionary_test.rs
@@ -889,7 +889,7 @@ func variant_script_dict() -> Dictionary[Variant, CustomScriptForDictionaries]:
 
 #[cfg(since_api = "4.4")]
 mod typed_dictionary_tests {
-    use godot::builtin::dict;
+    use godot::builtin::{array, dict};
 
     use super::*;
 
@@ -943,18 +943,36 @@ mod typed_dictionary_tests {
         assert_eq!(d.get("num"), Some(23.to_variant()));
     }
 
-    #[itest(skip)] // TODO(v0.5): fix {keys,values}_array and re-enable.
-    #[expect(clippy::dbg_macro)]
+    #[itest]
     fn dictionary_typed_kv_array() {
-        // Value type needs to be specified for now, due to GString/StringName/NodePath ambiguity.
-        let dict: Dictionary<GString, i32> = dict! {
+        // Key type needs to be specified for now, due to GString/StringName/NodePath ambiguity.
+        let dict: Dictionary<GString, _> = dict! {
             "key1": 10,
             "key2": 20,
         };
 
-        dbg!(dict.keys_array());
-        dbg!(dict.keys_array().element_type());
-        dbg!(dict.values_array());
-        dbg!(dict.values_array().element_type());
+        assert_eq!(dict.keys_array(), array!["key1", "key2"]);
+        assert_eq!(
+            dict.keys_array().element_type(),
+            ElementType::Builtin(VariantType::STRING)
+        );
+        assert_eq!(dict.values_array(), array![10, 20]);
+        assert_eq!(
+            dict.values_array().element_type(),
+            ElementType::Builtin(VariantType::INT)
+        );
+    }
+
+    #[itest]
+    fn dictionary_typed_duplicate() {
+        let dict = Dictionary::<GString, i64>::new();
+
+        let shallow = dict.duplicate_shallow();
+        assert_eq!(shallow.key_element_type(), dict.key_element_type());
+        assert_eq!(shallow.value_element_type(), dict.value_element_type());
+
+        let deep = dict.duplicate_deep();
+        assert_eq!(deep.key_element_type(), dict.key_element_type());
+        assert_eq!(deep.value_element_type(), dict.value_element_type());
     }
 }


### PR DESCRIPTION
#1357 introduced special codegen: selected builtin methods returning arrays are now unsafe, and some of them generic. The reason behind this was that methods like `Array::duplicate` returned `VarArray` per JSON declaration, but in fact the returned array is typed. This is unsound if used as-is, which is why there was an `unsafe`  conversion for the `Array` client code.

The existence of `AnyArray` (and `AnyDictionary`) as a covariant base makes this no longer necessary: we can simply return `AnyArray` and then use a _safe_ downcast to the correct type. This would theoretically panic (not cause UB), but as long as Godot upholds its contract, it's infallible.