### PR TITLE
Improve `#[var(no_get)]` UX

### DIFF
--- a/godot-macros/src/class/data_models/field_var.rs
+++ b/godot-macros/src/class/data_models/field_var.rs
@@ -221,7 +221,13 @@ impl GetterSetter {
         rust_public: bool,
     ) -> Option<GetterSetterImpl> {
         match self {
-            GetterSetter::Disabled => None,
+            GetterSetter::Disabled => match kind {
+                // #[var(no_get)] *does* register a getter, but a special one which panics, to improve UX over Godot's default behavior.
+                GetSet::Get => Some(GetterSetterImpl::from_write_only_getter(
+                    class_name, field, rename,
+                )),
+                GetSet::Set => None,
+            },
             GetterSetter::Generated => Some(GetterSetterImpl::from_generated_impl(
                 class_name,
                 kind,
@@ -415,9 +421,72 @@ impl GetterSetterImpl {
             #deprecated_function
         };
 
+        let (funcs_collection_constant, export_token) =
+            Self::make_registration(class_name, &rust_accessor, &godot_function_name, signature);
+
+        Self {
+            rust_accessor,
+            function_impl,
+            export_token,
+            funcs_collection_constant,
+        }
+    }
+
+    /// Generates a getter that panics with a descriptive message for write-only (`#[var(no_get)]`) fields.
+    fn from_write_only_getter(class_name: &Ident, field: &Field, rename: &Option<Ident>) -> Self {
+        let Field {
+            name: field_name,
+            ty: field_type,
+            ..
+        } = field;
+
+        let field_span = field_name.span();
+        let prefix = GetSet::Get.prefix();
+        // Use a mangled name so the panicking getter is not accidentally called as `get_field()` in GDScript.
+        let godot_function_name =
+            format_ident!("__disabled_{prefix}{field_name}", span = field_span);
+        let rust_accessor = format_ident!("__godot_{prefix}{field_name}", span = field_span);
+
+        let panic_message = format!(
+            "property '{}::{}' is write-only through #[var(no_get)]",
+            class_name,
+            rename.as_ref().unwrap_or(field_name),
+        );
+
+        let signature = quote_spanned! { field_span=>
+            fn #rust_accessor(&self) -> <#field_type as ::godot::meta::GodotConvert>::Via
+        };
+
+        let function_impl = quote_spanned! { field_span=>
+            #[doc(hidden)]
+            pub #signature {
+                panic!(#panic_message)
+            }
+        };
+
+        let (funcs_collection_constant, export_token) =
+            Self::make_registration(class_name, &rust_accessor, &godot_function_name, signature);
+
+        Self {
+            rust_accessor,
+            function_impl,
+            export_token,
+            funcs_collection_constant,
+        }
+    }
+
+    /// Registers a generated accessor with Godot. Shared by `from_generated_impl` and `from_write_only_getter`.
+    ///
+    /// Returns `(funcs_collection_constant, export_token)`.
+    fn make_registration(
+        class_name: &Ident,
+        rust_accessor: &Ident,
+        godot_function_name: &Ident,
+        signature: TokenStream,
+    ) -> (TokenStream, TokenStream) {
         let funcs_collection_constant = make_funcs_collection_constant(
             class_name,
-            &rust_accessor,
+            rust_accessor,
             Some(&godot_function_name.to_string()),
             &[],
         );
@@ -427,11 +496,10 @@ impl GetterSetterImpl {
             class_name,
             FuncDefinition {
                 signature_info: into_signature_info(signature, class_name, false),
-                // Since we're analyzing a struct's field, we don't have access to the corresponding get/set function's
-                // external (non-#[func]) attributes. We have to assume the function exists and has the name the user
-                // gave us, with the expected signature.
-                // Ideally, we'd be able to place #[cfg_attr] on #[var(get)] and #[var(set)] to be able to match a
-                // #[cfg()] (for instance) placed on the getter/setter function, but that is not currently supported.
+                // Since we're analyzing a struct's field, we don't have access to the corresponding get/set function's external (non-#[func])
+                // attributes. We have to assume the function exists and has the name the user gave us, with the expected signature.
+                // Ideally, we'd be able to place #[cfg_attr] on #[var(get)] and #[var(set)] to be able to match a #[cfg()] (for instance)
+                // placed on the getter/setter function, but that is not currently supported.
                 external_attributes: Vec::new(),
                 // The Rust function name may differ from the Godot name (e.g. `__godot_get_field` vs `get_field`).
                 registered_name: Some(godot_function_name.to_string()),
@@ -442,14 +510,9 @@ impl GetterSetterImpl {
             None,
         );
 
-        let export_token = export_token.expect("getter/setter generation should not fail");
+        let export_token = export_token.expect("accessor registration should not fail");
 
-        Self {
-            rust_accessor,
-            function_impl,
-            export_token,
-            funcs_collection_constant,
-        }
+        (funcs_collection_constant, export_token)
     }
 
     fn generate_tool_button_impl(

--- a/godot-macros/src/class/derive_godot_class.rs
+++ b/godot-macros/src/class/derive_godot_class.rs
@@ -816,6 +816,14 @@ fn parse_fields(
                 );
             }
 
+            // #[export] with #[var(no_get)] is not supported: Godot editor needs to read exported properties.
+            if var.getter == GetterSetter::Disabled && field.export.is_some() {
+                return bail!(
+                    var.span,
+                    "#[export] with #[var(no_get)] is not supported; the editor requires a getter for serialization and inspector display"
+                );
+            }
+
             field.var = Some(var);
             parser.finish()?;
         }

--- a/itest/godot/ManualFfiTests.gd
+++ b/itest/godot/ManualFfiTests.gd
@@ -71,6 +71,26 @@ func test_var_accessors():
 
 	obj.free()
 
+func test_var_no_get_panics_on_read():
+	mark_test_pending()
+
+	var obj = VarAccessors.new()
+	# Getter is registered (panicking), unlike old behavior where no getter existed.
+	assert_that(obj.has_method("__disabled_get_g_noget"), "panicking getter should be registered")
+
+	obj.g_noget = 7
+	Engine.print_error_messages = false
+	var val = obj.g_noget # Getter panics in Rust; returns default, execution continues.
+	Engine.print_error_messages = true
+
+	# Panic was caught: returned default (0) instead of actual field value (7).
+	assert_eq(val, 0, "no_get getter should return default after panic")
+	# The field itself is intact.
+	assert_eq(obj.gdscript_get("g"), 7, "actual field value should be preserved")
+
+	obj.free()
+	mark_test_succeeded()
+
 func test_export():
 	var obj = HasProperty.new()
 

--- a/itest/rust/src/register_tests/var_test.rs
+++ b/itest/rust/src/register_tests/var_test.rs
@@ -169,11 +169,11 @@ fn var_orthogonal_getters_setters() {
     assert!(obj.has_method("get_f_noset"));
     assert!(!obj.has_method("set_f_noset"));
 
-    // g) write-only (no getter).
+    // g) write-only (no getter -- panicking getter is registered).
     obj.set("g_noget", &7.to_variant()); // Dynamic (no Rust setter).
     assert_eq!(obj.bind().g_noget, 7);
     assert!(obj.has_method("set_g_noget"));
-    assert!(!obj.has_method("get_g_noget"));
+    assert!(obj.has_method("__disabled_get_g_noget")); // panics.
 
     // h) custom getter (custom name), no setter.
     obj.bind_mut().h_myget_noset = 8;
@@ -181,11 +181,11 @@ fn var_orthogonal_getters_setters() {
     assert!(obj.has_method("my_custom_get"));
     assert!(!obj.has_method("set_h_myget_noset"));
 
-    // i) no getter, custom setter (custom name).
+    // i) no getter (panicking getter registered), custom setter (custom name).
     obj.bind_mut().my_custom_set(9); // Sets e, i, j to 9.
     assert_eq!(obj.bind().i_noget_myset, 9);
     assert!(obj.has_method("my_custom_set"));
-    assert!(!obj.has_method("get_i_noget_myset"));
+    assert!(obj.has_method("__disabled_get_i_noget_myset")); // panics.
 
     // j) custom getter (custom name), custom setter (custom name).
     assert_eq!(obj.bind().j_myget_myset, 9); // Set by my_custom_set(9) above.


### PR DESCRIPTION
Register a panicking getter behind the scenes, with helpful error message. Should improve usability slightly compared to Godot's default behavior:
- `#[var(no_get)]` + `#[export]` are mutually exclusive.
- when reading a non-existent getter from GDScript, a panic (Godot error message) occurs instead of silently reading the default value.
- a getter _is_ registered to achieve this, but its name is mangled instead of `get_xy`, to avoid accidentally calling it from GDScript or reflection.

Closes #1264.