### PR TITLE
`#[signal(internal)]`: hide from Godot docs/autocomplete

### DIFF
--- a/godot-core/src/deprecated.rs
+++ b/godot-core/src/deprecated.rs
@@ -45,11 +45,6 @@ pub use crate::emit_deprecated_warning;
 #[deprecated = "\nUse `key => value` syntax in `vdict!` macro.\nOld syntax `key: value` will be removed."]
 pub const fn vdict_colon_syntax() {}
 
-// ----------------------------------------------------------------------------------------------------------------------------------------------
-// Godot-side deprecations (we may mark them deprecated but keep support).
-
-// Past removals: `radians` in #[export(range)].
-
 // Virtual method renames (can be removed together with maybe_rename_deprecated_virtual() in godot-macros).
 #[deprecated = "\n\
     Virtual method `get_property` has been renamed to `on_get`.\n\
@@ -75,3 +70,14 @@ pub const fn virtual_method_get_property_list() {}
     Virtual method `property_get_revert` has been renamed to `on_property_get_revert`.\n\
     See https://github.com/godot-rust/gdext/pull/1527."]
 pub const fn virtual_method_property_get_revert() {}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// Godot-side deprecations (we may mark them deprecated but keep support).
+
+// Past removals: `radians` in #[export(range)].
+
+#[deprecated = "\n\
+    Signal names starting with `_` are discouraged in Rust.\n\
+    Instead, use: `#[signal(internal)] fn my_signal();`\n\
+    This registers it as `_my_signal`, effectively hiding it in Godot."]
+pub const fn signal_underscore_prefix() {}

--- a/godot-macros/src/class/data_models/inherent_impl.rs
+++ b/godot-macros/src/class/data_models/inherent_impl.rs
@@ -64,6 +64,7 @@ struct FuncAttr {
 #[derive(Default)]
 struct SignalAttr {
     pub no_builder: bool,
+    pub internal: bool,
 }
 
 pub(crate) struct InherentImplAttr {
@@ -373,6 +374,7 @@ fn process_godot_fns(
                     fn_signature,
                     external_attributes,
                     has_builder: !signal.no_builder,
+                    is_internal: signal.internal,
                 });
 
                 removed_indexes.push(index);
@@ -695,10 +697,14 @@ fn parse_signal_attr(
 
     // Private #[signal(__no_builder)]
     let no_builder = parser.handle_alone("__no_builder")?;
+    let internal = parser.handle_alone("internal")?;
 
     parser.finish()?;
 
-    let signal_attr = SignalAttr { no_builder };
+    let signal_attr = SignalAttr {
+        no_builder,
+        internal,
+    };
 
     Ok(AttrParseResult::Signal(signal_attr, attr.value.clone()))
 }

--- a/godot-macros/src/class/data_models/signal.rs
+++ b/godot-macros/src/class/data_models/signal.rs
@@ -23,6 +23,10 @@ pub struct SignalDefinition {
 
     /// Whether there is going to be a type-safe builder for this signal (true by default).
     pub has_builder: bool,
+
+    /// Whether to register with Godot using a `_`-prefixed name, hiding the signal from docs/autocomplete.
+    /// Consistent with `#[class(internal)]` naming.
+    pub is_internal: bool,
 }
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
@@ -105,8 +109,8 @@ struct SignalDetails<'a> {
     param_tuple: TokenStream,
     /// `MySignal`
     signal_name: &'a Ident,
-    /// `"MySignal"`
-    signal_name_str: String,
+    /// `"_my_signal"` if `is_internal`, otherwise `"my_signal"`. Used for Godot registration and `TypedSignal::extract`.
+    godot_name_str: String,
     /// `#[cfg(..)] #[cfg(..)]`
     signal_cfg_attrs: Vec<&'a venial::Attribute>,
     /// `///` `#[doc = ...]`
@@ -124,6 +128,7 @@ impl<'a> SignalDetails<'a> {
         fn_signature: &'a venial::Function, // *Not* the original #[signal], just the signature part (no attributes, body, etc).
         class_name: &'a Ident,
         external_attributes: &'a [venial::Attribute],
+        is_internal: bool,
     ) -> ParseResult<SignalDetails<'a>> {
         let mut param_types = vec![];
         let mut param_names = vec![];
@@ -155,6 +160,12 @@ impl<'a> SignalDetails<'a> {
 
         let param_tuple = quote! { ( #( #param_types, )* ) };
         let signal_name = &fn_signature.name;
+        let rust_name_str = fn_signature.name.to_string();
+        let godot_name_str = if is_internal {
+            format!("_{rust_name_str}")
+        } else {
+            rust_name_str.clone()
+        };
         let individual_struct_name = format_ident!(
             "__godot_Signal_{class_name}_{signal_name}",
             span = signal_name.span()
@@ -177,7 +188,7 @@ impl<'a> SignalDetails<'a> {
             param_names_str,
             param_tuple,
             signal_name,
-            signal_name_str: fn_signature.name.to_string(),
+            godot_name_str,
             signal_cfg_attrs,
             signal_doc_attrs,
             individual_struct_name,
@@ -206,9 +217,11 @@ pub fn make_signal_registrations(
             fn_signature,
             external_attributes,
             has_builder,
+            is_internal,
         } = signal;
 
-        let details = SignalDetails::extract(fn_signature, class_name, external_attributes)?;
+        let details =
+            SignalDetails::extract(fn_signature, class_name, external_attributes, *is_internal)?;
 
         // Type-safe signal builder API, if available.
         if *has_builder {
@@ -234,7 +247,7 @@ fn make_signal_registration(details: &SignalDetails, class_name_obj: &TokenStrea
         param_types,
         param_names,
         param_names_str,
-        signal_name_str,
+        godot_name_str,
         signal_cfg_attrs,
         ..
     } = details;
@@ -264,7 +277,7 @@ fn make_signal_registration(details: &SignalDetails, class_name_obj: &TokenStrea
             let mut parameters_info_sys: [sys::GDExtensionPropertyInfo; #signal_parameters_count] =
                 std::array::from_fn(|i| parameters_info[i].property_sys());
 
-            let signal_name = ::godot::builtin::StringName::from(#signal_name_str);
+            let signal_name = ::godot::builtin::StringName::from(#godot_name_str);
 
             sys::interface_fn!(classdb_register_extension_class_signal)(
                 sys::get_library(),
@@ -295,7 +308,7 @@ impl SignalCollection {
     fn extend_with(&mut self, details: &SignalDetails) {
         let SignalDetails {
             signal_name,
-            signal_name_str,
+            godot_name_str,
             signal_cfg_attrs,
             signal_doc_attrs,
             individual_struct_name,
@@ -314,7 +327,7 @@ impl SignalCollection {
             // visibility that exceeds the class visibility). So, we can as well declare the visibility here.
             #vis_marker fn #signal_name(&mut self) -> #individual_struct_name<'c, C> {
                 #individual_struct_name {
-                    __typed: ::godot::signal::TypedSignal::<'c, C, _>::extract(&mut self.__internal_obj, #signal_name_str)
+                    __typed: ::godot::signal::TypedSignal::<'c, C, _>::extract(&mut self.__internal_obj, #godot_name_str)
                 }
             }
         });

--- a/godot-macros/src/class/data_models/signal.rs
+++ b/godot-macros/src/class/data_models/signal.rs
@@ -229,7 +229,18 @@ pub fn make_signal_registrations(
             // max_visibility = max_visibility.max(details.vis_classified);
         }
 
-        let registration = make_signal_registration(&details, class_name_obj);
+        let mut registration = make_signal_registration(&details, class_name_obj);
+
+        // Warn if signal name starts with `_` but isn't declared as #[signal(internal)].
+        if !is_internal && details.godot_name_str.starts_with('_') {
+            let warning_fn = Ident::new("signal_underscore_prefix", fn_signature.name.span());
+
+            registration = quote! {
+                ::godot::__deprecated::emit_deprecated_warning!(#warning_fn);
+                #registration
+            };
+        }
+
         signal_registrations.push(registration);
     }
 

--- a/godot-macros/src/docs/extract_docs.rs
+++ b/godot-macros/src/docs/extract_docs.rs
@@ -225,6 +225,10 @@ fn format_venial_params_xml(params: &venial::Punctuated<venial::FnParam>) -> Str
 }
 
 fn format_signal_xml(signal: &SignalDefinition) -> Option<String> {
+    if signal.is_internal {
+        return None;
+    }
+
     let name = &signal.fn_signature.name;
     let name = xml_escape(name.to_string());
 

--- a/godot-macros/src/docs/extract_docs.rs
+++ b/godot-macros/src/docs/extract_docs.rs
@@ -4,6 +4,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
+
+// Doc generation overview:
+//
+// Only items with at least one `///` doc comment are emitted into the XML. Items without Rustdoc are still registered with Godot
+// via ClassDb API, so they appear in the editor (autocomplete, signal connection dialog, etc.), just without a description.
+
 use proc_macro2::{Ident, TokenStream};
 use quote::{ToTokens, quote};
 

--- a/godot-macros/src/lib.rs
+++ b/godot-macros/src/lib.rs
@@ -1135,6 +1135,35 @@ pub fn derive_godot_class(input: TokenStream) -> TokenStream {
 ///
 /// A detailed explanation with examples is available in the [book chapter _Registering signals_](https://godot-rust.github.io/book/register/signals.html).
 ///
+/// ## Internal signals
+///
+/// To hide a signal from the Godot editor (docs, autocomplete, signal connection dialog), use `#[signal(internal)]`.
+/// The signal is then registered under a `_`-prefixed name in Godot, while the Rust API still uses the original name.
+///
+/// ```no_run
+/// # use godot::prelude::*;
+/// # #[derive(GodotClass)]
+/// # #[class(init)]
+/// # struct MyClass {
+/// #     base: Base<RefCounted>,
+/// # }
+/// #[godot_api]
+/// impl MyClass {
+///     #[signal(internal)]
+///     fn hidden_signal(value: i64);
+///
+///     #[func]
+///     fn usage_example(&mut self) {
+///         self.signals().hidden_signal().emit(123);
+///
+///         // Untyped API uses Godot name, with `_` prefix:
+///         self.base_mut().emit_signal("_hidden_signal", vslice![123]);
+///     }
+/// }
+/// ```
+///
+/// This is consistent with `#[class(internal)]` for hiding classes.
+///
 /// [`WithSignals`]: ../obj/trait.WithSignals.html
 /// [`TypedSignal`]: ../register/struct.TypedSignal.html
 ///
@@ -1206,7 +1235,8 @@ pub fn derive_godot_class(input: TokenStream) -> TokenStream {
     alias = "signal",
     alias = "constant",
     alias = "rename",
-    alias = "secondary"
+    alias = "secondary",
+    alias = "internal"
 )]
 #[proc_macro_attribute]
 pub fn godot_api(meta: TokenStream, input: TokenStream) -> TokenStream {

--- a/itest/rust/src/builtin_tests/containers/signal_test.rs
+++ b/itest/rust/src/builtin_tests/containers/signal_test.rs
@@ -219,6 +219,37 @@ fn signal_symbols_external_builder() {
     emitter.free();
 }
 
+/// Tests `#[signal(internal)]`: Rust accessor uses clean name, Godot registration uses `_` prefix.
+#[itest]
+fn signal_internal_attribute() {
+    let mut emitter = Emitter::new_alloc();
+
+    let tracker = Rc::new(Cell::new(0i64));
+    {
+        let tracker = tracker.clone();
+        // Rust accessor uses name `internal_sig` without underscore.
+        emitter.signals().internal_sig().connect(move |v| {
+            tracker.set(v);
+        });
+    }
+
+    // Godot-side name has `_` prefix -- verify signal is registered under that name.
+    assert!(
+        emitter.has_signal("_internal_sig"),
+        "internal signal should be registered as '_internal_sig' in Godot"
+    );
+
+    // Emit via typed API (uses Godot name internally).
+    emitter.signals().internal_sig().emit(42);
+    assert_eq!(tracker.get(), 42, "emit via typed API failed");
+
+    // Emit as untyped signal.
+    emitter.emit_signal("_internal_sig", &[99i64.to_variant()]);
+    assert_eq!(tracker.get(), 99, "emit via Object::emit_signal() failed");
+
+    emitter.free();
+}
+
 #[cfg(feature = "experimental-threads")]
 #[itest]
 fn signal_symbols_sync() {
@@ -572,6 +603,9 @@ mod emitter {
 
         #[signal]
         pub(super) fn signal_obj(arg1: Gd<Object>, arg2: GString);
+
+        #[signal(internal)]
+        pub fn internal_sig(value: i64);
 
         #[func]
         pub fn self_receive(&mut self, arg1: i64) {

--- a/itest/rust/src/register_tests/register_docs_test.rs
+++ b/itest/rust/src/register_tests/register_docs_test.rs
@@ -158,23 +158,29 @@ pub struct FairlyDocumented {
     #[doc = r#"this is very documented"#]
     #[var]
     item: f32,
+
     #[doc = "@deprecated use on your own risk!!"]
     #[doc = ""]
     #[doc = "not to be confused with B!"]
     #[export]
     a: i32,
+
     /// Some docs…
     /// @experimental idk.
     #[export]
     b: i64,
+
     /// is it documented?
     #[var]
     item_2: i64,
+
     #[var]
     /// this docstring has < a special character
     item_xml: GString,
-    /// this isnt documented
+
+    /// this isn't documented
     _other_item: (),
+
     /// nor this
     base: Base<Node>,
 }
@@ -286,6 +292,15 @@ impl FairlyDocumented {
     /// The `Gd<Node>` param should be properly escaped
     #[signal]
     fn documented_signal(p: Vector3, w: f64, node: Gd<Node>);
+
+    // Unlike #[signal(internal)], a leading underscore does NOT hide the signal from docs/editor.
+    /// Underscore signal docs.
+    #[signal]
+    fn _underscore_signal(p: Vector2);
+
+    /// Won't appear in editor, due to #[signal(internal)].
+    #[signal(internal)]
+    fn internal_signal(q: Vector2i);
 
     /// My signal
     ///

--- a/itest/rust/src/register_tests/register_docs_test.rs
+++ b/itest/rust/src/register_tests/register_docs_test.rs
@@ -293,11 +293,6 @@ impl FairlyDocumented {
     #[signal]
     fn documented_signal(p: Vector3, w: f64, node: Gd<Node>);
 
-    // Unlike #[signal(internal)], a leading underscore does NOT hide the signal from docs/editor.
-    /// Underscore signal docs.
-    #[signal]
-    fn _underscore_signal(p: Vector2);
-
     /// Won't appear in editor, due to #[signal(internal)].
     #[signal(internal)]
     fn internal_signal(q: Vector2i);
@@ -332,6 +327,37 @@ impl FairlyDocumented {
     /// Documented method in other godot_api secondary block
     #[func]
     fn tertiary_but_documented(&self, _smth: i64) {}
+}
+
+// Verify that #[signal] with a leading underscore emits a deprecation warning, unlike #[signal(internal)].
+// Keep the scope of #[expect(deprecated)] as small as possible to avoid masking real warnings. Test just below.
+#[expect(deprecated)]
+mod check_warnings {
+    use super::*;
+
+    #[derive(GodotClass)]
+    #[class(base=Object, init)]
+    struct UnderscoreSignal {
+        base: Base<Object>,
+    }
+
+    #[godot_api]
+    impl UnderscoreSignal {
+        /// Needs docs to show up in XML (the signal will appear in editor docs anyway, but without description otherwise).
+        #[signal]
+        fn _underscored(p: Vector2);
+    }
+}
+
+#[itest]
+fn test_underscore_signal_in_docs() {
+    let xml = find_class_docs("UnderscoreSignal");
+
+    // Don't do full XML file check, contains() is enough.
+    assert!(
+        xml.contains("<signal name=\"_underscored\">"),
+        "underscore signal should appear in docs XML:\n{xml}"
+    );
 }
 
 #[itest]

--- a/itest/rust/src/register_tests/res/registered_docs.xml
+++ b/itest/rust/src/register_tests/res/registered_docs.xml
@@ -98,6 +98,13 @@ public class Player : Node2D
   </description>
 </signal>
 
+<signal name="_underscore_signal">
+  <param index="0" name="p" type="Vector2" />
+  <description>
+  Underscore signal docs.
+  </description>
+</signal>
+
 <signal name="deprecated" deprecated="– use other_signal instead.">
   <param index="0" name="x" type="i64" />
   <description>

--- a/itest/rust/src/register_tests/res/registered_docs.xml
+++ b/itest/rust/src/register_tests/res/registered_docs.xml
@@ -98,13 +98,6 @@ public class Player : Node2D
   </description>
 </signal>
 
-<signal name="_underscore_signal">
-  <param index="0" name="p" type="Vector2" />
-  <description>
-  Underscore signal docs.
-  </description>
-</signal>
-
 <signal name="deprecated" deprecated="– use other_signal instead.">
   <param index="0" name="x" type="i64" />
   <description>


### PR DESCRIPTION
Closes #1483.

```rs
#[signal(internal)]
fn hidden(...);

// Usage (typed and untyped):
self.signals().hidden().emit(...);
self.base_mut().emit_signal("_hidden", ...);
```

This is now official way of registering internal (private, hidden) signals with godot-rust.

`#[signal(internal)]` is preferred over `_my_signal`, which has the Rust "unused" connotation and makes the typed `.signals()` API harder to use. Signals declared with underscores will emit a warning, pointing to this attribute.

Also updates register-docs tests.