### PR TITLE
Use `iarray!` + `idict!` instead of `=` syntax

### DIFF
--- a/godot-core/src/builtin/collections/array.rs
+++ b/godot-core/src/builtin/collections/array.rs
@@ -84,7 +84,7 @@ use crate::registry::property::{BuiltinExport, Export, GodotElementShape, GodotS
 /// array.push(30);
 ///
 /// // Or create the same array in a single expression.
-/// let array = array![= 10, 20, 30];
+/// let array = iarray![10, 20, 30];
 ///
 /// // Access elements.
 /// let value: i64 = array.at(0); // 10
@@ -130,9 +130,9 @@ use crate::registry::property::{BuiltinExport, Export, GodotElementShape, GodotS
 /// For negative indices, use [`wrapped()`](crate::meta::wrapped).
 ///
 /// ```no_run
-/// # use godot::builtin::array;
+/// # use godot::builtin::{array, iarray};
 /// # use godot::meta::wrapped;
-/// let arr = array![= 0, 1, 2, 3, 4, 5];
+/// let arr = iarray![0, 1, 2, 3, 4, 5];
 ///
 /// // The values of `begin` (inclusive) and `end` (exclusive) will be clamped to the array size.
 /// let clamped_array = arr.subarray_deep(999..99999, None);
@@ -1193,7 +1193,7 @@ impl<T: Element + fmt::Display> fmt::Display for Array<T> {
     /// # Example
     /// ```no_run
     /// # use godot::prelude::*;
-    /// let a = array![= 1,2,3,4];
+    /// let a = iarray![1,2,3,4];
     /// assert_eq!(format!("{a}"), "[1, 2, 3, 4]");
     /// ```
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -1502,22 +1502,25 @@ impl<T: Element> PartialOrd for Array<T> {
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Expression macros
+// Intra-doc-links use HTML to stay in same module (not switch to prelude when looking at godot::builtin).
 
-/// Constructs [`Array`] literals, similar to Rust's standard `vec!` macro.
+/// **Array**: constructs `Array` literals for all possible element types.
 ///
 /// # Type inference
-/// By default, `array!` uses [`AsArg`][crate::meta::AsArg] to push elements. This works when the array's element type `T` is already
-/// determined from context -- a type annotation, function parameter, etc. This supports all element types including `Gd<T>` and `Variant`.
+/// There are three related macros, all of which create [`Array<T>`] expressions, but they differ in how the type `T` is inferred:
 ///
-/// The `= ` prefix (`array![= ...]`) switches to [`AsDirectElement`][crate::meta::AsDirectElement], enabling unambiguous type inference
-/// from the elements themselves -- no external type context needed. Covers only common types and provides only conversions that are opinionated
-/// but unambiguous. For example, `array![= "hello"]` will infer as `Array<GString>`, never `Array<StringName>` or `Array<Variant>`.
+/// - `array!` uses [`AsArg`][crate::meta::AsArg] to push elements. This works when the array's element type `T` is already
+///   determined from context -- a type annotation, function parameter, etc. This supports all element types including `Gd<T>` and `Variant`.
+/// - [`iarray!`](macro.iarray.html) uses [`AsDirectElement`][crate::meta::AsDirectElement] for (opinionated) type inference from literals.
+///   This macro needs no type annotations, however is limited to common types, like `i32`, `&str` (inferred as `GString`), etc.
+/// - [`varray!`](macro.varray.html) uses `AsArg<Variant>`, meaning it's like `array!` but inferred as [`VarArray`].
 ///
 /// # Examples
 /// ```no_run
 /// # use godot::prelude::*;
-/// // Type annotation provides context; no prefix needed.
-/// // Multiple assignments possible.
+/// // array! requires type context (e.g. annotation, return type, etc.).
+/// // The same expression can be used to initialize different array types:
+///
 /// let ints: Array<i8>      = array![3, 1, 4];
 /// let ints: Array<i64>     = array![3, 1, 4];
 /// let ints: Array<Variant> = array![3, 1, 4];
@@ -1526,18 +1529,20 @@ impl<T: Element> PartialOrd for Array<T> {
 /// let strs: Array<StringName> = array!["a", "b"];
 /// let strs: Array<Variant>    = array!["a", "b"];
 ///
-/// // No type context, so use `=` for unambiguous inference.
-/// let ints = array![= 3, 1, 4];  // Array<i32>.
-/// let strs = array![= "a", "b"]; // Array<GString>.
+/// // More strict inference with iarray! and varray! macros:
+///
+/// let ints = iarray![3, 1, 4];  // Array<i32>.
+/// let strs = iarray!["a", "b"]; // Array<GString>.
+///
+/// let strs = varray!["a", "b"]; // VarArray.
 /// ```
 ///
 /// # See also
-/// To create an `Array` of variants, see the [`varray!`] macro.
+/// For dictionaries, a similar macro [`dict!`](macro.dict.html) exists.
 ///
-/// For dictionaries, a similar macro [`dict!`] exists.
+/// To construct slices of variants, use [`vslice!`](macro.vslice.html).
 #[macro_export]
 macro_rules! array {
-    // Default: old `AsArg` semantics (needed for `Gd`, `Variant`, or explicit disambiguation).
     ($($elements:expr_2021),* $(,)?) => {
         {
             let mut array = $crate::builtin::Array::default();
@@ -1545,9 +1550,14 @@ macro_rules! array {
             array
         }
     };
+}
 
-    // `=` prefix: `AsDirectElement` (unambiguous type inference; covers `i32`, `&str` -> `GString`, `&GString`, ...).
-    (= $($elements:expr_2021),* $(,)?) => {
+/// **I**nferred **array**: constructs `Array` literals without ambiguity.
+///
+/// See [`array!`](macro.array.html) for docs and examples.
+#[macro_export]
+macro_rules! iarray {
+    ($($elements:expr_2021),* $(,)?) => {
         {
             let mut array = $crate::builtin::Array::default();
             $(array.__macro_push_direct($elements);)*
@@ -1556,22 +1566,9 @@ macro_rules! array {
     };
 }
 
-/// Constructs [`VarArray`] literals, similar to Rust's standard `vec!` macro.
+/// **V**ariant **array**: constructs [`VarArray`] literals.
 ///
-/// Elements need to implement [`AsArg<Variant>`].
-///
-/// # Example
-/// ```no_run
-/// # use godot::prelude::*;
-/// let arr: VarArray = varray![42_i64, "hello", true];
-/// ```
-///
-/// # See also
-/// To create a typed `Array` with a single element type, see the [`array!`] macro.
-///
-/// For dictionaries, a similar macro [`vdict!`] exists.
-///
-/// To construct slices of variants, use [`vslice!`].
+/// See [`array!`](macro.array.html) for docs and examples.
 #[macro_export]
 macro_rules! varray {
     // Uses `AsArg` semantics, consistent with `array!`.
@@ -1617,7 +1614,7 @@ macro_rules! varray {
 /// ```
 ///
 /// # See also
-/// To create typed and untyped `Array`s, use the [`array!`] and [`varray!`] macros respectively.
+/// To create typed and untyped `Array`s, use the [`array!`] macro and its variants.
 ///
 /// For dictionaries, a similar macro [`vdict!`] exists.
 #[macro_export]

--- a/godot-core/src/builtin/collections/array_functional_ops.rs
+++ b/godot-core/src/builtin/collections/array_functional_ops.rs
@@ -42,7 +42,7 @@ impl<'a, T: Element> ArrayFunctionalOps<'a, T> {
     /// # Example
     /// ```no_run
     /// # use godot::prelude::*;
-    /// let array = array![= 1, 2, 3, 4, 5];
+    /// let array = iarray![1, 2, 3, 4, 5];
     /// let even = array.functional_ops().filter(&Callable::from_fn("is_even", |args| {
     ///     args[0].to::<i64>() % 2 == 0
     /// }));
@@ -63,7 +63,7 @@ impl<'a, T: Element> ArrayFunctionalOps<'a, T> {
     /// # Example
     /// ```no_run
     /// # use godot::prelude::*;
-    /// let array = array![= 1.1, 1.5, 1.9];
+    /// let array = iarray![1.1, 1.5, 1.9];
     /// let rounded = array.functional_ops().map(&Callable::from_fn("round", |args| {
     ///     args[0].to::<f64>().round() as i64
     /// }));
@@ -84,7 +84,7 @@ impl<'a, T: Element> ArrayFunctionalOps<'a, T> {
     /// # Example
     /// ```no_run
     /// # use godot::prelude::*;
-    /// let array = array![= 1, 2, 3, 4];
+    /// let array = iarray![1, 2, 3, 4];
     /// let sum = array.functional_ops().reduce(
     ///     &Callable::from_fn("sum", |args| {
     ///         args[0].to::<i64>() + args[1].to::<i64>()
@@ -107,7 +107,7 @@ impl<'a, T: Element> ArrayFunctionalOps<'a, T> {
     /// # Example
     /// ```no_run
     /// # use godot::prelude::*;
-    /// let array = array![= 1, 2, 3, 4];
+    /// let array = iarray![1, 2, 3, 4];
     /// let any_even = array.functional_ops().any(&Callable::from_fn("is_even", |args| {
     ///     args[0].to::<i64>() % 2 == 0
     /// }));
@@ -126,7 +126,7 @@ impl<'a, T: Element> ArrayFunctionalOps<'a, T> {
     /// # Example
     /// ```no_run
     /// # use godot::prelude::*;
-    /// let array = array![= 2, 4, 6];
+    /// let array = iarray![2, 4, 6];
     /// let all_even = array.functional_ops().all(&Callable::from_fn("is_even", |args| {
     ///     args[0].to::<i64>() % 2 == 0
     /// }));
@@ -148,7 +148,7 @@ impl<'a, T: Element> ArrayFunctionalOps<'a, T> {
     /// # Example
     /// ```no_run
     /// # use godot::prelude::*;
-    /// let array = array![= 1, 2, 3, 4, 5];
+    /// let array = iarray![1, 2, 3, 4, 5];
     /// let is_even = Callable::from_fn("is_even", |args| {
     ///     args[0].to::<i64>() % 2 == 0
     /// });
@@ -175,7 +175,7 @@ impl<'a, T: Element> ArrayFunctionalOps<'a, T> {
     /// # Example
     /// ```no_run
     /// # use godot::prelude::*;
-    /// let array = array![= 1, 2, 3, 4, 5];
+    /// let array = iarray![1, 2, 3, 4, 5];
     /// let is_even = Callable::from_fn("is_even", |args| {
     ///     args[0].to::<i64>() % 2 == 0
     /// });

--- a/godot-core/src/builtin/collections/dictionary.rs
+++ b/godot-core/src/builtin/collections/dictionary.rs
@@ -1255,38 +1255,41 @@ fn u8_to_bool(u: u8) -> bool {
 }
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
+// Expression macros
+// Intra-doc-links use HTML to stay in same module (not switch to prelude when looking at godot::builtin).
 
-/// Constructs typed [`Dictionary<K, V>`] literals, close to Godot's own syntax.
+/// **Dict**: constructs `Dictionary` literals for all possible key and value types.
 ///
-/// Any value can be used as a key, but to use an expression you need to surround it
-/// in `()` or `{}`.
+/// # Type inference
+/// There are three related macros, all of which create [`Dictionary<K, V>`] expressions, but they differ in how the types `K` and `V` are inferred:
 ///
-/// # Type annotation
-/// The macro creates a typed `Dictionary<K, V>`. You must provide an explicit type annotation
-/// to specify `K` and `V`. Keys must implement `AsArg<K>` and values must implement `AsArg<V>`.
+/// - `dict!` uses [`AsArg`][crate::meta::AsArg] to set entries. This works when the dictionary's key type `K` and value type `V` are already
+///   determined from context -- a type annotation, function parameter, etc. This supports all key/value types including `Gd<T>` and `Variant`.
+/// - [`idict!`](macro.idict.html) uses [`AsDirectElement`][crate::meta::AsDirectElement] for (opinionated) type inference from literals.
+///   This macro needs no type annotations, however is limited to common types, like `i32`, `&str` (inferred as `GString`), etc.
+/// - [`vdict!`](macro.vdict.html) uses `AsArg<Variant>`, meaning it's like `dict!` but inferred as [`VarDictionary`].
 ///
-/// The `= ` prefix (`dict! {= ...}`) switches to [`AsDirectElement`][crate::meta::AsDirectElement], enabling unambiguous type inference
-/// without an explicit type annotation. This covers types like `i32`, `&str` (inferred as `GString`), `&GString`, etc.
-///
-/// # Example
+/// # Examples
 /// ```no_run
-/// use godot::builtin::*;
+/// # use godot::prelude::*;
+/// // dict! requires type context (e.g. annotation, return type, etc.).
+/// // The same expression can be used to initialize different dictionary types:
 ///
-/// // Type annotation required, as the same initializer can be mapped to different types.
-/// let d: Dictionary<GString, i64> = dict! { "key1" => 10, "key2" => 20 };
-/// let d: Dictionary<StringName, i64> = dict! { "key1" => 10, "key2" => 20 };
-/// let d: Dictionary<GString, Variant> = dict! { "key1" => 10, "key2" => 20 };
+/// let d: Dictionary<GString, i64>     = dict! { "key1" => 10, "key2" => 20 };
+/// let d: Dictionary<StringName, u16>  = dict! { "key1" => 10, "key2" => 20 };
+/// let d: Dictionary<Variant, Variant> = dict! { "key1" => 10, "key2" => 20 };
 ///
-/// // `=` prefix: most common conversion, no type annotation needed.
-/// let d = dict! {= "key1" => 10, "key2" => 20 }; // Dictionary<GString, i32>.
+/// // More strict inference with idict! and vdict! macros:
+///
+/// let d = idict! { "key1" => 10, "key2" => 20 }; // Dictionary<GString, i32>.
+///
+/// let d = vdict! { "key1" => 10, "key2" => 20 }; // VarDictionary.
 /// ```
 ///
 /// # See also
-/// For untyped dictionaries, use [`vdict!`][macro@crate::builtin::vdict].
-/// For arrays, similar macros [`array!`][macro@crate::builtin::array] and [`varray!`][macro@crate::builtin::varray] exist.
+/// For arrays, a similar macro [`array!`](macro.array.html) exists.
 #[macro_export]
 macro_rules! dict {
-    // Default: `AsArg` semantics (needed for `Gd`, `Variant`, or explicit disambiguation).
     ($($key:expr => $value:expr),* $(,)?) => {
         {
             let mut d = $crate::builtin::Dictionary::new();
@@ -1296,9 +1299,14 @@ macro_rules! dict {
             d
         }
     };
+}
 
-    // `=` prefix: `AsDirectElement` (unambiguous type inference; covers `i32`, `&str` -> `GString`, `&GString`, ...).
-    (= $($key:expr => $value:expr),* $(,)?) => {
+/// **I**nferred **dict**: constructs `Dictionary` literals without ambiguity.
+///
+/// See [`dict!`](macro.dict.html) for docs and examples.
+#[macro_export]
+macro_rules! idict {
+    ($($key:expr => $value:expr),* $(,)?) => {
         {
             let mut d = $crate::builtin::Dictionary::new();
             $(
@@ -1309,27 +1317,9 @@ macro_rules! dict {
     };
 }
 
-/// Constructs [`VarDictionary`] literals, close to Godot's own syntax.
+/// **V**ariant **dict**: constructs [`VarDictionary`] literals.
 ///
-/// Keys and values need to implement [`AsArg<Variant>`].
-///
-/// # Example
-/// ```no_run
-/// use godot::builtin::{vdict, Variant};
-///
-/// let key = "my_key";
-/// let d = vdict! {
-///     "key1" => 10,
-///     "another" => &Variant::nil(),
-///     key => true,
-///     1 + 2 => "final",
-/// };
-/// ```
-///
-/// # See also
-///
-/// For typed dictionaries, use [`dict!`][macro@crate::builtin::dict].
-/// For arrays, similar macros [`array!`][macro@crate::builtin::array] and [`varray!`][macro@crate::builtin::varray] exist.
+/// See [`dict!`](macro.dict.html) for docs and examples.
 #[macro_export]
 macro_rules! vdict {
     // New primary syntax with `=>`. Uses `AsArg` semantics, consistent with `dict!`.

--- a/godot-core/src/builtin/mod.rs
+++ b/godot-core/src/builtin/mod.rs
@@ -21,7 +21,7 @@ pub use crate::r#gen::central::global_reexported_enums::{
 };
 pub use crate::sys::VariantType;
 // Re-export macros.
-pub use crate::{array, dict, real, reals, varray, vdict};
+pub use crate::{array, dict, iarray, idict, real, reals, varray, vdict};
 
 /// Abbreviation for occasionally used _owned or borrowed string_.
 #[doc(hidden)]
@@ -53,7 +53,7 @@ pub mod __prelude_reexport {
     pub use super::{EulerOrder, Side, VariantOperator, VariantType};
     #[cfg(feature = "trace")] // Test only.
     pub use crate::static_sname;
-    pub use crate::{array, dict, real, reals, varray, vdict, vslice};
+    pub use crate::{array, dict, iarray, idict, real, reals, varray, vdict, vslice};
 }
 
 pub use crate::r#gen::builtin_classes::*;

--- a/godot-core/src/meta/args/as_arg.rs
+++ b/godot-core/src/meta/args/as_arg.rs
@@ -868,6 +868,8 @@ impl_asarg_variant_for_ref!([T: GodotClass] Gd<T>);
 pub trait AsDirectElement<T: Element>: AsArg<T> {}
 
 // ByValue: T directly passes as element (i32, bool, Vector2, ...).
+//
+// Explicitly supports other integer types than i64.
 impl<T> AsDirectElement<T> for T where T: Element + ToGodot<Pass = ByValue> {}
 
 // ByRef: &T passes as element (GString, Array, Dictionary, ...).
@@ -880,8 +882,8 @@ impl<T> AsDirectElement<T> for &T where T: Element + ToGodot<Pass = ByRef> {}
 // String coercions: &str / &String -> GString only.
 //
 // Unlike impl_asarg_string!, we do NOT add impls for StringName/NodePath, to avoid ambiguity.
-// array![= "hello"] would otherwise be ambiguous between Array<GString>, Array<StringName>, Array<NodePath>.
-// Users who need Array<StringName> from literals can use array![StringName::from("hi")] or
+// iarray!["hello"] would otherwise be ambiguous between Array<GString>, Array<StringName>, Array<NodePath>.
+// Users who need Array<StringName> from literals can use iarray![StringName::from("hi")] or
 // provide a type annotation: let arr: Array<StringName> = array!["hi"].
 impl AsDirectElement<GString> for &str {}
 impl AsDirectElement<GString> for &String {}

--- a/itest/rust/src/builtin_tests/containers/array_test.rs
+++ b/itest/rust/src/builtin_tests/containers/array_test.rs
@@ -22,17 +22,30 @@ fn array_new() {
 
 #[itest]
 fn array_eq() {
-    let a = array![= 1, 2];
-    let b = array![= 1, 2];
+    let a = iarray![1, 2];
+    let b = iarray![1, 2];
     assert_eq!(a, b);
 
-    let c = array![= 2, 1];
+    let c = iarray![2, 1];
     assert_ne!(a, c);
 }
 
 #[itest]
+fn array_type_inference() {
+    // Don't check static type, as that might affect inference.
+
+    // Following is inferred as i32, not i64. Reason is blanket impl for Pass=ByValue, which would make it difficult to exclude non-i64 integers
+    // without also excluding enums etc.
+    let a = iarray![1, 2];
+    assert_eq!(godot::sys::short_type_name_of_val(&a), "Array<i32>");
+
+    let a = iarray!["hello"];
+    assert_eq!(godot::sys::short_type_name_of_val(&a), "Array<GString>");
+}
+
+#[itest]
 fn typed_array_from_to_variant() {
-    let array = array![= 1, 2];
+    let array = iarray![1, 2];
     let variant = array.to_variant();
     let result = Array::try_from_variant(&variant).expect("typed array conversion should succeed");
     assert_eq!(result, array);
@@ -67,7 +80,7 @@ fn array_from_slice() {
 
 #[itest]
 fn array_try_into_vec() {
-    let array = array![= 1, 2];
+    let array = iarray![1, 2];
 
     #[allow(clippy::unnecessary_fallible_conversions)]
     let result = Vec::<i64>::try_from(&array);
@@ -76,7 +89,7 @@ fn array_try_into_vec() {
 
 #[itest]
 fn array_iter_shared() {
-    let array = array![= 1, 2];
+    let array = iarray![1, 2];
     let mut iter = array.iter_shared();
     assert_eq!(iter.size_hint(), (2, Some(2)));
     assert_eq!(iter.next(), Some(1));
@@ -88,14 +101,15 @@ fn array_iter_shared() {
 
 #[itest]
 fn array_hash() {
-    let array = array![= 1, 2];
-    // Just testing that it converts successfully from i64 to u32.
-    array.hash_u32();
+    let typed = iarray![1, 2];
+    let untyped = varray![1, 2];
+
+    assert_eq!(typed.hash_u32(), untyped.hash_u32());
 }
 
 #[itest]
 fn array_clone() {
-    let mut array = array![= 1, 2];
+    let mut array = iarray![1, 2];
     let shared = array.clone();
     array.set(0, 3);
     assert_eq!(shared.at(0), 3);
@@ -103,7 +117,7 @@ fn array_clone() {
 
 #[itest]
 fn array_duplicate_shallow() {
-    let subarray = array![= 2, 3];
+    let subarray = iarray![2, 3];
     assert_eq!(
         subarray.duplicate_shallow().element_type(),
         ElementType::Builtin(VariantType::INT)
@@ -119,7 +133,7 @@ fn array_duplicate_shallow() {
 
 #[itest]
 fn array_duplicate_deep() {
-    let subarray = array![= 2, 3];
+    let subarray = iarray![2, 3];
     assert_eq!(
         subarray.duplicate_deep().element_type(),
         ElementType::Builtin(VariantType::INT)
@@ -135,7 +149,7 @@ fn array_duplicate_deep() {
 
 #[itest]
 fn array_any_duplicate_deep() {
-    let typed = array![= 2, 3].upcast_any_array();
+    let typed = iarray![2, 3].upcast_any_array();
     assert_eq!(
         typed.duplicate_deep().element_type(),
         ElementType::Builtin(VariantType::INT)
@@ -151,7 +165,7 @@ fn array_any_duplicate_deep() {
 #[itest]
 #[allow(clippy::reversed_empty_ranges)]
 fn array_subarray_shallow() {
-    let array = array![= 0, 1, 2, 3, 4, 5];
+    let array = iarray![0, 1, 2, 3, 4, 5];
 
     let normal_slice = array.subarray_shallow(4..=5, None);
     assert_eq!(normal_slice, array![4, 5]);
@@ -171,7 +185,7 @@ fn array_subarray_shallow() {
     let other_clamped_slice = array.subarray_shallow(5.., Some(2));
     assert_eq!(other_clamped_slice, array![5]);
 
-    let subarray = array![= 2, 3];
+    let subarray = iarray![2, 3];
     let array = varray![1, &subarray];
     let slice = array.subarray_shallow(1..2, None);
     Array::<i64>::try_from_variant(&slice.at(0))
@@ -183,7 +197,7 @@ fn array_subarray_shallow() {
 #[itest]
 #[allow(clippy::reversed_empty_ranges)]
 fn array_subarray_deep() {
-    let array = array![= 0, 1, 2, 3, 4, 5];
+    let array = iarray![0, 1, 2, 3, 4, 5];
 
     let normal_slice = array.subarray_deep(4..=5, None);
     assert_eq!(normal_slice, array![4, 5]);
@@ -203,7 +217,7 @@ fn array_subarray_deep() {
     let other_clamped_slice = array.subarray_deep(5.., Some(2));
     assert_eq!(other_clamped_slice, array![5]);
 
-    let subarray = array![= 2, 3];
+    let subarray = iarray![2, 3];
     let array = varray![1, &subarray];
     let slice = array.subarray_deep(1..2, None);
     Array::<i64>::try_from_variant(&slice.at(0))
@@ -214,7 +228,7 @@ fn array_subarray_deep() {
 
 #[itest]
 fn array_get() {
-    let array = array![= 1, 2];
+    let array = iarray![1, 2];
 
     assert_eq!(array.at(0), 1);
     assert_eq!(array.at(1), 2);
@@ -225,7 +239,7 @@ fn array_get() {
 
 #[itest]
 fn array_try_get() {
-    let array = array![= 1, 2];
+    let array = iarray![1, 2];
 
     assert_eq!(array.get(0), Some(1));
     assert_eq!(array.get(1), Some(2));
@@ -234,7 +248,7 @@ fn array_try_get() {
 
 #[itest]
 fn array_first_last() {
-    let array = array![= 1, 2];
+    let array = iarray![1, 2];
 
     assert_eq!(array.front(), Some(1));
     assert_eq!(array.back(), Some(2));
@@ -247,7 +261,7 @@ fn array_first_last() {
 
 #[itest]
 fn array_find() {
-    let array = array![= 1, 2, 1];
+    let array = iarray![1, 2, 1];
 
     assert_eq!(array.find(0, None), None);
     assert_eq!(array.find(1, None), Some(0));
@@ -256,7 +270,7 @@ fn array_find() {
 
 #[itest]
 fn array_rfind() {
-    let array = array![= 1, 2, 1];
+    let array = iarray![1, 2, 1];
 
     assert_eq!(array.rfind(0, None), None);
     assert_eq!(array.rfind(1, None), Some(2));
@@ -265,7 +279,7 @@ fn array_rfind() {
 
 #[itest]
 fn array_min_max() {
-    let int_array = array![= 1, 2];
+    let int_array = iarray![1, 2];
 
     assert_eq!(int_array.min(), Some(1));
     assert_eq!(int_array.max(), Some(2));
@@ -284,12 +298,12 @@ fn array_min_max() {
 #[itest]
 fn array_pick_random() {
     assert_eq!(VarArray::new().pick_random(), None);
-    assert_eq!(array![= 1].pick_random(), Some(1));
+    assert_eq!(iarray![1].pick_random(), Some(1));
 }
 
 #[itest]
 fn array_set() {
-    let mut array = array![= 1, 2];
+    let mut array = iarray![1, 2];
 
     array.set(0, 3);
     assert_eq!(array.at(0), 3);
@@ -301,7 +315,7 @@ fn array_set() {
 
 #[itest]
 fn array_set_readonly() {
-    let mut array = array![= 1, 2].into_read_only();
+    let mut array = iarray![1, 2].into_read_only();
 
     #[cfg(safeguards_balanced)]
     expect_panic("Mutating read-only array with balanced safeguards", || {
@@ -316,7 +330,7 @@ fn array_set_readonly() {
 
 #[itest]
 fn array_push_pop() {
-    let mut array = array![= 1, 2];
+    let mut array = iarray![1, 2];
 
     array.push(3);
     assert_eq!(array.pop(), Some(3));
@@ -333,7 +347,7 @@ fn array_push_pop() {
 
 #[itest]
 fn array_insert() {
-    let mut array = array![= 1, 2];
+    let mut array = iarray![1, 2];
 
     array.insert(0, 3);
     assert_eq!(array, array![3, 1, 2]);
@@ -344,22 +358,22 @@ fn array_insert() {
 
 #[itest]
 fn array_extend() {
-    let mut array = array![= 1, 2];
-    let other = array![= 3, 4];
+    let mut array = iarray![1, 2];
+    let other = iarray![3, 4];
     array.extend_array(&other);
     assert_eq!(array, array![1, 2, 3, 4]);
 }
 
 #[itest]
 fn array_reverse() {
-    let mut array = array![= 1, 2];
+    let mut array = iarray![1, 2];
     array.reverse();
     assert_eq!(array, array![2, 1]);
 }
 
 #[itest]
 fn array_shuffle() {
-    let mut array = array![= 1];
+    let mut array = iarray![1];
     array.shuffle();
     assert_eq!(array, array![1]);
 }
@@ -369,7 +383,7 @@ fn array_mixed_values() {
     let int = 1;
     let string = GString::from("hello");
     let packed_array = PackedByteArray::from(&[1, 2]);
-    let typed_array = array![= 1, 2];
+    let typed_array = iarray![1, 2];
     let object = Object::new_alloc();
     let node = Node::new_alloc();
     let engine_refc = RefCounted::new_gd();
@@ -428,7 +442,7 @@ fn array_mixed_values() {
 
 #[itest]
 fn array_typed_conversions() {
-    let typed = array![= 1, 2, 3];
+    let typed = iarray![1, 2, 3];
     let any = typed.clone().upcast_any_array();
 
     let typed_back = any
@@ -599,7 +613,7 @@ fn untyped_array_try_from_typed() {
 
 #[itest]
 fn array_should_format_with_display() {
-    let a = array![= 1, 2, 3, 4];
+    let a = iarray![1, 2, 3, 4];
     assert_eq!(format!("{a}"), "[1, 2, 3, 4]");
 
     let a = Array::<real>::new();
@@ -608,7 +622,7 @@ fn array_should_format_with_display() {
 
 #[itest]
 fn array_sort_unstable() {
-    let mut array = array![= 2, 1];
+    let mut array = iarray![2, 1];
     array.sort_unstable();
     assert_eq!(array, array![1, 2]);
 }
@@ -622,7 +636,7 @@ fn array_sort_unstable_by() {
 
 #[itest]
 fn array_sort_unstable_custom() {
-    let mut a = array![= 1, 2, 3, 4];
+    let mut a = iarray![1, 2, 3, 4];
     let func = backwards_sort_callable();
     a.sort_unstable_custom(&func);
     assert_eq!(a, array![4, 3, 2, 1]);
@@ -630,7 +644,7 @@ fn array_sort_unstable_custom() {
 
 #[itest]
 fn array_bsearch() {
-    let array = array![= 1, 3];
+    let array = iarray![1, 3];
 
     assert_eq!(array.bsearch(0), 0);
     assert_eq!(array.bsearch(1), 0);
@@ -653,7 +667,7 @@ fn array_bsearch_by() {
 
 #[itest]
 fn array_fops_bsearch_custom() {
-    let a = array![= 5, 4, 2, 1];
+    let a = iarray![5, 4, 2, 1];
     let func = backwards_sort_callable();
     assert_eq!(a.functional_ops().bsearch_custom(1, &func), 3);
     assert_eq!(a.functional_ops().bsearch_custom(3, &func), 2);
@@ -661,7 +675,7 @@ fn array_fops_bsearch_custom() {
 
 #[itest]
 fn array_shrink() {
-    let mut a = array![= 1, 5, 4, 3, 8];
+    let mut a = iarray![1, 5, 4, 3, 8];
 
     assert!(!a.shrink(10));
     assert_eq!(a.len(), 5);
@@ -673,7 +687,7 @@ fn array_shrink() {
 
 #[itest]
 fn array_resize() {
-    let mut a = array![= "hello", "bar", "mixed", "baz", "meow"];
+    let mut a = iarray!["hello", "bar", "mixed", "baz", "meow"];
 
     let new = GString::from("new!");
 
@@ -793,7 +807,7 @@ fn array_inner_type() {
 fn array_fops_filter() {
     let is_even = is_even_callable();
 
-    let array = array![= 1, 2, 3, 4, 5, 6];
+    let array = iarray![1, 2, 3, 4, 5, 6];
     assert_eq!(array.functional_ops().filter(&is_even), array![2, 4, 6]);
 }
 
@@ -801,7 +815,7 @@ fn array_fops_filter() {
 fn array_fops_map() {
     let f = Callable::from_fn("round", |args| args[0].to::<f64>().round() as i64);
 
-    let array = array![= 0.7, 1.0, 1.3, 1.6];
+    let array = iarray![0.7, 1.0, 1.3, 1.6];
     let result = array.functional_ops().map(&f);
 
     assert_eq!(result, varray![1, 1, 1, 2]);
@@ -811,7 +825,7 @@ fn array_fops_map() {
 fn array_fops_reduce() {
     let f = Callable::from_fn("sum", |args| args[0].to::<i64>() + args[1].to::<i64>());
 
-    let array = array![= 1, 2, 3, 4];
+    let array = iarray![1, 2, 3, 4];
     let result = array.functional_ops().reduce(&f, &0.to_variant());
 
     assert_eq!(result.to::<i64>(), 10);
@@ -821,16 +835,16 @@ fn array_fops_reduce() {
 fn array_fops_any() {
     let is_even = is_even_callable();
 
-    assert!(array![= 1, 2, 3].functional_ops().any(&is_even));
-    assert!(!array![= 1, 3, 5].functional_ops().any(&is_even));
+    assert!(iarray![1, 2, 3].functional_ops().any(&is_even));
+    assert!(!iarray![1, 3, 5].functional_ops().any(&is_even));
 }
 
 #[itest]
 fn array_fops_all() {
     let is_even = is_even_callable();
 
-    assert!(!array![= 1, 2, 3].functional_ops().all(&is_even));
-    assert!(array![= 2, 4, 6].functional_ops().all(&is_even));
+    assert!(!iarray![1, 2, 3].functional_ops().all(&is_even));
+    assert!(iarray![2, 4, 6].functional_ops().all(&is_even));
 }
 
 #[itest]
@@ -838,10 +852,10 @@ fn array_fops_all() {
 fn array_fops_find_custom() {
     let is_even = is_even_callable();
 
-    let array = array![= 1, 2, 3, 4, 5];
+    let array = iarray![1, 2, 3, 4, 5];
     assert_eq!(array.functional_ops().find_custom(&is_even, None), Some(1));
 
-    let array = array![= 1, 3, 5];
+    let array = iarray![1, 3, 5];
     assert_eq!(array.functional_ops().find_custom(&is_even, None), None);
 }
 
@@ -850,10 +864,10 @@ fn array_fops_find_custom() {
 fn array_fops_rfind_custom() {
     let is_even = is_even_callable();
 
-    let array = array![= 1, 2, 3, 4, 5];
+    let array = iarray![1, 2, 3, 4, 5];
     assert_eq!(array.functional_ops().rfind_custom(&is_even, None), Some(3));
 
-    let array = array![= 1, 3, 5];
+    let array = iarray![1, 3, 5];
     assert_eq!(array.functional_ops().rfind_custom(&is_even, None), None);
 }
 

--- a/itest/rust/src/builtin_tests/containers/callable_test.rs
+++ b/itest/rust/src/builtin_tests/containers/callable_test.rs
@@ -10,7 +10,7 @@ use std::sync::atomic::{AtomicU32, Ordering};
 
 use godot::builtin::{
     Array, Callable, Color, GString, NodePath, StringName, VarArray, Variant, Vector2, array,
-    varray, vdict, vslice,
+    iarray, varray, vdict, vslice,
 };
 use godot::classes::{Node2D, Object, RefCounted};
 use godot::init::GdextBuild;
@@ -154,7 +154,7 @@ fn callable_static() {
     let result = callable.callv(&varray![
         10,
         "hello",
-        &array![= &NodePath::from("my/node/path")],
+        &iarray![&NodePath::from("my/node/path")],
         &RefCounted::new_gd()
     ]);
 
@@ -177,7 +177,7 @@ fn callable_static_bind() {
     // Last 3 of 4 arguments. Within Godot, bound arguments are used in-order AFTER call arguments.
     let bindv = callable.bindv(&varray![
         "two",
-        &array![= &NodePath::from("three/four")],
+        &iarray![&NodePath::from("three/four")],
         &RefCounted::new_gd(),
     ]);
     assert!(bindv.is_valid());

--- a/itest/rust/src/builtin_tests/containers/dictionary_test.rs
+++ b/itest/rust/src/builtin_tests/containers/dictionary_test.rs
@@ -8,7 +8,7 @@
 use std::collections::{HashMap, HashSet};
 
 use godot::builtin::{
-    AnyDictionary, Dictionary, GString, VarDictionary, Variant, VariantType, varray, vdict,
+    AnyDictionary, Dictionary, GString, VarDictionary, Variant, VariantType, idict, varray, vdict,
 };
 use godot::classes::RefCounted;
 use godot::init::GdextBuild;
@@ -947,7 +947,7 @@ mod typed_dictionary_tests {
     #[itest]
     fn dictionary_typed() {
         // No type annotation needed with `=` prefix.
-        let dict = dict! {=
+        let dict = idict! {
             "key1" => 10,
             "key2" => 20,
         };
@@ -1030,7 +1030,7 @@ mod typed_dictionary_tests {
 
     #[itest]
     fn dictionary_typed_iter_for_loop() {
-        let dict = dict! {= "key1" => 10, "key2" => 20, "key3" => 30 };
+        let dict = idict! { "key1" => 10, "key2" => 20, "key3" => 30 };
 
         // Dictionaries are ordered in Godot, so appending is deterministic.
         let mut keys = GString::new();
@@ -1067,7 +1067,7 @@ mod typed_dictionary_tests {
 
     #[itest]
     fn dictionary_typed_modify() {
-        let mut bool_dict = dict! {= "key1" => true, "key2" => false };
+        let mut bool_dict = idict! { "key1" => true, "key2" => false };
 
         map_in_place(&mut bool_dict, &GString::from("key1"), |v| !*v);
         assert!(!bool_dict.at("key1"));

--- a/itest/rust/src/builtin_tests/containers/variant_test.rs
+++ b/itest/rust/src/builtin_tests/containers/variant_test.rs
@@ -12,8 +12,8 @@ use std::fmt::Display;
 use godot::builtin::{
     Array, Basis, Color, GString, NodePath, PackedInt32Array, PackedStringArray, Projection,
     Quaternion, Signal, StringName, Transform2D, Transform3D, VarArray, VarDictionary, Variant,
-    VariantOperator, VariantType, Vector2, Vector2i, Vector3, Vector3i, array, varray, vdict,
-    vslice,
+    VariantOperator, VariantType, Vector2, Vector2i, Vector3, Vector3i, array, iarray, varray,
+    vdict, vslice,
 };
 use godot::classes::{Node, Node2D, Resource};
 use godot::meta::{FromGodot, ToGodot};
@@ -136,13 +136,13 @@ fn variant_relaxed_conversions() {
     let packed_strings = PackedStringArray::from(["a".into(), "bb".into()]);
     let strings: Array<GString> = array!["a", "bb"];
 
-    convert_relaxed_to(array![= 1, 2, 3], packed_ints.clone());
+    convert_relaxed_to(iarray![1, 2, 3], packed_ints.clone());
     convert_relaxed_to(varray![1, 2, 3], packed_ints.clone());
     convert_relaxed_to(strings.clone(), packed_strings.clone());
     convert_relaxed_to(varray!["a", "bb"], packed_strings.clone());
 
     // Packed*Array -> Array
-    convert_relaxed_to(packed_ints.clone(), array![= 1, 2, 3]);
+    convert_relaxed_to(packed_ints.clone(), iarray![1, 2, 3]);
     convert_relaxed_to(packed_ints, varray![1, 2, 3]);
     convert_relaxed_to(packed_strings.clone(), strings);
     convert_relaxed_to(packed_strings, varray!["a", "bb"]);

--- a/itest/rust/src/builtin_tests/convert_test.rs
+++ b/itest/rust/src/builtin_tests/convert_test.rs
@@ -7,7 +7,7 @@
 
 use godot::builtin::{
     Array, GString, NodePath, StringName, VarArray, VarDictionary, Variant, Vector2, Vector2Axis,
-    array, vdict,
+    array, iarray, vdict,
 };
 use godot::classes::{Node, Resource};
 use godot::meta;
@@ -269,16 +269,16 @@ fn vec_to_array() {
 
 #[itest]
 fn array_to_vec() {
-    let from = array![= 1, 2, 3];
+    let from = iarray![1, 2, 3];
     let to = from.to_variant().to::<Vec<i32>>();
     assert_eq!(to, vec![1, 2, 3]);
 
-    let from = array![= "Hello", "World"];
+    let from = iarray!["Hello", "World"];
     let to = from.to_variant().to::<Vec<GString>>();
     assert_eq!(to, vec![GString::from("Hello"), GString::from("World")]);
 
     // Invalid conversion.
-    let from = array![= 1, 2, 3];
+    let from = iarray![1, 2, 3];
     let to = from.to_variant().try_to::<Vec<f32>>();
     assert!(to.is_err());
 }
@@ -301,16 +301,16 @@ fn rust_array_to_array() {
 
 #[itest]
 fn array_to_rust_array() {
-    let from = array![= 1, 2, 3];
+    let from = iarray![1, 2, 3];
     let to = from.to_variant().to::<[i32; 3]>();
     assert_eq!(to, [1, 2, 3]);
 
-    let from = array![= "Hello", "World"];
+    let from = iarray!["Hello", "World"];
     let to = from.to_variant().to::<[GString; 2]>();
     assert_eq!(to, [GString::from("Hello"), GString::from("World")]);
 
     // Invalid conversion.
-    let from = array![= 1, 2, 3];
+    let from = iarray![1, 2, 3];
     let to = from.to_variant().try_to::<[f32; 3]>();
     assert!(to.is_err());
 }
@@ -375,7 +375,7 @@ fn strings_as_arg() {
 #[itest]
 fn to_arg_helpers() {
     let i: i8 = 3;
-    let mut ints = array![= 1, 2];
+    let mut ints = iarray![1, 2];
     ints.push(meta::ref_to_arg(&i));
     ints.push(meta::owned_into_arg(i));
 

--- a/itest/rust/src/engine_tests/async_test.rs
+++ b/itest/rust/src/engine_tests/async_test.rs
@@ -7,7 +7,7 @@
 
 use std::ops::Deref;
 
-use godot::builtin::{Array, Callable, Signal, array, vslice};
+use godot::builtin::{Array, Callable, Signal, array, iarray, vslice};
 use godot::classes::{Object, RefCounted};
 use godot::obj::{Base, Gd, NewAlloc, NewGd};
 use godot::prelude::{GodotClass, godot_api};
@@ -73,7 +73,7 @@ fn async_task_array() -> TaskHandle {
 
     object.emit_signal(
         "custom_signal_array",
-        vslice![array![= 1, 2, 3], ref_counted_arg],
+        vslice![iarray![1, 2, 3], ref_counted_arg],
     );
 
     task_handle


### PR DESCRIPTION
Looks a bit less exotic to the eye.

Also now, there's a nice correspondence between the different expression macros:

|           | Plain    | Inferred  | Variant   |
|-----------|----------|-----------|-----------|
| **Array** | `array!` | `iarray!` | `varray!` |
| **Dictionary**  | `dict!`  | `idict!`  | `vdict!`  |

I made sure to update the docs to highlight when to use which.