### PR TITLE
Update `markdown` to `1.0.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ which = "7"
 # * venial: 0.6.1 contains some bugfixes.
 heck = "0.5"
 litrs = { version = "1.0", features = ["proc-macro2"] }
-markdown = "=1.0.0-alpha.23"
+markdown = "1.0.0"
 nanoserde = "0.2"
 proc-macro2 = "1.0.80"
 quote = "1.0.37"


### PR DESCRIPTION
I was able to run this on [GodotBoy](https://gitlab.com/greenfox/godot-boy) and my docs worked in engine. If other people would like to verify this as well with more complex docs, I'd appreciate it. 

Markdown alpha.24 was the last Markdown alpha and 1.0.0 is the same. alpha.23->24 seems to be fairly minimal changes.