### PR TITLE
Map non-global enums to their classes during codegen

### DIFF
--- a/godot-codegen/src/context.rs
+++ b/godot-codegen/src/context.rs
@@ -33,6 +33,7 @@ pub struct Context<'a> {
     notification_enum_names_by_class: HashMap<TyName, NotificationEnum>,
     method_table_indices: HashMap<MethodTableKey, usize>,
     method_table_next_index: HashMap<String, usize>,
+    class_enums: HashMap<String, String>,
 }
 
 impl<'a> Context<'a> {
@@ -70,6 +71,14 @@ impl<'a> Context<'a> {
 
             // Populate class lookup by name.
             engine_classes.insert(class_name.clone(), class);
+
+            // Populate class-local enums map for resolving enums from external GDExtensions.
+            if let Some(enums) = &class.enums {
+                for json_enum in enums {
+                    ctx.class_enums
+                        .insert(json_enum.name.clone(), class.name.clone());
+                }
+            }
 
             if !option_as_slice(&class.signals).is_empty() {
                 ctx.classes_with_signals.insert(class_name.clone());
@@ -304,6 +313,10 @@ impl<'a> Context<'a> {
 
     pub fn is_singleton(&self, class_name: &TyName) -> bool {
         self.singletons.contains(class_name.godot_ty.as_str())
+    }
+
+    pub fn find_enum_class(&self, enum_name: &str) -> Option<&str> {
+        self.class_enums.get(enum_name).map(|s| s.as_str())
     }
 
     pub fn is_final(&self, class_name: &TyName) -> bool {

--- a/godot-codegen/src/conv/type_conversions.rs
+++ b/godot-codegen/src/conv/type_conversions.rs
@@ -254,9 +254,9 @@ fn to_rust_type_uncached(full_ty: &GodotTy, ctx: &mut Context) -> RustTy {
     }
 
     if let Some(bitfield) = ty.strip_prefix("bitfield::") {
-        return to_enum_type_uncached(bitfield, true);
+        return to_enum_type_uncached(bitfield, true, Some(ctx));
     } else if let Some(qualified_enum) = ty.strip_prefix("enum::") {
-        return to_enum_type_uncached(qualified_enum, false);
+        return to_enum_type_uncached(qualified_enum, false, Some(ctx));
     } else if let Some(packed_arr_ty) = ty.strip_prefix("Packed") {
         // Don't trigger on PackedScene ;P
         if packed_arr_ty.ends_with("Array") {
@@ -336,13 +336,16 @@ fn to_rust_type_uncached(full_ty: &GodotTy, ctx: &mut Context) -> RustTy {
 ///
 /// Input: `bitfield::Mesh.ArrayFormat` or `enum::Error` **without** the `bitfield::` or `enum::` prefix.  \
 /// I.e. just `Mesh.ArrayFormat` or `Error`.
-pub(crate) fn to_enum_type_uncached(enum_or_bitfield: &str, is_bitfield: bool) -> RustTy {
+pub(crate) fn to_enum_type_uncached(enum_or_bitfield: &str, is_bitfield: bool, ctx: Option<&Context>) -> RustTy {
     if let Some((class, enum_)) = enum_or_bitfield.split_once('.') {
         to_class_enum_uncached(class, enum_, is_bitfield)
     } else if enum_or_bitfield == "ResourceDeepDuplicateMode" {
         // FIXME – in https://github.com/godotengine/godot/pull/100673#issuecomment-2916116489 `ResourceDeepDuplicateMode` has been wrongly marked as an Engine Enum.
         // Remove this workaround after the fix appears.
         to_class_enum_uncached("Resource", enum_or_bitfield, is_bitfield)
+    } else if let Some(class) = ctx.and_then(|c| c.find_enum_class(enum_or_bitfield)) {
+        // Enum found in a class's enum list (from external GDExtension).
+        to_class_enum_uncached(class, enum_or_bitfield, is_bitfield)
     } else {
         // Global enum or bitfield.
         let enum_or_bitfield_name = conv::make_enum_name(enum_or_bitfield);

--- a/godot-codegen/src/models/domain.rs
+++ b/godot-codegen/src/models/domain.rs
@@ -628,7 +628,7 @@ impl FnParamBuilder {
                 );
             }
 
-            conv::to_enum_type_uncached(enum_name, *is_bitfield)
+            conv::to_enum_type_uncached(enum_name, *is_bitfield, Some(ctx))
         } else {
             type_
         };
@@ -695,7 +695,7 @@ impl FnReturn {
                         ty
                     );
                 }
-                conv::to_enum_type_uncached(enum_name, *is_bitfield)
+                conv::to_enum_type_uncached(enum_name, *is_bitfield, Some(ctx))
             } else {
                 ty
             };

--- a/godot-codegen/src/special_cases/special_cases.rs
+++ b/godot-codegen/src/special_cases/special_cases.rs
@@ -1344,6 +1344,6 @@ pub fn as_enum_bitmaskable(enum_: &Enum) -> Option<RustTy> {
         "Enum {enum_name} with bitmask mapping cannot be exhaustive"
     );
 
-    let rust_ty = to_enum_type_uncached(mapped, true);
+    let rust_ty = to_enum_type_uncached(mapped, true, None);
     Some(rust_ty)
 }


### PR DESCRIPTION
Adds a `class_enums` registry in Context to track class-local enums. This enables `to_enum_type_uncached` to resolve unqualified enum names by looking up their owning class, which is needed for enums defined in external GDExtensions that aren't exposed as global enums.

This helps resolve enums that were bond only in their classes, not globally. My main use for this has been for using GodotSteam. I'm still pretty new to rust and Godot as a whole so if this is hacky or non-standard any feedback would be great.