### PR TITLE
Type-Safe API for User-defined RPCs

### DIFF
--- a/godot-core/src/meta/error/mod.rs
+++ b/godot-core/src/meta/error/mod.rs
@@ -12,6 +12,7 @@ mod call_error_type;
 mod convert_error;
 mod error_to_godot;
 mod io_error;
+mod rpc_error;
 mod string_error;
 
 pub mod strat;
@@ -21,6 +22,7 @@ pub use call_error_type::*;
 pub use convert_error::*;
 pub use error_to_godot::*;
 pub use io_error::*;
+pub use rpc_error::*;
 pub use string_error::*;
 
 pub use crate::func_bail;

--- a/godot-core/src/meta/error/rpc_error.rs
+++ b/godot-core/src/meta/error/rpc_error.rs
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use std::error::Error;
+use std::fmt;
+
+use crate::global;
+use crate::obj::EngineEnum;
+
+#[derive(Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum RpcError {
+    /// The callee node was not connected to a server.
+    NotConnected,
+    /// The RPC was called with incorrect arguments.
+    ///
+    /// _If this error occurs through the type-safe API, it is probably a bug._
+    InvalidArguments,
+    /// The callee node's multiplayer could not be fetched. This is likely to happen when the node has yet to be added to the
+    /// tree.
+    Unconfigured,
+    /// An error that is unlikely to come from interacting with RPCs.
+    Unrelated(global::Error),
+}
+
+impl Error for RpcError {}
+
+impl fmt::Display for RpcError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RpcError::NotConnected => write!(
+                f,
+                "The node that this RPC was called on is not connected to a server."
+            ),
+            RpcError::InvalidArguments => write!(
+                f,
+                "The arguments passed to the RPC method do not match what was expected."
+            ),
+            RpcError::Unconfigured => write!(
+                f,
+                "Could not get the multiplayer field for the node that this RPC was called on."
+            ),
+            RpcError::Unrelated(error) => write!(
+                f,
+                "An error unrelated to RPCs has occurred. Check the Godot error documentation \
+                (https://docs.godotengine.org/en/stable/classes/class_@globalscope.html#enum-globalscope-error) for the error \
+                at ordinal '{}'. Error message: {error:?}",
+                error.ord(),
+            ),
+        }
+    }
+}
+
+impl TryFrom<global::Error> for RpcError {
+    type Error = ();
+
+    fn try_from(error: global::Error) -> Result<Self, Self::Error> {
+        match error {
+            global::Error::ERR_UNCONFIGURED => Ok(RpcError::Unconfigured),
+            global::Error::ERR_INVALID_PARAMETER => Ok(RpcError::InvalidArguments),
+            global::Error::ERR_CONNECTION_ERROR => Ok(RpcError::NotConnected),
+            global::Error::OK => Err(()),
+            _ => Ok(RpcError::Unrelated(error)),
+        }
+    }
+}

--- a/godot-core/src/obj/mod.rs
+++ b/godot-core/src/obj/mod.rs
@@ -28,6 +28,7 @@ mod base_init;
 mod base_strong_initialization;
 #[cfg(before_api = "4.7")]
 mod base_weak_initialization;
+pub mod rpc;
 pub(crate) mod rtti;
 // TODO(v0.6): godot::obj::signal was accidentally public; kept for SemVer -> remove in next minor. Canonical is godot::signal.
 #[doc(hidden)]

--- a/godot-core/src/obj/rpc/builder.rs
+++ b/godot-core/src/obj/rpc/builder.rs
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use crate::builtin::Variant;
+use crate::r#gen::classes::Node;
+use crate::meta::error::RpcError;
+use crate::obj::rpc::{GodotClass, UserRpcObject};
+use crate::obj::{Inherits, WithBaseField};
+
+/// Represents an RPC, and the object that it can be called on, and is usually obtained through the type-safe RPC API. See
+/// the [relevant section]() in the book for more information about type-safe RPC calls.
+pub struct RpcBuilder<'c, C: GodotClass> {
+    object: UserRpcObject<'c, C>,
+    rpc_name: &'c str,
+    arguments: Vec<Variant>,
+}
+
+impl<'c, C: GodotClass> RpcBuilder<'c, C> {
+    pub fn new(object: UserRpcObject<'c, C>, rpc_name: &'c str, arguments: Vec<Variant>) -> Self {
+        Self {
+            object,
+            rpc_name,
+            arguments,
+        }
+    }
+}
+
+impl<'c, C> RpcBuilder<'c, C>
+where
+    C: WithBaseField + Inherits<Node>,
+{
+    pub fn call(self) -> Result<(), RpcError> {
+        self.object.call_rpc(self.rpc_name, &self.arguments)
+    }
+
+    pub fn call_id(self, id: i64) -> Result<(), RpcError> {
+        self.object.call_rpc_id(self.rpc_name, id, &self.arguments)
+    }
+}

--- a/godot-core/src/obj/rpc/mod.rs
+++ b/godot-core/src/obj/rpc/mod.rs
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+pub use builder::*;
+pub use rpc_object::*;
+
+use crate::obj::GodotClass;
+
+mod builder;
+mod rpc_object;
+
+/// Represents a collection of RPCs that can be constructed with a [`UserRpcObject`].
+pub trait RpcCollection<'c, C>
+where
+    C: GodotClass,
+{
+    #[doc(hidden)]
+    fn from_user_rpc_object(object: UserRpcObject<'c, C>) -> Self;
+}

--- a/godot-core/src/obj/rpc/rpc_object.rs
+++ b/godot-core/src/obj/rpc/rpc_object.rs
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use crate::builtin::Variant;
+use crate::r#gen::classes::Node;
+use crate::r#gen::virtuals::RefCounted::Gd;
+use crate::meta::error::RpcError;
+use crate::obj::{GodotClass, Inherits, WithBaseField};
+
+/// Represents an object that RPCs can be called on.
+///
+/// You generally do not need to create this manually, rather it used internally by the type-safe RPC API.
+pub enum UserRpcObject<'c, C: GodotClass> {
+    /// Used in [`Self::call_rpc`] and [`Self::call_rpc_id`] to access the base class and call an RPC.
+    Internal(&'c mut C),
+    /// RPCs are called on this object directly in [`Self::call_rpc`] and [`Self::call_rpc_id`].
+    External(Gd<C>),
+}
+
+impl<'c, C> UserRpcObject<'c, C>
+where
+    C: WithBaseField + Inherits<Node>,
+{
+    /// Consumes [`Self`], calling the RPC with the provided arguments.
+    pub fn call_rpc(self, name: &str, args: &[Variant]) -> Result<(), RpcError> {
+        let error = match self {
+            UserRpcObject::Internal(self_mut) => self_mut
+                .base_mut()
+                .clone()
+                .owned_cast::<Node>()
+                .expect("This is a bug, please report it.")
+                .rpc(name, args),
+            UserRpcObject::External(mut gd) => gd.upcast_mut::<Node>().rpc(name, args),
+        };
+
+        match error.try_into() {
+            Ok(error) => Err(error),
+            // We only fail to convert the error if it is `Error::OK`.
+            Err(_) => Ok(()),
+        }
+    }
+
+    /// Consumes [`Self`], calling the RPC by a specific ID with the provided arguments.
+    pub fn call_rpc_id(self, name: &str, id: i64, args: &[Variant]) -> Result<(), RpcError> {
+        let error = match self {
+            UserRpcObject::Internal(self_mut) => self_mut
+                .base_mut()
+                .clone()
+                .owned_cast::<Node>()
+                .expect("This is a bug, please report it.")
+                .rpc_id(id, name, args),
+            UserRpcObject::External(mut gd) => gd.upcast_mut::<Node>().rpc_id(id, name, args),
+        };
+
+        match error.try_into() {
+            Ok(error) => Err(error),
+            // We only fail to convert the error if it is `Error::OK`.
+            Err(_) => Ok(()),
+        }
+    }
+}

--- a/godot-core/src/obj/traits.rs
+++ b/godot-core/src/obj/traits.rs
@@ -12,6 +12,7 @@ use crate::builtin::GString;
 use crate::init::InitLevel;
 use crate::meta::ClassId;
 use crate::meta::inspect::EnumConstant;
+use crate::obj::rpc::{RpcCollection, UserRpcObject};
 use crate::obj::{Base, BaseMut, BaseRef, Bounds, Gd, bounds};
 use crate::signal::SignalObject;
 use crate::storage::Storage;
@@ -627,6 +628,52 @@ pub trait WithUserSignals: WithSignals + WithBaseField {
     ///
     /// See [`TypedSignal`][crate::signal::TypedSignal] for more information.
     fn signals(&mut self) -> Self::SignalCollection<'_, Self>;
+}
+
+/// Represents an object, generally a node, that can provide a [collection](RpcCollection) of RPCs available on this object.
+///
+/// Implemented by default for classes that inherit [`Node`](crate::classes::Node) and contain at least one `#[rpc]`.
+pub trait WithUserRpcs<'c, C>
+where
+    C: GodotClass,
+{
+    type Collection: RpcCollection<'c, C>;
+
+    /// Returns [`Self::Collection`], which generally holds a reference to [`Self`].
+    /// Refer to the [chapter about RPCs]() in the book for more information.
+    ///
+    /// # Provided API
+    ///
+    /// The returned collection provides an API for calling all defined RPCs.
+    ///
+    /// For example, the following RPC:
+    ///
+    /// ```ignore
+    /// #[rpc]
+    /// fn say_hello_to(&mut self, to: String) {
+    ///     godot_print!("hello, {to}");
+    /// }
+    /// ```
+    ///
+    /// can be called with:
+    ///
+    /// ```ignore
+    /// my_node.rpcs().say_hello_to("world".to_string()).call();
+    /// my_node.rpcs().say_hello_to("world".to_string()).call_id(1); // call RPC on specific peer
+    /// ```
+    fn rpcs(&'c mut self) -> Self::Collection;
+}
+
+impl<'c, C> WithUserRpcs<'c, C> for Gd<C>
+where
+    C: Inherits<crate::classes::Node> + WithUserRpcs<'c, C>,
+{
+    type Collection = <C as WithUserRpcs<'c, C>>::Collection;
+
+    /// Returns `Self::Collection`, which generally holds a [`Gd`] pointer to [`Self`].
+    fn rpcs(&'c mut self) -> Self::Collection {
+        Self::Collection::from_user_rpc_object(UserRpcObject::External(self.clone()))
+    }
 }
 
 /// Extension trait for all reference-counted classes.

--- a/godot-macros/src/class/data_models/inherent_impl.rs
+++ b/godot-macros/src/class/data_models/inherent_impl.rs
@@ -74,6 +74,9 @@ pub(crate) struct InherentImplAttr {
 
     /// When typed signal generation is explicitly disabled by the user.
     pub no_typed_signals: bool,
+
+    /// When the type-safe RPC API is disabled by the user.
+    pub no_typed_rpcs: bool,
 }
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
@@ -133,10 +136,8 @@ pub fn transform_inherent_impl(
         meta.no_typed_signals,
     )?;
 
-    #[cfg(feature = "codegen-full")]
-    let rpc_registrations = crate::class::make_rpc_registrations_fn(&class_name, &funcs);
-    #[cfg(not(feature = "codegen-full"))]
-    let rpc_registrations = TokenStream::new();
+    let (rpc_registrations, rpc_api) =
+        crate::class::make_rpc_registrations(&class_name, &funcs, meta.no_typed_rpcs);
 
     let method_registrations: Vec<TokenStream> = funcs
         .into_iter()
@@ -213,6 +214,7 @@ pub fn transform_inherent_impl(
             #fill_storage
             #class_registration
             #signal_symbol_types
+            #rpc_api
             #inherent_impl_docs
         };
 

--- a/godot-macros/src/class/data_models/rpc.rs
+++ b/godot-macros/src/class/data_models/rpc.rs
@@ -6,7 +6,7 @@
  */
 
 use proc_macro2::{Ident, TokenStream};
-use quote::quote;
+use quote::{TokenStreamExt, format_ident, quote};
 
 use crate::class::FuncDefinition;
 
@@ -62,7 +62,11 @@ impl TransferMode {
     }
 }
 
-pub fn make_rpc_registrations_fn(class_name: &Ident, funcs: &[FuncDefinition]) -> TokenStream {
+pub fn make_rpc_registrations(
+    class_name: &Ident,
+    funcs: &[FuncDefinition],
+    no_typed_rpcs: bool,
+) -> (TokenStream, Option<TokenStream>) {
     let rpc_registrations = funcs
         .iter()
         .filter_map(make_rpc_registration)
@@ -71,31 +75,48 @@ pub fn make_rpc_registrations_fn(class_name: &Ident, funcs: &[FuncDefinition]) -
     // This check is necessary because the class might not implement `WithBaseField` or `Inherits<Node>`,
     //   which means `to_gd` wouldn't exist or the trait bounds on `RpcConfig::register` wouldn't be satisfied.
     if rpc_registrations.is_empty() {
-        return TokenStream::new();
+        return (TokenStream::new(), None);
     }
 
-    quote! {
-        // Clippy complains about using `..RpcConfig::default()` if all fields are overridden.
-        #[allow(clippy::needless_update)]
-        fn __register_rpcs(object: &mut dyn ::std::any::Any) {
-            use ::std::any::Any;
-            use ::godot::register::RpcConfig;
-            use ::godot::classes::multiplayer_api::RpcMode;
-            use ::godot::classes::multiplayer_peer::TransferMode;
-            use ::godot::classes::Node;
-            use ::godot::obj::{WithBaseField, Gd};
+    (
+        if cfg!(feature = "codegen-full") {
+            quote! {
+                // Clippy complains about using `..RpcConfig::default()` if all fields are overridden.
+                #[allow(clippy::needless_update)]
+                fn __register_rpcs(object: &mut dyn ::std::any::Any) {
+                    use ::std::any::Any;
+                    use ::godot::register::RpcConfig;
+                    use ::godot::classes::multiplayer_api::RpcMode;
+                    use ::godot::classes::multiplayer_peer::TransferMode;
+                    use ::godot::classes::Node;
+                    use ::godot::obj::{WithBaseField, Gd};
 
-            let this = object
-                .downcast_ref::<#class_name>()
-                .expect("bad type erasure when registering RPCs");
+                    let this = object
+                        .downcast_ref::<#class_name>()
+                        .expect("bad type erasure when registering RPCs");
 
-            // Use fully-qualified syntax, so that error message isn't just "no method named `to_gd` found".
-            let mut gd = ::godot::obj::WithBaseField::to_gd(this);
+                    // Use fully-qualified syntax, so that error message isn't just "no method named `to_gd` found".
+                    let mut gd = ::godot::obj::WithBaseField::to_gd(this);
 
-            let node = gd.upcast_mut::<Node>();
-            #( #rpc_registrations )*
-        }
-    }
+                    let node = gd.upcast_mut::<Node>();
+                    #( #rpc_registrations )*
+                }
+            }
+        } else {
+            TokenStream::new()
+        },
+        if !no_typed_rpcs {
+            make_rpc_api(
+                class_name,
+                funcs
+                    .iter()
+                    .filter(|func| func.rpc_info.is_some())
+                    .collect(),
+            )
+        } else {
+            None
+        },
+    )
 }
 
 fn make_rpc_registration(func_def: &FuncDefinition) -> Option<TokenStream> {
@@ -160,4 +181,80 @@ fn make_rpc_registration(func_def: &FuncDefinition) -> Option<TokenStream> {
     };
 
     Some(registration)
+}
+
+// TODO: respect function visibility when generating builders
+pub fn make_rpc_api(class_name: &Ident, rpcs: Vec<&FuncDefinition>) -> Option<TokenStream> {
+    if rpcs.is_empty() {
+        return None;
+    }
+
+    let collection_name = format_ident!("__godot_Rpcs_{class_name}", span = class_name.span());
+
+    let mut collection_impl_methods = TokenStream::new();
+    for rpc in rpcs {
+        let rust_name = rpc.rust_ident();
+        let rpc_name = &rpc.godot_name();
+        let param_idents = &rpc.signature_info.param_idents;
+        let rpc_typed_args = param_idents
+            .iter()
+            .zip(&rpc.signature_info.param_types)
+            .map(|(param_name, param_type)| {
+                quote! {
+                    #param_name: impl ::godot::meta::AsArg<#param_type>
+                }
+            });
+
+        collection_impl_methods.append_all(quote! {
+            #[must_use]
+            pub fn #rust_name(self, #( #rpc_typed_args ),*) -> RpcBuilder<'c, #class_name> {
+                RpcBuilder::new(
+                    self.object,
+                    #rpc_name,
+                    vec![#( ::godot::meta::ToGodot::to_variant(&#param_idents.into_arg()) ),*],
+                )
+            }
+        });
+    }
+
+    let rpc_mod = format_ident!("__{class_name}_rpcs");
+    Some(quote! {
+        use #rpc_mod::*;
+
+        #[allow(non_camel_case_types)]
+        mod #rpc_mod {
+            use super::*;
+            use ::godot::obj::rpc::{RpcCollection, UserRpcObject, RpcBuilder};
+
+            #[doc(hidden)]
+            pub struct #collection_name<'c> {
+                object: UserRpcObject<'c, #class_name>,
+            }
+
+            impl<'c> #collection_name<'c> {
+                #collection_impl_methods
+            }
+
+            impl<'c> RpcCollection<'c, #class_name> for #collection_name<'c> {
+                fn from_user_rpc_object(object: UserRpcObject<'c, #class_name>) -> Self {
+                    #collection_name {
+                        object,
+                    }
+                }
+            }
+
+            impl<'c> ::godot::obj::WithUserRpcs<'c, #class_name> for #class_name
+            where
+                #class_name: ::godot::obj::WithBaseField,
+            {
+                type Collection = #collection_name<'c>;
+
+                fn rpcs(&'c mut self) -> Self::Collection {
+                    Self::Collection::from_user_rpc_object(
+                        UserRpcObject::Internal(self)
+                    )
+                }
+            }
+        }
+    })
 }

--- a/godot-macros/src/class/godot_api.rs
+++ b/godot-macros/src/class/godot_api.rs
@@ -17,6 +17,7 @@ fn parse_inherent_impl_attr(meta: TokenStream) -> Result<super::InherentImplAttr
     let mut attr = KvParser::parse_required(item.attributes(), "godot_api", &meta)?;
     let secondary = attr.handle_alone("secondary")?;
     let no_typed_signals = attr.handle_alone("no_typed_signals")?;
+    let no_typed_rpcs = attr.handle_alone("no_typed_rpcs")?;
     attr.finish()?;
 
     if no_typed_signals && secondary {
@@ -25,10 +26,17 @@ fn parse_inherent_impl_attr(meta: TokenStream) -> Result<super::InherentImplAttr
             "#[godot_api]: keys `secondary` and `no_typed_signals` are mutually exclusive; secondary blocks allow no signals anyway"
         )?;
     }
+    if no_typed_rpcs && secondary {
+        return bail!(
+            meta,
+            "#[godot_api]: keys `secondary` and `no_typed_rpcs` are mutually exclusive; secondary blocks don't allow rpcs anyway"
+        )?;
+    }
 
     Ok(super::InherentImplAttr {
         secondary,
         no_typed_signals,
+        no_typed_rpcs,
     })
 }
 

--- a/godot-macros/src/lib.rs
+++ b/godot-macros/src/lib.rs
@@ -1081,6 +1081,9 @@ pub fn derive_godot_class(input: TokenStream) -> TokenStream {
 ///         ..Default::default() // only possible in fn, not in const.
 ///     }
 /// }
+/// # // Required because the type-safe RPC API generates a submodule that imports the owning class with `super`.
+/// # // See https://github.com/rust-lang/rust/issues/130274
+/// # fn main() {}
 /// ```
 ///
 // Note: for some reason, the intra-doc links don't work here, despite dev-dependency on godot.

--- a/godot/src/prelude.rs
+++ b/godot/src/prelude.rs
@@ -37,6 +37,7 @@ mod trait_reexports {
     pub use crate::obj::WithBaseField as _; // base(), base_mut(), to_gd(), run_deferred(), run_deferred_gd()
     pub use crate::obj::WithSignals as _; // Gd::signals()
     pub use crate::obj::WithUserSignals as _; // self.signals()
+    pub use crate::obj::WithUserRpcs as _; // rpcs()
 }
 
 pub use trait_reexports::*;

--- a/itest/rust/src/builtin_tests/containers/rpc_test.rs
+++ b/itest/rust/src/builtin_tests/containers/rpc_test.rs
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use godot::meta::error::RpcError;
+use godot::prelude::*;
+use godot::test::itest;
+
+use crate::framework::TestContext;
+
+#[derive(GodotClass)]
+#[class(init, base = Node)]
+pub struct RpcCallableNode {
+    base: Base<Node>,
+}
+
+#[godot_api]
+impl INode for RpcCallableNode {}
+
+#[godot_api]
+impl RpcCallableNode {
+    #[rpc]
+    pub fn say_hello_world(&mut self) {
+        godot_print!("hello, world");
+    }
+
+    #[rpc(call_local)]
+    pub fn say_hello_world_everywhere(&mut self) {
+        godot_print!("hello, world");
+    }
+
+    #[rpc]
+    pub fn say_hello_to(&mut self, to: String) {
+        godot_print!("hello, {to}");
+    }
+
+    #[rpc]
+    pub fn say_number(&self, number: i32) {
+        godot_print!("{number}");
+    }
+
+    #[rpc]
+    #[func(rename = renamed_rpc_function)]
+    pub fn rpc_function(&self) {}
+}
+
+#[itest]
+fn type_safe_rpc_test(context: &TestContext) {
+    // This peer id doesn't, or at least shouldn't, exist.
+    const NON_EXISTENT_ID: i64 = 100000;
+
+    let mut node = RpcCallableNode::new_alloc();
+
+    let mut root = context.scene_tree.clone();
+
+    // Before we add the node to the tree, RPCs will fail.
+    assert_eq!(
+        Err(RpcError::Unconfigured),
+        node.bind_mut().rpcs().say_hello_world().call()
+    );
+    // We'll still fail with `Unconfigured` here even if the ID passed here doesn't belong to an existing node.
+    assert_eq!(
+        Err(RpcError::Unconfigured),
+        node.bind_mut()
+            .rpcs()
+            .say_hello_world()
+            .call_id(NON_EXISTENT_ID)
+    );
+
+    root.add_child(&node);
+
+    #[cfg(feature = "codegen-full")]
+    {
+        assert_eq!(Ok(()), node.rpcs().say_hello_world().call());
+
+        let arg = "godot".to_string();
+        assert_eq!(Ok(()), node.rpcs().say_hello_to(arg.clone()).call());
+        assert_eq!(Ok(()), node.bind_mut().rpcs().say_hello_to(arg).call());
+        assert_eq!(Ok(()), node.rpcs().say_number(3).call());
+
+        // Calling the renamed function should work.
+        assert_eq!(Ok(()), node.rpcs().rpc_function().call());
+
+        // Even though the node with the ID doesn't exist, godot will still report the RPC as a success.
+        assert_eq!(Ok(()), node.rpcs().say_number(5).call_id(NON_EXISTENT_ID));
+
+        // Gets the peer ID for this node.
+        let node_id = node
+            .get_multiplayer()
+            .expect("Multiplayer should exist")
+            .get_unique_id() as i64;
+        // The `say_hello_world` RPC does not define `call_local` meaning it will error when called upon itself.
+        assert_eq!(
+            Err(RpcError::InvalidArguments),
+            node.rpcs().say_hello_world().call_id(node_id)
+        );
+        // The `say_hello_world_everywhere` RPC does define `call_local` so it won't error when called upon itself.
+        assert_eq!(
+            Ok(()),
+            node.rpcs().say_hello_world_everywhere().call_id(node_id)
+        );
+    }
+    root.remove_child(&node);
+    node.free();
+}

--- a/itest/rust/src/builtin_tests/mod.rs
+++ b/itest/rust/src/builtin_tests/mod.rs
@@ -31,6 +31,7 @@ mod containers {
     mod dictionary_test;
     mod packed_array_test;
     mod rid_test;
+    mod rpc_test;
     mod signal_disconnect_test;
     mod signal_test;
     mod variant_test;


### PR DESCRIPTION
_Edit bromeon: closes #1158_

This is a basic implementation of generating a type-safe api for calling RPCs in rust code.

## Design

A `rpcs()` method is exposed on both the owning class/node and the `Gd<T>` smart pointer to it. Calling this method will build a struct containing a `UserRpcObject` enum, and a method that returns a RPC-builder for each user-defined RPC. Calling one of these RPC-builder methods will pass the `UserRpcObject` into a builder. The builder can then be used to call the RPC via `call()` or `call_id(i64)`.

`UserRpcObject` contains two variants: 1) `Internal` containing a mutable reference to a `GodotClass` that implements `WithBaseField` and 2) `External` containing a `Gd` pointer.

Method parameters of the RPC function are passed in the RPC-builder function and stored in the builder until they are used when the RPC is called.

This API differs from the one proposed in #1158 (`.rpc()` & `.rpc_id(id)`) for two reasons:

1. It brings the API more inline with the signal API.
2. It makes it easier to add optional parameters without having to split the api style:
  ```rust
  // We could require a `.done()` call at the end, but that brings us back to where we
  // are with this implementation.
  node.rpc().rpc_with_optionals();
  node.rpc().rpc_with_optionals().optional(3).done();
  ```
  vs.
  ```rust
  node.rpcs().rpc_with_optionals().call();
  node.rpcs().rpc_with_optionals().optional(3).call();
  ```

Regardless, switching to the style proposed in #1158 wouldn't be hard.


## Example

```rust
// class definition, must inherit `Node`.
use godot::prelude::*;

#[derive(GodotClass)]
#[class(base = Node, init)]
struct MyClass {
  base: Base<Node>
}

#[godot_api]
impl MyClass {
  #[rpc]
  pub fn my_rpc(&mut self) {}
}

// somewhere else.
let mut my_class: MyClass = ...;
my_class.rpcs().my_rpc().call();

let mut my_class_gd: Gd<MyClass> = MyClass::new_alloc();
my_class_gd.rpcs().my_rpc().call_id(1);
```

## Todo (non-exhaustive)

* [ ] Document the api & traits.
* [x] Tests
  * The `rpc_test.rs` acts as an indirect test to see if the generated code compiles, but dedicated test(s) should be added.
* [x] Fix anything that these changes break
* [x] Attempt to loosen trait bounds where possible.
* [x] Attempt to reduce the amount of generated code
* [x] Attempt to reduce the runtime impact
* [x] Propagate errors from the `rpc()`/`rpc_id()` godot calls

## Future Works

This implementation is not the final stop. Several more pieces need to be addressed, either in this PR, or future PRs.

* Optional Parameters: The generated builders need to have support for optional parameters added. Currently the builder requires all parameters upfront (which I believe includes optional parameters, though I may be wrong).
* Documentation Generation: Generated builders and functions should probably be documented. They could take the documentation from the original function, or generate new documentation.
  In my original, external, implementation of this system, generated documentation included the parameter names & types.