### PR TITLE
Unique<T> for thread-safe usage of engine types

### DIFF
--- a/check.sh
+++ b/check.sh
@@ -195,7 +195,7 @@ function cmd_test() {
 
 function cmd_itest() {
     findGodot && \
-        run cargo build -p itest "${extraCargoArgs[@]}" || return 1
+        run cargo build -p itest --features itest/experimental-threads --features itest/codegen-full "${extraCargoArgs[@]}" || return 1
 
     # Keep in sync with: .github/composite/godot-itest/action.yml (steps "Run Godot integration tests" and "Check for memory leaks").
 

--- a/godot-codegen/src/generator/default_parameters.rs
+++ b/godot-codegen/src/generator/default_parameters.rs
@@ -16,6 +16,7 @@ use crate::generator::functions_common::{
 };
 use crate::generator::import_docs;
 use crate::models::domain::{ApiView, FnParam, FnQualifier, Function, RustTy, TyName};
+use crate::special_cases::is_method_threadsafe_return;
 use crate::util::{ident, safe_ident};
 use crate::{conv, special_cases};
 
@@ -66,7 +67,14 @@ pub fn make_function_definition_with_defaults(
         &default_fn_params,
     );
 
-    let return_decl = &sig.return_value().decl;
+    let return_decl = if let Some(class_name) = sig.surrounding_class()
+        && is_method_threadsafe_return(class_name, sig.godot_name())
+    {
+        sig.return_value().thread_safe_decl()
+    } else {
+        sig.return_value().decl.clone()
+    };
+
     let (maybe_deprecated, maybe_expect_deprecated) = fns::make_deprecation_attribute(sig);
 
     // If either the builder has a lifetime (non-static/global method), or one of its parameters is a reference,

--- a/godot-codegen/src/generator/default_parameters.rs
+++ b/godot-codegen/src/generator/default_parameters.rs
@@ -11,9 +11,10 @@ use quote::{format_ident, quote};
 
 use crate::context::Context;
 use crate::generator::functions_common::{
-    FnArgExpr, FnCode, FnKind, FnMeta, FnParamDecl, make_arg_expr, make_param_or_field_type,
+    self, FnArgExpr, FnCode, FnKind, FnMeta, FnParamDecl, make_arg_expr,
+    make_arg_thread_validator_expr, make_param_or_field_type,
 };
-use crate::generator::{functions_common, import_docs};
+use crate::generator::import_docs;
 use crate::models::domain::{ApiView, FnParam, FnQualifier, Function, RustTy, TyName};
 use crate::util::{ident, safe_ident};
 use crate::{conv, special_cases};
@@ -75,6 +76,14 @@ pub fn make_function_definition_with_defaults(
     let extended_receiver_param = &code.receiver.param_lifetime_ex;
     let cfg_attributes = &meta.cfg_attributes;
     let maybe_specific_docs = &meta.specific_docs;
+    let required_arg_thread_verifiers = if !sig.is_private() {
+        required_fn_params
+            .iter()
+            .filter_map(|param| make_arg_thread_validator_expr(&param.name, &param.type_))
+            .collect()
+    } else {
+        Vec::with_capacity(0)
+    };
 
     let mut maybe_godot_doc = TokenStream::new();
     if let Some(doc) = import_docs::import_function_docs(sig, ctx, view) {
@@ -148,6 +157,7 @@ pub fn make_function_definition_with_defaults(
             #extended_receiver_param
             #( #class_method_required_params_lifetimed, )*
         ) -> #builder_ty<'ex> {
+            #(#required_arg_thread_verifiers)*
             #builder_ty::new(
                 #object_arg
                 #( #class_method_required_args, )*
@@ -333,10 +343,13 @@ fn make_extender(
             make_param_or_field_type(name, type_, param_decl, &mut dummy_lifetime_gen);
 
         let arg_expr = make_arg_expr(name, type_, FnArgExpr::StoreInField);
+        let arg_thread_verifier = make_arg_thread_validator_expr(name, type_);
 
         let method = quote! {
             #[inline]
             pub fn #name(self, #param_decl) -> Self {
+                #arg_thread_verifier
+
                 // Currently not testing whether the parameter was already set.
                 Self {
                     #name: #arg_expr,

--- a/godot-codegen/src/generator/enums.rs
+++ b/godot-codegen/src/generator/enums.rs
@@ -166,6 +166,7 @@ pub fn make_enum_definition_with(
 
             impl crate::meta::ToGodot for #name {
                 type Pass = crate::meta::ByValue;
+                type Threads = crate::meta::ThreadSafeArg;
 
                 fn to_godot(&self) -> Self::Via {
                     <Self as #engine_trait>::ord(*self)

--- a/godot-codegen/src/generator/functions_common.rs
+++ b/godot-codegen/src/generator/functions_common.rs
@@ -5,6 +5,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+use std::ops::Not;
+
 use proc_macro2::{Ident, TokenStream};
 use quote::{format_ident, quote};
 
@@ -108,6 +110,7 @@ pub struct FnParamTokens {
     /// Generic argument list `<'a0, 'a1, ...>` after `type CallSig`, if available.
     pub callsig_lifetime_args: Option<TokenStream>,
     pub arg_exprs: Vec<TokenStream>,
+    pub arg_thread_validators: Vec<TokenStream>,
 }
 
 pub fn make_function_definition(
@@ -151,6 +154,7 @@ pub fn make_function_definition(
         callsig_param_types: param_types,
         callsig_lifetime_args,
         arg_exprs: arg_names,
+        arg_thread_validators,
     } = if sig.is_virtual() {
         make_params_exprs_virtual(sig.params().iter(), sig)
     } else {
@@ -210,6 +214,14 @@ pub fn make_function_definition(
         }
     };
 
+    let arg_thread_validators = if sig.is_exposed_outer_builtin()
+        || (!sig.is_builtin() && !sig.is_private() && !has_default_params)
+    {
+        arg_thread_validators
+    } else {
+        Vec::with_capacity(0)
+    };
+
     let return_decl = &sig.return_value().decl;
     let fn_body = if code.is_virtual_required {
         quote! { ; }
@@ -237,6 +249,13 @@ pub fn make_function_definition(
         // If the return type is not Variant, then convert to concrete target type.
         let varcall_invocation = &code.varcall_invocation;
 
+        let vararg_thread_validator = sig.is_private().not().then(|| {
+            quote! {
+                #[cfg(all(feature = "experimental-threads", safeguards_balanced))]
+                ThreadSafeArgContext::guarantee_thread_safe(&varargs);
+            }
+        });
+
         // TODO Utility functions: update as well.
         if !code.is_varcall_fallible {
             quote! {
@@ -250,6 +269,8 @@ pub fn make_function_definition(
                     varargs: &[Variant]
                 ) #return_decl {
                     #call_sig_decl
+                    #(#arg_thread_validators)*
+                    #vararg_thread_validator
 
                     let args = (#( #arg_names, )*);
 
@@ -284,6 +305,9 @@ pub fn make_function_definition(
                     #( #params, )*
                     varargs: &[Variant]
                 ) #return_decl {
+                    #(#arg_thread_validators)*
+                    #vararg_thread_validator
+
                     Self::#try_fn_name(self, #( #arg_names_without_asarg, )* varargs)
                         .unwrap_or_else(|e| panic!("{e}"))
                 }
@@ -324,6 +348,7 @@ pub fn make_function_definition(
             ) #return_decl
             {
                 #call_sig_decl
+                #(#arg_thread_validators)*
 
                 let args = (#( #arg_names, )*);
 
@@ -587,7 +612,8 @@ pub(crate) fn make_arg_expr(name: &Ident, ty: &RustTy, expr: FnArgExpr) -> Token
             ..
         } => match expr {
             FnArgExpr::PassToFfi => quote! { #name.into_arg() },
-            FnArgExpr::PassToFfiFromEx => quote! { #name }, // both field and parameter types are Cow -> forward.
+            // Both field and parameter types are Cow -> forward.
+            FnArgExpr::PassToFfiFromEx => quote! { #name },
             FnArgExpr::Forward => quote! { #name },
             FnArgExpr::StoreInField => quote! { #name.into_arg() },
             FnArgExpr::StoreInDefaultField => quote! { CowArg::Owned(#name) },
@@ -611,6 +637,25 @@ pub(crate) fn make_arg_expr(name: &Ident, ty: &RustTy, expr: FnArgExpr) -> Token
         _ => {
             quote! { #name }
         }
+    }
+}
+
+pub(crate) fn make_arg_thread_validator_expr(name: &Ident, ty: &RustTy) -> Option<TokenStream> {
+    match ty {
+        // Objects.
+        RustTy::EngineClass { .. }
+        | RustTy::BuiltinIdent {
+            arg_passing: ArgPassing::ByRef | ArgPassing::ImplAsArg,
+            ..
+        }
+        | RustTy::TypedArray { .. }
+        | RustTy::TypedDictionary { .. } => Some(quote! {
+            #[cfg(all(feature = "experimental-threads", safeguards_balanced))]
+            ThreadSafeArgContext::guarantee_thread_safe(&#name);
+        }),
+
+        // By value.
+        _ => None,
     }
 }
 
@@ -653,6 +698,10 @@ pub(crate) fn make_params_exprs<'a>(
         ret.param_decls.push(param_decl);
         ret.arg_exprs.push(arg_expr);
         ret.callsig_param_types.push(param_ty);
+
+        if let Some(arg_validator) = make_arg_thread_validator_expr(param_name, param_rust_ty) {
+            ret.arg_thread_validators.push(arg_validator);
+        }
     }
 
     ret.callsig_lifetime_args = lifetime_gen.all_generic_args();

--- a/godot-codegen/src/generator/functions_common.rs
+++ b/godot-codegen/src/generator/functions_common.rs
@@ -13,7 +13,7 @@ use quote::{format_ident, quote};
 use crate::context::Context;
 use crate::generator::{default_parameters, import_docs};
 use crate::models::domain::{ApiView, ArgPassing, FnParam, FnQualifier, Function, RustTy};
-use crate::special_cases;
+use crate::special_cases::{self, is_method_threadsafe_return};
 use crate::util::lifetime;
 
 pub struct FnReceiver {
@@ -222,11 +222,36 @@ pub fn make_function_definition(
         Vec::with_capacity(0)
     };
 
-    let return_decl = &sig.return_value().decl;
+    let return_decl = if let Some(class_name) = sig.surrounding_class()
+        && is_method_threadsafe_return(class_name, sig.godot_name())
+    {
+        sig.return_value().thread_safe_decl()
+    } else {
+        sig.return_value().decl.clone()
+    };
+
     let fn_body = if code.is_virtual_required {
         quote! { ; }
     } else {
         quote! { { unimplemented!() } }
+    };
+
+    let return_wrapper = if let Some(class_name) = sig.surrounding_class()
+        && is_method_threadsafe_return(class_name, sig.godot_name())
+    {
+        if matches!(
+            sig.return_value().type_,
+            Some(RustTy::EngineClass {
+                is_nullable: true,
+                ..
+            })
+        ) {
+            quote! { unsafe { crate::obj::Unique::new_optional_unchecked(return_value) } }
+        } else {
+            quote! { unsafe { crate::obj::Unique::new_unchecked(return_value) } }
+        }
+    } else {
+        quote! { return_value }
     };
 
     let receiver_param = &code.receiver.param;
@@ -274,9 +299,11 @@ pub fn make_function_definition(
 
                     let args = (#( #arg_names, )*);
 
-                    unsafe {
+                    let return_value = unsafe {
                         #varcall_invocation
-                    }
+                    };
+
+                    #return_wrapper
                 }
             }
         } else {
@@ -326,9 +353,11 @@ pub fn make_function_definition(
 
                     let args = (#( #arg_names, )*);
 
-                    unsafe {
+                    let return_value = unsafe {
                         #varcall_invocation
-                    }
+                    };
+
+                    #return_wrapper
                 }
             }
         }
@@ -352,9 +381,11 @@ pub fn make_function_definition(
 
                 let args = (#( #arg_names, )*);
 
-                unsafe {
+                let return_value = unsafe {
                     #ptrcall_invocation
-                }
+                };
+
+                #return_wrapper
             }
         }
     };

--- a/godot-codegen/src/models/domain.rs
+++ b/godot-codegen/src/models/domain.rs
@@ -802,6 +802,29 @@ impl FnReturn {
         }
     }
 
+    pub fn type_tokens_non_null(&self) -> TokenStream {
+        match &self.type_ {
+            Some(ty) => ty.tokens_non_null(),
+            _ => quote! { () },
+        }
+    }
+
+    pub fn thread_safe_decl(&self) -> TokenStream {
+        let ret = self.type_tokens_non_null();
+
+        if matches!(
+            self.type_,
+            Some(RustTy::EngineClass {
+                is_nullable: true,
+                ..
+            })
+        ) {
+            quote! { -> Option<crate::obj::Unique<#ret>> }
+        } else {
+            quote! { -> crate::obj::Unique<#ret> }
+        }
+    }
+
     pub fn call_result_decl(&self) -> TokenStream {
         let ret = self.type_tokens();
         quote! { -> Result<#ret, crate::meta::error::CallError> }

--- a/godot-codegen/src/special_cases/special_cases.rs
+++ b/godot-codegen/src/special_cases/special_cases.rs
@@ -452,6 +452,9 @@ pub fn is_class_method_replaced_with_type_safe(class_ty: &TyName, godot_method_n
         | ("Object", "get_script")
         | ("Object", "set_script")
 
+        // thread_safe_unchecked
+        | ("Object", "emit_signal")
+
         // u32 -> ConnectFlags
         | ("Object", "connect")
 

--- a/godot-codegen/src/special_cases/special_cases.rs
+++ b/godot-codegen/src/special_cases/special_cases.rs
@@ -874,6 +874,19 @@ pub fn is_utility_function_private(function: &JsonUtilityFunction) -> bool {
     }
 }
 
+/// Whether a class or builtin methods return value is thread-safe.
+///
+/// This is a hand-picked list of methods which have been manually verified to return unique values. 
+#[rustfmt::skip]
+pub fn is_method_threadsafe_return(class_or_builtin_ty: &TyName, godot_method_name: &str) -> bool {
+    match (class_or_builtin_ty.godot_ty.as_str(), godot_method_name) {
+        | ("SurfaceTool", "commit")
+        | ("SurfaceTool", "commit_to_arrays")
+
+        => true, _ => false
+    }
+}
+
 pub fn maybe_rename_class_method<'m>(
     class_name: &TyName,
     godot_method_name: &'m str,

--- a/godot-codegen/src/util.rs
+++ b/godot-codegen/src/util.rs
@@ -25,7 +25,7 @@ pub fn make_imports() -> TokenStream {
     quote! {
         use godot_ffi as sys;
         use crate::builtin::*;
-        use crate::meta::{AsArg, ClassId, CowArg, InParamTuple, OutParamTuple, ParamTuple, RawPtr, RefArg};
+        use crate::meta::{AsArg, ClassId, CowArg, InParamTuple, OutParamTuple, ParamTuple, RawPtr, RefArg, ThreadSafeArgContext};
         use crate::private::Signature;
         use crate::classes::native::*;
         use crate::classes::Object;

--- a/godot-core/src/builtin/callable.rs
+++ b/godot-core/src/builtin/callable.rs
@@ -538,7 +538,7 @@ unsafe impl GodotFfi for Callable {
     }
 }
 
-meta::impl_godot_as_self!(Callable: ByRef);
+meta::impl_godot_as_self!(Callable: ByRef, NonThreadSafeArg);
 
 impl fmt::Debug for Callable {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/godot-core/src/builtin/collections/any_array.rs
+++ b/godot-core/src/builtin/collections/any_array.rs
@@ -529,6 +529,7 @@ impl GodotConvert for AnyArray {
 
 impl ToGodot for AnyArray {
     type Pass = meta::ByValue;
+    type Threads = meta::NonThreadSafeArg;
 
     fn to_godot(&self) -> meta::ToArg<'_, Self::Via, Self::Pass> {
         self.clone()

--- a/godot-core/src/builtin/collections/any_dictionary.rs
+++ b/godot-core/src/builtin/collections/any_dictionary.rs
@@ -482,6 +482,7 @@ impl GodotConvert for AnyDictionary {
 
 impl ToGodot for AnyDictionary {
     type Pass = meta::ByValue;
+    type Threads = meta::NonThreadSafeArg;
 
     fn to_godot(&self) -> meta::ToArg<'_, Self::Via, Self::Pass> {
         self.clone()

--- a/godot-core/src/builtin/collections/array.rs
+++ b/godot-core/src/builtin/collections/array.rs
@@ -15,6 +15,8 @@ use sys::{GodotFfi, ffi_methods, interface_fn};
 use crate::builtin::iter::ArrayFunctionalOps;
 use crate::builtin::*;
 use crate::meta;
+#[cfg(all(feature = "experimental-threads", safeguards_balanced))]
+use crate::meta::ThreadSafeArgContext;
 use crate::meta::error::{ArrayMismatch, ConvertError, FromGodotError, FromVariantError};
 use crate::meta::inspect::ElementType;
 use crate::meta::shape::{GodotElementShape, GodotShape};
@@ -285,6 +287,8 @@ impl<T: Element> Array<T> {
 
     /// Returns `true` if the array contains the given value. Equivalent of `has` in GDScript.
     pub fn contains(&self, value: impl AsArg<T>) -> bool {
+        #[cfg(all(feature = "experimental-threads", safeguards_balanced))]
+        ThreadSafeArgContext::guarantee_thread_safe(&value);
         meta::arg_into_ref!(value: T);
         self.as_inner().has(&value.to_variant())
     }
@@ -323,6 +327,8 @@ impl<T: Element> Array<T> {
 
         let ptr_mut = self.ptr_mut(index);
 
+        #[cfg(all(feature = "experimental-threads", safeguards_balanced))]
+        ThreadSafeArgContext::guarantee_thread_safe(&value);
         meta::arg_into_ref!(value: T);
         let variant = value.to_variant();
 
@@ -338,6 +344,8 @@ impl<T: Element> Array<T> {
     pub fn push(&mut self, value: impl AsArg<T>) {
         self.balanced_ensure_mutable();
 
+        #[cfg(all(feature = "experimental-threads", safeguards_balanced))]
+        ThreadSafeArgContext::guarantee_thread_safe(&value);
         meta::arg_into_ref!(value: T);
 
         // SAFETY: The array has type `T` and we're writing a value of type `T` to it.
@@ -358,6 +366,8 @@ impl<T: Element> Array<T> {
     pub fn push_front(&mut self, value: impl AsArg<T>) {
         self.balanced_ensure_mutable();
 
+        #[cfg(all(feature = "experimental-threads", safeguards_balanced))]
+        ThreadSafeArgContext::guarantee_thread_safe(&value);
         meta::arg_into_ref!(value: T);
 
         // SAFETY: The array has type `T` and we're writing a value of type `T` to it.
@@ -409,6 +419,8 @@ impl<T: Element> Array<T> {
             "Array insertion index {index} is out of bounds: length is {len}",
         );
 
+        #[cfg(all(feature = "experimental-threads", safeguards_balanced))]
+        ThreadSafeArgContext::guarantee_thread_safe(&value);
         meta::arg_into_ref!(value: T);
 
         // SAFETY: The array has type `T` and we're writing a value of type `T` to it.
@@ -442,6 +454,8 @@ impl<T: Element> Array<T> {
     pub fn erase(&mut self, value: impl AsArg<T>) {
         self.balanced_ensure_mutable();
 
+        #[cfg(all(feature = "experimental-threads", safeguards_balanced))]
+        ThreadSafeArgContext::guarantee_thread_safe(&value);
         meta::arg_into_ref!(value: T);
 
         // SAFETY: We don't write anything to the array.
@@ -474,6 +488,8 @@ impl<T: Element> Array<T> {
         // array are of type `T` still.
         unsafe { self.as_inner_mut() }.resize(to_i64(new_size));
 
+        #[cfg(all(feature = "experimental-threads", safeguards_balanced))]
+        ThreadSafeArgContext::guarantee_thread_safe(&value);
         meta::arg_into_ref!(value: T);
 
         // If new_size < original_size then this is an empty iterator and does nothing.
@@ -1161,6 +1177,7 @@ impl<T: Element> GodotConvert for Array<T> {
 
 impl<T: Element> ToGodot for Array<T> {
     type Pass = meta::ByRef;
+    type Threads = meta::NonThreadSafeArg;
 
     fn to_godot(&self) -> &Self::Via {
         self

--- a/godot-core/src/builtin/collections/dictionary.rs
+++ b/godot-core/src/builtin/collections/dictionary.rs
@@ -16,6 +16,8 @@ use sys::{GodotFfi, ffi_methods, interface_fn};
 use super::any_dictionary::AnyDictionary;
 use crate::builtin::{AnyArray, Array, VarArray, Variant, VariantType, inner};
 use crate::meta;
+#[cfg(all(feature = "experimental-threads", safeguards_balanced))]
+use crate::meta::ThreadSafeArgContext;
 use crate::meta::inspect::ElementType;
 use crate::meta::shape::{GodotElementShape, GodotShape};
 use crate::meta::{AsArg, Element, ExtVariantType, FromGodot, ToGodot};
@@ -163,6 +165,8 @@ impl<K: Element, V: Element> Dictionary<K, V> {
     /// # Panics
     /// If there is no value for the given key. Note that this is distinct from a `NIL` value, which is returned as `Variant::nil()`.
     pub fn at(&self, key: impl AsArg<K>) -> V {
+        #[cfg(all(feature = "experimental-threads", safeguards_balanced))]
+        ThreadSafeArgContext::guarantee_thread_safe(&key);
         meta::arg_into_ref!(key: K);
         let key_variant = key.to_variant();
         if self.as_inner().has(&key_variant) {
@@ -181,6 +185,8 @@ impl<K: Element, V: Element> Dictionary<K, V> {
     ///
     /// This can be combined with Rust's `Option` methods, e.g. `dict.get(key).unwrap_or(default)`.
     pub fn get(&self, key: impl AsArg<K>) -> Option<V> {
+        #[cfg(all(feature = "experimental-threads", safeguards_balanced))]
+        ThreadSafeArgContext::guarantee_thread_safe(&key);
         meta::arg_into_ref!(key: K);
         let key_variant = key.to_variant();
         if self.as_inner().has(&key_variant) {
@@ -192,12 +198,16 @@ impl<K: Element, V: Element> Dictionary<K, V> {
 
     /// Returns the value at the key, converted to `V`. Panics on conversion failure.
     fn get_or_panic(&self, key: Variant) -> V {
+        #[cfg(all(feature = "experimental-threads", safeguards_balanced))]
+        ThreadSafeArgContext::guarantee_thread_safe(&key);
         V::from_variant(&self.as_inner().get(&key, &Variant::nil()))
     }
 
     // TODO(v0.6): avoid double FFI round-trip (has + get); consider using get(key, sentinel) pattern.
     /// Gets and removes the old value for a key, if it exists.
     fn take_old_value(&self, key_variant: &Variant) -> Option<V> {
+        #[cfg(all(feature = "experimental-threads", safeguards_balanced))]
+        ThreadSafeArgContext::guarantee_thread_safe(&key_variant);
         self.as_inner()
             .has(key_variant)
             .then(|| self.get_or_panic(key_variant.clone()))
@@ -213,7 +223,11 @@ impl<K: Element, V: Element> Dictionary<K, V> {
     pub fn get_or_insert(&mut self, key: impl AsArg<K>, default: impl AsArg<V>) -> V {
         self.balanced_ensure_mutable();
 
+        #[cfg(all(feature = "experimental-threads", safeguards_balanced))]
+        ThreadSafeArgContext::guarantee_thread_safe(&key);
         meta::arg_into_ref!(key: K);
+        #[cfg(all(feature = "experimental-threads", safeguards_balanced))]
+        ThreadSafeArgContext::guarantee_thread_safe(&default);
         meta::arg_into_ref!(default: V);
 
         let key_variant = key.to_variant();
@@ -249,6 +263,8 @@ impl<K: Element, V: Element> Dictionary<K, V> {
     /// _Godot equivalent: `has`_
     #[doc(alias = "has")]
     pub fn contains_key(&self, key: impl AsArg<K>) -> bool {
+        #[cfg(all(feature = "experimental-threads", safeguards_balanced))]
+        ThreadSafeArgContext::guarantee_thread_safe(&key);
         meta::arg_into_ref!(key: K);
         let key = key.to_variant();
         self.as_inner().has(&key)
@@ -259,6 +275,8 @@ impl<K: Element, V: Element> Dictionary<K, V> {
     /// _Godot equivalent: `has_all`_
     #[doc(alias = "has_all")]
     pub fn contains_all_keys(&self, keys: &VarArray) -> bool {
+        #[cfg(all(feature = "experimental-threads", safeguards_balanced))]
+        ThreadSafeArgContext::guarantee_thread_safe(&keys);
         self.as_inner().has_all(keys)
     }
 
@@ -315,6 +333,12 @@ impl<K: Element, V: Element> Dictionary<K, V> {
     pub fn set(&mut self, key: impl AsArg<K>, value: impl AsArg<V>) {
         self.balanced_ensure_mutable();
 
+        #[cfg(all(feature = "experimental-threads", safeguards_balanced))]
+        {
+            key.guarantee_thread_safe();
+            value.guarantee_thread_safe();
+        }
+
         meta::arg_into_ref!(key: K);
         meta::arg_into_ref!(value: V);
 
@@ -339,6 +363,12 @@ impl<K: Element, V: Element> Dictionary<K, V> {
     pub fn insert(&mut self, key: impl AsArg<K>, value: impl AsArg<V>) -> Option<V> {
         self.balanced_ensure_mutable();
 
+        #[cfg(all(feature = "experimental-threads", safeguards_balanced))]
+        {
+            key.guarantee_thread_safe();
+            value.guarantee_thread_safe();
+        }
+
         meta::arg_into_ref!(key: K);
         meta::arg_into_ref!(value: V);
 
@@ -359,6 +389,8 @@ impl<K: Element, V: Element> Dictionary<K, V> {
     pub fn remove(&mut self, key: impl AsArg<K>) -> Option<V> {
         self.balanced_ensure_mutable();
 
+        #[cfg(all(feature = "experimental-threads", safeguards_balanced))]
+        ThreadSafeArgContext::guarantee_thread_safe(&key);
         meta::arg_into_ref!(key: K);
 
         let key_variant = key.to_variant();
@@ -683,6 +715,8 @@ impl<K: Element> Dictionary<K, Variant> {
     /// `Deref<Target = AnyDictionary>`, any method on `AnyDictionary` is inherited by _all_ dictionaries -- including typed ones
     /// like `Dictionary<K, i64>`, where a `Variant` return would be surprising.
     pub fn get_or_nil(&self, key: impl AsArg<K>) -> Variant {
+        #[cfg(all(feature = "experimental-threads", safeguards_balanced))]
+        ThreadSafeArgContext::guarantee_thread_safe(&key);
         meta::arg_into_ref!(key: K);
         let key_variant = key.to_variant();
         self.as_inner().get(&key_variant, &Variant::nil())
@@ -863,6 +897,7 @@ impl<K: Element, V: Element> meta::GodotConvert for Dictionary<K, V> {
 
 impl<K: Element, V: Element> ToGodot for Dictionary<K, V> {
     type Pass = meta::ByRef;
+    type Threads = meta::NonThreadSafeArg;
 
     fn to_godot(&self) -> &Self::Via {
         self

--- a/godot-core/src/builtin/collections/packed_array.rs
+++ b/godot-core/src/builtin/collections/packed_array.rs
@@ -518,6 +518,7 @@ impl<T: PackedElement> GodotConvert for PackedArray<T> {
 
 impl<T: PackedElement> ToGodot for PackedArray<T> {
     type Pass = meta::ByRef;
+    type Threads = meta::NonThreadSafeArg;
 
     fn to_godot(&self) -> &Self::Via {
         self

--- a/godot-core/src/builtin/signal.rs
+++ b/godot-core/src/builtin/signal.rs
@@ -209,7 +209,7 @@ impl_builtin_traits! {
     }
 }
 
-meta::impl_godot_as_self!(Signal: ByRef);
+meta::impl_godot_as_self!(Signal: ByRef, NonThreadSafeArg);
 
 impl fmt::Debug for Signal {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/godot-core/src/builtin/strings/gstring.rs
+++ b/godot-core/src/builtin/strings/gstring.rs
@@ -74,6 +74,9 @@ pub struct GString {
 // SAFETY: The Godot implementation of String uses an atomic copy on write pointer, making this thread-safe as we never write to it unless we own it.
 unsafe impl Send for GString {}
 
+// SAFETY: The Godot implementation of String uses an atomic copy on write pointer, making this Send as we never write to it unless we own it.
+unsafe impl Sync for GString {}
+
 impl GString {
     /// Construct a new empty `GString`.
     pub fn new() -> Self {

--- a/godot-core/src/builtin/strings/mod.rs
+++ b/godot-core/src/builtin/strings/mod.rs
@@ -32,6 +32,7 @@ impl GodotConvert for &str {
 
 impl ToGodot for &str {
     type Pass = meta::ByValue;
+    type Threads = meta::ThreadSafeArg;
 
     fn to_godot(&self) -> Self::Via {
         GString::from(*self)
@@ -48,6 +49,7 @@ impl GodotConvert for String {
 
 impl ToGodot for String {
     type Pass = meta::ByValue;
+    type Threads = meta::ThreadSafeArg;
 
     fn to_godot(&self) -> Self::Via {
         GString::from(self)

--- a/godot-core/src/builtin/strings/node_path.rs
+++ b/godot-core/src/builtin/strings/node_path.rs
@@ -199,7 +199,7 @@ unsafe impl GodotFfi for NodePath {
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Opaque; .. }
 }
 
-crate::meta::impl_godot_as_self!(NodePath: ByRef);
+crate::meta::impl_godot_as_self!(NodePath: ByRef, NonThreadSafeArg);
 
 impl_builtin_traits! {
     for NodePath {

--- a/godot-core/src/builtin/variant/impls.rs
+++ b/godot-core/src/builtin/variant/impls.rs
@@ -11,7 +11,7 @@ use sys::GodotFfi;
 use crate::builtin::*;
 use crate::meta::error::{ConvertError, FromVariantError};
 use crate::meta::sealed::Sealed;
-use crate::meta::{Element, GodotFfiVariant, GodotType, RefArg};
+use crate::meta::{Element, GodotFfiVariant, GodotType, RefArg, ThreadSafeArgContext};
 use crate::registry::info::ParamMetadata;
 use crate::task::{DynamicSend, IntoDynamicSend, ThreadConfined, impl_dynamic_send};
 
@@ -57,9 +57,9 @@ macro_rules! impl_ffi_variant {
 
             fn ffi_from_variant(variant: &Variant) -> Result<Self, ConvertError> {
                 // Type check -- at the moment, a strict match is required.
-                if variant.get_type() != Self::VARIANT_TYPE.variant_as_nil() {
+                if variant.get_type() != <Self as godot_ffi::GodotFfi>::VARIANT_TYPE.variant_as_nil() {
                     return Err(FromVariantError::BadType {
-                        expected: Self::VARIANT_TYPE.variant_as_nil(),
+                        expected: <Self as godot_ffi::GodotFfi>::VARIANT_TYPE.variant_as_nil(),
                         actual: variant.get_type(),
                     }
                     .into_error(variant.clone()));
@@ -119,6 +119,9 @@ macro_rules! impl_ffi_variant {
 #[rustfmt::skip]
 #[allow(clippy::module_inception)]
 mod impls {
+    use crate::{impl_non_thread_safe_arg, impl_thread_safe_arg};
+    use crate::meta::PackedElement;
+
     use super::*;
 
     // IMPORTANT: the presence/absence of `ref` here should be aligned with the ArgPassing variant
@@ -145,10 +148,24 @@ mod impls {
     impl_ffi_variant!(Color, color_to_variant, color_from_variant);
     impl_ffi_variant!(Rid, rid_to_variant, rid_from_variant);
     impl_ffi_variant!(ref GString, string_to_variant, string_from_variant);
+    impl_thread_safe_arg!(&GString);
     impl_ffi_variant!(ref StringName, string_name_to_variant, string_name_from_variant);
+    impl_thread_safe_arg!(&StringName);
     impl_ffi_variant!(ref NodePath, node_path_to_variant, node_path_from_variant);
+    impl_non_thread_safe_arg!(NodePath);
+    impl_non_thread_safe_arg!(&NodePath);
     impl_ffi_variant!(ref Signal, signal_to_variant, signal_from_variant);
+    impl_non_thread_safe_arg!(Signal, &Signal);
     impl_ffi_variant!(ref Callable, callable_to_variant, callable_from_variant);
+    impl_non_thread_safe_arg!(Callable, &Callable);
+    impl_non_thread_safe_arg!([K: Element, V: Element] Dictionary<K, V>);
+    impl_non_thread_safe_arg!([K: Element, V: Element] &Dictionary<K, V>);
+    impl_non_thread_safe_arg!(AnyDictionary, &AnyDictionary);
+    impl_non_thread_safe_arg!([T: Element] Array<T>);
+    impl_non_thread_safe_arg!( [T: Element] &Array<T>);
+    impl_non_thread_safe_arg!(AnyArray, &AnyArray);
+    impl_non_thread_safe_arg!([T: PackedElement] PackedArray<T>);
+    impl_non_thread_safe_arg!([T: PackedElement] &PackedArray<T>);
 }
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
@@ -220,11 +237,14 @@ mod api_4_3 {
 // - DynamicSend
 // - GodotType
 // - Element
+// - ThreadSafeArg
 const _: () = {
     use crate::classes::Object;
     use crate::obj::{Gd, IndexEnum};
 
-    const fn variant_type<T: crate::task::IntoDynamicSend + GodotType + Element>() -> VariantType {
+    const fn variant_type<
+        T: crate::task::IntoDynamicSend + GodotType + Element + ThreadSafeArgContext,
+    >() -> VariantType {
         <T::Ffi as sys::GodotFfi>::VARIANT_TYPE.variant_as_nil()
     }
 

--- a/godot-core/src/builtin/variant/mod.rs
+++ b/godot-core/src/builtin/variant/mod.rs
@@ -529,7 +529,7 @@ unsafe impl GodotFfi for Variant {
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Self; .. }
 }
 
-crate::meta::impl_godot_as_self!(Variant: ByVariant);
+crate::meta::impl_godot_as_self!(Variant: ByVariant, NonThreadSafeArg);
 
 impl Default for Variant {
     fn default() -> Self {

--- a/godot-core/src/builtin/vectors/vector_axis.rs
+++ b/godot-core/src/builtin/vectors/vector_axis.rs
@@ -79,6 +79,7 @@ macro_rules! impl_vector_axis_enum {
 
         impl ToGodot for $AxisEnum {
             type Pass = crate::meta::ByValue;
+            type Threads = $crate::meta::ThreadSafeArg;
 
             fn to_godot(&self) -> Self::Via {
                 self.ord()

--- a/godot-core/src/classes/type_safe_replacements.rs
+++ b/godot-core/src/classes/type_safe_replacements.rs
@@ -17,6 +17,8 @@ use crate::classes::object::ConnectFlags;
 use crate::classes::scene_tree::GroupCallFlags;
 use crate::classes::{Node, Object, SceneTree, Script};
 use crate::global::Error;
+#[cfg(feature = "experimental-threads")]
+use crate::meta::ThreadSafeArgContext;
 use crate::meta::{AsArg, ToGodot, arg_into_ref};
 use crate::obj::{EngineBitfield, Gd};
 
@@ -31,12 +33,21 @@ impl Object {
     }
 
     pub fn set_script(&mut self, script: impl AsArg<Option<Gd<Script>>>) {
-        arg_into_ref!(script);
+        #[cfg(all(feature = "experimental-threads", safeguards_balanced))]
+        {
+            ThreadSafeArgContext::guarantee_thread_safe(&script);
+        }
 
+        arg_into_ref!(script);
         self.raw_set_script(&script.to_variant());
     }
 
     pub fn connect(&mut self, signal: impl AsArg<StringName>, callable: &Callable) -> Error {
+        #[cfg(all(feature = "experimental-threads", safeguards_balanced))]
+        {
+            ThreadSafeArgContext::guarantee_thread_safe(&callable);
+        }
+
         self.raw_connect(signal, callable)
     }
 
@@ -46,9 +57,26 @@ impl Object {
         callable: &Callable,
         flags: ConnectFlags,
     ) -> Error {
+        #[cfg(all(feature = "experimental-threads", safeguards_balanced))]
+        {
+            ThreadSafeArgContext::guarantee_thread_safe(&callable);
+        }
+
         self.raw_connect_ex(signal, callable)
             .flags(flags.ord() as u32)
             .done()
+    }
+
+    pub fn emit_signal(
+        &mut self,
+        name: impl AsArg<StringName>,
+        vargs: &[Variant],
+    ) -> crate::global::Error {
+        #[cfg(all(feature = "experimental-threads", safeguards_balanced))]
+        {
+            ThreadSafeArgContext::guarantee_thread_safe(&vargs);
+        }
+        self.raw_emit_signal(name, vargs)
     }
 }
 
@@ -81,6 +109,11 @@ impl SceneTree {
         method: impl AsArg<StringName>,
         varargs: &[Variant],
     ) {
+        #[cfg(all(feature = "experimental-threads", safeguards_balanced))]
+        {
+            ThreadSafeArgContext::guarantee_thread_safe(&varargs);
+        }
+
         self.raw_call_group_flags(flags.ord() as i64, group, method, varargs)
     }
 
@@ -91,6 +124,11 @@ impl SceneTree {
         property: impl AsArg<GString>,
         value: &Variant,
     ) {
+        #[cfg(all(feature = "experimental-threads", safeguards_balanced))]
+        {
+            ThreadSafeArgContext::guarantee_thread_safe(&value);
+        }
+
         self.raw_set_group_flags(call_flags.ord() as u32, group, property, value)
     }
 

--- a/godot-core/src/meta/args/as_arg.rs
+++ b/godot-core/src/meta/args/as_arg.rs
@@ -8,7 +8,9 @@
 use crate::builtin::{Callable, GString, NodePath, Signal, StringName, Variant};
 use crate::meta::sealed::Sealed;
 use crate::meta::traits::{Element, GodotFfiVariant, GodotNullableType, PackedElement};
-use crate::meta::{CowArg, EngineToGodot, FfiArg, GodotType, ObjectArg, ToGodot};
+use crate::meta::{
+    CowArg, EngineToGodot, FfiArg, GodotType, ObjectArg, ThreadSafeArgContext, ToGodot,
+};
 use crate::obj::{DynGd, Gd, GodotClass, Inherits};
 
 /// Implicit conversions for arguments passed to Godot APIs.
@@ -81,7 +83,7 @@ use crate::obj::{DynGd, Gd, GodotClass, Inherits};
     note = "GString/StringName/NodePath aren't implicitly convertible for performance reasons; use `From` conversions.",
     note = "see also `AsArg` docs: https://godot-rust.github.io/docs/gdext/master/godot/meta/trait.AsArg.html"
 )]
-pub trait AsArg<T: ToGodot>
+pub trait AsArg<T: ToGodot>: ThreadSafeArgContext
 where
     Self: Sized,
 {
@@ -109,6 +111,7 @@ where
 impl<T> AsArg<T> for &T
 where
     T: ToGodot<Pass = ByRef>,
+    for<'a> &'a T: ThreadSafeArgContext,
 {
     fn into_arg<'arg>(self) -> CowArg<'arg, T>
     where
@@ -130,7 +133,7 @@ impl AsArg<Variant> for &Variant {
 
 impl<T> AsArg<T> for T
 where
-    T: ToGodot<Pass = ByValue> + Sized, // Sized may rule out some coherence issues.
+    T: ToGodot<Pass = ByValue> + Sized + ThreadSafeArgContext, // Sized may rule out some coherence issues.
 {
     fn into_arg<'arg>(self) -> CowArg<'arg, T>
     where
@@ -427,7 +430,7 @@ where
 /// ```
 pub fn owned_into_arg<'arg, T>(owned_val: T) -> impl AsArg<T> + 'arg
 where
-    T: ToGodot + 'arg,
+    T: ToGodot + ThreadSafeArgContext + 'arg,
 {
     CowArg::Owned(owned_val)
 }
@@ -454,7 +457,7 @@ where
 /// ```
 pub fn ref_to_arg<'r, T>(ref_val: &'r T) -> impl AsArg<T> + 'r
 where
-    T: ToGodot + 'r,
+    T: ToGodot + ThreadSafeArgContext + 'r,
 {
     CowArg::Borrowed(ref_val)
 }
@@ -507,7 +510,7 @@ macro_rules! arg_into_owned {
 /// This is necessary for packed array dispatching to different "inner" backend signatures.
 impl<T> AsArg<T> for CowArg<'_, T>
 where
-    for<'r> T: ToGodot,
+    for<'r> T: ToGodot + ThreadSafeArgContext,
 {
     fn into_arg<'arg>(self) -> CowArg<'arg, T>
     where
@@ -792,7 +795,7 @@ struct PhantomAsArgDoctests;
 // Blanket: ByValue types -> Variant (i32, f64, bool, Vector2, Color, &str, String, user enums, etc.).
 impl<T> AsArg<Variant> for T
 where
-    T: ToGodot<Pass = ByValue>,
+    T: ToGodot<Pass = ByValue> + ThreadSafeArgContext,
 {
     fn into_arg<'arg>(self) -> CowArg<'arg, Variant>
     where
@@ -805,7 +808,10 @@ where
 // Macro for ByRef types -> Variant. Generic params go in `[]`, empty for non-generic types.
 macro_rules! impl_asarg_variant_for_ref {
     ([$($gen:tt)*] $T:ty) => {
-        impl<$($gen)*> AsArg<Variant> for &$T {
+        impl<$($gen)*> AsArg<Variant> for &$T
+        where
+            for <'a> &'a $T: $crate::meta::ThreadSafeArgContext
+        {
             fn into_arg<'arg>(self) -> CowArg<'arg, Variant>
             where
                 Self: 'arg,
@@ -841,10 +847,15 @@ pub trait AsDirectElement<T: Element>: AsArg<T> {}
 // ByValue: T directly passes as element (i32, bool, Vector2, ...).
 //
 // Explicitly supports other integer types than i64.
-impl<T> AsDirectElement<T> for T where T: Element + ToGodot<Pass = ByValue> {}
+impl<T> AsDirectElement<T> for T where T: Element + ToGodot<Pass = ByValue> + ThreadSafeArgContext {}
 
 // ByRef: &T passes as element (GString, Array, Dictionary, ...).
-impl<T> AsDirectElement<T> for &T where T: Element + ToGodot<Pass = ByRef> {}
+impl<T> AsDirectElement<T> for &T
+where
+    T: Element + ToGodot<Pass = ByRef>,
+    for<'a> &'a T: ThreadSafeArgContext,
+{
+}
 
 // Potentially allow this? However, it encourages manual case differentiation when working with objects,
 // which goes against the idea of implicit upcasts/option-casts/dyn-casts.

--- a/godot-core/src/meta/args/cow_arg.rs
+++ b/godot-core/src/meta/args/cow_arg.rs
@@ -84,6 +84,8 @@ where
     T: ToGodot,
 {
     type Pass = T::Pass;
+    // We intentionally mark CowArg as unsafe so we can implement our own pass-through version of `ThreadSafeArgContext`.
+    type Threads = crate::meta::NonThreadSafeArg;
 
     fn to_godot(&self) -> crate::meta::ToArg<'_, Self::Via, Self::Pass> {
         // Forward to the wrapped type's to_godot implementation

--- a/godot-core/src/meta/args/mod.rs
+++ b/godot-core/src/meta/args/mod.rs
@@ -9,6 +9,7 @@ mod as_arg;
 mod cow_arg;
 mod object_arg;
 mod ref_arg;
+mod thread_safe;
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Public APIs
@@ -30,3 +31,5 @@ pub(crate) use cow_arg::{CowArg, FfiArg};
 pub use cow_arg::{CowArg, FfiArg};
 pub use object_arg::ObjectArg;
 pub(crate) use ref_arg::RefArg;
+pub(crate) use thread_safe::ThreadSafeSealed;
+pub use thread_safe::{NonThreadSafeArg, ThreadSafeArg, ThreadSafeArgContext, ThreadSafety};

--- a/godot-core/src/meta/args/ref_arg.rs
+++ b/godot-core/src/meta/args/ref_arg.rs
@@ -100,6 +100,7 @@ where
     T: ToGodot,
 {
     type Pass = T::Pass;
+    type Threads = T::Threads;
 
     fn to_godot(&self) -> crate::meta::ToArg<'_, Self::Via, Self::Pass> {
         let shared_ref = self

--- a/godot-core/src/meta/args/thread_safe.rs
+++ b/godot-core/src/meta/args/thread_safe.rs
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use godot_ffi::VariantType;
+
+use crate::builtin::Variant;
+use crate::meta::sealed::Sealed;
+use crate::meta::{CowArg, GodotConvert, NullArg, ToGodot};
+use crate::obj::{DynGd, Gd, GodotClass};
+
+// We can't use private::Sealed due to blanket impl for all T: Send.
+pub(crate) trait ThreadSafeSealed {}
+
+/// Runtime restrictions for [`AsArg`](super::AsArg) to guarantee thread safe usage of engine types.
+///
+/// For thread safe types that implement `Send + Sync` this trait is implemented as a no-op. For non thread-safe engine types, a runtime
+/// check is performed that ensures the types can only be passed to the engine on the main thread.
+#[expect(private_bounds)]
+pub trait ThreadSafeArgContext: ThreadSafeSealed {
+    /// Panics if the value is being used in a non thread-safe context.
+    fn guarantee_thread_safe(&self);
+}
+
+impl<T: ToGodot<Threads = crate::meta::ThreadSafeArg> + Send> ThreadSafeArgContext for T
+where
+    <Self as GodotConvert>::Via: Send + Sync,
+{
+    fn guarantee_thread_safe(&self) {}
+}
+
+impl<T: ToGodot<Threads = crate::meta::ThreadSafeArg> + Send> ThreadSafeSealed for T where
+    <Self as GodotConvert>::Via: Send + Sync
+{
+}
+
+#[macro_export(local_inner_macros)]
+macro_rules! impl_thread_safe_arg {
+    ([$($bounds:tt)*] $ty:ty) => {
+        impl<$($bounds)*> $crate::meta::ThreadSafeArgContext for $ty {
+            fn guarantee_thread_safe(&self) {}
+        }
+
+        impl<$($bounds)*> $crate::meta::ThreadSafeSealed for $ty {}
+    };
+
+    ($($ty:ty),+) => {
+        $(impl_thread_safe_arg!([] $ty);)+
+    };
+}
+
+#[macro_export(local_inner_macros)]
+macro_rules! impl_non_thread_safe_arg {
+    ([$($bounds:tt)*] $ty:ty) => {
+        impl<$($bounds)*> $crate::meta::ThreadSafeArgContext for $ty {
+            fn guarantee_thread_safe(&self) {
+                if !$crate::sys::is_main_thread() {
+                    ::std::panic!(
+                        "Value of type {} can not be passed to the engine outside the main thread",
+                        ::std::any::type_name::<$ty>()
+                    );
+                }
+            }
+        }
+
+        impl<$($bounds)*> $crate::meta::ThreadSafeSealed for $ty {}
+    };
+
+    ($($ty:ty),+) => {
+        $(impl_non_thread_safe_arg!([] $ty);)+
+    };
+}
+
+impl<T: ThreadSafeArgContext> ThreadSafeArgContext for Option<T> {
+    fn guarantee_thread_safe(&self) {
+        if let Some(value) = self {
+            value.guarantee_thread_safe();
+        }
+    }
+}
+
+impl<T: ThreadSafeSealed> ThreadSafeSealed for Option<T> {}
+
+impl_non_thread_safe_arg!([T: GodotClass] Gd<T>);
+impl_non_thread_safe_arg!([T: GodotClass] &Gd<T>);
+impl_non_thread_safe_arg!([T: GodotClass, D: ?Sized + 'static] DynGd<T, D>);
+impl_non_thread_safe_arg!([T: GodotClass, D: ?Sized] &DynGd<T, D>);
+impl_thread_safe_arg!(&String);
+
+// NullArg<T> maps to None so it should be fine to be passed to the engine.
+impl<T> ThreadSafeArgContext for NullArg<T> {
+    fn guarantee_thread_safe(&self) {}
+}
+
+impl<T> ThreadSafeSealed for NullArg<T> {}
+
+impl<T> ThreadSafeArgContext for CowArg<'_, T>
+where
+    for<'a> T: ThreadSafeArgContext,
+{
+    fn guarantee_thread_safe(&self) {
+        self.cow_as_ref().guarantee_thread_safe();
+    }
+}
+
+impl<T> ThreadSafeSealed for CowArg<'_, T> where for<'a> T: ThreadSafeSealed {}
+
+impl ThreadSafeArgContext for Variant {
+    fn guarantee_thread_safe(&self) {
+        match self.get_type() {
+            VariantType::NIL
+            | VariantType::BOOL
+            | VariantType::INT
+            | VariantType::FLOAT
+            | VariantType::STRING
+            | VariantType::VECTOR2
+            | VariantType::VECTOR2I
+            | VariantType::RECT2
+            | VariantType::RECT2I
+            | VariantType::VECTOR3
+            | VariantType::VECTOR3I
+            | VariantType::TRANSFORM2D
+            | VariantType::VECTOR4
+            | VariantType::VECTOR4I
+            | VariantType::PLANE
+            | VariantType::QUATERNION
+            | VariantType::AABB
+            | VariantType::BASIS
+            | VariantType::TRANSFORM3D
+            | VariantType::PROJECTION
+            | VariantType::COLOR
+            | VariantType::STRING_NAME
+            | VariantType::RID => (),
+            _ => {
+                if !crate::sys::is_main_thread() {
+                    ::std::panic!(
+                        "Variant value of type {} can not be passed to the engine outside the main thread",
+                        self.get_type().godot_type_name()
+                    );
+                }
+            }
+        }
+    }
+}
+
+impl ThreadSafeArgContext for &Variant {
+    fn guarantee_thread_safe(&self) {
+        (*self).guarantee_thread_safe();
+    }
+}
+
+impl ThreadSafeArgContext for &[Variant] {
+    fn guarantee_thread_safe(&self) {
+        for var in *self {
+            var.guarantee_thread_safe();
+        }
+    }
+}
+
+impl ThreadSafeSealed for Variant {}
+impl ThreadSafeSealed for &Variant {}
+impl ThreadSafeSealed for &[Variant] {}
+
+/// Determines if a type is expected to be thread safe or not.
+///
+/// See [ToGodot::Threads](crate::meta::ToGodot).
+pub trait ThreadSafety: Sealed {}
+
+/// Argument is thread-safe, the type has to be `Send`.
+///
+/// See [`ToGodot::Threads`].
+pub struct ThreadSafeArg;
+
+impl ThreadSafety for ThreadSafeArg {}
+impl Sealed for ThreadSafeArg {}
+
+/// Argument is not thread-safe, the type requires a custom implementation of [`ThreadSafeArgContext`].
+///
+/// See [`ToGodot::Threads`].
+pub struct NonThreadSafeArg;
+
+impl ThreadSafety for NonThreadSafeArg {}
+impl Sealed for NonThreadSafeArg {}

--- a/godot-core/src/meta/error/convert_error.rs
+++ b/godot-core/src/meta/error/convert_error.rs
@@ -164,6 +164,7 @@ pub(crate) enum ErrorKind {
     FromGodot(FromGodotError),
     FromFfi(FromFfiError),
     FromVariant(FromVariantError),
+    InvalidThread,
     // FromAnyArray(ArrayMismatch), -- needed if AnyArray downcasts return ConvertError one day.
     Custom(Option<Cause>),
 }
@@ -174,6 +175,7 @@ impl fmt::Display for ErrorKind {
             Self::FromGodot(from_godot) => write!(f, "{from_godot}"),
             Self::FromVariant(from_variant) => write!(f, "{from_variant}"),
             Self::FromFfi(from_ffi) => write!(f, "{from_ffi}"),
+            Self::InvalidThread => write!(f, "InstanceID can not be converted outside main-thread"),
             Self::Custom(cause) => match cause {
                 Some(c) => write!(f, "{c}"),
                 None => write!(f, "custom error"),

--- a/godot-core/src/meta/godot_convert/impls.rs
+++ b/godot-core/src/meta/godot_convert/impls.rs
@@ -94,6 +94,8 @@ where
 {
     // Basically ByRef, but allows Option<T> -> Option<&T::Via> conversion.
     type Pass = meta::ByOption<T::Via>;
+    // Intentionally marked as unsafe so we can create our own pass-through impl.
+    type Threads = meta::NonThreadSafeArg;
 
     fn to_godot(&self) -> Option<&T::Via> {
         self.as_ref().map(T::to_godot)
@@ -296,6 +298,7 @@ macro_rules! impl_godot_scalar {
 
         impl ToGodot for $T {
             type Pass = meta::ByValue;
+            type Threads = $crate::meta::ThreadSafeArg;
 
             fn to_godot(&self) -> Self::Via {
                *self
@@ -391,6 +394,7 @@ impl<T: Element> GodotConvert for Vec<T> {
 
 impl<T: Element> ToGodot for Vec<T> {
     type Pass = meta::ByValue;
+    type Threads = meta::ThreadSafeArg;
 
     fn to_godot(&self) -> Self::Via {
         Array::from(self.as_slice())
@@ -413,6 +417,7 @@ impl<T: Element, const LEN: usize> GodotConvert for [T; LEN] {
 
 impl<T: Element, const LEN: usize> ToGodot for [T; LEN] {
     type Pass = meta::ByValue;
+    type Threads = meta::ThreadSafeArg;
 
     fn to_godot(&self) -> Self::Via {
         Array::from(self)
@@ -457,6 +462,7 @@ impl<T: Element> GodotConvert for &[T] {
 
 impl<T: Element> ToGodot for &[T] {
     type Pass = meta::ByValue;
+    type Threads = <T as ToGodot>::Threads;
 
     fn to_godot(&self) -> Self::Via {
         Array::from(*self)

--- a/godot-core/src/meta/godot_convert/mod.rs
+++ b/godot-core/src/meta/godot_convert/mod.rs
@@ -11,7 +11,7 @@ use crate::builtin::Variant;
 use crate::meta::error::ConvertError;
 use crate::meta::shape::GodotShape;
 use crate::meta::traits::GodotFfiVariant;
-use crate::meta::{ArgPassing, GodotType, ToArg};
+use crate::meta::{ArgPassing, GodotType, ThreadSafety, ToArg};
 
 /// Indicates that a type can be passed to/from Godot, either directly or through an intermediate "via" type.
 ///
@@ -88,6 +88,14 @@ pub trait ToGodot: Sized + GodotConvert {
     /// This has an influence on contexts such as [`Array::push()`][crate::builtin::Array::push], the [`array![...]`][crate::builtin::array]
     /// macro or generated signal `emit()` signatures.
     type Pass: ArgPassing;
+
+    /// Whether arguments of this type are thread-safe or not.
+    ///
+    /// Can be either [`ThreadSafeArg`](crate::meta::ThreadSafeArg) or [`NonThreadSafeArg`](crate::meta::NonThreadSafeArg). Only engine
+    /// types make use of `NonThreadSafeArg`, all user defined types should use `ThreadSafeArg` by deriving [`GodotConvert`] or by manually
+    /// implementing this trait. The use of `ThreadSafeArg` also requires the type to be [`Send`]. Non [`Send`] user defined types are
+    /// currenlty not supported.
+    type Threads: ThreadSafety;
 
     /// Converts this type to Godot representation, optimizing for zero-copy when possible.
     ///
@@ -273,6 +281,10 @@ impl<T: FromGodot> EngineFromGodot for T {
 #[macro_export]
 macro_rules! impl_godot_as_self {
     ($T:ty: $Passing:ident) => {
+        $crate::impl_godot_as_self!($T: $Passing, ThreadSafeArg);
+    };
+
+    ($T:ty: $Passing:ident, $Threads:ident) => {
         impl $crate::meta::GodotConvert for $T {
             type Via = $T;
 
@@ -281,7 +293,7 @@ macro_rules! impl_godot_as_self {
             }
         }
 
-        $crate::impl_godot_as_self!(@to_godot $T: $Passing);
+        $crate::impl_godot_as_self!(@to_godot $T: $Passing, $Threads);
 
         impl $crate::meta::FromGodot for $T {
             #[inline]
@@ -291,9 +303,10 @@ macro_rules! impl_godot_as_self {
         }
     };
 
-    (@to_godot $T:ty: ByValue) => {
+    (@to_godot $T:ty: ByValue, $Threads:ident) => {
         impl $crate::meta::ToGodot for $T {
             type Pass = $crate::meta::ByValue;
+            type Threads = $crate::meta::$Threads;
 
             #[inline]
             fn to_godot(&self) -> Self::Via {
@@ -302,9 +315,10 @@ macro_rules! impl_godot_as_self {
         }
     };
 
-    (@to_godot $T:ty: ByRef) => {
+    (@to_godot $T:ty: ByRef, $Threads:ident) => {
         impl $crate::meta::ToGodot for $T {
             type Pass = $crate::meta::ByRef;
+            type Threads = $crate::meta::$Threads;
 
             #[inline]
             fn to_godot(&self) -> &Self::Via {
@@ -313,9 +327,10 @@ macro_rules! impl_godot_as_self {
         }
     };
 
-    (@to_godot $T:ty: ByVariant) => {
+    (@to_godot $T:ty: ByVariant, $Threads:ident) => {
         impl $crate::meta::ToGodot for $T {
             type Pass = $crate::meta::ByVariant;
+            type Threads = $crate::meta::$Threads;
 
             #[inline]
             fn to_godot(&self) -> &Self::Via {

--- a/godot-core/src/meta/raw_ptr.rs
+++ b/godot-core/src/meta/raw_ptr.rs
@@ -110,6 +110,7 @@ where
     P: FfiRawPointer + 'static,
 {
     type Pass = crate::meta::ByValue;
+    type Threads = super::NonThreadSafeArg;
 
     fn to_godot(&self) -> Self::Via {
         *self

--- a/godot-core/src/meta/traits.rs
+++ b/godot-core/src/meta/traits.rs
@@ -10,7 +10,7 @@ use godot_ffi as sys;
 use crate::builtin;
 use crate::builtin::{Variant, VariantType};
 use crate::meta::error::ConvertError;
-use crate::meta::{FromGodot, GodotConvert, ToGodot, sealed};
+use crate::meta::{FromGodot, GodotConvert, ThreadSafeArgContext, ToGodot, sealed};
 use crate::registry::info::ParamMetadata;
 
 // Re-export sys traits in this module, so all are in one place.
@@ -171,7 +171,7 @@ pub(crate) trait GodotNullableType: GodotType {
     label = "has invalid element type"
 )]
 // TODO(v0.6): consider supertraits like PartialEq or Debug. For enums, align with #[derive(GodotConvert)].
-pub trait Element: ToGodot + FromGodot + 'static {
+pub trait Element: ToGodot + FromGodot + ThreadSafeArgContext + 'static {
     // Note: several indirections in `Element` and the global `element_*` functions go through `GodotConvert::Via`,
     // to not require Self: `GodotType`. What matters is how array elements map to Godot on the FFI level (`GodotType` trait).
 

--- a/godot-core/src/obj/dyn_gd.rs
+++ b/godot-core/src/obj/dyn_gd.rs
@@ -618,6 +618,7 @@ where
 {
     // Delegate to Gd<T> passing strategy.
     type Pass = <Gd<T> as ToGodot>::Pass;
+    type Threads = <Gd<T> as ToGodot>::Threads;
 
     fn to_godot(&self) -> &Self::Via {
         self.obj.to_godot()

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -13,7 +13,7 @@ use godot_ffi::is_main_thread;
 use sys::{SysPtr as _, static_assert_eq_size_align};
 
 use crate::builtin::{Callable, NodePath, StringName, Variant};
-use crate::meta::error::{ConvertError, FromFfiError};
+use crate::meta::error::{ConvertError, ErrorKind, FromFfiError};
 use crate::meta::shape::GodotShape;
 use crate::meta::{
     AsArg, ClassId, Element, FromGodot, GodotConvert, GodotNullableType, GodotType, RefArg, ToGodot,
@@ -226,9 +226,15 @@ where
 impl<T: GodotClass> Gd<T> {
     /// Looks up the given instance ID and returns the associated object, if possible.
     ///
-    /// If no such instance ID is registered, or if the dynamic type of the object behind that instance ID
-    /// is not compatible with `T`, then `None` is returned.
+    /// # Errors
+    /// - If no such instance ID is registered, or if the dynamic type of the object behind that instance ID
+    ///   is not compatible with `T`, then `Err(...)` is returned.
+    /// - If called outside the main-thread, then `Err(...)` is returned as well.
     pub fn try_from_instance_id(instance_id: InstanceId) -> Result<Self, ConvertError> {
+        if !sys::is_main_thread() {
+            return Err(ConvertError::with_kind(ErrorKind::InvalidThread));
+        }
+
         let ptr = classes::object_ptr_from_id(instance_id);
 
         // SAFETY: assumes that the returned GDExtensionObjectPtr is convertible to Object* (i.e. C++ upcast doesn't modify the pointer)
@@ -243,10 +249,15 @@ impl<T: GodotClass> Gd<T> {
     /// Corresponds to Godot's global function `instance_from_id()`.
     ///
     /// # Panics
-    /// If no such instance ID is registered, or if the dynamic type of the object behind that instance ID
-    /// is not compatible with `T`.
+    /// - If no such instance ID is registered, or if the dynamic type of the object behind that instance ID
+    ///   is not compatible with `T`.
+    /// - If called on a different thread than the main-thread.
     #[doc(alias = "instance_from_id")]
     pub fn from_instance_id(instance_id: InstanceId) -> Self {
+        if !sys::is_main_thread() {
+            panic!("Gd::instance_from_id is can not be called outside the main-thread");
+        }
+
         Self::try_from_instance_id(instance_id).unwrap_or_else(|err| {
             panic!(
                 "Instance ID {} does not belong to a valid object of class '{}': {}",

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -1030,6 +1030,7 @@ impl<T: GodotClass> GodotConvert for Gd<T> {
 
 impl<T: GodotClass> ToGodot for Gd<T> {
     type Pass = meta::ByObject;
+    type Threads = meta::NonThreadSafeArg;
 
     fn to_godot(&self) -> &Self {
         // Note: Gd<T> never null, so no need to check raw.is_null().

--- a/godot-core/src/obj/instance_id.rs
+++ b/godot-core/src/obj/instance_id.rs
@@ -102,6 +102,7 @@ impl GodotConvert for InstanceId {
 
 impl ToGodot for InstanceId {
     type Pass = crate::meta::ByValue;
+    type Threads = crate::meta::NonThreadSafeArg;
 
     fn to_godot(&self) -> Self::Via {
         self.to_i64()

--- a/godot-core/src/obj/mod.rs
+++ b/godot-core/src/obj/mod.rs
@@ -22,6 +22,7 @@ mod on_ready;
 mod passive_gd;
 mod raw_gd;
 mod traits;
+mod unique;
 
 mod base_init;
 #[cfg(since_api = "4.7")]
@@ -53,6 +54,7 @@ pub use on_ready::*;
 pub(crate) use passive_gd::PassiveGd;
 pub use raw_gd::*;
 pub use traits::*;
+pub use unique::{Unique, UniqueType};
 
 pub mod bounds;
 pub mod script;

--- a/godot-core/src/obj/raw_gd.rs
+++ b/godot-core/src/obj/raw_gd.rs
@@ -639,6 +639,7 @@ impl<T: GodotClass> GodotConvert for RawGd<T> {
 
 impl<T: GodotClass> ToGodot for RawGd<T> {
     type Pass = meta::ByRef;
+    type Threads = <Gd<T> as ToGodot>::Threads;
 
     fn to_godot(&self) -> &Self::Via {
         self

--- a/godot-core/src/obj/unique.rs
+++ b/godot-core/src/obj/unique.rs
@@ -1,0 +1,437 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use std::collections::VecDeque;
+
+use godot_ffi::VariantType;
+
+use crate::builtin::{AnyArray, AnyDictionary, Array, Callable, Dictionary, StringName, Variant};
+use crate::classes::class_db::ApiType;
+use crate::classes::{ClassDb, RefCounted};
+use crate::meta::sealed::Sealed;
+use crate::meta::{AsArg, ByValue, Element, ToGodot};
+use crate::obj::bounds::{self, DynMemory as _};
+use crate::obj::{Bounds, Gd, GodotClass, Inherits, NewAlloc, NewGd, Singleton as _};
+
+/// Marker trait to make a type eligible to be used in `Unique<T>`.
+pub trait UniqueType: Sealed {}
+
+impl<T: GodotClass> UniqueType for Gd<T> {}
+impl<K: Element, V: Element> UniqueType for Dictionary<K, V> {}
+impl<V: Element> UniqueType for Array<V> {}
+impl UniqueType for AnyArray {}
+impl UniqueType for AnyDictionary {}
+
+/// Makes sure the inner value is unique and can be safely shared across threads.
+///
+/// No other part of the engine will have access to the inner value and only `Send + Sync` or other `Unique<T>` values can be passed to
+/// functions on `T`. Unique also blocks access to `Gd::clone` or to their `InstanceId`.
+///
+/// `Unique` supports these generally not thread safe types:
+/// - [`Gd`]
+/// - [`Dictionary`]
+/// - [`Array`]
+pub struct Unique<T: UniqueType> {
+    inner: T,
+}
+
+impl<T: UniqueType> Unique<T> {
+    pub(crate) unsafe fn new_unchecked(inner: T) -> Self {
+        Self { inner }
+    }
+
+    pub(crate) unsafe fn new_optional_unchecked(inner: Option<T>) -> Option<Self> {
+        inner.map(|inner| unsafe { Self::new_unchecked(inner) })
+    }
+}
+
+impl<T: GodotClass + NewAlloc> Unique<Gd<T>> {
+    pub fn new_alloc() -> Self {
+        Self {
+            inner: T::new_alloc(),
+        }
+    }
+}
+
+impl<T: GodotClass + NewGd> Unique<Gd<T>> {
+    pub fn new_gd() -> Self {
+        Self { inner: T::new_gd() }
+    }
+}
+
+impl<K: Element, V: Element> Unique<Dictionary<K, V>> {
+    #[expect(clippy::new_without_default)]
+    pub fn new() -> Self {
+        Unique {
+            inner: Dictionary::new(),
+        }
+    }
+}
+
+impl<V: Element> Unique<Array<V>> {
+    #[expect(clippy::new_without_default)]
+    pub fn new() -> Self {
+        Unique {
+            inner: Array::new(),
+        }
+    }
+}
+
+/// Recursively check a [`Refcounted`] engine class for unique access (ref-count = 1).
+///
+/// It only reliably works for engine types as it is safe to assume that they expose all their internal references to other objects via the
+/// get_property_list method. The engine uses the same approach to verify resource uniqueness. We can not be certain that custom, user
+/// implemented types reliably do so as well.
+fn verify_unique_recursive<
+    T: GodotClass<Declarer = bounds::DeclEngine, Memory = bounds::MemRefCounted>
+        + Inherits<RefCounted>,
+>(
+    value: Gd<T>,
+) -> Option<Gd<T>> {
+    match bounds::MemRefCounted::get_ref_count(&value.raw) {
+        Some(0) => unreachable!(),
+        Some(1) => (),
+        None | Some(2..) => return None,
+    }
+
+    let mut queue = VecDeque::from_iter([value.clone().upcast::<RefCounted>()]);
+
+    while let Some(next) = queue.pop_front() {
+        const VAR_TYPE_MAX: i32 = VariantType::MAX.ord;
+
+        let count = bounds::MemRefCounted::get_ref_count(&value.raw)?;
+
+        // Sub resources should have a count of 2. One ref for the root-object and one for us.
+        if count > 2 {
+            return None;
+        }
+
+        let ref_counted_value = value.upcast_ref::<RefCounted>();
+
+        // Scripts could hold references to other objects.
+        if ref_counted_value.get_script().is_some() {
+            return None;
+        }
+
+        let api_type = ClassDb::singleton()
+            .class_get_api_type(&StringName::from(&ref_counted_value.get_class()));
+
+        // Runtime class could be user defined, so it has to match compile-time class.
+        if !matches!(api_type, ApiType::CORE | ApiType::EDITOR) {
+            return None;
+        }
+
+        for dict in next.upcast_object().get_property_list().iter_shared() {
+            for (_, value) in dict.iter_shared() {
+                match value.get_type() {
+                    VariantType { ord: ..=-1 } => unreachable!(),
+                    VariantType::NIL
+                    | VariantType::BOOL
+                    | VariantType::INT
+                    | VariantType::FLOAT
+                    | VariantType::STRING
+                    | VariantType::VECTOR2
+                    | VariantType::VECTOR2I
+                    | VariantType::RECT2
+                    | VariantType::RECT2I
+                    | VariantType::VECTOR3
+                    | VariantType::VECTOR3I
+                    | VariantType::TRANSFORM2D
+                    | VariantType::VECTOR4
+                    | VariantType::VECTOR4I
+                    | VariantType::PLANE
+                    | VariantType::QUATERNION
+                    | VariantType::AABB
+                    | VariantType::BASIS
+                    | VariantType::TRANSFORM3D
+                    | VariantType::PROJECTION
+                    | VariantType::COLOR
+                    | VariantType::STRING_NAME
+                    | VariantType::NODE_PATH
+                    | VariantType::SIGNAL
+                    | VariantType::RID => continue,
+
+                    VariantType::OBJECT => {
+                        let object = value.try_to::<Gd<RefCounted>>();
+
+                        match object {
+                            Ok(ref_counted) => queue.push_back(ref_counted),
+                            // Object does not inherit RefCounted and is manually managed.
+                            Err(_) => return None,
+                        }
+                    }
+
+                    VariantType::CALLABLE => {
+                        let callable = value.try_to::<Callable>();
+
+                        match callable {
+                            // Custom callables are ref-counted, but we don't have access to the count.
+                            Ok(callable) if callable.is_custom() => return None,
+                            Ok(_) => (),
+                            Err(_) => return None,
+                        }
+                    }
+
+                    // Dictionary and all Array types are ref-counted, but we don't have access to the count.
+                    VariantType::DICTIONARY
+                    | VariantType::ARRAY
+                    | VariantType::PACKED_BYTE_ARRAY
+                    | VariantType::PACKED_INT32_ARRAY
+                    | VariantType::PACKED_INT64_ARRAY
+                    | VariantType::PACKED_FLOAT32_ARRAY
+                    | VariantType::PACKED_FLOAT64_ARRAY
+                    | VariantType::PACKED_STRING_ARRAY
+                    | VariantType::PACKED_VECTOR2_ARRAY
+                    | VariantType::PACKED_VECTOR3_ARRAY
+                    | VariantType::PACKED_COLOR_ARRAY
+                    | VariantType::PACKED_VECTOR4_ARRAY => return None,
+
+                    // Everything outside the VariantType range is unreachable.
+                    VariantType {
+                        ord: VAR_TYPE_MAX..,
+                    } => unreachable!(),
+                }
+            }
+        }
+    }
+
+    Some(value)
+}
+
+impl<T: GodotClass + Bounds<Memory = bounds::MemRefCounted>> Unique<Gd<T>> {
+    /// Attempts to verify that the provided ref-counted object is in fact unique.
+    ///
+    /// This might fail if the object is referenced by anything else or any of its internal references are shared with other objects.
+    /// Specific reasons for this conversion to fail:
+    ///
+    /// - Object class is user created.
+    /// - Object has a script attached.
+    /// - Reference counter is > 1.
+    /// - Reference count of any property value is > 1.
+    /// - Any property value directly inherits from Object (manually managed).
+    /// - Any property value is of type Dictionary or any of the Array types.
+    /// - Any property is a custom callable.
+    /// - Any property fails these checks recursively.
+    ///
+    /// Since all checks are applied recursively to all objects which are referenced by the given value this conversion can potentially be quite expensive.
+    pub fn try_from_ref_counted(value: Gd<T>) -> Option<Self>
+    where
+        T: GodotClass<Declarer = bounds::DeclEngine, Memory = bounds::MemRefCounted>
+            + Inherits<RefCounted>,
+    {
+        verify_unique_recursive(value).map(|verified| Self { inner: verified })
+    }
+}
+
+impl<T: GodotClass<Declarer = bounds::DeclEngine>> Unique<Gd<T>> {
+    /// Apply modifications to unique instance of the inner type.
+    ///
+    /// All captured outer variables must be thread-safe.
+    pub fn apply_gd<F: FnOnce(&mut T) + Send + Sync>(&mut self, f: F) {
+        f(&mut *self.inner);
+    }
+}
+
+impl<T: GodotClass<Declarer = bounds::DeclUser>> Unique<Gd<T>> {
+    /// Apply modifications to unique instance of the inner type.
+    ///
+    /// All captured outer variables must be thread-safe.
+    pub fn apply<F: FnOnce(&mut T) + Send + Sync>(&mut self, f: F) {
+        f(&mut *self.inner.bind_mut());
+    }
+}
+
+impl<K: Element, V: Element> Unique<Dictionary<K, V>> {
+    /// Apply modifications to unique instance of the inner type.
+    ///
+    /// All captured outer variables must be thread-safe.
+    pub fn apply<F: FnOnce(&mut Dictionary<K, V>) + Send + Sync>(&mut self, f: F) {
+        f(&mut self.inner)
+    }
+
+    /// Downgrades this typed/untyped `Unique<Dictionary<T>>` into a `Unique<AnyArray>`.
+    ///
+    /// This method is useful if you need `AnyArray` instead of a typed one.
+    pub fn upcast_any_dictionary(self) -> Unique<AnyDictionary> {
+        Unique {
+            inner: self.inner.upcast_any_dictionary(),
+        }
+    }
+}
+
+impl<V: Element> Unique<Array<V>> {
+    /// Apply modifications to unique instance of the inner type.
+    ///
+    /// All captured outer variables must be thread-safe.
+    pub fn apply<F: FnOnce(&mut Array<V>) + Send + Sync>(&mut self, f: F) {
+        f(&mut self.inner);
+    }
+
+    /// Downgrades this typed/untyped `Unique<Array<T>>` into a `Unique<AnyArray>`.
+    ///
+    /// This method is useful if you need `AnyArray` instead of a typed one.
+    pub fn upcast_any_array(self) -> Unique<AnyArray> {
+        Unique {
+            inner: self.inner.upcast_any_array(),
+        }
+    }
+}
+
+impl<V: Element + Send + Sync> Array<V> {
+    /// Create a unique copy of the array if all elements are thread-safe.
+    ///
+    /// Arrays are reference counted and could be accessed by multiple threads at the same time. By creating a shallow copy of the array
+    /// it can be guaranteed that there are no other references to the array.
+    pub fn to_unique(&self) -> Unique<Self> {
+        Unique {
+            inner: self.duplicate_shallow(),
+        }
+    }
+}
+
+impl<T: UniqueType> Unique<T> {
+    /// Unwraps the inner value and gives up all uniqueness guarantees.
+    pub fn share(self) -> T {
+        self.inner
+    }
+}
+
+unsafe impl<T: UniqueType> Send for Unique<T> {}
+unsafe impl<T: UniqueType> Sync for Unique<T> {}
+
+impl<T: GodotClass> AsArg<Gd<T>> for Unique<Gd<T>> {
+    fn into_arg<'arg>(self) -> crate::meta::CowArg<'arg, Gd<T>>
+    where
+        Self: 'arg,
+    {
+        crate::meta::CowArg::Owned(self.inner)
+    }
+}
+
+impl<T: GodotClass> AsArg<Option<Gd<T>>> for Unique<Gd<T>> {
+    fn into_arg<'arg>(self) -> crate::meta::CowArg<'arg, Option<Gd<T>>>
+    where
+        Self: 'arg,
+    {
+        crate::meta::CowArg::Owned(Some(self.inner))
+    }
+}
+
+impl<T: GodotClass> AsArg<Variant> for Unique<Gd<T>> {
+    fn into_arg<'arg>(self) -> crate::meta::CowArg<'arg, Variant>
+    where
+        Self: 'arg,
+    {
+        crate::meta::CowArg::Owned(self.inner.to_variant())
+    }
+}
+
+impl<K: Element, V: Element> AsArg<Dictionary<K, V>> for Unique<Dictionary<K, V>> {
+    fn into_arg<'arg>(self) -> crate::meta::CowArg<'arg, Dictionary<K, V>>
+    where
+        Self: 'arg,
+    {
+        crate::meta::CowArg::Owned(self.inner)
+    }
+}
+
+impl<K: Element, V: Element> AsArg<AnyDictionary> for Unique<Dictionary<K, V>> {
+    fn into_arg<'arg>(self) -> crate::meta::CowArg<'arg, AnyDictionary>
+    where
+        Self: 'arg,
+    {
+        crate::meta::CowArg::Owned(self.inner.upcast_any_dictionary())
+    }
+}
+
+impl AsArg<AnyDictionary> for Unique<AnyDictionary> {
+    fn into_arg<'arg>(self) -> crate::meta::CowArg<'arg, AnyDictionary>
+    where
+        Self: 'arg,
+    {
+        crate::meta::CowArg::Owned(self.inner)
+    }
+}
+
+impl<K: Element, V: Element> AsArg<Variant> for Unique<Dictionary<K, V>> {
+    fn into_arg<'arg>(self) -> crate::meta::CowArg<'arg, Variant>
+    where
+        Self: 'arg,
+    {
+        crate::meta::CowArg::Owned(self.inner.to_variant())
+    }
+}
+
+impl<V: Element> AsArg<Array<V>> for Unique<Array<V>> {
+    fn into_arg<'arg>(self) -> crate::meta::CowArg<'arg, Array<V>>
+    where
+        Self: 'arg,
+    {
+        crate::meta::CowArg::Owned(self.inner)
+    }
+}
+
+impl<V: Element> AsArg<AnyArray> for Unique<Array<V>> {
+    fn into_arg<'arg>(self) -> crate::meta::CowArg<'arg, AnyArray>
+    where
+        Self: 'arg,
+    {
+        crate::meta::CowArg::Owned(self.inner.upcast_any_array())
+    }
+}
+
+impl AsArg<AnyArray> for Unique<AnyArray> {
+    fn into_arg<'arg>(self) -> crate::meta::CowArg<'arg, AnyArray>
+    where
+        Self: 'arg,
+    {
+        crate::meta::CowArg::Owned(self.inner)
+    }
+}
+
+impl<V: Element> AsArg<Variant> for Unique<Array<V>> {
+    fn into_arg<'arg>(self) -> crate::meta::CowArg<'arg, Variant>
+    where
+        Self: 'arg,
+    {
+        crate::meta::CowArg::Owned(self.inner.to_variant())
+    }
+}
+
+impl<I> FromIterator<I> for Unique<Array<I>>
+where
+    I: Element + ToGodot<Pass = ByValue> + Send + Sync,
+{
+    fn from_iter<T: IntoIterator<Item = I>>(iter: T) -> Self {
+        let mut array = Unique::<Array<I>>::new();
+
+        for item in iter {
+            array.apply(|array| {
+                array.push(item);
+            })
+        }
+
+        array
+    }
+}
+
+impl<I: Element, T: UniqueType> FromIterator<Unique<T>> for Unique<Array<I>>
+where
+    Unique<T>: AsArg<I>,
+{
+    fn from_iter<Iter: IntoIterator<Item = Unique<T>>>(iter: Iter) -> Self {
+        let mut array = Unique::<Array<I>>::new();
+
+        for item in iter {
+            array.apply(|array| {
+                array.push(item);
+            });
+        }
+
+        array
+    }
+}

--- a/godot-core/src/obj/unique.rs
+++ b/godot-core/src/obj/unique.rs
@@ -13,7 +13,7 @@ use crate::builtin::{AnyArray, AnyDictionary, Array, Callable, Dictionary, Strin
 use crate::classes::class_db::ApiType;
 use crate::classes::{ClassDb, RefCounted};
 use crate::meta::sealed::Sealed;
-use crate::meta::{AsArg, ByValue, Element, ToGodot};
+use crate::meta::{AsArg, ByValue, Element, ThreadSafeArgContext, ThreadSafeSealed, ToGodot};
 use crate::obj::bounds::{self, DynMemory as _};
 use crate::obj::{Bounds, Gd, GodotClass, Inherits, NewAlloc, NewGd, Singleton as _};
 
@@ -434,4 +434,10 @@ where
 
         array
     }
+}
+
+impl<T: UniqueType> ThreadSafeSealed for Unique<T> {}
+
+impl<T: UniqueType> ThreadSafeArgContext for Unique<T> {
+    fn guarantee_thread_safe(&self) {}
 }

--- a/godot-core/src/signal/typed_signal.rs
+++ b/godot-core/src/signal/typed_signal.rs
@@ -16,7 +16,7 @@ use crate::builtin::{Callable, CowStr, Variant};
 use crate::classes::object::ConnectFlags;
 use crate::meta;
 use crate::meta::{InParamTuple, ObjectToOwned, UniformObjectDeref};
-use crate::obj::{Gd, GodotClass, WithSignals};
+use crate::obj::{EngineBitfield, Gd, GodotClass, WithSignals};
 
 /// Type-safe version of a Godot signal.
 ///
@@ -186,7 +186,7 @@ impl<'c, C: WithSignals, Ps: meta::ParamTuple> TypedSignal<'c, C, Ps> {
         let name = self.name.as_ref();
 
         self.object.with_object_mut(|obj| {
-            obj.emit_signal(name, &args.to_variant_array());
+            obj.raw_emit_signal(name, &args.to_variant_array());
         });
     }
 
@@ -226,9 +226,11 @@ impl<'c, C: WithSignals, Ps: meta::ParamTuple> TypedSignal<'c, C, Ps> {
         let mut owned_object = self.object.to_owned_object();
         owned_object.with_object_mut(|obj| {
             if let Some(flags) = flags {
-                obj.connect_flags(signal_name, &callable, flags);
+                obj.raw_connect_ex(signal_name, &callable)
+                    .flags(flags.ord() as u32)
+                    .done();
             } else {
-                obj.connect(signal_name, &callable);
+                obj.raw_connect(signal_name, &callable);
             }
         });
 

--- a/godot-macros/src/derive/derive_to_godot.rs
+++ b/godot-macros/src/derive/derive_to_godot.rs
@@ -43,6 +43,7 @@ fn make_togodot_for_newtype_struct(name: &Ident, field: &NewtypeStruct) -> Token
     quote! {
         impl ::godot::meta::ToGodot for #name {
             type Pass = <#via_type as ::godot::meta::ToGodot>::Pass;
+            type Threads = ::godot::meta::ThreadSafeArg;
 
             fn to_godot(&self) -> ::godot::meta::ToArg<'_, Self::Via, Self::Pass> {
                 ::godot::meta::ToGodot::to_godot(&self.#field_name)
@@ -66,6 +67,7 @@ fn make_togodot_for_int_enum(
     quote! {
         impl ::godot::meta::ToGodot for #name {
             type Pass = ::godot::meta::conv::ByValue;
+            type Threads = ::godot::meta::ThreadSafeArg;
 
             #[allow(unused_parens)] // Error "unnecessary parentheses around block return value"; comes from ord expressions like (1 + 2).
             fn to_godot(&self) -> Self::Via {
@@ -87,6 +89,7 @@ fn make_togodot_for_string_enum(name: &Ident, enum_: &CStyleEnum) -> TokenStream
     quote! {
         impl ::godot::meta::ToGodot for #name {
             type Pass = ::godot::meta::conv::ByValue;
+            type Threads = ::godot::meta::ThreadSafeArg;
 
             fn to_godot(&self) -> Self::Via {
                 match self {

--- a/godot/src/lib.rs
+++ b/godot/src/lib.rs
@@ -257,8 +257,9 @@ pub mod init {
 pub mod meta {
     pub use godot_core::meta::{
         AsArg, ClassId, Element, EngineFromGodot, EngineToGodot, FromGodot, GodotConvert,
-        GodotImmutable, GodotType, ObjectArg, PackedElement, SignedRange, ToArg, ToGodot,
-        element_variant_type, owned_into_arg, ref_to_arg, wrapped,
+        GodotImmutable, GodotType, NonThreadSafeArg, ObjectArg, PackedElement, SignedRange,
+        ThreadSafeArg, ThreadSafeArgContext, ThreadSafety, ToArg, ToGodot, element_variant_type,
+        owned_into_arg, ref_to_arg, wrapped,
     };
     #[doc(inline)]
     pub use godot_core::meta::{conv, error, inspect, shape};

--- a/itest/rust/build.rs
+++ b/itest/rust/build.rs
@@ -92,6 +92,7 @@ macro_rules! push_newtype {
 
             impl godot::meta::ToGodot for $name {
                 type Pass = godot::meta::conv::ByValue;
+                type Threads = godot::meta::ThreadSafeArg;
 
                 #[allow(clippy::clone_on_copy)]
                 fn to_godot(&self) -> Self::Via {

--- a/itest/rust/src/builtin_tests/containers/callable_test.rs
+++ b/itest/rust/src/builtin_tests/containers/callable_test.rs
@@ -427,7 +427,7 @@ pub mod custom_callable {
                 || {
                     quick_thread(|| {
                         let callable = unsafe { crosser.extract() };
-                        callable.callv(&varray![5]);
+                        callable.call(vslice![5]);
                     });
                 },
             );
@@ -435,7 +435,7 @@ pub mod custom_callable {
             // Multi-threaded OR safeguards disengaged: No FFI panic, but callable may or may not execute.
             quick_thread(|| {
                 let callable = unsafe { crosser.extract() };
-                callable.callv(&varray![5]);
+                callable.call(vslice![5]);
             });
         }
 

--- a/itest/rust/src/builtin_tests/containers/packed_array_test.rs
+++ b/itest/rust/src/builtin_tests/containers/packed_array_test.rs
@@ -14,7 +14,9 @@ use godot::builtin::{
 };
 use godot::global::godot_str;
 use godot::meta::inspect::ElementType;
-use godot::meta::{PackedElement, ToGodot, owned_into_arg, ref_to_arg, wrapped};
+use godot::meta::{
+    PackedElement, ThreadSafeArgContext, ToGodot, owned_into_arg, ref_to_arg, wrapped,
+};
 
 use crate::assert_match;
 use crate::framework::{expect_panic, itest, suppress_godot_print};
@@ -750,7 +752,7 @@ fn packed_array_from_array() {
 
 #[itest]
 fn packed_array_all_types() {
-    fn test<T: PackedElement + Default + PartialEq + fmt::Debug>() {
+    fn test<T: PackedElement + Default + PartialEq + fmt::Debug + ThreadSafeArgContext>() {
         let val = T::default();
 
         let mut array: PackedArray<T> = PackedArray::new();
@@ -814,7 +816,7 @@ fn packed_array_array_conversions_gstring() {
 // Generator trait and implementations
 
 /// Deterministic value generator for tests.
-trait Generator: PackedElement + Default + PartialEq + fmt::Debug {
+trait Generator: PackedElement + Default + PartialEq + fmt::Debug + ThreadSafeArgContext {
     /// Deterministically generate a value depending on the index.
     ///
     /// Values may repeat, but the period must be at least 5.

--- a/itest/rust/src/builtin_tests/containers/signal_test.rs
+++ b/itest/rust/src/builtin_tests/containers/signal_test.rs
@@ -536,6 +536,7 @@ fn enums_as_signal_args() {
 
     impl ToGodot for EventType {
         type Pass = godot::meta::conv::ByValue;
+        type Threads = godot::meta::ThreadSafeArg;
 
         fn to_godot(&self) -> Self::Via {
             match self {

--- a/itest/rust/src/builtin_tests/convert_test.rs
+++ b/itest/rust/src/builtin_tests/convert_test.rs
@@ -113,6 +113,7 @@ impl GodotConvert for ConvertedStruct {
 
 impl ToGodot for ConvertedStruct {
     type Pass = godot::meta::conv::ByValue;
+    type Threads = godot::meta::ThreadSafeArg;
 
     fn to_godot(&self) -> Self::Via {
         vdict! {

--- a/itest/rust/src/engine_tests/async_test.rs
+++ b/itest/rust/src/engine_tests/async_test.rs
@@ -135,15 +135,25 @@ fn signal_future_non_send_arg_panic() -> TaskHandle {
 
     use crate::framework::ThreadCrosser;
 
-    let mut object = RefCounted::new_gd();
-    let signal = Signal::from_object_signal(&object, "custom_signal");
+    #[derive(GodotClass)]
+    #[class(base = RefCounted, init)]
+    struct SignalClass {
+        base: Base<RefCounted>,
+    }
 
-    object.add_user_signal("custom_signal");
+    #[godot_api]
+    impl SignalClass {
+        #[signal]
+        fn custom_signal(arg: Gd<RefCounted>);
+    }
+
+    let object = SignalClass::new_gd();
+    let signal = object.signals().custom_signal().to_future();
 
     let handle = task::spawn(expect_async_panic(
         "future should panic when the Gd<RefCounted> is sent between threads",
         async move {
-            signal.to_future::<(Gd<RefCounted>,)>().await;
+            signal.await;
         },
     ));
 
@@ -156,14 +166,14 @@ fn signal_future_non_send_arg_panic() -> TaskHandle {
     let object = ThreadCrosser::new(object);
 
     let thread = std::thread::spawn(move || {
-        let mut object = unsafe { object.extract() };
+        let object = unsafe { object.extract() };
 
         let arg = RefCounted::new_gd();
         // Eject the RefCounted before panic explodes the thread.
         *ESCAPE_POD.lock() = Some(ThreadCrosser::new(arg.clone()));
 
-        // This will panic:
-        object.emit_signal("custom_signal", vslice![arg])
+        // This will cause a panic on the main-thread:
+        object.signals().custom_signal().emit(&arg);
     });
 
     // Wait until thread concludes, also to avoid race conditions.

--- a/itest/rust/src/object_tests/mod.rs
+++ b/itest/rust/src/object_tests/mod.rs
@@ -33,5 +33,8 @@ mod validate_property_test;
 mod virtual_methods_niche_test;
 mod virtual_methods_test;
 
+#[cfg(feature = "experimental-threads")]
+mod thread_safety;
+
 // Need to test this in the init level method.
 pub use init_stage_test::*;

--- a/itest/rust/src/object_tests/property_test.rs
+++ b/itest/rust/src/object_tests/property_test.rs
@@ -451,6 +451,8 @@ impl GodotConvert for ManualEnumShape {
 
 impl ToGodot for ManualEnumShape {
     type Pass = godot::meta::conv::ByValue;
+    type Threads = godot::meta::ThreadSafeArg;
+
     fn to_godot(&self) -> i64 {
         *self as i64
     }

--- a/itest/rust/src/object_tests/thread_safety.rs
+++ b/itest/rust/src/object_tests/thread_safety.rs
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use godot::builtin::VarDictionary;
+use godot::classes::{ArrayMesh, Node, RefCounted, Resource};
+use godot::meta::{ToGodot, owned_into_arg};
+use godot::obj::{Gd, NewAlloc, NewGd, Unique};
+
+use crate::framework::{expect_panic_or_nothing, itest};
+
+#[itest]
+fn valid_use_case() {
+    std::thread::spawn(|| {
+        let shadow_mesh: Unique<Gd<ArrayMesh>> = Unique::new_gd();
+        let mut mesh: Unique<Gd<ArrayMesh>> = Unique::new_gd();
+
+        mesh.apply_gd(|mesh| {
+            mesh.set_shadow_mesh(shadow_mesh);
+        });
+    })
+    .join()
+    .unwrap();
+}
+
+#[itest]
+fn trying_to_cheat() {
+    std::thread::spawn(|| {
+        thread_local! {
+            static CHILD_NODE: Gd<Node> = Node::new_alloc();
+        }
+
+        let mut node = Unique::<Gd<Node>>::new_alloc();
+        let mut dict = Unique::<VarDictionary>::new();
+
+        expect_panic_or_nothing("thread should panic when passing by ref", || {
+            node.apply_gd(|node: &mut Node| {
+                let owned_node = CHILD_NODE.with(|value: &Gd<Node>| value.clone());
+                node.add_child(&owned_node);
+            });
+        });
+
+        expect_panic_or_nothing("thread should panic when passing by option ref", || {
+            node.apply_gd(|node: &mut Node| {
+                let owned_node = CHILD_NODE.with(|value: &Gd<Node>| value.clone());
+                node.set_owner(&owned_node);
+            });
+        });
+
+        expect_panic_or_nothing("thread should panic when passing object by variant", || {
+            dict.apply(|dict| {
+                let obj = RefCounted::new_gd();
+                dict.contains_key(&obj.to_variant());
+            });
+        });
+
+        expect_panic_or_nothing("thread should panic when passing by own reference", || {
+            dict.apply(|dict| {
+                let _ = dict.insert("key", &dict.clone());
+            });
+        });
+
+        expect_panic_or_nothing("thread should panic when passing by Gd<T> by value", || {
+            node.apply_gd(|node: &mut Node| {
+                let owned_node = CHILD_NODE.with(|value: &Gd<Node>| value.clone());
+                node.add_child(owned_into_arg(owned_node));
+            });
+        });
+
+        // Test clean-up to avoid memory leaks.
+        CHILD_NODE.with(|value| value.clone().free());
+        node.share().free();
+    })
+    .join()
+    .unwrap();
+}
+
+#[itest]
+fn recursive_unique_check() {
+    let resource = Resource::new_gd();
+
+    let unique_res = Unique::try_from_ref_counted(resource);
+
+    assert!(
+        unique_res.is_some(),
+        "Uniqueness verification with a single ref should succeed"
+    );
+
+    let resource = unique_res.unwrap().share();
+    let second_ref = resource.clone();
+
+    assert!(
+        Unique::try_from_ref_counted(resource).is_none(),
+        "Uniqueness verification with two refs should fail"
+    );
+
+    drop(second_ref);
+}
+
+#[itest]
+#[cfg(feature = "codegen-full")]
+fn sub_thread_surface_tool() {
+    use godot::builtin::Vector3;
+    use godot::classes::SurfaceTool;
+    use godot::classes::mesh::PrimitiveType;
+
+    let result = std::thread::spawn(|| {
+        let mut builder: Gd<SurfaceTool> = SurfaceTool::new_gd();
+
+        builder.begin(PrimitiveType::TRIANGLES);
+        builder.add_vertex(Vector3::new(1.0, 1.0, 1.0));
+        builder.add_vertex(Vector3::new(1.0, 2.0, 1.0));
+        builder.add_vertex(Vector3::new(1.0, 1.0, 2.0));
+
+        let existing_mesh: Unique<Gd<ArrayMesh>> = Unique::new_gd();
+
+        builder.commit_ex().existing(existing_mesh).done().unwrap()
+    })
+    .join()
+    .expect("sub-thread should not have paniced");
+
+    assert_eq!(result.share().get_reference_count(), 1);
+}


### PR DESCRIPTION
The `Unique<T>` type constrains the way non-thread-safe engine types can be used outside the main thread. With these constraints applied, we can safely send types that are wrapped by `Unique<T>` across threads.

Values that are wrapped by `Unique` can only be accessed via the `Unique::apply` or `Unique::apply_gd` functions. These functions accept a `Send + Sync` closure to prevent any non-thread-safe values from getting passed into the wrapped types. 

## Usage Example

```rs
std::thread::spawn(|| {
    let node: Unique<Gd<Node3D>> = Unique::new_alloc();
    let child: Unique<Gd<Node3D>> = Unique::new_alloc();
    
    node.apply_gd(move |node| {
         node.add_child(child);
    });

    node // A unique node can be returned by the thread back to the main thread.
});
```

## Breaking Changes
This will very likely break code that relies on the `experimental-threads` feature.  The extent of the breakage needs to be assessed, and ideally a migration path can be offered for all safe use cases.

- `ToGodot` has a new associated type `Threads` that has to be added to all manual implementations of the trait. Default values for associated types are still not stable.

## To Dos:
- [x] test the implementation with an actual project
   - [ ] It's currently possible to pass array and dictionary types to the engine by reference. This breaks the uniqueness constraints when storing such types in a thread-local variable.
- [x] verify_unique_recursive needs more thorough testing.
- [ ] check older API version compatibility.