### PR TITLE
Address unsoundness of typed signals after hot reload

### DIFF
--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -289,7 +289,7 @@ jobs:
             os: macos-latest
             artifact-name: macos-arm-nightly
             godot-binary: godot.macos.editor.dev.arm64
-            hot-reload: stable
+            hot-reload: stable signal-test
 
            # api-custom on macOS arm64 not working, due to clang linker issues.
 #          - name: macos-double-arm
@@ -311,7 +311,7 @@ jobs:
             os: windows-latest
             artifact-name: windows-nightly
             godot-binary: godot.windows.editor.dev.x86_64.exe
-            hot-reload: stable
+            hot-reload: stable signal-test
 
           - name: windows-double
             os: windows-latest
@@ -339,7 +339,7 @@ jobs:
             godot-binary: godot.linuxbsd.editor.dev.x86_64
             rust-extra-args: --features itest/codegen-full,itest/test-gdextension-dependency
             rust-extra-env: GODOT_RUST_MAIN_EXTENSION=IntegrationTests
-            hot-reload: api-custom
+            hot-reload: api-custom signal-test
 
           # Combines now a lot of features, but should be OK. lazy-function-tables doesn't work with experimental-threads.
           - name: linux-double-lazy
@@ -381,21 +381,21 @@ jobs:
             artifact-name: linux-4.6
             godot-binary: godot.linuxbsd.editor.dev.x86_64
             #godot-prebuilt-patch: '4.6'
-            hot-reload: stable
+            hot-reload: stable signal-test
 
           - name: linux-4.5
             os: ubuntu-22.04
             artifact-name: linux-4.5
             godot-binary: godot.linuxbsd.editor.dev.x86_64
             godot-prebuilt-patch: '4.5'
-            hot-reload: api-4-5
+            hot-reload: api-4-5 signal-test
 
           - name: linux-4.4
             os: ubuntu-22.04
             artifact-name: linux-4.4
             godot-binary: godot.linuxbsd.editor.dev.x86_64
             godot-prebuilt-patch: '4.4'
-            hot-reload: api-4-4
+            hot-reload: api-4-4 signal-test
 
           - name: linux-4.3
             os: ubuntu-22.04

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .vscode
 .idea
 .run
+.zed
 
 # Rust
 target
@@ -23,6 +24,7 @@ gen
 *.bat
 config.toml
 exp.rs
+/extension_api.json
 
 # Mac specific
 .DS_Store

--- a/godot-core/src/init/mod.rs
+++ b/godot-core/src/init/mod.rs
@@ -11,14 +11,20 @@ use godot_ffi as sys;
 use sys::GodotFfi;
 
 use crate::builtin::{GString, StringName};
+use crate::obj::Singleton;
 use crate::out;
 
 mod reexport_pub {
+    // `Engine::singleton()` is not available before `InitLevel::Scenes` for Godot before 4.4.
+    #[cfg(since_api = "4.4")]
+    pub use super::sys::is_editor_hint;
     #[cfg(not(wasm_nothreads))]
     pub use super::sys::main_thread_id;
     pub use super::sys::{GdextBuild, InitStage, is_main_thread};
 }
 pub use reexport_pub::*;
+
+use crate::registry::signal::prune_stored_signal_connections;
 
 #[repr(C)]
 struct InitUserData {
@@ -218,6 +224,9 @@ unsafe fn gdext_on_level_init(level: InitLevel, _userdata: &InitUserData) {
                     &raw const _userdata.main_loop_callbacks,
                 )
             };
+
+            #[cfg(since_api = "4.4")]
+            sys::set_editor_hint(crate::classes::Engine::singleton().is_editor_hint());
         }
         InitLevel::Servers => {
             // SAFETY: called from the main thread, sys::initialized has already been called.
@@ -241,6 +250,10 @@ unsafe fn gdext_on_level_init(level: InitLevel, _userdata: &InitUserData) {
 
 /// Tasks needed to be done by gdext internally upon unloading an initialization level. Called after user code.
 fn gdext_on_level_deinit(level: InitLevel) {
+    if level == InitLevel::Editor {
+        prune_stored_signal_connections();
+    }
+
     crate::registry::class::unregister_classes(level);
 
     if level == InitLevel::Core {

--- a/godot-core/src/registry/signal/mod.rs
+++ b/godot-core/src/registry/signal/mod.rs
@@ -7,6 +7,7 @@
 
 mod connect_builder;
 mod connect_handle;
+mod signal_connections_registry;
 mod signal_object;
 mod signal_receiver;
 mod typed_signal;
@@ -15,6 +16,7 @@ use std::borrow::Cow;
 
 pub(crate) use connect_builder::*;
 pub(crate) use connect_handle::*;
+pub(crate) use signal_connections_registry::*;
 pub(crate) use signal_object::*;
 pub(crate) use typed_signal::*;
 

--- a/godot-core/src/registry/signal/signal_connections_registry.rs
+++ b/godot-core/src/registry/signal/signal_connections_registry.rs
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+//! Signal connection registry
+//!
+//! Interacting with custom callables (used by typed signals) after hot reload in any way is instant UB.
+//! We prevent unsoundness by disconnecting all the signals before the hot reload.
+//!
+//! To achieve this, we store all connections in a global registry as long as the library remains loaded and given receiver object is alive.
+//!
+//! For upstream issue, see: <https://github.com/godotengine/godot/issues/105802>.
+
+use std::cell::RefCell;
+
+use crate::builtin::{Callable, CowStr};
+use crate::classes::Object;
+use crate::obj::Gd;
+use crate::{godot_warn, sys};
+
+thread_local! {
+    static SIGNAL_CONNECTIONS_REGISTRY: RefCell<Vec<CachedSignalConnection >> = RefCell::default();
+}
+
+struct CachedSignalConnection {
+    // `Option`, so we can mark objects for removal by setting receiver to None.
+    receiver_object: Option<Gd<Object>>,
+    signal_name: CowStr,
+    callable: Callable,
+}
+
+/// Prunes stale connections to objects that are no longer valid.
+///
+/// This method does not check the validity of the signals themselves due to the overhead required.
+/// Additionally, the number of connections to alive objects is finite -- unlike connections to freed objects,
+/// which can accumulate to a critical mass simply by opening and closing tabs in the editor.
+fn prune_stale_connections(registry: &mut Vec<CachedSignalConnection>) {
+    registry.retain_mut(|connection| {
+        if let Some(obj) = connection
+            .receiver_object
+            .take_if(|obj| obj.is_instance_valid())
+        {
+            obj.drop_weak();
+            false
+        } else {
+            true
+        }
+    });
+}
+
+/// Stores the given connection in a registry so it can be disconnected during library deinitialization,
+/// and prunes any existing connections to objects that are no longer valid.
+pub(crate) fn store_signal_connection(
+    receiver_object: &Gd<Object>,
+    signal_name: &CowStr,
+    callable: &Callable,
+) {
+    if !sys::is_editor_hint() {
+        return;
+    }
+
+    SIGNAL_CONNECTIONS_REGISTRY.with_borrow_mut(|connection_registry| {
+        prune_stale_connections(connection_registry);
+
+        // SAFETY: Given weak pointer to the Object is accessed only once in `prune_stored_signal_connections` or `prune_stale_connections`,
+        // inaccessible outside this module, validated before use and properly disposed of by using `drop_weak`.
+        let weak_object_ptr = unsafe { receiver_object.clone_weak() };
+        connection_registry.push(CachedSignalConnection {
+            receiver_object: Some(weak_object_ptr),
+            signal_name: signal_name.clone(),
+            callable: callable.clone(),
+        });
+    });
+}
+
+/// Disconnects all the registered signals.
+///
+/// Should be run only once during initialization of the library on [`InitLevel::Editor`].
+/// (Running it multiple times is safe, but has no effect.)
+pub(crate) fn prune_stored_signal_connections() {
+    SIGNAL_CONNECTIONS_REGISTRY.with_borrow_mut(|connection_registry| {
+        if connection_registry.is_empty() {
+            return;
+        }
+
+        // TODO(v0.5): shorten this message and point to newly-written chapter in the book.
+        godot_warn!(
+            "godot-rust: Automatically disconnecting all registered typed signal connections. \n\
+            Custom callables used by godot-rust signals become invalid after a hot reload. \
+            All the registered connections will be automatically disconnected to prevent unsoundness. \
+            After hot reload connections must be recreated with `ObjectNotification::EXTENSION_RELOADED`. \
+            You may also consider using untyped signals in this scenario. \
+            For more information, see: https://godot-rust.github.io/book/register/signals.html#untyped-signals."
+        );
+
+        for connection in connection_registry.drain(..) {
+            let CachedSignalConnection {
+                receiver_object: Some(mut receiver_object),
+                signal_name,
+                callable,
+            } = connection
+            else {
+                continue;
+            };
+
+            // Bail if object has been freed in a meanwhile -- Godot handled disconnecting by itself.
+            if !receiver_object.is_instance_valid() {
+                receiver_object.drop_weak();
+                continue;
+            }
+
+            if receiver_object.is_connected(&*signal_name, &callable) {
+                receiver_object.disconnect(&*signal_name, &callable);
+            }
+
+            receiver_object.drop_weak();
+        }
+    });
+}

--- a/godot-core/src/registry/signal/typed_signal.rs
+++ b/godot-core/src/registry/signal/typed_signal.rs
@@ -15,6 +15,7 @@ use crate::classes::object::ConnectFlags;
 use crate::meta;
 use crate::meta::{InParamTuple, ObjectToOwned, UniformObjectDeref};
 use crate::obj::{Gd, GodotClass, WithSignals};
+use crate::registry::signal::signal_connections_registry::store_signal_connection;
 use crate::registry::signal::signal_receiver::{IndirectSignalReceiver, SignalReceiver};
 
 /// Type-safe version of a Godot signal.
@@ -230,6 +231,8 @@ impl<'c, C: WithSignals, Ps: meta::ParamTuple> TypedSignal<'c, C, Ps> {
                 obj.connect(signal_name, &callable);
             }
         });
+
+        store_signal_connection(&owned_object, &self.name, &callable);
 
         ConnectHandle::new(owned_object, self.name.clone(), callable)
     }

--- a/godot-ffi/src/lib.rs
+++ b/godot-ffi/src/lib.rs
@@ -84,6 +84,8 @@ mod plugins;
 mod string_cache;
 mod toolbox;
 
+use std::sync::atomic::{AtomicBool, Ordering};
+
 // Other
 pub use extras::*;
 pub use r#gen::central::*;
@@ -594,6 +596,19 @@ pub fn is_main_thread() -> bool {
     {
         true
     }
+}
+
+static IS_EDITOR_HINT: AtomicBool = AtomicBool::new(false);
+
+/// Caches the current value of `Engine::is_editor_hint`.
+/// Should be called only once, during bindings initialization.
+pub fn set_editor_hint(is_editor_hint: bool) {
+    IS_EDITOR_HINT.store(is_editor_hint, Ordering::Relaxed);
+}
+
+/// Cached output of `Engine::is_editor_hint`, allowing to fetch the value without crossing the FFI barrier.
+pub fn is_editor_hint() -> bool {
+    IS_EDITOR_HINT.load(Ordering::Relaxed)
 }
 
 /// Assign the current thread id to be the main thread.

--- a/godot-macros/src/util/mod.rs
+++ b/godot-macros/src/util/mod.rs
@@ -94,7 +94,9 @@ macro_rules! error {
     }
 }
 
-pub(crate) use {bail, error, require_api_version};
+pub(crate) use bail;
+pub(crate) use error;
+pub(crate) use require_api_version;
 
 /// Keeps all attributes except the one specified (e.g. `"itest"`).
 pub fn retain_attributes_except<'a>(

--- a/itest/hot-reload/godot/ReloadTest.gd
+++ b/itest/hot-reload/godot/ReloadTest.gd
@@ -15,6 +15,8 @@ var extension_name: String
 
 var retained_obj: Reloadable
 
+var signal_obj: Object
+
 
 func _ready() -> void:
 	print("[GD Editor] Start...")
@@ -28,13 +30,20 @@ func _ready() -> void:
 	var planet = retained_obj.favorite_planet
 
 	print("[GD Editor] Sanity check: initial number is ", num, "; planet is ", planet)
-	
+
 	var extensions = GDExtensionManager.get_loaded_extensions()
 	if extensions.size() == 1:
 		extension_name = extensions[0]
 	else:
 		fail(str("Must have 1 extension, has: ", extensions))
 		return
+
+	if ClassDB.class_exists("Signaller"):
+		self.signal_obj = ClassDB.instantiate("Signaller")
+		self.signal_obj.reloadable_signal.emit(42)
+		print("[GD Editor] Sanity check: Signaller emitted signal and holds ", self.signal_obj.value)
+	else:
+		print("[GD Editor] Skipping signal test: hot reloading with typed signals is not supported for this Godot version")
 
 	udp.bind(1337)
 	print("[GD Editor] ReloadTest ready to receive...")
@@ -72,6 +81,14 @@ func _process(delta: float) -> void:
 	if not _hot_reload():
 		return
 
+	if self.signal_obj:
+		# Test if previous signal has been properly disconnected before hot-reload.
+		self.signal_obj.reloadable_signal.emit(12)
+		# We did not crash thus all works well :).
+		print("[GD Editor] Signal has been properly hot reloaded!")
+
+		self.signal_obj.free()
+
 	var r = Reloadable.new()
 	var num = r.get_number()
 	r.free()
@@ -103,5 +120,3 @@ func _hot_reload():
 func fail(s: String) -> void:
 	print("::error::[GD Editor] ", s) # GitHub Action syntax
 	get_tree().quit(1)
-
-

--- a/itest/hot-reload/godot/run-test.sh
+++ b/itest/hot-reload/godot/run-test.sh
@@ -18,6 +18,10 @@ else
   exit 1
 fi
 
+if [[ $2 == "signal-test" ]]; then
+    cargoArgs="${cargoArgs} --features signal-test"
+fi
+
 # Restore un-reloaded files on exit (for local testing).
 cleanedUp=0 # avoid recursion if cleanup fails
 godotPid=0 # kill previous instance if necessary

--- a/itest/hot-reload/rust/Cargo.toml
+++ b/itest/hot-reload/rust/Cargo.toml
@@ -6,6 +6,9 @@ rust-version.workspace = true
 license = "MPL-2.0"
 publish = false
 
+[features]
+signal-test = []
+
 [lib]
 crate-type = ["cdylib"]
 

--- a/itest/hot-reload/rust/src/lib.rs
+++ b/itest/hot-reload/rust/src/lib.rs
@@ -71,3 +71,58 @@ enum Planet {
     Mars,
     Venus,
 }
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// Signal soundness: https://github.com/godot-rust/gdext/pull/1512.
+
+#[cfg(feature = "signal-test")]
+pub use signal_test::*;
+
+#[cfg(feature = "signal-test")]
+mod signal_test {
+    use godot::classes::notify::ObjectNotification;
+
+    use super::*;
+
+    #[derive(GodotClass)]
+    #[class(init, tool, base = Object)]
+    struct Signaller {
+        #[var]
+        value: i64,
+        base: Base<Object>,
+    }
+
+    #[godot_api]
+    impl IObject for Signaller {
+        fn on_notification(&mut self, what: ObjectNotification) {
+            // Recreate signal after hot reload.
+            // Doesn't really matter much for this test - it does NOT replace previous signal (which should be disconnected at this point).
+            if what == ObjectNotification::EXTENSION_RELOADED {
+                self.signals()
+                    .reloadable_signal()
+                    .connect_self(|this, val| this.value = val);
+            }
+        }
+    }
+
+    #[godot_api]
+    impl Signaller {
+        #[func]
+        fn initialize_connections(&mut self) {
+            self.signals()
+                .reloadable_signal()
+                .connect_self(|this, val| this.value = val);
+
+            // Given RefCounted will be instantly freed after this function execution,
+            // but signal connection will be registered and pruned upon hot reload.
+            let some_refcounted = RefCounted::new_gd();
+            some_refcounted
+                .signals()
+                .property_list_changed()
+                .connect(|| godot_print!("Henlo!"));
+        }
+
+        #[signal]
+        fn reloadable_signal(val: i64);
+    }
+}


### PR DESCRIPTION
tl;dr – due to https://github.com/godotengine/godot/issues/105802 custom callables (a big flying vtables with refcount attached) change into UB-bomb after hot reload and poking them is guaranteed UB. 

This is very bad, since making editor plugins is one of the advertised features of the GDExtension. Theoretically users can take care of it by themselves but I would like to have all the critical paths in library sound, thankyouverymuch.

This PR introduces global signal connections storage – when user makes a new connection firstly we prune all the connections to stale objects (one can check the necessity of doing so by making few connections and then opening and closing editor tab ~2 000 times) and then we put the new signal connection in the registry. Upon deinit we go through all the stored connections and disconnect them, additionally printing a warning which should simply link to a book or something.

I considered few other approaches (using `mem_alloc2` (no idea what I wanted to achieve honestly – is it even possible to store some function (is_valid in this case) outside the library itself?), exposing better API for untyped signals (bad, doesn't address the root issue – unsoundness – and putting a lot of work to support obviously inferior approach bloating the API in the process is bad)) and global registry looks like the sanest one :weary:.
