### PR TITLE
Improve error message for reference params/returns in `#[func]`

### DIFF
--- a/godot-macros/src/class/data_models/inherent_impl.rs
+++ b/godot-macros/src/class/data_models/inherent_impl.rs
@@ -5,7 +5,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use proc_macro2::{Delimiter, Group, Ident, Span, TokenStream};
+use proc_macro2::{Delimiter, Group, Ident, Span, TokenStream, TokenTree};
 use quote::spanned::Spanned;
 use quote::{ToTokens, format_ident, quote};
 
@@ -287,6 +287,8 @@ fn process_godot_fns(
             );
         }
 
+        validate_no_references(function)?;
+
         match attr.ty {
             ItemAttrType::Func(func, rpc_info) => {
                 if rpc_info.is_some() && is_secondary_impl {
@@ -528,6 +530,37 @@ fn add_virtual_script_call(
     virtual_functions.push(early_bound_function);
 
     method_name_str
+}
+
+/// Validates that a function uses no reference types (`&T`, `&mut T`) in parameters or return type.
+///
+/// References cannot cross Godot FFI. Without this check, users get a confusing error, see <https://github.com/godot-rust/gdext/pull/1542>.
+fn validate_no_references(function: &venial::Function) -> ParseResult<()> {
+    for (param, _) in function.params.inner.iter() {
+        if let venial::FnParam::Typed(arg) = param
+            && let Some(TokenTree::Punct(p)) = arg.ty.tokens.first()
+            && p.as_char() == '&'
+        {
+            return bail!(
+                &arg.ty,
+                "#[func] does not support reference parameters \
+                (`&T` or `&mut T`); use a value type instead"
+            );
+        }
+    }
+
+    if let Some(ref ret_ty) = function.return_ty
+        && let Some(TokenTree::Punct(p)) = ret_ty.tokens.first()
+        && p.as_char() == '&'
+    {
+        return bail!(
+            ret_ty,
+            "#[func] does not support reference return types \
+            (`&T` or `&mut T`); use a value type instead"
+        );
+    }
+
+    Ok(())
 }
 
 /// Parses an entire item (`fn`, `const`) inside an `impl` block and returns a domain representation.


### PR DESCRIPTION
Closes #691.

Before:
```rs
error[E0106]: missing lifetime specifier
   --> itest/rust/src/object_tests/onready_test.rs:391:37
    |
391 |     fn add_two(&mut self, my_param: &String) {}
    |                                     ^ expected named lifetime parameter
    |
help: consider introducing a named lifetime parameter
    |
388 ~ #[godot_api]<'a>
389 | impl Bar {
390 |     #[func]
391 ~     fn add_two(&mut self, my_param: &'a String) {}
    |
```

After:
```rs
error: #[func] does not support reference parameters (`&T` or `&mut T`); use a value type instead
   --> itest/rust/src/object_tests/onready_test.rs:391:37
    |
391 |     fn add_two(&mut self, my_param: &String) {}
    |                                     ^^^^^^^
```

I also fixed the same problem for return types:
```rs
error: #[func] does not support reference return types (`&T` or `&mut T`); use a value type instead
   --> itest/rust/src/object_tests/onready_test.rs:394:30
    |
394 |     fn add_two(&mut self) -> &String { todo!() }
    |                              ^^^^^^^
```

<br>
<details>
<summary>Here's the test code. Comment one function out.</summary>

```rs
#[derive(GodotClass)]
#[class(init, base = Node)]
struct Bar {
    base: Base<Node>,
}

#[godot_api]
impl Bar {
    #[func]
    fn add_two(&mut self, my_param: &String) {}

    #[func]
    fn add_two(&mut self) -> &String { todo!() }
}
```

</details>