### PR TITLE
Reorganize `meta` + `register` modules

### DIFF
--- a/godot-codegen/src/generator/enums.rs
+++ b/godot-codegen/src/generator/enums.rs
@@ -134,7 +134,7 @@ pub fn make_enum_definition_with(
             let display_name = enumerator.godot_name.to_title_case(); // Inspector UI Name: "KEY_ESCAPE" -> "Key Escape".
             let value = enumerator.value.to_i64();
             quote! {
-                Enumerator::new_int(#display_name, #value)
+                EnumeratorShape::new_int(#display_name, #value)
             }
         });
 
@@ -148,9 +148,9 @@ pub fn make_enum_definition_with(
             impl crate::meta::GodotConvert for #name {
                 type Via = #ord_type;
 
-                fn godot_shape() -> crate::registry::property::GodotShape {
-                    use crate::registry::property::{Enumerator, GodotShape};
-                    const ENUMERATORS: &[Enumerator] = const {
+                fn godot_shape() -> crate::meta::shape::GodotShape {
+                    use crate::meta::shape::{EnumeratorShape, GodotShape};
+                    const ENUMERATORS: &[EnumeratorShape] = const {
                         &[
                             #( #enumerator_defs ),*
                         ]

--- a/godot-codegen/src/generator/virtual_traits.rs
+++ b/godot-codegen/src/generator/virtual_traits.rs
@@ -139,7 +139,7 @@ fn make_special_virtual_methods(notification_enum_name: &Ident) -> TokenStream {
         /// See also in Godot docs:
         /// * [`Object::_get_property_list`](https://docs.godotengine.org/en/latest/classes/class_object.html#class-object-private-method-get-property-list)
         #[cfg(since_api = "4.3")]
-        fn on_get_property_list(&mut self) -> Vec<crate::meta::PropertyInfo> {
+        fn on_get_property_list(&mut self) -> Vec<crate::registry::info::PropertyInfo> {
             unimplemented!()
         }
 
@@ -150,7 +150,7 @@ fn make_special_virtual_methods(notification_enum_name: &Ident) -> TokenStream {
         ///
         /// See also in the Godot docs:
         /// * [`Object::_validate_property`](https://docs.godotengine.org/en/stable/classes/class_object.html#class-object-private-method-validate-property)
-        fn on_validate_property(&self, property: &mut crate::meta::PropertyInfo) {
+        fn on_validate_property(&self, property: &mut crate::registry::info::PropertyInfo) {
             unimplemented!()
         }
 

--- a/godot-codegen/src/special_cases/special_cases.rs
+++ b/godot-codegen/src/special_cases/special_cases.rs
@@ -1259,6 +1259,11 @@ pub fn is_enum_private(class_name: Option<&TyName>, enum_name: &str) -> bool {
         | (None, "Variant.Operator")
         | (None, "Variant.Type")
 
+        // Re-exported to godot::register::info.
+        | (None, "PropertyHint")
+        | (None, "PropertyUsageFlags")
+        | (None, "MethodFlags")
+
         => true, _ => false
     }
 }

--- a/godot-core/src/builtin/collections/any_array.rs
+++ b/godot-core/src/builtin/collections/any_array.rs
@@ -14,9 +14,8 @@ use crate::builtin::iter::ArrayFunctionalOps;
 use crate::builtin::*;
 use crate::meta;
 use crate::meta::error::ConvertError;
-use crate::meta::{
-    Element, ElementType, FromGodot, GodotConvert, GodotFfiVariant, GodotType, ToGodot,
-};
+use crate::meta::inspect::ElementType;
+use crate::meta::{Element, FromGodot, GodotConvert, GodotFfiVariant, GodotType, ToGodot};
 use crate::registry::property::GodotShape;
 
 /// Covariant `Array` that can be either typed or untyped.

--- a/godot-core/src/builtin/collections/any_dictionary.rs
+++ b/godot-core/src/builtin/collections/any_dictionary.rs
@@ -15,9 +15,8 @@ use sys::{GodotFfi, ffi_methods};
 use crate::builtin::*;
 use crate::meta;
 use crate::meta::error::ConvertError;
-use crate::meta::{
-    AsArg, Element, ElementType, FromGodot, GodotConvert, GodotFfiVariant, GodotType, ToGodot,
-};
+use crate::meta::inspect::ElementType;
+use crate::meta::{AsArg, Element, FromGodot, GodotConvert, GodotFfiVariant, GodotType, ToGodot};
 use crate::registry::property::GodotShape;
 
 /// Covariant `Dictionary` that can be typed or untyped.

--- a/godot-core/src/builtin/collections/array.rs
+++ b/godot-core/src/builtin/collections/array.rs
@@ -16,12 +16,14 @@ use crate::builtin::iter::ArrayFunctionalOps;
 use crate::builtin::*;
 use crate::meta;
 use crate::meta::error::{ArrayMismatch, ConvertError, FromGodotError, FromVariantError};
+use crate::meta::inspect::ElementType;
 use crate::meta::signed_range::SignedRange;
 use crate::meta::{
-    AsArg, ClassId, Element, ElementType, ExtVariantType, FromGodot, GodotConvert, GodotFfiVariant,
-    GodotType, PropertyHintInfo, RefArg, ToGodot, element_variant_type,
+    AsArg, ClassId, Element, ExtVariantType, FromGodot, GodotConvert, GodotFfiVariant, GodotType,
+    RefArg, ToGodot, element_variant_type,
 };
 use crate::obj::{Bounds, DynGd, Gd, GodotClass, bounds};
+use crate::registry::info::PropertyHintInfo;
 use crate::registry::property::{BuiltinExport, Export, GodotElementShape, GodotShape, Var};
 
 /// Godot's `Array` type.

--- a/godot-core/src/builtin/collections/dictionary.rs
+++ b/godot-core/src/builtin/collections/dictionary.rs
@@ -16,7 +16,8 @@ use sys::{GodotFfi, ffi_methods, interface_fn};
 use super::any_dictionary::AnyDictionary;
 use crate::builtin::{AnyArray, Array, VarArray, Variant, VariantType, inner};
 use crate::meta;
-use crate::meta::{AsArg, Element, ElementType, ExtVariantType, FromGodot, ToGodot};
+use crate::meta::inspect::ElementType;
+use crate::meta::{AsArg, Element, ExtVariantType, FromGodot, ToGodot};
 use crate::registry::property::{BuiltinExport, Export, GodotElementShape, GodotShape, Var};
 
 /// Godot's `Dictionary` type.

--- a/godot-core/src/builtin/mod.rs
+++ b/godot-core/src/builtin/mod.rs
@@ -50,7 +50,7 @@ pub mod __prelude_reexport {
     pub use vectors::*;
 
     pub use super::math::XformInv;
-    pub use super::{EulerOrder, Side, VariantOperator, VariantType};
+    pub use super::{EulerOrder, VariantOperator, VariantType};
     #[cfg(feature = "trace")] // Test only.
     pub use crate::static_sname;
     pub use crate::{array, dict, iarray, idict, real, reals, varray, vdict, vslice};

--- a/godot-core/src/global/mod.rs
+++ b/godot-core/src/global/mod.rs
@@ -9,8 +9,17 @@
 //!
 //! See also [Godot docs for `@GlobalScope`](https://docs.godotengine.org/en/stable/classes/class_@globalscope.html#methods).
 //!
-//! # Builtin-related enums
+//! # Functions moved to dedicated APIs
+//! Some methods in `@GlobalScope` are not directly available in `godot::global` module, but rather in their related types.  \
+//! You can find them as follows:
 //!
+//! | Godot utility function | godot-rust APIs                                                                                                                        |
+//! |------------------------|----------------------------------------------------------------------------------------------------------------------------------------|
+//! | `instance_from_id`     | [`Gd::from_instance_id()`][crate::obj::Gd::from_instance_id]<br>[`Gd::try_from_instance_id()`][crate::obj::Gd::try_from_instance_id()] |
+//! | `is_instance_valid`    | [`Gd::is_instance_valid()`][crate::obj::Gd::is_instance_valid()]                                                                       |
+//! | `is_instance_id_valid` | [`InstanceId::lookup_validity()`][crate::obj::InstanceId::lookup_validity()]                                                           |
+//!
+//! # Global enums in other modules
 //! The library ships several additional enums in places where GDScript would use magic numbers. These are co-located with
 //! builtin types, in the [`godot::builtin`][crate::builtin] module. The enums are:
 //!
@@ -21,17 +30,11 @@
 //! - Variant: [`VariantType`][crate::builtin::VariantType], [`VariantOperator`][crate::builtin::VariantOperator]
 //! - Vector: [`Vector2Axis`][crate::builtin::Vector2Axis], [`Vector3Axis`][crate::builtin::Vector3Axis], [`Vector4Axis`][crate::builtin::Vector4Axis]
 //!
-//! # Functions moved to dedicated APIs
+//! Some enums are closely related to property/method registration and are located in [`godot::register::info`][crate::registry::info]:
 //!
-//! Some methods in `@GlobalScope` are not directly available in `godot::global` module, but rather in their related types.  \
-//! You can find them as follows:
-//!
-//! | Godot utility function | godot-rust APIs                                                                                                                      |
-//! |------------------------|--------------------------------------------------------------------------------------------------------------------------------------|
-//! | `instance_from_id`     | [`Gd::from_instance_id()`][crate::obj::Gd::from_instance_id]<br>[`Gd::try_from_instance_id()`][crate::obj::Gd::try_from_instance_id()] |
-//! | `is_instance_valid`    | [`Gd::is_instance_valid()`][crate::obj::Gd::is_instance_valid()]                                                                     |
-//! | `is_instance_id_valid` | [`InstanceId::lookup_validity()`][crate::obj::InstanceId::lookup_validity()]                                                         |
-//!
+//! - [`PropertyHint`] <sub>(godot-generated)</sub>
+//! - [`PropertyUsageFlags`] <sub>(godot-generated)</sub>
+//! - [`MethodFlags`] <sub>(godot-generated)</sub>
 
 // Doc aliases are also available in dedicated APIs, but directing people here may give them a bit more context.
 #![doc(
@@ -56,6 +59,10 @@ pub use crate::{
 #[allow(unused_imports)] // micromanaging imports for generated code is not fun
 #[rustfmt::skip] // Do not reorder.
 pub(crate) use crate::builtin::{Corner, EulerOrder, Side};
+
+// This is needed for generated code to find symbols that have been moved to crate::registry::info.
+#[allow(unused_imports)]
+pub(crate) use crate::registry::info::{MethodFlags, PropertyHint, PropertyUsageFlags};
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Deprecations

--- a/godot-core/src/meta/class_id.rs
+++ b/godot-core/src/meta/class_id.rs
@@ -136,7 +136,8 @@ impl ClassId {
     /// Returns a `ClassId` representing "no class" (empty class name) for non-object property types.
     ///
     /// This is used for properties that don't have an associated class, e.g. built-in types like `i32`, `GString`, `Vector3` etc.
-    /// When constructing a [`PropertyInfo`](crate::meta::PropertyInfo) for non-class types, you can use `StringName::default()` for the `class_name` field.
+    /// When constructing a [`PropertyInfo`][crate::registry::info::PropertyInfo] for non-class types, you can use `StringName::default()`
+    /// for the `class_name` field.
     pub fn none() -> Self {
         // First element is always the empty string name.
         Self { global_index: 0 }

--- a/godot-core/src/meta/conv.rs
+++ b/godot-core/src/meta/conv.rs
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+//! Advanced conversion machinery.
+
+pub use super::args::{ArgPassing, AsDirectElement, ByObject, ByOption, ByRef, ByValue, ByVariant};
+pub use super::object_to_owned::ObjectToOwned;
+pub use super::param_tuple::{InParamTuple, OutParamTuple, ParamTuple, TupleFromGodot};
+pub use super::raw_ptr::{FfiRawPointer, RawPtr};
+pub use super::uniform_object_deref::UniformObjectDeref;

--- a/godot-core/src/meta/error/convert_error.rs
+++ b/godot-core/src/meta/error/convert_error.rs
@@ -11,7 +11,8 @@ use std::fmt;
 use godot_ffi::VariantType;
 
 use crate::builtin::Variant;
-use crate::meta::{ClassId, ElementType, ToGodot};
+use crate::meta::inspect::ElementType;
+use crate::meta::{ClassId, ToGodot};
 
 type Cause = Box<dyn Error + Send + Sync>;
 

--- a/godot-core/src/meta/error/mod.rs
+++ b/godot-core/src/meta/error/mod.rs
@@ -5,7 +5,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-//! Errors in the gdext library.
+//! Custom error types.
 
 mod call_error;
 mod call_error_type;

--- a/godot-core/src/meta/inspect/element_type.rs
+++ b/godot-core/src/meta/inspect/element_type.rs
@@ -9,8 +9,9 @@ use std::fmt;
 
 use crate::builtin::VariantType;
 use crate::classes::Script;
+use crate::meta::shape::GodotShape;
 use crate::meta::traits::element_variant_type;
-use crate::meta::{ClassId, Element, GodotConvert as _, GodotShape};
+use crate::meta::{ClassId, Element, GodotConvert as _};
 use crate::obj::{Gd, InstanceId};
 
 /// Dynamic type information of Godot arrays and dictionaries.

--- a/godot-core/src/meta/inspect/mod.rs
+++ b/godot-core/src/meta/inspect/mod.rs
@@ -5,7 +5,14 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-//! Introspection metadata for Godot engine types.
+//! Runtime type information for Godot arrays and dictionaries.
+
+pub mod element_type;
+
+pub use element_type::{ElementScript, ElementType};
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// EnumConstant
 
 /// Metadata for a single enum or bitfield constant.
 ///

--- a/godot-core/src/meta/mod.rs
+++ b/godot-core/src/meta/mod.rs
@@ -45,12 +45,9 @@
 
 mod args;
 mod class_id;
-mod element_type;
 mod godot_convert;
-mod method_info;
 mod object_to_owned;
 mod param_tuple;
-mod property_info;
 mod raw_ptr;
 mod signature;
 mod traits;
@@ -58,19 +55,18 @@ mod uniform_object_deref;
 
 pub(crate) mod sealed;
 
+pub mod conv;
 pub mod error;
 pub mod inspect;
+pub mod shape;
 pub(crate) mod signed_range;
 
 // Public re-exports
 pub use args::*;
 pub use class_id::ClassId;
-pub use element_type::{ElementScript, ElementType};
 pub use godot_convert::{EngineFromGodot, EngineToGodot, FromGodot, GodotConvert, ToGodot};
-pub use method_info::MethodInfo;
 pub use object_to_owned::ObjectToOwned;
 pub use param_tuple::{InParamTuple, OutParamTuple, ParamTuple, TupleFromGodot};
-pub use property_info::{PropertyHintInfo, PropertyInfo};
 pub use raw_ptr::{FfiRawPointer, RawPtr};
 #[cfg(feature = "trace")]
 pub use signature::trace;
@@ -80,18 +76,18 @@ pub use signed_range::{SignedRange, wrapped};
 pub use traits::{Element, GodotImmutable, GodotType, PackedElement, element_variant_type};
 pub use uniform_object_deref::UniformObjectDeref;
 
-// Public due to signals emit() needing it. Should be made pub(crate) again if that changes.
+// Macro re-exports (used as `meta::arg_into_owned!` etc.).
 pub use crate::arg_into_owned;
-pub use crate::registry::property::GodotShape;
+pub use crate::arg_into_ref;
 
-// Crate-local re-exports
+// Crate-local re-exports.
 mod reexport_crate {
     pub(crate) use super::traits::{
         ExtVariantType, GodotFfiVariant, GodotNullableFfi, ffi_variant_type,
     };
     // Private imports for this module only.
     pub(super) use crate::registry::method::MethodParamOrReturnInfo;
-    pub(crate) use crate::{arg_into_ref, declare_arg_method, impl_godot_as_self};
+    pub(crate) use crate::{declare_arg_method, impl_godot_as_self};
 }
 pub(crate) use reexport_crate::*;
 

--- a/godot-core/src/meta/param_tuple.rs
+++ b/godot-core/src/meta/param_tuple.rs
@@ -8,8 +8,9 @@
 use godot_ffi as sys;
 
 use crate::builtin::Variant;
+use crate::meta::CallContext;
 use crate::meta::error::CallResult;
-use crate::meta::{CallContext, PropertyInfo};
+use crate::registry::info::PropertyInfo;
 
 mod impls;
 

--- a/godot-core/src/meta/raw_ptr.rs
+++ b/godot-core/src/meta/raw_ptr.rs
@@ -20,7 +20,8 @@ use crate::registry::property::GodotShape;
 ///
 /// # Example
 /// ```no_run
-/// use godot::meta::{RawPtr, ToGodot};
+/// use godot::meta::conv::RawPtr;
+/// use godot::meta::ToGodot;
 /// use godot::classes::native::AudioFrame;
 ///
 /// let frame = AudioFrame { left: 0.0, right: 1.0 };

--- a/godot-core/src/meta/shape.rs
+++ b/godot-core/src/meta/shape.rs
@@ -5,14 +5,26 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+//! Static type descriptors for Rust types towards Godot.
+//!
+//! The symbols in this module and primarily [`GodotShape`] are used to describe the _shape_ of a Rust type, which combines information about:
+//! - To which Godot type it maps.
+//! - Metadata relevant for properties (var/export).
+//! - Metadata relevant for method signatures (parameters and return values).
+//!
+//! These shapes are then transformed to lower-level GDExtension descriptors, located in [`register::info`][crate::registry::info].
+//! Godot then accepts those for registration.
+
 use std::borrow::Cow;
+use std::fmt::Display;
 
 use godot_ffi as sys;
 
 use crate::builtin::{CowStr, GString, StringName, VariantType};
-use crate::global::{PropertyHint, PropertyUsageFlags, godot_str};
-use crate::meta::{ClassId, GodotConvert, PropertyHintInfo, PropertyInfo};
+use crate::global::godot_str;
+use crate::meta::{ClassId, GodotConvert};
 use crate::obj::EngineEnum as _;
+use crate::registry::info::{PropertyHint, PropertyHintInfo, PropertyInfo, PropertyUsageFlags};
 
 /// The "shape" of a Godot type: whether it's a builtin, a class, an enum/bitfield, etc.
 ///
@@ -104,7 +116,7 @@ pub enum GodotShape {
         variant_type: VariantType,
 
         /// Display name and ordinal for each enumerator. `Borrowed` for compile-time data, `Owned` for dynamic enumerators.
-        enumerators: Cow<'static, [Enumerator]>,
+        enumerators: Cow<'static, [EnumeratorShape]>,
 
         /// Godot-qualified enum name. `Some("Orientation")` or `Some("Node.ProcessMode")` for engine enums; `None` for user enums.
         ///
@@ -457,7 +469,7 @@ impl ClassHeritage {
 /// Matches the same layout as `GodotShape`, exists to avoid recursive definition (and also `Box` allocations). Also constrains the possible
 /// shapes (elements cannot be typed arrays/dictionaries themselves).
 ///
-/// In contrast to [`ElementType`][crate::meta::ElementType], this is a _static_ type description for Godot registration purposes.
+/// In contrast to [`ElementType`][crate::meta::inspect::ElementType], this is a _static_ type description for Godot registration purposes.
 ///
 /// Use [`into_outer()`][Self::into_outer] to convert into a full `GodotShape`.
 #[non_exhaustive]
@@ -477,7 +489,7 @@ pub enum GodotElementShape {
 
     Enum {
         variant_type: VariantType,
-        enumerators: Cow<'static, [Enumerator]>,
+        enumerators: Cow<'static, [EnumeratorShape]>,
         godot_name: Option<CowStr>,
         is_bitfield: bool,
     },
@@ -620,15 +632,15 @@ impl GodotElementShape {
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 
-/// A single enumerator entry: display name and ordinal value. Used in [`GodotShape::Enum`].
+/// Describes a single enumerator entry: display name and ordinal value. Used in [`GodotShape::Enum`].
 #[derive(Clone, Debug)]
-pub struct Enumerator {
+pub struct EnumeratorShape {
     pub name: CowStr,
     /// Ordinal value. `None` for string-backed enums (hint string omits ordinals: `"Grass,Rock,Water"`).
     pub value: Option<i64>,
 }
 
-impl Enumerator {
+impl EnumeratorShape {
     /// Creates a new int-backed enumerator.
     pub const fn new_int(name: &'static str, value: i64) -> Self {
         Self {
@@ -652,7 +664,7 @@ impl Enumerator {
 /// Builds the element type string used in Godot's `TYPE_STRING` hint for typed collections.
 ///
 /// Format: `"{vtype}:"` if `hint` is `NONE`, otherwise `"{vtype}/{hint}:{hint_string}"`.
-pub(super) fn format_elements_typed(
+pub(crate) fn format_elements_typed(
     variant_type: VariantType,
     hint: PropertyHint,
     hint_string: impl std::fmt::Display,
@@ -673,7 +685,7 @@ fn format_elements_untyped(variant_type: VariantType) -> String {
 
 /// Returns `PropertyHintInfo` for an enum or bitfield: `ENUM`/`FLAGS` hint with formatted hint string.
 fn enum_hint_info(
-    enumerators: &[Enumerator],
+    enumerators: &[EnumeratorShape],
     is_bitfield: bool,
     is_engine_enum: bool,
 ) -> PropertyHintInfo {
@@ -696,12 +708,20 @@ fn enum_hint_info(
 }
 
 /// Builds `"Name:0,Name2:1"` or `"Name,Name2"` hint string from enumerators.
-fn format_hint_string(enumerators: &[Enumerator]) -> String {
+fn format_hint_string(enumerators: &[EnumeratorShape]) -> String {
     enumerators
         .iter()
-        .map(|e| super::format_hint_entry(&e.name, e.value))
+        .map(|e| format_hint_entry(&e.name, e.value))
         .collect::<Vec<_>>()
         .join(",")
+}
+
+/// Formats a single hint as `"Name:value"` if value is `Some`, otherwise `"Name"`.
+pub(crate) fn format_hint_entry(name: &str, value: Option<impl Display>) -> String {
+    match value {
+        Some(v) => format!("{name}:{v}"),
+        None => name.to_string(),
+    }
 }
 
 /// Maps a packed array's variant type to its element's variant type, if applicable.

--- a/godot-core/src/meta/traits.rs
+++ b/godot-core/src/meta/traits.rs
@@ -10,7 +10,8 @@ use godot_ffi as sys;
 use crate::builtin;
 use crate::builtin::{Variant, VariantType};
 use crate::meta::error::ConvertError;
-use crate::meta::{FromGodot, GodotConvert, PropertyInfo, ToGodot, sealed};
+use crate::meta::{FromGodot, GodotConvert, ToGodot, sealed};
+use crate::registry::info::PropertyInfo;
 use crate::registry::method::MethodParamOrReturnInfo;
 
 // Re-export sys traits in this module, so all are in one place.
@@ -136,7 +137,7 @@ pub trait GodotType: GodotConvert<Via = Self> + sealed::Sealed + Sized + 'static
 /// `VarDictionary` (special case of the former with `T=Variant`), because godot-rust cannot statically guarantee that the nested collections
 /// are indeed untyped. In a GDScript `Array[Array]`, you can store both typed and untyped arrays, even within the same collection.
 ///
-/// See also [`ElementType`][crate::meta::ElementType] for a runtime representation of this.
+/// See also [`ElementType`][crate::meta::inspect::ElementType] for a runtime representation of this.
 ///
 /// # Integer and float types
 /// `u8`, `i8`, `u16`, `i16`, `u32`, `i32` and `f32` are supported by this trait, however they don't have their own array type in Godot.

--- a/godot-core/src/meta/uniform_object_deref.rs
+++ b/godot-core/src/meta/uniform_object_deref.rs
@@ -33,7 +33,7 @@ use crate::obj::{Gd, GdMut, GdRef, GodotClass, WithBaseField};
 ///
 /// Despite being 2 different traits, a function can accept both by simply being generic over `Declarer`:
 /// ```no_run
-/// use godot::meta::UniformObjectDeref;
+/// use godot::meta::conv::UniformObjectDeref;
 /// # use godot::prelude::*;
 ///
 /// fn abstract_over_objects<Declarer, C>(obj: &Gd<C>)

--- a/godot-core/src/obj/dyn_gd.rs
+++ b/godot-core/src/obj/dyn_gd.rs
@@ -11,10 +11,11 @@ use godot_ffi::is_main_thread;
 
 use crate::builtin::{Callable, Variant};
 use crate::meta::error::ConvertError;
-use crate::meta::{ClassId, FromGodot, GodotConvert, PropertyHintInfo, ToGodot};
+use crate::meta::{ClassId, FromGodot, GodotConvert, ToGodot};
 use crate::obj::guards::DynGdRef;
 use crate::obj::{AsDyn, Bounds, DynGdMut, Gd, GodotClass, Inherits, OnEditor, bounds};
 use crate::registry::class::{get_dyn_implementor_class_ids, try_dynify_object};
+use crate::registry::info::PropertyHintInfo;
 use crate::registry::property::{Export, GodotShape, Var};
 use crate::{meta, sys};
 

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -14,15 +14,14 @@ use sys::{SysPtr as _, static_assert_eq_size_align};
 
 use crate::builtin::{Callable, NodePath, StringName, Variant};
 use crate::meta::error::{ConvertError, FromFfiError};
-use crate::meta::{
-    AsArg, ClassId, Element, FromGodot, GodotConvert, GodotType, PropertyHintInfo, RefArg, ToGodot,
-};
+use crate::meta::{AsArg, ClassId, Element, FromGodot, GodotConvert, GodotType, RefArg, ToGodot};
 use crate::obj::{
     Bounds, DynGd, GdDerefTarget, GdMut, GdRef, GodotClass, Inherits, InstanceId, OnEditor, RawGd,
     WithBaseField, WithSignals, bounds, cap,
 };
 use crate::private::{PanicPayload, callbacks};
 use crate::registry::class::try_dynify_object;
+use crate::registry::info::PropertyHintInfo;
 use crate::registry::property::{Export, GodotShape, SimpleVar, Var};
 use crate::{classes, meta, out};
 

--- a/godot-core/src/obj/instance_id.rs
+++ b/godot-core/src/obj/instance_id.rs
@@ -9,7 +9,8 @@ use std::fmt::{Debug, Display, Formatter, Result as FmtResult};
 use std::num::NonZeroU64;
 
 use crate::meta::error::{ConvertError, FromGodotError};
-use crate::meta::{FromGodot, GodotConvert, GodotShape, ToGodot};
+use crate::meta::shape::GodotShape;
+use crate::meta::{FromGodot, GodotConvert, ToGodot};
 use crate::registry::property::SimpleVar;
 
 /// Represents a non-zero instance ID.

--- a/godot-core/src/obj/script.rs
+++ b/godot-core/src/obj/script.rs
@@ -22,9 +22,10 @@ use godot_cell::panicking::{GdCell, MutGuard, RefGuard};
 
 use crate::builtin::{GString, StringName, Variant, VariantType};
 use crate::classes::{Object, Script, ScriptLanguage};
+use crate::meta::RawPtr;
 use crate::meta::error::CallErrorType;
-use crate::meta::{MethodInfo, PropertyInfo, RawPtr};
 use crate::obj::{Base, Gd, GodotClass};
+use crate::registry::info::{MethodInfo, PropertyInfo};
 use crate::sys;
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
@@ -409,7 +410,7 @@ impl<'a, T: ScriptInstance> SiMut<'a, T> {
     /// # use godot::prelude::*;
     /// # use godot::classes::{ScriptLanguage, Script};
     /// # use godot::obj::script::{ScriptInstance, SiMut};
-    /// # use godot::meta::{MethodInfo, PropertyInfo};
+    /// # use godot::register::info::{MethodInfo, PropertyInfo};
     /// # use godot::meta::error::CallErrorType;
     /// # use godot::sys;
     ///
@@ -467,7 +468,7 @@ impl<'a, T: ScriptInstance> SiMut<'a, T> {
     /// # use godot::prelude::*;
     /// # use godot::classes::{ScriptLanguage, Script};
     /// # use godot::obj::script::{ScriptInstance, SiMut};
-    /// # use godot::meta::{MethodInfo, PropertyInfo};
+    /// # use godot::register::info::{MethodInfo, PropertyInfo};
     /// # use godot::meta::error::CallErrorType;
     /// # use godot::sys;
     ///
@@ -616,8 +617,8 @@ mod script_instance_info {
 
     use super::{ScriptInstance, ScriptInstanceData, SiMut};
     use crate::builtin::{StringName, Variant};
-    use crate::meta::{MethodInfo, PropertyInfo};
     use crate::private::{PanicPayload, handle_panic};
+    use crate::registry::info::{MethodInfo, PropertyInfo};
     use crate::sys;
 
     /// # Safety

--- a/godot-core/src/obj/traits.rs
+++ b/godot-core/src/obj/traits.rs
@@ -187,7 +187,7 @@ pub trait UserClass: Bounds<Declarer = bounds::DeclUser> {
 ///
 /// # Future direction: `GodotEnum` unification
 /// Currently engine enums implement this trait with `all_constants()` returning `&[EnumConstant<Self>]`, while user enums provide
-/// metadata through `GodotShape::Enum` with `&[Enumerator]`. A future `GodotEnum` trait could unify both, providing a single
+/// metadata through `GodotShape::Enum` with `&[EnumeratorShape]`. A future `GodotEnum` trait could unify both, providing a single
 /// interface for enumerator introspection, constant registration via `classdb_register_extension_class_integer_constant` (which
 /// also accepts `p_is_bitfield`), and shared `GodotShape` construction. This would let user enums opt-in to the same capabilities
 /// as engine enums (GDScript name resolution, editor integration).
@@ -767,8 +767,8 @@ pub mod cap {
 
     use super::*;
     use crate::builtin::{StringName, Variant};
-    use crate::meta::PropertyInfo;
     use crate::obj::{Base, Gd};
+    use crate::registry::info::PropertyInfo;
     use crate::storage::{IntoVirtualMethodReceiver, VirtualMethodReceiver};
 
     /// Trait for all classes that are default-constructible from the Godot engine.
@@ -879,7 +879,7 @@ pub mod cap {
         #[doc(hidden)]
         fn __godot_get_property_list(
             this: VirtualMethodReceiver<Self>,
-        ) -> Vec<crate::meta::PropertyInfo>;
+        ) -> Vec<crate::registry::info::PropertyInfo>;
     }
 
     #[doc(hidden)]

--- a/godot-core/src/registry/callbacks.rs
+++ b/godot-core/src/registry/callbacks.rs
@@ -19,9 +19,9 @@ use sys::interface_fn;
 use crate::builder::ClassBuilder;
 use crate::builtin::{StringName, Variant};
 use crate::classes::Object;
-use crate::meta::PropertyInfo;
 use crate::obj::{AsDyn, Base, Bounds, Gd, GodotClass, Inherits, UserClass, bounds, cap};
 use crate::private::{IntoVirtualMethodReceiver, PanicPayload, handle_panic};
+use crate::registry::info::PropertyInfo;
 use crate::registry::plugin::ErasedDynGd;
 use crate::storage::{InstanceStorage, Storage, StorageRefCounted, as_storage};
 
@@ -381,7 +381,7 @@ pub unsafe extern "C" fn free_property_list<T: cap::GodotGetPropertyList>(
         // SAFETY: The structs contained in this list were all returned from `into_owned_property_sys`.
         // We only call this method once for each struct and for each list.
         unsafe {
-            crate::meta::PropertyInfo::free_owned_property_sys(*property_info);
+            crate::registry::info::PropertyInfo::free_owned_property_sys(*property_info);
         }
     }
 }

--- a/godot-core/src/registry/godot_register_wrappers.rs
+++ b/godot-core/src/registry/godot_register_wrappers.rs
@@ -8,9 +8,9 @@
 //! Internal registration machinery used by proc-macro APIs.
 
 use crate::builtin::{GString, StringName};
-use crate::global::PropertyUsageFlags;
-use crate::meta::{ClassId, PropertyHintInfo, PropertyInfo};
+use crate::meta::ClassId;
 use crate::obj::GodotClass;
+use crate::registry::info::{PropertyHintInfo, PropertyInfo, PropertyUsageFlags};
 use crate::registry::property::{Export, Var};
 use crate::{classes, sys};
 

--- a/godot-core/src/registry/info/method_info.rs
+++ b/godot-core/src/registry/info/method_info.rs
@@ -8,8 +8,8 @@
 use godot_ffi::conv::u32_to_usize;
 
 use crate::builtin::{StringName, Variant};
-use crate::global::MethodFlags;
-use crate::meta::{ClassId, PropertyInfo};
+use crate::meta::ClassId;
+use crate::registry::info::{MethodFlags, PropertyInfo};
 use crate::sys;
 
 /// Describes a method's signature and metadata required by the Godot engine.
@@ -23,11 +23,11 @@ use crate::sys;
 ///
 /// # Example
 /// ```no_run
-/// use godot::meta::{MethodInfo, PropertyInfo, PropertyHintInfo, ClassId};
 /// use godot::builtin::{StringName, Variant, VariantType};
-/// use godot::global::{MethodFlags, PropertyUsageFlags};
 /// use godot::classes::Node2D;
+/// use godot::meta::ClassId;
 /// use godot::obj::GodotClass; // Trait method ::class_id().
+/// use godot::register::info::{MethodInfo, PropertyInfo, PropertyHintInfo, MethodFlags, PropertyUsageFlags};
 ///
 /// // Describe a Godot method (`World` is a GDScript class):
 /// //   func spawn_at(world: World, position: Vector2) -> Node2D.

--- a/godot-core/src/registry/info/mod.rs
+++ b/godot-core/src/registry/info/mod.rs
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+//! Metadata types for property and method registration.
+//!
+//! Provides Rust mappings of types used for GDExtension registration of properties, methods and their type metadata.
+//! See also [`meta::shape`](crate::meta::shape) for the static type description of those.
+
+mod method_info;
+mod property_info;
+
+pub use self::method_info::MethodInfo;
+pub use self::property_info::{PropertyHintInfo, PropertyInfo};
+pub use crate::r#gen::central::global_reexported_enums::{
+    MethodFlags, PropertyHint, PropertyUsageFlags,
+};

--- a/godot-core/src/registry/info/property_info.rs
+++ b/godot-core/src/registry/info/property_info.rs
@@ -6,9 +6,9 @@
  */
 
 use crate::builtin::{GString, StringName, VariantType};
-use crate::global::{PropertyHint, PropertyUsageFlags};
 use crate::meta::ClassId;
 use crate::obj::{Bounds, EngineBitfield, EngineEnum, GodotClass, bounds};
+use crate::registry::info::{PropertyHint, PropertyUsageFlags};
 use crate::registry::property::{Export, Var};
 use crate::{classes, sys};
 
@@ -20,7 +20,7 @@ use crate::{classes, sys};
 /// only stores pointers, `PropertyInfo` owns its data, ensuring it remains valid for the lifetime of the struct.
 /// For a high-level representation of properties, see [`GodotShape`][crate::registry::property::GodotShape].
 ///
-/// See also [`MethodInfo`](crate::meta::MethodInfo) for describing method signatures and [`ClassId`] for type-IDs of Godot classes.
+/// See also [`MethodInfo`](super::MethodInfo) for describing method signatures and [`ClassId`] for type-IDs of Godot classes.
 ///
 /// # Construction
 /// For most use cases, prefer the convenience constructors:
@@ -30,9 +30,8 @@ use crate::{classes, sys};
 ///
 /// # Example
 /// ```no_run
-/// use godot::meta::{PropertyInfo, PropertyHintInfo};
+/// use godot::register::info::{PropertyInfo, PropertyHintInfo, PropertyUsageFlags};
 /// use godot::builtin::{StringName, VariantType};
-/// use godot::global::PropertyUsageFlags;
 ///
 /// // Integer property without a specific class
 /// let count_property = PropertyInfo {
@@ -98,7 +97,7 @@ pub struct PropertyInfo {
 
     /// Additional type information and validation constraints for this property.
     ///
-    /// Use functions from [`export_info_functions`](crate::registry::property::export_info_functions) to create common hints,
+    /// Use functions from [`export_fns`](crate::registry::property::export_fns) to create common hints,
     /// or [`PropertyHintInfo::none()`] for no hints.
     ///
     /// See [`PropertyHintInfo`] struct in Rust, as well as [`PropertyHint`] in the official Godot documentation.
@@ -140,7 +139,7 @@ impl PropertyInfo {
 
     /// Change the `hint` and `hint_string` to be the given `hint_info`.
     ///
-    /// See [`export_info_functions`](crate::registry::property::export_info_functions) for functions that return appropriate `PropertyHintInfo`s for
+    /// See [`export_fns`](crate::registry::property::export_fns) for functions that return appropriate `PropertyHintInfo`s for
     /// various Godot annotations.
     ///
     /// # Example
@@ -148,11 +147,11 @@ impl PropertyInfo {
     ///
     // TODO: Make this nicer to use.
     /// ```no_run
-    /// use godot::register::property::export_info_functions;
-    /// use godot::meta::PropertyInfo;
+    /// use godot::register::property::export_fns;
+    /// use godot::register::info::PropertyInfo;
     ///
     /// let property = PropertyInfo::new_export::<f64>("my_range_property")
-    ///     .with_hint_info(export_info_functions::export_range(
+    ///     .with_hint_info(export_fns::export_range(
     ///         0.0,
     ///         10.0,
     ///         Some(0.1),

--- a/godot-core/src/registry/method.rs
+++ b/godot-core/src/registry/method.rs
@@ -9,9 +9,9 @@ use godot_ffi as sys;
 use sys::interface_fn;
 
 use crate::builtin::{StringName, Variant};
-use crate::global::MethodFlags;
-use crate::meta::{ClassId, GodotConvert, GodotType, ParamTuple, PropertyInfo, Signature};
+use crate::meta::{ClassId, GodotConvert, GodotType, ParamTuple, Signature};
 use crate::obj::GodotClass;
+use crate::registry::info::{MethodFlags, PropertyInfo};
 
 /// Info relating to an argument or return type in a method.
 pub struct MethodParamOrReturnInfo {

--- a/godot-core/src/registry/mod.rs
+++ b/godot-core/src/registry/mod.rs
@@ -11,6 +11,7 @@
 pub mod callbacks;
 pub mod class;
 pub mod constant;
+pub mod info;
 pub mod method;
 pub mod plugin;
 pub mod property;

--- a/godot-core/src/registry/property/mod.rs
+++ b/godot-core/src/registry/property/mod.rs
@@ -7,28 +7,15 @@
 
 //! Registration support for property types.
 
-use std::fmt::Display;
-
 use godot_ffi::GodotNullableFfi;
 
 use crate::meta::{ClassId, FromGodot, GodotConvert, GodotType, ToGodot};
 
-mod godot_shape;
 mod phantom_var;
 
-pub use godot_shape::{ClassHeritage, Enumerator, GodotElementShape, GodotShape};
 pub use phantom_var::PhantomVar;
 
-// ----------------------------------------------------------------------------------------------------------------------------------------------
-// Shared hint-string helpers
-
-/// Formats a single hint as `"Name:value"` if value is `Some`, otherwise `"Name"`.
-pub(crate) fn format_hint_entry(name: &str, value: Option<impl Display>) -> String {
-    match value {
-        Some(v) => format!("{name}:{v}"),
-        None => name.to_string(),
-    }
-}
+pub(crate) use crate::meta::shape::{ClassHeritage, GodotElementShape, GodotShape};
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Var trait
@@ -341,13 +328,13 @@ where
 ///
 /// Each function is named the same as the equivalent Godot annotation.  
 /// For instance, `@export_range` in Godot is `fn export_range` here.
-pub mod export_info_functions {
+pub mod export_fns {
     use godot_ffi::VariantType;
 
     use crate::builtin::GString;
-    use crate::global::PropertyHint;
-    use crate::meta::{GodotConvert, PropertyHintInfo};
+    use crate::meta::GodotConvert;
     use crate::obj::EngineEnum;
+    use crate::registry::info::{PropertyHint, PropertyHintInfo};
     use crate::registry::property::{Export, GodotElementShape, GodotShape};
     use crate::sys;
 
@@ -441,7 +428,7 @@ pub mod export_info_functions {
 
     impl<T: std::fmt::Display> ExportValueWithKey<T> {
         fn as_hint_string(&self) -> String {
-            super::format_hint_entry(&self.variant, self.key.as_ref())
+            crate::meta::shape::format_hint_entry(&self.variant, self.key.as_ref())
         }
 
         fn slice_as_hint_string<V>(values: &[V]) -> String
@@ -479,7 +466,7 @@ pub mod export_info_functions {
     /// # Examples
     ///
     /// ```no_run
-    /// # use godot::register::property::export_info_functions::export_enum;
+    /// # use godot::register::property::export_fns::export_enum;
     /// export_enum(&[("a", None), ("b", Some(10))]);
     /// ```
     pub fn export_enum<T>(variants: &[T]) -> PropertyHintInfo
@@ -512,7 +499,7 @@ pub mod export_info_functions {
     /// # Examples
     ///
     /// ```no_run
-    /// # use godot::register::property::export_info_functions::export_flags;
+    /// # use godot::register::property::export_fns::export_flags;
     /// export_flags(&[("a", None), ("b", Some(10))]);
     /// ```
     pub fn export_flags<T>(bits: &[T]) -> PropertyHintInfo
@@ -605,7 +592,7 @@ pub mod export_info_functions {
     fn to_string_array_hint(hint: PropertyHint, filter: &str) -> PropertyHintInfo {
         PropertyHintInfo {
             hint: PropertyHint::TYPE_STRING,
-            hint_string: GString::from(&super::godot_shape::format_elements_typed(
+            hint_string: GString::from(&crate::meta::shape::format_elements_typed(
                 VariantType::STRING,
                 hint,
                 filter,

--- a/godot-core/src/registry/signal/signal_receiver.rs
+++ b/godot-core/src/registry/signal/signal_receiver.rs
@@ -56,7 +56,7 @@ pub trait SignalReceiver<C, Ps>: 'static {
 /// **In addition to that**, they have a rather complex bound involving [`IndirectSignalReceiver`]:
 ///
 /// ```no_run
-/// # use godot::register::{IndirectSignalReceiver, SignalReceiver};
+/// # use godot::signal::{IndirectSignalReceiver, SignalReceiver};
 /// # use godot_core::meta::InParamTuple;
 /// # use godot_core::obj::WithSignals;
 /// # struct TypedSignal<'c, C: WithSignals, Ps> { _phantom: std::marker::PhantomData<&'c (C, Ps)> }
@@ -84,7 +84,7 @@ pub trait SignalReceiver<C, Ps>: 'static {
 /// When using the trait bounds as described above, you can access the actual function in the following way:
 ///
 /// ```no_run
-/// # use godot::register::{IndirectSignalReceiver, SignalReceiver};
+/// # use godot::signal::{IndirectSignalReceiver, SignalReceiver};
 /// # let mut function = || {};
 /// # let args = ();
 /// IndirectSignalReceiver::from(&mut function)

--- a/godot-core/src/tools/save_load.rs
+++ b/godot-core/src/tools/save_load.rs
@@ -14,7 +14,7 @@ use crate::obj::{Gd, Inherits, Singleton};
 
 /// ⚠️ Loads a resource from the filesystem located at `path`, panicking on error.
 ///
-/// See [`try_load`] for more information.
+/// See [`try_load()`] for more information.
 ///
 /// # Example
 ///
@@ -75,7 +75,7 @@ where
 
 /// ⚠️ Saves a [`Resource`]-inheriting object into the file located at `path`.
 ///
-/// See [`try_save`] for more information.
+/// See [`try_save()`] for more information.
 ///
 /// # Panics
 /// If the resource cannot be saved.
@@ -87,7 +87,6 @@ where
 /// let obj = Resource::new_gd();
 /// save(&obj, "res://BaseResource.tres")
 /// ```
-/// use godot::
 #[inline]
 pub fn save<T>(obj: &Gd<T>, path: impl AsArg<GString>)
 where

--- a/godot-macros/src/class/data_models/field_export.rs
+++ b/godot-macros/src/class/data_models/field_export.rs
@@ -419,7 +419,7 @@ impl ExportType {
 macro_rules! quote_export_func {
     ($function_name:ident($($tt:tt)*)) => {
         Some(quote! {
-            ::godot::register::property::export_info_functions::$function_name($($tt)*)
+            ::godot::register::property::export_fns::$function_name($($tt)*)
         })
     };
 
@@ -427,7 +427,7 @@ macro_rules! quote_export_func {
     // Doesn't work if function takes other generic arguments -- in that case it could be converted to a Type<...> parameter.
     ($function_name:ident < T > ($($tt:tt)*)) => {
         Some(quote! {
-            ::godot::register::property::export_info_functions::$function_name::<FieldType>($($tt)*)
+            ::godot::register::property::export_fns::$function_name::<FieldType>($($tt)*)
         })
     };
 }

--- a/godot-macros/src/class/data_models/func.rs
+++ b/godot-macros/src/class/data_models/func.rs
@@ -602,7 +602,7 @@ fn make_method_flags(
     method_type: ReceiverType,
     is_script_virtual: bool,
 ) -> Result<TokenStream, String> {
-    let flags = quote! { ::godot::global::MethodFlags };
+    let flags = quote! { ::godot::register::info::MethodFlags };
 
     let base_flags = match method_type {
         ReceiverType::Ref => {

--- a/godot-macros/src/class/data_models/interface_trait_impl.rs
+++ b/godot-macros/src/class/data_models/interface_trait_impl.rs
@@ -449,7 +449,10 @@ fn handle_validate_property<'a>(
         impl ::godot::obj::cap::GodotValidateProperty for #class_name {
             type Recv = #receiver_path;
 
-            fn __godot_validate_property(mut this: ::godot::private::VirtualMethodReceiver<Self>, property: &mut ::godot::meta::PropertyInfo) {
+            fn __godot_validate_property(
+                mut this: ::godot::private::VirtualMethodReceiver<Self>,
+                property: &mut ::godot::register::info::PropertyInfo,
+            ) {
                 use ::godot::obj::UserClass as _;
 
                 #inactive_class_early_return
@@ -500,7 +503,7 @@ fn handle_get_property_list<'a>(
         impl ::godot::obj::cap::GodotGetPropertyList for #class_name {
             type Recv = #receiver_path;
 
-            fn __godot_get_property_list(mut this: ::godot::private::VirtualMethodReceiver<Self>) -> Vec<::godot::meta::PropertyInfo> {
+            fn __godot_get_property_list(mut this: ::godot::private::VirtualMethodReceiver<Self>) -> Vec<::godot::register::info::PropertyInfo> {
                 // #inactive_class_early_return
                 #type_decl::on_get_property_list(#receiver_call)
             }

--- a/godot-macros/src/class/data_models/property.rs
+++ b/godot-macros/src/class/data_models/property.rs
@@ -114,7 +114,7 @@ pub fn make_property_impl(class_name: &Ident, fields: &Fields) -> TokenStream {
             }
             UsageFlags::Custom(flags) => quote! {
                 Some(#(
-                    ::godot::global::PropertyUsageFlags::#flags
+                    ::godot::register::info::PropertyUsageFlags::#flags
                 )|*)
             },
         };
@@ -130,15 +130,15 @@ pub fn make_property_impl(class_name: &Ident, fields: &Fields) -> TokenStream {
             FieldHint::Hint(hint) => {
                 // User specified hint without hint_string — use empty string.
                 quote! {
-                    Some(::godot::meta::PropertyHintInfo {
-                        hint: ::godot::global::PropertyHint::#hint,
+                    Some(::godot::register::info::PropertyHintInfo {
+                        hint: ::godot::register::info::PropertyHint::#hint,
                         hint_string: ::godot::builtin::GString::new(),
                     })
                 }
             }
             FieldHint::HintWithString { hint, hint_string } => quote! {
-                Some(::godot::meta::PropertyHintInfo {
-                    hint: ::godot::global::PropertyHint::#hint,
+                Some(::godot::register::info::PropertyHintInfo {
+                    hint: ::godot::register::info::PropertyHint::#hint,
                     hint_string: ::godot::builtin::GString::from(#hint_string),
                 })
             },

--- a/godot-macros/src/class/data_models/signal.rs
+++ b/godot-macros/src/class/data_models/signal.rs
@@ -246,7 +246,7 @@ fn make_signal_registration(details: &SignalDetails, class_name_obj: &TokenStrea
         [
             // Don't use raw sys pointers directly; it's very easy to have objects going out of scope.
             #(
-                <#param_list as ::godot::meta::ParamTuple>
+                <#param_list as ::godot::meta::conv::ParamTuple>
                     ::property_info(#indexes, #param_names_str).unwrap(),
             )*
         ]
@@ -259,7 +259,7 @@ fn make_signal_registration(details: &SignalDetails, class_name_obj: &TokenStrea
         #(#signal_cfg_attrs)*
         unsafe {
             use ::godot::sys;
-            let parameters_info: [::godot::meta::PropertyInfo; #signal_parameters_count] = #param_property_infos;
+            let parameters_info: [::godot::register::info::PropertyInfo; #signal_parameters_count] = #param_property_infos;
 
             let mut parameters_info_sys: [sys::GDExtensionPropertyInfo; #signal_parameters_count] =
                 std::array::from_fn(|i| parameters_info[i].property_sys());
@@ -314,7 +314,7 @@ impl SignalCollection {
             // visibility that exceeds the class visibility). So, we can as well declare the visibility here.
             #vis_marker fn #signal_name(&mut self) -> #individual_struct_name<'c, C> {
                 #individual_struct_name {
-                    __typed: ::godot::register::TypedSignal::<'c, C, _>::extract(&mut self.__internal_obj, #signal_name_str)
+                    __typed: ::godot::signal::TypedSignal::<'c, C, _>::extract(&mut self.__internal_obj, #signal_name_str)
                 }
             }
         });
@@ -388,7 +388,7 @@ fn make_signal_individual_struct(details: &SignalDetails) -> TokenStream {
         #[doc(hidden)] // Signal struct is hidden, but the method returning it is not (IDE completion).
         #vis_marker struct #individual_struct_name<'c, C: ::godot::obj::WithSignals> {
             #[doc(hidden)]
-            __typed: ::godot::register::TypedSignal<'c, C, #param_tuple>,
+            __typed: ::godot::signal::TypedSignal<'c, C, #param_tuple>,
         }
 
         // Concrete convenience API is macro-based; many parts are delegated to TypedSignal via Deref/DerefMut.
@@ -407,7 +407,7 @@ fn make_signal_individual_struct(details: &SignalDetails) -> TokenStream {
 
         #(#signal_cfg_attrs)*
         impl<'c, C: ::godot::obj::WithSignals> std::ops::Deref for #individual_struct_name<'c, C> {
-            type Target = ::godot::register::TypedSignal<'c, C, #param_tuple>;
+            type Target = ::godot::signal::TypedSignal<'c, C, #param_tuple>;
 
             fn deref(&self) -> &Self::Target {
                 &self.__typed

--- a/godot-macros/src/derive/derive_godot_convert.rs
+++ b/godot-macros/src/derive/derive_godot_convert.rs
@@ -51,7 +51,7 @@ fn make_shape_override(convert_type: &ConvertType, cache: &mut EnumeratorExprCac
 
             let enumerator_entries: Vec<TokenStream> = match via {
                 ViaType::Int { int_ident, .. } => {
-                    // Int-backed enum: Enumerator::new_int("Grass", <ord> as i64).
+                    // Int-backed enum: EnumeratorShape::new_int("Grass", <ord> as i64).
                     let ord_exprs = variants.enumerator_ord_exprs();
                     let mapped = cache.map_ord_exprs(int_ident, names, ord_exprs);
                     names
@@ -60,19 +60,19 @@ fn make_shape_override(convert_type: &ConvertType, cache: &mut EnumeratorExprCac
                         .map(|(ident, ord_expr)| {
                             let name_str = ident.to_string();
                             quote! {
-                                ::godot::register::property::Enumerator::new_int(#name_str, #ord_expr as i64)
+                                ::godot::meta::shape::EnumeratorShape::new_int(#name_str, #ord_expr as i64)
                             }
                         })
                         .collect()
                 }
                 ViaType::GString { .. } => {
-                    // String-backed enum: Enumerator::new_string("Grass").
+                    // String-backed enum: EnumeratorShape::new_string("Grass").
                     names
                         .iter()
                         .map(|ident| {
                             let name_str = ident.to_string();
                             quote! {
-                                ::godot::register::property::Enumerator::new_string(#name_str)
+                                ::godot::meta::shape::EnumeratorShape::new_string(#name_str)
                             }
                         })
                         .collect()
@@ -80,12 +80,12 @@ fn make_shape_override(convert_type: &ConvertType, cache: &mut EnumeratorExprCac
             };
 
             quote! {
-                fn godot_shape() -> ::godot::register::property::GodotShape {
+                fn godot_shape() -> ::godot::meta::shape::GodotShape {
                     // Rust enum discriminants are always const expressions, so this works even for `MyVariant = OTHER_CONST as isize`.
-                    const ENUMERATORS: &[::godot::register::property::Enumerator] = &[
+                    const ENUMERATORS: &[::godot::meta::shape::EnumeratorShape] = &[
                         #( #enumerator_entries ),*
                     ];
-                    ::godot::register::property::GodotShape::Enum {
+                    ::godot::meta::shape::GodotShape::Enum {
                         variant_type: ::godot::meta::element_variant_type::<Self>(),
                         enumerators: std::borrow::Cow::Borrowed(ENUMERATORS),
                         godot_name: None, // User enums have no Godot class_name (future: register via classdb FFI).
@@ -97,7 +97,7 @@ fn make_shape_override(convert_type: &ConvertType, cache: &mut EnumeratorExprCac
         ConvertType::NewType { .. } => {
             // Newtypes delegate to the Via type's shape.
             quote! {
-                fn godot_shape() -> ::godot::register::property::GodotShape {
+                fn godot_shape() -> ::godot::meta::shape::GodotShape {
                     <Self::Via as ::godot::meta::GodotConvert>::godot_shape()
                 }
             }

--- a/godot-macros/src/derive/derive_to_godot.rs
+++ b/godot-macros/src/derive/derive_to_godot.rs
@@ -65,7 +65,7 @@ fn make_togodot_for_int_enum(
 
     quote! {
         impl ::godot::meta::ToGodot for #name {
-            type Pass = ::godot::meta::ByValue;
+            type Pass = ::godot::meta::conv::ByValue;
 
             #[allow(unused_parens)] // Error "unnecessary parentheses around block return value"; comes from ord expressions like (1 + 2).
             fn to_godot(&self) -> Self::Via {
@@ -86,7 +86,7 @@ fn make_togodot_for_string_enum(name: &Ident, enum_: &CStyleEnum) -> TokenStream
 
     quote! {
         impl ::godot::meta::ToGodot for #name {
-            type Pass = ::godot::meta::ByValue;
+            type Pass = ::godot::meta::conv::ByValue;
 
             fn to_godot(&self) -> Self::Via {
                 match self {

--- a/godot-macros/src/lib.rs
+++ b/godot-macros/src/lib.rs
@@ -393,8 +393,8 @@ use crate::util::{KvParser, bail, ident};
 /// while hint strings are dependent on the hint, property type and context. Using these low-level keys is rarely necessary, as most common
 /// combinations are covered by `#[var]` and `#[export]` already.
 ///
-/// [`PropertyHint`]: ../global/struct.PropertyHint.html
-/// [`PropertyUsageFlags`]: ../global/struct.PropertyUsageFlags.html
+/// [`PropertyHint`]: ../register/info/struct.PropertyHint.html
+/// [`PropertyUsageFlags`]: ../register/info/struct.PropertyUsageFlags.html
 ///
 /// ```no_run
 /// # use godot::prelude::*;

--- a/godot/src/lib.rs
+++ b/godot/src/lib.rs
@@ -32,8 +32,9 @@
 //!
 //! * [`register`], used to register **your own** Rust symbols (classes, methods, constants etc.) with Godot.
 //! * [`obj`], everything related to handling Godot objects, such as the `Gd<T>` type.
+//! * [`signal`], machinery for type-safe signals.
 //! * [`tools`], higher-level utilities that extend the generated code, e.g. `load<T>()`.
-//! * [`meta`], fundamental information about types, properties and conversions.
+//! * [`meta`], fundamental information about types and conversions.
 //! * [`init`], entry point and global library configuration.
 //! * [`task`], integration with async code.
 //!
@@ -241,7 +242,7 @@ pub use godot_core::possibly_docs as docs;
 #[doc(hidden)]
 pub use godot_core::sys;
 #[doc(inline)]
-pub use godot_core::{builtin, classes, global, meta, obj, task, tools};
+pub use godot_core::{builtin, classes, global, obj, task, tools};
 
 /// Entry point and global init/shutdown of the library.
 pub mod init {
@@ -250,13 +251,57 @@ pub mod init {
     pub use godot_macros::gdextension;
 }
 
+/// Meta-information about Godot types, their properties and conversions between them.
+pub mod meta {
+    // Submodules.
+    // Derive macro (moved from `register`).
+    pub use godot_core::meta::ClassId;
+    #[doc(hidden)]
+    pub use godot_core::meta::arg_into_owned;
+    #[cfg(feature = "__trace")]
+    #[doc(hidden)]
+    pub use godot_core::meta::trace;
+    // Argument conversions that stay in flat `meta`.
+    pub use godot_core::meta::{AsArg, ObjectArg, ToArg, owned_into_arg, ref_to_arg};
+    // Hidden internal items for proc-macros and generated code.
+    #[doc(hidden)]
+    pub use godot_core::meta::{CallContext, Signature, ensure_func_bounds};
+    #[cfg(feature = "__trace")]
+    #[doc(hidden)]
+    pub use godot_core::meta::{CowArg, FfiArg};
+    // Type traits.
+    pub use godot_core::meta::{
+        Element, GodotImmutable, GodotType, PackedElement, element_variant_type,
+    };
+    // Conversion traits.
+    pub use godot_core::meta::{EngineFromGodot, EngineToGodot, FromGodot, GodotConvert, ToGodot};
+    // Range utilities.
+    pub use godot_core::meta::{SignedRange, wrapped};
+    #[doc(inline)]
+    pub use godot_core::meta::{conv, error, inspect, shape};
+    pub use godot_macros::GodotConvert;
+}
+
+/// Runtime types for working with signals: connecting, emitting, and handling.
+pub mod signal {
+    pub use godot_core::registry::signal::re_export::*;
+}
+
 /// Register/export Rust symbols to Godot: classes, methods, enums...
 pub mod register {
     #[cfg(feature = "__codegen-full")]
     pub use godot_core::registry::RpcConfig;
-    pub use godot_core::registry::property;
-    pub use godot_core::registry::signal::re_export::*;
-    pub use godot_macros::{Export, GodotClass, GodotConvert, Var, godot_api, godot_dyn};
+    pub use godot_macros::{GodotClass, godot_api, godot_dyn};
+
+    /// Register Rust fields as Godot properties.
+    pub mod property {
+        pub use godot_core::registry::property::*;
+        // Derive macros for property traits.
+        pub use godot_macros::{Export, Var};
+    }
+
+    #[doc(inline)]
+    pub use godot_core::registry::info;
 
     /// Re-exports used by proc-macro API.
     #[doc(hidden)]

--- a/godot/src/prelude.rs
+++ b/godot/src/prelude.rs
@@ -14,7 +14,7 @@ pub use super::global::{
     godot_error, godot_print, godot_print_rich, godot_script_error, godot_warn,
 };
 pub use super::init::{ExtensionLibrary, InitLevel, InitStage, gdextension};
-pub use super::meta::error::{ConvertError, IoError};
+pub use super::meta::error::ConvertError;
 pub use super::meta::{FromGodot, GodotConvert, ToGodot};
 pub use super::obj::{
     AsDyn, Base, DynGd, DynGdMut, DynGdRef, Gd, GdMut, GdRef, GodotClass, Inherits, InstanceId,
@@ -22,7 +22,7 @@ pub use super::obj::{
 };
 pub use super::register::property::{Export, PhantomVar, Var};
 // Re-export macros.
-pub use super::register::{Export, GodotClass, GodotConvert, Var, godot_api, godot_dyn};
+pub use super::register::{GodotClass, godot_api, godot_dyn};
 pub use super::tools::{GFile, load, save, try_load, try_save};
 
 // Make trait methods available.

--- a/itest/rust/build.rs
+++ b/itest/rust/build.rs
@@ -85,13 +85,13 @@ macro_rules! push_newtype {
             impl godot::meta::GodotConvert for $name {
                 type Via = $T;
 
-                fn godot_shape() -> godot::meta::GodotShape {
+                fn godot_shape() -> godot::meta::shape::GodotShape {
                     <$T as godot::meta::GodotConvert>::godot_shape()
                 }
             }
 
             impl godot::meta::ToGodot for $name {
-                type Pass = godot::meta::ByValue;
+                type Pass = godot::meta::conv::ByValue;
 
                 #[allow(clippy::clone_on_copy)]
                 fn to_godot(&self) -> Self::Via {

--- a/itest/rust/src/builtin_tests/containers/array_test.rs
+++ b/itest/rust/src/builtin_tests/containers/array_test.rs
@@ -5,7 +5,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use godot::meta::{ElementType, wrapped};
+use godot::meta::inspect::ElementType;
+use godot::meta::wrapped;
 use godot::prelude::*;
 
 use crate::framework::{assert_match, create_gdscript, expect_panic, itest};

--- a/itest/rust/src/builtin_tests/containers/dictionary_test.rs
+++ b/itest/rust/src/builtin_tests/containers/dictionary_test.rs
@@ -12,7 +12,8 @@ use godot::builtin::{
 };
 use godot::classes::RefCounted;
 use godot::init::GdextBuild;
-use godot::meta::{Element, ElementType, FromGodot, ToGodot};
+use godot::meta::inspect::ElementType;
+use godot::meta::{Element, FromGodot, ToGodot};
 use godot::obj::NewGd;
 
 use crate::framework::{
@@ -806,7 +807,7 @@ fn dictionary_should_format_with_display() {
 #[itest]
 #[cfg(since_api = "4.4")]
 fn dictionary_element_type() {
-    use godot::meta::ElementType;
+    use godot::meta::inspect::ElementType;
 
     // Test untyped dictionary
     let untyped = VarDictionary::new();

--- a/itest/rust/src/builtin_tests/containers/packed_array_test.rs
+++ b/itest/rust/src/builtin_tests/containers/packed_array_test.rs
@@ -13,7 +13,8 @@ use godot::builtin::{
     vdict,
 };
 use godot::global::godot_str;
-use godot::meta::{ElementType, PackedElement, ToGodot, owned_into_arg, ref_to_arg, wrapped};
+use godot::meta::inspect::ElementType;
+use godot::meta::{PackedElement, ToGodot, owned_into_arg, ref_to_arg, wrapped};
 
 use crate::assert_match;
 use crate::framework::{expect_panic, itest};

--- a/itest/rust/src/builtin_tests/containers/signal_disconnect_test.rs
+++ b/itest/rust/src/builtin_tests/containers/signal_disconnect_test.rs
@@ -8,7 +8,8 @@
 use godot::builtin::{Callable, Signal};
 use godot::classes::Object;
 use godot::obj::{Base, Gd, NewAlloc};
-use godot::register::{ConnectHandle, GodotClass, godot_api};
+use godot::register::{GodotClass, godot_api};
+use godot::signal::ConnectHandle;
 
 use crate::framework::{expect_panic, expect_panic_or_nothing, itest};
 

--- a/itest/rust/src/builtin_tests/containers/signal_test.rs
+++ b/itest/rust/src/builtin_tests/containers/signal_test.rs
@@ -498,13 +498,13 @@ fn enums_as_signal_args() {
     impl GodotConvert for EventType {
         type Via = u8;
 
-        fn godot_shape() -> godot::meta::GodotShape {
+        fn godot_shape() -> godot::meta::shape::GodotShape {
             <u8 as GodotConvert>::godot_shape()
         }
     }
 
     impl ToGodot for EventType {
-        type Pass = godot::meta::ByValue;
+        type Pass = godot::meta::conv::ByValue;
 
         fn to_godot(&self) -> Self::Via {
             match self {

--- a/itest/rust/src/builtin_tests/convert_test.rs
+++ b/itest/rust/src/builtin_tests/convert_test.rs
@@ -106,13 +106,13 @@ impl ConvertedStruct {
 impl GodotConvert for ConvertedStruct {
     type Via = VarDictionary;
 
-    fn godot_shape() -> godot::meta::GodotShape {
+    fn godot_shape() -> godot::meta::shape::GodotShape {
         <VarDictionary as GodotConvert>::godot_shape()
     }
 }
 
 impl ToGodot for ConvertedStruct {
-    type Pass = godot::meta::ByValue;
+    type Pass = godot::meta::conv::ByValue;
 
     fn to_godot(&self) -> Self::Via {
         vdict! {

--- a/itest/rust/src/builtin_tests/script/script_instance_tests.rs
+++ b/itest/rust/src/builtin_tests/script/script_instance_tests.rs
@@ -12,11 +12,13 @@ use godot::classes::{
     IScriptExtension, IScriptLanguageExtension, Object, Script, ScriptExtension, ScriptLanguage,
     ScriptLanguageExtension,
 };
-use godot::global::{Error, MethodFlags};
+use godot::global::Error;
+use godot::meta::conv::RawPtr;
 use godot::meta::error::CallErrorType;
-use godot::meta::{ClassId, FromGodot, MethodInfo, PropertyInfo, RawPtr, ToGodot};
+use godot::meta::{ClassId, FromGodot, ToGodot};
 use godot::obj::script::{ScriptInstance, SiMut, create_script_instance};
 use godot::obj::{Base, Gd, NewAlloc, WithBaseField};
+use godot::register::info::{MethodFlags, MethodInfo, PropertyInfo};
 use godot::register::{GodotClass, godot_api};
 
 use crate::framework::itest;

--- a/itest/rust/src/engine_tests/engine_enum_test.rs
+++ b/itest/rust/src/engine_tests/engine_enum_test.rs
@@ -6,8 +6,9 @@
  */
 
 use godot::classes::{mesh, window};
-use godot::global::{InlineAlignment, Key, KeyModifierMask, Orientation, PropertyUsageFlags};
+use godot::global::{InlineAlignment, Key, KeyModifierMask, Orientation};
 use godot::obj::{EngineBitfield, EngineEnum};
+use godot::register::info::PropertyUsageFlags;
 
 use crate::framework::itest;
 

--- a/itest/rust/src/engine_tests/native_st_niche_audio_test.rs
+++ b/itest/rust/src/engine_tests/native_st_niche_audio_test.rs
@@ -19,7 +19,7 @@ use godot::classes::{
     AudioStreamGeneratorPlayback, AudioStreamPlayer, Engine, IAudioEffect, IAudioEffectInstance,
     SceneTree,
 };
-use godot::meta::RawPtr;
+use godot::meta::conv::RawPtr;
 use godot::obj::{Base, Gd, NewAlloc, NewGd, Singleton};
 use godot::register::{GodotClass, godot_api};
 

--- a/itest/rust/src/engine_tests/native_st_niche_pointer_test.rs
+++ b/itest/rust/src/engine_tests/native_st_niche_pointer_test.rs
@@ -15,7 +15,7 @@ use godot::builtin::{Rect2, Rid, VarDictionary, vslice};
 use godot::classes::native::{CaretInfo, Glyph, ObjectId, PhysicsServer2DExtensionShapeResult};
 use godot::classes::text_server::Direction;
 use godot::classes::{IRefCounted, Node3D, RefCounted};
-use godot::meta::RawPtr;
+use godot::meta::conv::RawPtr;
 use godot::obj::{Base, NewAlloc, NewGd};
 use godot::register::{GodotClass, godot_api};
 

--- a/itest/rust/src/object_tests/get_property_list_test.rs
+++ b/itest/rust/src/object_tests/get_property_list_test.rs
@@ -9,9 +9,8 @@ use std::collections::HashMap;
 
 use godot::builtin::{GString, StringName, VarDictionary, VariantType, Vector2, Vector3};
 use godot::classes::{IObject, Node};
-use godot::global::{PropertyHint, PropertyUsageFlags};
-use godot::meta::PropertyInfo;
 use godot::obj::{Gd, NewAlloc};
+use godot::register::info::{PropertyHint, PropertyInfo, PropertyUsageFlags};
 use godot::register::{GodotClass, godot_api};
 use godot::test::itest;
 

--- a/itest/rust/src/object_tests/property_template_test.rs
+++ b/itest/rust/src/object_tests/property_template_test.rs
@@ -12,8 +12,8 @@
 
 use std::collections::HashMap;
 
-use godot::global::PropertyUsageFlags;
 use godot::prelude::*;
+use godot::register::info::PropertyUsageFlags;
 use godot::sys::GdextBuild;
 
 use crate::framework::{TestContext, itest};

--- a/itest/rust/src/object_tests/property_test.rs
+++ b/itest/rust/src/object_tests/property_test.rs
@@ -8,12 +8,13 @@ use godot::builtin::{
     Color, GString, PackedInt32Array, VarDictionary, Variant, VariantType, vdict, vslice,
 };
 use godot::classes::{INode, IRefCounted, Node, Object, RefCounted, Resource};
-use godot::global::{PropertyHint, PropertyUsageFlags};
 use godot::init::GdextBuild;
-use godot::meta::{FromGodot, GodotConvert, PropertyHintInfo, ToGodot};
+use godot::meta::shape::GodotShape;
+use godot::meta::{FromGodot, GodotConvert, ToGodot};
 use godot::obj::{Base, Gd, NewAlloc, NewGd, OnEditor};
-use godot::register::property::{Export, GodotShape, Var};
-use godot::register::{Export, GodotClass, GodotConvert, Var, godot_api};
+use godot::register::info::{PropertyHint, PropertyHintInfo, PropertyUsageFlags};
+use godot::register::property::{Export, Var};
+use godot::register::{GodotClass, godot_api};
 use godot::test::itest;
 
 #[derive(GodotClass)]
@@ -406,8 +407,6 @@ fn enum_var_hint() {
 
 #[itest]
 fn enum_manual_shape() {
-    use godot::register::property::GodotShape;
-
     // Test GodotShape::Enum with manually constructed enumerators (the recommended way for manual impls).
     let shape = ManualEnumShape::godot_shape();
     assert!(matches!(shape, GodotShape::Enum { .. }));
@@ -434,10 +433,12 @@ impl GodotConvert for ManualEnumShape {
     type Via = i64;
 
     fn godot_shape() -> GodotShape {
-        use godot::register::property::{Enumerator, GodotShape};
+        use godot::meta::shape::{EnumeratorShape, GodotShape};
 
-        const ENUMERATORS: &[Enumerator] =
-            &[Enumerator::new_int("X", 0), Enumerator::new_int("Y", 1)];
+        const ENUMERATORS: &[EnumeratorShape] = &[
+            EnumeratorShape::new_int("X", 0),
+            EnumeratorShape::new_int("Y", 1),
+        ];
         GodotShape::Enum {
             variant_type: VariantType::INT,
             enumerators: std::borrow::Cow::Borrowed(ENUMERATORS),
@@ -448,7 +449,7 @@ impl GodotConvert for ManualEnumShape {
 }
 
 impl ToGodot for ManualEnumShape {
-    type Pass = godot::meta::ByValue;
+    type Pass = godot::meta::conv::ByValue;
     fn to_godot(&self) -> i64 {
         *self as i64
     }

--- a/itest/rust/src/object_tests/validate_property_test.rs
+++ b/itest/rust/src/object_tests/validate_property_test.rs
@@ -7,9 +7,8 @@
 
 use godot::builtin::{Array, GString, StringName, VarDictionary};
 use godot::classes::IObject;
-use godot::global::{PropertyHint, PropertyUsageFlags};
-use godot::meta::PropertyInfo;
 use godot::obj::NewAlloc;
+use godot::register::info::{PropertyHint, PropertyInfo, PropertyUsageFlags};
 use godot::register::{GodotClass, godot_api};
 use godot::test::itest;
 

--- a/itest/rust/src/register_tests/derive_godotconvert_test.rs
+++ b/itest/rust/src/register_tests/derive_godotconvert_test.rs
@@ -8,8 +8,7 @@
 use std::fmt::Debug;
 
 use godot::builtin::{GString, Vector2, array, dict};
-use godot::meta::ToGodot;
-use godot::register::GodotConvert;
+use godot::meta::{GodotConvert, ToGodot};
 
 use crate::common::roundtrip;
 use crate::framework::itest;


### PR DESCRIPTION
Closes #1475.

New module structure:
- `signal` - typed signals
- `meta` is for common symbols
- `meta::shape` for high-level type descriptors for Godot
- `meta::conv` for more niche/low-level conversions
- `register` for common class registration
- `register::property` for registration of properties (fields)
- `register::info` -- Rust mapping of GDExtension registration types (property info, hints, usage flags)