### PR TITLE
Implement convenience conversions for `Error`

### DIFF
--- a/godot-core/src/classes/manual_extensions.rs
+++ b/godot-core/src/classes/manual_extensions.rs
@@ -14,6 +14,7 @@
 
 use crate::builtin::NodePath;
 use crate::classes::{Node, PackedScene};
+use crate::global::Error;
 use crate::meta::{AsArg, arg_into_ref};
 use crate::obj::{Gd, Inherits};
 
@@ -77,5 +78,42 @@ impl PackedScene {
         T: Inherits<Node>,
     {
         self.instantiate().and_then(|gd| gd.try_cast::<T>().ok())
+    }
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+
+/// Manual extensions for the `global::Error` enum.
+impl Error {
+    /// Returns `Ok(())` for `Error::OK`, and `Err(self)` for any `Error::ERR_*`.
+    ///
+    /// This is a convenience method that may be used to convert this type into one that can be used with the try operator (`?`)
+    /// for easy short circuiting of Godot `Error`s.
+    ///
+    /// ```
+    /// use godot::global::Error;
+    ///
+    /// assert_eq!(Error::OK.into_result(), Ok(()));
+    /// assert_eq!(Error::FAILED.into_result(), Err(Error::FAILED));
+    /// ```
+    pub fn into_result(self) -> Result<(), Self> {
+        if self == Error::OK { Ok(()) } else { Err(self) }
+    }
+
+    /// Creates an `Error` from a `Result<(), Error>`.
+    ///
+    /// `Ok(())` becomes `Error::OK`, and `Err(e)` becomes `e` (even in the unusual case where `e == Error::OK`).
+    ///
+    /// ```
+    /// use godot::global::Error;
+    ///
+    /// assert_eq!(Error::from_result(Ok(())), Error::OK);
+    /// assert_eq!(Error::from_result(Err(Error::FAILED)), Error::FAILED);
+    /// ```
+    pub fn from_result(result: Result<(), Self>) -> Self {
+        match result {
+            Ok(()) => Error::OK,
+            Err(e) => e,
+        }
     }
 }


### PR DESCRIPTION
This PR implements convenience conversions from `Error` to `Result<(), Error>` and back to help with short-circuiting Godot `Error`s.

## Conversions
- `Error` to `Result<(), Error>`: `Error::err()` and `FromGodot`
- `Result<(), Error>` to `Error`: `Error::from_result()` and `ToGodot`

# Why?
Godot's `Error` is already conceptually similar to `Result`, having an `OK` and `ERR_*` variants, so being able to use the try operator (`?`) on them would be convenient.

Being able to return `Result<(), Error>` from a `#[func]` also helps with this.

# Open questions
- [ ] Should `Result<(), Error>` be a type alias, such as `ErrorResult`?

# Considered alternatives
- Implementing `Try` directly is nightly-only.