### PR TITLE
Mute godot-rust preamble in the presence of `--no-header` too.

### DIFF
--- a/godot-ffi/src/lib.rs
+++ b/godot-ffi/src/lib.rs
@@ -402,10 +402,10 @@ pub fn print_deferred_startup_messages() {
 }
 
 fn print_preamble(version: GDExtensionGodotVersion) {
-    // Check if `--quiet` flag is present in Godot's command line arguments, before `--` separator that separates Godot from application args.
+    // Check if `--quiet` or `--no-header` flag is present in Godot's command line arguments, before `--` separator that separates Godot from application args.
     let is_quiet = std::env::args()
         .take_while(|arg| arg != "--")
-        .any(|arg| arg == "--quiet");
+        .any(|arg| arg == "--quiet" || arg == "--no-header");
 
     if is_quiet {
         return;


### PR DESCRIPTION
follow-up to: https://github.com/godot-rust/gdext/pull/1487

https://docs.godotengine.org/en/latest/tutorials/editor/command_line_tutorial.html

Long story short `--no-header` should apply to header only (godot-rust preamble being part of it IMO), while `--quiet` should suppress _some_ stdout (handled automatically while we use `godot_print`/warn and whatnot)