### PR TITLE
 Support `Result<T, E>` as return type in `#[func]`

### DIFF
--- a/godot-core/src/builtin/callable.rs
+++ b/godot-core/src/builtin/callable.rs
@@ -667,12 +667,12 @@ mod custom_callable {
         let ctx = meta::CallContext::custom_callable(name.as_ref());
 
         let err = unsafe { &mut *r_error };
-        crate::private::handle_fallible_varcall(&ctx, err, move || {
+        crate::private::handle_fallible_varcall(&ctx, err, || {
             // Re-borrow inside closure so C doesn't have to be UnwindSafe.
             let c: &mut C = unsafe { CallableUserdata::inner_from_raw(callable_userdata) };
             let result = c.invoke(arg_refs);
 
-            unsafe { meta::varcall_return_checked(Ok(result), r_return, r_error) };
+            unsafe { meta::varcall_return_checked(Ok(result), r_return, r_error, &ctx)? };
             Ok(())
         });
     }
@@ -697,7 +697,7 @@ mod custom_callable {
         let ctx = meta::CallContext::custom_callable(&w.name);
 
         let err = unsafe { &mut *r_error };
-        crate::private::handle_fallible_varcall(&ctx, err, move || {
+        crate::private::handle_fallible_varcall(&ctx, err, || {
             // Re-borrow inside closure so FnMut doesn't have to be UnwindSafe.
             let w: &mut FnWrapper<F> =
                 unsafe { CallableUserdata::inner_from_raw(callable_userdata) };
@@ -712,7 +712,7 @@ mod custom_callable {
             );
 
             let result = (w.rust_function)(arg_refs).to_variant();
-            unsafe { meta::varcall_return_checked(Ok(result), r_return, r_error) };
+            unsafe { meta::varcall_return_checked(Ok(result), r_return, r_error, &ctx)? };
             Ok(())
         });
     }

--- a/godot-core/src/meta/error/call_error.rs
+++ b/godot-core/src/meta/error/call_error.rs
@@ -326,6 +326,11 @@ impl CallError {
         err
     }
 
+    /// `#[func]` returning `Result<T, E>` which hits the `Err(E)` case *and* intends to fail the Godot call.
+    pub(crate) fn failed_by_user_result(call_ctx: &CallContext, message: String) -> Self {
+        Self::new(call_ctx, message, None)
+    }
+
     /// Whether this error was caused by a Rust panic (as opposed to a Godot or godot-rust error).
     ///
     /// If true, the panic hook has already printed the error; callers can avoid printing it again.

--- a/godot-core/src/meta/error/error_to_godot.rs
+++ b/godot-core/src/meta/error/error_to_godot.rs
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+//! The [`ErrorToGodot`] trait for mapping `Result<T, E>` to Godot return types.
+//!
+//! Built-in strategies are in the [`strat`][super::strat] module.
+
+use crate::meta::ToGodot;
+
+/// Defines how `Result<T, E>` returned by `#[func]` is mapped to Godot.
+///
+/// When implemented for a type `E`, this trait enables `Result<T, E>` return types
+/// [through a blanket impl](../trait.ToGodot.html#impl-ToGodot-for-Result%3CT,+E%3E).
+///
+/// # Implementing the trait
+/// The associated type [`Mapped`][Self::Mapped] determines what GDScript sees as the function's return type. This type
+/// can depend on `T` -- the ok-value type of the `Result` -- because the trait is generic over `T`.
+///
+/// Users then override [`result_to_godot()`][Self::result_to_godot], returning a [`CallOutcome`]:
+/// - [`CallOutcome::Return(mapped)`][CallOutcome::Return] -- the call succeeds; pass `mapped` back to GDScript.
+/// - [`CallOutcome::CallFailed(msg)`][CallOutcome::CallFailed] -- an unexpected error occurred; log `msg` and fail the call.
+///
+/// # Built-in strategies
+/// See the [`strat`][crate::meta::error::strat] module for all provided implementations, or for inspirations for custom error handling.
+///
+/// # Example: typed `Array<T>` with 0 or 1 elements
+/// Since the trait is generic over `T`, custom implementations can require tighter bounds (such as [`Element`][crate::meta::Element]) and use
+/// a typed `Array<T>` as the mapped type.
+///
+/// This example returns a 1-element array on success, or a 0-element one on error -- a poor man's `Option<T>` in GDScript.
+///
+/// ```no_run
+/// # use godot::prelude::*;
+/// use godot::builtin::Array;
+/// use godot::meta::error::{CallOutcome, ErrorToGodot};
+/// use godot::meta::{Element, ref_to_arg};
+///
+/// struct MyError(String);
+///
+/// impl<T: Element> ErrorToGodot<T> for MyError {
+///     // GDScript sees Array[T] as the #[func]'s return type.
+///     type Mapped = Array<T>;
+///
+///     fn result_to_godot(result: Result<&T, &Self>) -> CallOutcome<Array<T>> {
+///         // Construct [elem] or [].
+///         let array = match result {
+///             Ok(elem) => array![ref_to_arg(elem)],
+///             Err(_) => Array::new(),
+///         };
+///
+///         // We always return a value, never fail the call -> only use CallOutcome::Return.
+///         CallOutcome::Return(array)
+///     }
+/// }
+/// ```
+///
+/// GDScript usage:
+/// ```gdscript
+/// var result := node.some_fn()  # typed Array[...]
+/// if result.is_empty():
+///     print("Operation failed")
+/// else:
+///     var value := result.front()  # typed!
+/// ```
+pub trait ErrorToGodot<T: ToGodot>: Sized {
+    /// The type to which `Result<T, Self>` is mapped on Godot side.
+    type Mapped: ToGodot;
+
+    /// Map a `Result<T, Self>` to a Godot return value or an unexpected-error message.
+    fn result_to_godot(result: Result<&T, &Self>) -> CallOutcome<Self::Mapped>;
+}
+
+/// Outcome of mapping a `Result<T, E>` for a `#[func]` return value.
+///
+/// Returned by [`ErrorToGodot::result_to_godot()`]. Decides how Godot handles the result of a user-defined `#[func]`.
+pub enum CallOutcome<R> {
+    /// Pass this value back to GDScript; the call succeeds.
+    Return(R),
+
+    /// The call encounters an unexpected error; log provided message and perform best-effort failure handling.
+    ///
+    /// This either stops the calling GDScript function or results in a default value of `R` on Godot side. Rust callers using
+    /// `Object::try_call()` always receive `Err`. For detailed Godot-side semantics and an example, see
+    /// [`strat::Unexpected`][crate::meta::error::strat::Unexpected].
+    CallFailed(String),
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// Macro for immediately exiting function.
+
+/// Return early from a `#[func]`, creating an error value from a format string (including string literals).
+///
+/// Same principle as [`eyre::bail!`](https://docs.rs/eyre/latest/eyre/macro.bail.html),
+/// [`miette::bail!`](https://docs.rs/miette/latest/miette/macro.bail.html), and
+/// [`anyhow::bail!`](https://docs.rs/anyhow/latest/anyhow/macro.bail.html).
+///
+/// This macro expands to `return Err(E::from(format!(...)))`, where `E` is inferred from the function's return type.
+/// Accepts a string literal or a `format!`-style format string with arguments.
+///
+/// Works with any error type `E` that implements `From<String>`, e.g. [`strat::Unexpected`][crate::meta::error::strat::Unexpected].
+#[macro_export]
+macro_rules! func_bail {
+    ($($arg:tt)*) => {
+        return ::std::result::Result::Err(::std::convert::From::from(
+            ::std::format!($($arg)*)
+        ))
+    };
+}

--- a/godot-core/src/meta/error/io_error.rs
+++ b/godot-core/src/meta/error/io_error.rs
@@ -12,7 +12,12 @@ use crate::classes::FileAccess;
 use crate::global::Error as GodotError;
 use crate::obj::Gd;
 
-/// Error that can occur while using `gdext` IO utilities.
+/// Error that can occur while using godot-rust I/O utilities.
+///
+/// Some APIs using this:
+/// - [`tools::try_load()`][crate::tools::try_load]
+/// - [`tools::try_save()`][crate::tools::try_save]
+/// - [`tools::GFile::try_from_unique()`][crate::tools::GFile::try_from_unique]
 #[derive(Debug)]
 pub struct IoError {
     data: ErrorData,

--- a/godot-core/src/meta/error/mod.rs
+++ b/godot-core/src/meta/error/mod.rs
@@ -10,11 +10,17 @@
 mod call_error;
 mod call_error_type;
 mod convert_error;
+mod error_to_godot;
 mod io_error;
 mod string_error;
+
+pub mod strat;
 
 pub use call_error::*;
 pub use call_error_type::*;
 pub use convert_error::*;
+pub use error_to_godot::*;
 pub use io_error::*;
 pub use string_error::*;
+
+pub use crate::func_bail;

--- a/godot-core/src/meta/error/strat/mod.rs
+++ b/godot-core/src/meta/error/strat/mod.rs
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+//! Built-in [`ErrorToGodot`] strategies for mapping `Result<T, E>` return types of `#[func]` methods.
+//!
+//! This module is intended to be used qualified with `strat::` module: `strat::Unexpected` etc.
+//! It is re-exported in the prelude to enable this.
+//!
+//! # Overview
+//! Each type in this module implements [`ErrorToGodot`] with a different mapping strategy. Some strategies are not provided out-of-the-box
+//! but could serve as inspiration to build your own. If you find any of those useful, let us know, and we may consider adding them.
+//!
+//! | Strategy                                       | `Mapped` type                       | Ok path            | Err path                  | GDScript ergonomics                     |
+//! |------------------------------------------------|-------------------------------------|--------------------|---------------------------|-----------------------------------------|
+//! | [`strat::Unexpected`]<br>Unexpected errors     | `T`                                 | `val.clone()`      | Default or<br>failed call | Sees `T`; `?` works with any `Error`    |
+//! | `()`<br>Nil on error                           | `Variant`                           | `val.to_variant()` | `null`                    | `if val == null`                        |
+//! | [`global::Error`]<br>Godot error enum          | `global::Error`                     | `OK` constant      | `ERR_*` constant          | `val == OK`                             |
+//! | _(not provided)_<br>`Variant`                  | `Variant`                           | `val.to_variant()` | `err.to_variant()`        | Must check type/value                   |
+//! | _(not provided)_<br>Dictionary `ok`/`err`      | `Dictionary`<br>`<GString,Variant>` | `{"ok" => val}`    | `{"err" => msg}`          | `d.has("ok")`<br>`d["ok"]`              |
+//! | _(not provided)_<br>Array 0/1 elems            | `Array<T>`                          | `[val]`            | `[]`                      | `a.is_empty()`<br>`a.front()` -- typed! |
+//! | _(not provided)_<br>Custom class               | `Gd<RustResult>`                    | wrap in class      | wrap in class             | `r.is_ok()`<br>`r.unwrap()`             |
+
+mod unexpected;
+
+pub use unexpected::*;
+
+use super::{CallOutcome, ErrorToGodot};
+use crate::global;
+use crate::meta::ToGodot;
+#[expect(unused)] // for docs.
+use crate::meta::error::strat;
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// () impl: GDScript sees Variant -- nil on error, val.to_variant() on success.
+
+/// Error strategy that returns `null` on error, instead of making the call fail.
+///
+/// Use this when an absent value is a normal outcome that GDScript should handle, for example a missing save file
+/// for a new player. GDScript receives a `Variant` containing either the value or `null`.
+///
+/// Since `()` discards all error information, use `.map_err(|_| ())?` to propagate any error into it.
+///
+/// # Example
+/// ```no_run
+/// use godot::prelude::*;
+/// # #[derive(GodotClass)] #[class(init, base=Node)] struct PlayerData;
+///
+/// #[godot_api]
+/// impl PlayerData {
+///     // Returns the high score from a save file, or null if absent or unreadable.
+///     // A missing file is normal for new players -- GDScript handles null gracefully.
+///     #[func]
+///     fn load_high_score(&self, save_path: GString) -> Result<i64, ()> {
+///         let text = std::fs::read_to_string(save_path.to_string()).map_err(|_| ())?;
+///         text.trim().parse::<i64>().map_err(|_| ())
+///     }
+/// }
+/// ```
+///
+/// GDScript usage:
+/// ```gdscript
+/// var score = player.load_high_score("user://save.dat")
+/// if score == null:
+///     score = 0  # New player, no save file yet.
+/// ```
+impl<T: ToGodot> ErrorToGodot<T> for () {
+    type Mapped = crate::builtin::Variant;
+
+    fn result_to_godot(result: Result<&T, &Self>) -> CallOutcome<crate::builtin::Variant> {
+        match result {
+            Ok(val) => CallOutcome::Return(val.to_variant()),
+            Err(()) => CallOutcome::Return(crate::builtin::Variant::nil()),
+        }
+    }
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// global::Error impl: GDScript sees the Error enum.
+//
+// Note: ok_to_mapped discards the Ok value and returns Error::OK. The typical use case is Result<(), global::Error>.
+
+impl<T: ToGodot> ErrorToGodot<T> for global::Error {
+    type Mapped = global::Error;
+
+    fn result_to_godot(result: Result<&T, &Self>) -> CallOutcome<global::Error> {
+        match result {
+            Ok(_) => CallOutcome::Return(global::Error::OK),
+            Err(&e) => CallOutcome::Return(e),
+        }
+    }
+}

--- a/godot-core/src/meta/error/strat/unexpected.rs
+++ b/godot-core/src/meta/error/strat/unexpected.rs
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use std::error::Error;
+use std::fmt;
+
+use crate::meta::ToGodot;
+use crate::meta::error::{CallOutcome, ErrorToGodot};
+
+/// Ergonomic catch-all error type for `#[func]` methods.
+///
+/// `strat::Unexpected` is intended for potential bugs that are **fixed during development**. They should not appear in Release builds.  \
+/// Do **not** use this for runtime errors that are expected (e.g. loading a savegame that can be corrupted).
+///
+/// When this error is returned, Godot logs it with [`godot_error!`]. The calling code [cannot reliably handle it][godot-proposal-7751].
+/// This strategy is comparable to panics in Rust: the calling code is more ergonomic in the happy path, assuming that there are no errors.
+/// In case that `Err(strat::Unexpected)` is returned, the calling code either aborts the function (debug varcall only) or continues with a
+/// default value of the declared return type, which may introduce silent logic errors. GDScript has best-effort detection of such errors in Debug
+/// mode; see [below](#behavior-on-the-call-site). The Rust object and its state remain valid after an error and can be used in subsequent calls.
+///
+/// This is currently the only [`ErrorToGodot`] impl that preserves type safety: for a Rust `#[func]` returning `Result<T, strat::Unexpected>`,
+/// GDScript's static analysis sees the return type `T`. If you want to handle errors at runtime, choose another `ErrorToGodot` impl.
+///
+/// `strat::Unexpected` enables automatic conversions from other errors via `?` operator. This means you can mix different error types within the
+/// same function body -- each one propagates via `?` and its message is forwarded to Godot. Use the [`func_bail!`] macro for early returns with
+/// an error message.
+///
+/// [godot-proposal-7751]: https://github.com/godotengine/godot-proposals/discussions/7751
+/// [`godot_error!`]: crate::global::godot_error
+/// [`func_bail!`]: crate::meta::error::func_bail
+///
+/// # Example
+/// ```no_run
+/// use godot::prelude::*;
+/// # #[derive(GodotClass)] #[class(init, base=Node3D)]
+/// # struct PlayerCharacter { base: Base<Node3D>, config_map: std::collections::HashMap<String, String>, id: i32 }
+///
+/// #[godot_api]
+/// impl PlayerCharacter {
+///     // Verifies that required nodes are present in the developer-authored scene tree.
+///     // Missing nodes are a scene setup bug, not an expected runtime condition.
+///     #[func]
+///     fn init_player(&mut self) -> Result<(), strat::Unexpected> {
+///         // Node missing = scene setup bug.
+///         let Some(hand) = self.base().try_get_node_as::<Node3D>("Skeleton3D/Hand") else {
+///             func_bail!("Player {}: 3D model is missing a hand", self.id);
+///         };
+///
+///         // HashMap loaded at startup; missing or unparseable values are a code bug.
+///         let max_health = self.config_map
+///             .get("max_health")
+///             .ok_or("'max_health' key missing in config")?  // &str
+///             .parse::<i64>()?;                              // ParseIntError
+///
+///         // Initialize self with hand + max_health...
+///         Ok(())
+///     }
+/// }
+/// ```
+///
+/// This example uses [`Node::try_get_node_as()`][crate::classes::Node::try_get_node_as], the fallible counterpart to
+/// [`Node::get_node_as()`][crate::classes::Node::get_node_as]. The latter panics on failure. From GDScript, the observable behavior is
+/// the same, however the `try_*` + `?` approach allows more control over error propagation and works entirely without a Rust panic.
+///
+/// # Behavior on the call site
+/// How a caller sees the `Err` variant of a returned `Result<T, strat::Unexpected>` depends:
+///
+/// - **Rust:** When calling a `#[func]` via `Object::try_call()` reflection, the caller will always see `Unexpected` errors manifest as `Err` in
+///   the return type. This is the only way to reliably catch `Unexpected` errors, and works only because godot-rust maintains internal state.
+/// - **GDScript:** If an `Unexpected` error is returned from Rust, the calling GDScript function will abort/fail if both conditions are true:
+///   - the call uses _varcall_ (not _ptrcall_): invoked on an untyped `Variant` or using reflection via `Object.call()`.
+///   - it runs in a Godot debug/editor build.
+/// - Everything else returns Godot's default value for the type `T` (e.g. `null` for objects/variants, 0 for ints, etc.). This also applies to
+///   other languages calling such a method (C#, godot-cpp, etc.).
+// A small edge case seems to be a scene with a Rust class, that has a script attached. The GDScript _init() method then calls self.method(),
+// which seems to behave like varcall rather than ptrcall, thus failing the call. Adding a `var x: MyClass = self; x.method()` however
+// turns it into regular ptrcall, with continued execution and default value. Not yet reproduced in itest.
+///
+/// # `std::error::Error` and trait coherence
+/// This type intentionally does **not** implement [`std::error::Error`] -- the reason is a Rust coherence constraint.
+///
+/// If `Unexpected` implemented `Error`, the blanket `impl<E: Into<Box<dyn Error + ...>>> From<E> for Unexpected` would conflict with the standard
+/// library's `impl<T> From<T> for T`, because `Unexpected` would satisfy both `E = Unexpected` and `Unexpected: Into<Box<dyn Error>>`.
+/// Omitting the `Error` impl sidesteps this conflict and is the same technique used by [`anyhow::Error`](https://docs.rs/anyhow).
+///
+/// Because `Unexpected` is typically the last error in a chain -- returned to Godot via `#[func]` -- the lack of direct error APIs is usually
+/// not a big problem.
+pub struct Unexpected {
+    inner: Box<dyn Error + Send + Sync + 'static>,
+}
+
+impl Unexpected {
+    /// Create a `Unexpected` from any type implementing [`std::error::Error`].
+    pub fn new(err: impl Error + Send + Sync + 'static) -> Self {
+        Self {
+            inner: Box::new(err),
+        }
+    }
+
+    /// Attempt to downcast the inner error to a concrete type.
+    pub fn downcast_ref<E: Error + 'static>(&self) -> Option<&E> {
+        self.inner.downcast_ref::<E>()
+    }
+}
+
+impl fmt::Display for Unexpected {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.inner, f)
+    }
+}
+
+impl fmt::Debug for Unexpected {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&self.inner, f)
+    }
+}
+
+// Unexpected intentionally does NOT implement std::error::Error -- see the type-level docs for why.
+
+/// Enables the `?` operator for any `E: Into<Box<dyn Error + Send + Sync + 'static>>`.
+///
+/// The following types satisfy this bound and can therefore be used with `?` or passed to [`Unexpected::new()`]:
+///
+/// | Source type | How it converts |
+/// |---|---|
+/// | Any `E: Error + Send + Sync + 'static` | Boxed directly; covers `std::io::Error`, `ParseIntError`, and any custom error type |
+/// | `Box<dyn Error + Send + Sync + 'static>` | Used as-is |
+/// | `String` | Wrapped in a message-only error |
+/// | `&str` (any lifetime) | Copied to `String`, then wrapped -- the lifetime is not propagated |
+impl<E: Into<Box<dyn Error + Send + Sync + 'static>>> From<E> for Unexpected {
+    fn from(err: E) -> Self {
+        Self { inner: err.into() }
+    }
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// ErrorToGodot impl -- unexpected mode
+
+impl<T: ToGodot + Clone> ErrorToGodot<T> for Unexpected {
+    type Mapped = T;
+
+    fn result_to_godot(result: Result<&T, &Self>) -> CallOutcome<T> {
+        match result {
+            Ok(val) => CallOutcome::Return(val.clone()),
+            Err(e) => CallOutcome::CallFailed(format!("Err(Unexpected) in #[func]: {e}")),
+        }
+    }
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::meta::error::func_bail;
+
+    // Type-checks the argument.
+    fn assert_bail(_: Unexpected) {}
+
+    #[test]
+    fn from_concrete_error() {
+        // Accepts any E: Error + Send + Sync + 'static -- here ParseIntError.
+        let err: Result<i32, _> = "x".parse();
+        assert_bail(err.unwrap_err().into());
+    }
+
+    #[test]
+    fn from_io_error() {
+        let err = std::io::Error::other("io failure");
+        assert_bail(err.into());
+    }
+
+    #[test]
+    fn from_boxed_error() {
+        let err: Box<dyn Error + Send + Sync + 'static> = Box::new(std::io::Error::other("boxed"));
+        assert_bail(err.into());
+    }
+
+    #[test]
+    fn from_string() {
+        assert_bail(String::from("string error").into());
+    }
+
+    #[test]
+    fn from_str_static() {
+        assert_bail("static str error".into());
+    }
+
+    #[test]
+    fn from_str_non_static() {
+        // Non-static &str: the slice is copied to String internally, so the lifetime is not propagated.
+        let s = String::from("runtime string");
+        let slice: &str = s.as_str();
+        assert_bail(slice.into());
+    }
+
+    #[test]
+    fn display_forwards_inner_message() {
+        let e: Unexpected = "hello error".into();
+        assert_eq!(e.to_string(), "hello error");
+    }
+
+    #[test]
+    fn macro_literal_returns_early() {
+        fn run() -> Result<i32, Unexpected> {
+            func_bail!("literal message");
+        }
+        let err = run().unwrap_err();
+        assert_eq!(err.to_string(), "literal message");
+    }
+
+    #[test]
+    fn macro_format_returns_early() {
+        fn run(x: i32) -> Result<i32, Unexpected> {
+            func_bail!("value was {x}");
+        }
+        let err = run(42).unwrap_err();
+        assert_eq!(err.to_string(), "value was 42");
+    }
+
+    #[test]
+    fn downcast_ref_succeeds() {
+        let inner = std::io::Error::other("downcastable");
+        let e: Unexpected = inner.into();
+        assert!(e.downcast_ref::<std::io::Error>().is_some());
+    }
+
+    #[test]
+    fn downcast_ref_wrong_type_returns_none() {
+        let e: Unexpected = "not an io::Error".into();
+        assert!(e.downcast_ref::<std::io::Error>().is_none());
+    }
+}

--- a/godot-core/src/meta/godot_convert/impls.rs
+++ b/godot-core/src/meta/godot_convert/impls.rs
@@ -7,7 +7,9 @@
 
 use crate::builtin::{Array, Variant};
 use crate::meta;
-use crate::meta::error::{ConvertError, ErrorKind, FromFfiError};
+use crate::meta::error::{
+    CallError, CallOutcome, ConvertError, ErrorKind, ErrorToGodot, FromFfiError,
+};
 use crate::meta::shape::GodotShape;
 use crate::meta::{Element, FromGodot, GodotConvert, GodotNullableType, GodotType, ToGodot};
 use crate::registry::info::ParamMetadata;
@@ -143,6 +145,67 @@ where
         }
 
         Some(T::from_variant(variant))
+    }
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// Result<T, E: ErrorToGodot>
+
+impl<T, E> GodotConvert for Result<T, E>
+where
+    T: ToGodot,
+    E: ErrorToGodot<T>,
+{
+    type Via = <<E as ErrorToGodot<T>>::Mapped as GodotConvert>::Via;
+
+    fn godot_shape() -> GodotShape {
+        <<E as ErrorToGodot<T>>::Mapped>::godot_shape()
+    }
+}
+
+impl<T, E> ToGodot for Result<T, E>
+where
+    T: ToGodot,
+    E: ErrorToGodot<T>,
+{
+    type Pass = meta::ByValue;
+
+    fn to_godot(&self) -> Self::Via {
+        // Two cases of result_to_godot():
+        // * Return -- pass forward.
+        // * CallFailed -- misuse: #[func] Result<T, E> is mapped in a separate code path; this is only for users
+        //   calling to_godot() manually, so panic.
+        //
+        // Exception safety (see to_variant() comment): this panic is safe because Result<T, E> does not implement Element.
+        // Array::resize() is thus never at risk of calling to_variant() on a Result and leaving the array in an inconsistent state.
+        match E::result_to_godot(self.as_ref()) {
+            CallOutcome::Return(mapped) => mapped.to_godot_owned(),
+            CallOutcome::CallFailed(msg) => panic!("Result::to_godot() called on Err: {msg}"),
+        }
+    }
+
+    // Two __godot_try* overrides are required: one for each calling convention. They can't be merged without sacrificing perf in one of the paths:
+    // - varcall writes a Variant to a GDExtensionVariantPtr. __godot_try_into_variant produces it directly; going through Via first would add
+    //   an intermediate clone for ByRef types.
+    // - ptrcall writes Via to a typed GDExtensionTypePtr. __godot_try_into_godot_owned produces Via directly; going through Variant first
+    //   would require a Variant→Via round-trip.
+    // Both methods also propagate unexpected errors as CallError instead of panicking.
+
+    fn __godot_try_into_variant(self, call_ctx: &meta::CallContext) -> Result<Variant, CallError> {
+        match E::result_to_godot(self.as_ref()) {
+            CallOutcome::Return(mapped) => Ok(mapped.to_variant()),
+            CallOutcome::CallFailed(msg) => Err(CallError::failed_by_user_result(call_ctx, msg)),
+        }
+    }
+
+    fn __godot_try_into_godot_owned(
+        self,
+        call_ctx: &meta::CallContext,
+    ) -> Result<Self::Via, CallError> {
+        match E::result_to_godot(self.as_ref()) {
+            CallOutcome::Return(mapped) => Ok(mapped.to_godot_owned()),
+            CallOutcome::CallFailed(msg) => Err(CallError::failed_by_user_result(call_ctx, msg)),
+        }
     }
 }
 

--- a/godot-core/src/meta/godot_convert/mod.rs
+++ b/godot-core/src/meta/godot_convert/mod.rs
@@ -85,20 +85,53 @@ pub trait ToGodot: Sized + GodotConvert {
     /// # Return type
     /// - For `Pass = ByValue`, returns owned `Self::Via`.
     /// - For `Pass = ByRef`, returns borrowed `&Self::Via`.
+    ///
+    /// # Panics
+    /// Generally never panics, except for the `Result<T, E>` impl in case of `Err(E)`.
     fn to_godot(&self) -> ToArg<'_, Self::Via, Self::Pass>;
 
     /// Converts this type to owned Godot representation.
     ///
     /// Always returns `Self::Via`, cloning if necessary for ByRef types.
+    ///
+    /// # Panics
+    /// See [`to_godot()`][Self::to_godot].
     fn to_godot_owned(&self) -> Self::Via {
         Self::Pass::ref_to_owned_via(self)
     }
 
     /// Converts this type to a [Variant].
+    ///
+    /// # Panics
+    /// See [`to_godot()`][Self::to_godot].
     // Exception safety: must not panic apart from exceptional circumstances (Nov 2024: only u64).
     // This has invariant implications, e.g. in Array::resize().
     fn to_variant(&self) -> Variant {
         Self::Pass::ref_to_variant(self)
+    }
+
+    /// Consuming conversion to `Variant` for `#[func]` varcall return values.
+    ///
+    /// Defaults to infallible [`to_variant()`][Self::to_variant]. Overridden for `Result<T, E>`
+    /// to propagate unexpected errors as [`CallError`][crate::meta::error::CallError] instead of panicking.
+    #[doc(hidden)]
+    fn __godot_try_into_variant(
+        self,
+        _call_ctx: &crate::meta::CallContext,
+    ) -> Result<Variant, crate::meta::error::CallError> {
+        Ok(self.to_variant())
+    }
+
+    /// Consuming conversion to the Godot `Via` type for `#[func]` ptrcall return values.
+    ///
+    /// Defaults to infallible [`to_godot_owned()`][Self::to_godot_owned]. Overridden for `Result<T, E>`
+    /// to propagate unexpected errors as [`CallError`][crate::meta::error::CallError] instead of panicking.
+    #[doc(hidden)]
+    fn __godot_try_into_godot_owned(
+        self,
+        _call_ctx: &crate::meta::CallContext,
+    ) -> Result<Self::Via, crate::meta::error::CallError> {
+        Ok(self.to_godot_owned())
     }
 }
 
@@ -177,6 +210,32 @@ pub trait EngineToGodot: Sized + GodotConvert {
     }
 
     fn engine_to_variant(&self) -> Variant;
+
+    /// Consuming conversion to `Variant` for `#[func]` varcall return values. Relevant for `Result<T, E>`.
+    ///
+    /// Defaults to infallible [`Self::engine_to_variant()`] for types without `ToGodot` (e.g. `u64`). For `ToGodot` types,
+    /// the blanket impl delegates to [`ToGodot::__godot_try_into_variant()`].
+    //
+    // Could alternatively be avoided by splitting Signature in-call methods into `in_varcall`/`in_ptrcall` (EngineToGodot, for virtual
+    // methods + property accessors) and `in_func_varcall`/`in_func_ptrcall` (ToGodot, for #[func]). That avoids this trait method but
+    // duplicates more code in signature.rs and requires is_func plumbing in the macro. Trying this resulted in ~120 additional LoC.
+    fn engine_try_into_variant(
+        self,
+        _call_ctx: &crate::meta::CallContext,
+    ) -> Result<Variant, crate::meta::error::CallError> {
+        Ok(self.engine_to_variant())
+    }
+
+    /// Consuming conversion to the Godot `Via` type for `#[func]` ptrcall return values.
+    ///
+    /// Defaults to infallible [`Self::engine_to_godot_owned()`]. For `ToGodot` types,
+    /// the blanket impl delegates to [`ToGodot::__godot_try_into_godot_owned()`].
+    fn engine_try_into_godot_owned(
+        self,
+        _call_ctx: &crate::meta::CallContext,
+    ) -> Result<Self::Via, crate::meta::error::CallError> {
+        Ok(self.engine_to_godot_owned())
+    }
 }
 
 // Blanket implementations: all user-facing types work in engine contexts.
@@ -193,6 +252,20 @@ impl<T: ToGodot> EngineToGodot for T {
 
     fn engine_to_variant(&self) -> Variant {
         <T as ToGodot>::to_variant(self)
+    }
+
+    fn engine_try_into_variant(
+        self,
+        call_ctx: &crate::meta::CallContext,
+    ) -> Result<Variant, crate::meta::error::CallError> {
+        T::__godot_try_into_variant(self, call_ctx)
+    }
+
+    fn engine_try_into_godot_owned(
+        self,
+        call_ctx: &crate::meta::CallContext,
+    ) -> Result<Self::Via, crate::meta::error::CallError> {
+        T::__godot_try_into_godot_owned(self, call_ctx)
     }
 }
 

--- a/godot-core/src/meta/signature.rs
+++ b/godot-core/src/meta/signature.rs
@@ -21,9 +21,10 @@ use crate::meta::{
 };
 use crate::obj::{GodotClass, ValidatedObject};
 
-/// Checks for `#[func]` expansions that all parameters implement `FromGodot` and the return type implements `ToGodot`.
+/// Checks for `#[func]` expansions that all parameters implement `FromGodot` and the return type implements `ToGodot`
+/// (or `Result<T: ToGodot, E: ErrorToGodot>`).
 ///
-/// [`Signature`] itself only requires `EngineFromGodot` and `EngineToGodot`.
+/// [`Signature`] itself only requires `EngineFromGodot` and `EngineToGodot` for out-calls.
 #[inline(always)]
 #[doc(hidden)]
 pub fn ensure_func_bounds<Params: TupleFromGodot, Ret: ToGodot>() {}
@@ -94,7 +95,7 @@ where
 
         let rust_result = unsafe { func(instance_ptr, args) };
         // SAFETY: TODO.
-        unsafe { varcall_return::<Ret>(rust_result, ret, err) };
+        unsafe { varcall_return::<Ret>(rust_result, ret, err, call_ctx)? };
         Ok(())
     }
 
@@ -123,7 +124,7 @@ where
         // SAFETY:
         // `ret` is always a pointer to an initialized value of type $R
         // TODO: double-check the above
-        unsafe { ptrcall_return::<Ret>(func(instance_ptr, args), ret, call_ctx, call_type) };
+        unsafe { ptrcall_return::<Ret>(func(instance_ptr, args), ret, call_ctx, call_type)? };
 
         Ok(())
     }
@@ -390,6 +391,8 @@ impl<Params: OutParamTuple, Ret: EngineFromGodot> Signature<Params, Ret> {
 
 /// Moves `ret_val` into `ret`.
 ///
+/// Uses [`ToGodot::__godot_try_into_variant`] (via [`EngineToGodot`]) to support `Result<T, E>` without panicking.
+///
 /// # Safety
 /// - `ret` must be a pointer to an initialized `Variant`.
 /// - It must be safe to write a `Variant` once to `ret`.
@@ -398,12 +401,16 @@ unsafe fn varcall_return<R: EngineToGodot>(
     ret_val: R,
     ret: sys::GDExtensionVariantPtr,
     err: *mut sys::GDExtensionCallError,
-) {
+    call_ctx: &CallContext,
+) -> CallResult<()> {
+    let ret_variant = ret_val.engine_try_into_variant(call_ctx)?;
+
     unsafe {
-        let ret_variant = ret_val.engine_to_variant();
         *(ret as *mut Variant) = ret_variant;
         (*err).error = sys::GDEXTENSION_CALL_OK;
     }
+
+    Ok(())
 }
 
 /// Moves `ret_val` into `ret`, if it is `Ok(...)`. Otherwise sets an error.
@@ -414,18 +421,26 @@ pub(crate) unsafe fn varcall_return_checked<R: ToGodot>(
     ret_val: Result<R, ()>, // TODO Err should be custom CallError enum
     ret: sys::GDExtensionVariantPtr,
     err: *mut sys::GDExtensionCallError,
-) {
-    unsafe {
-        if let Ok(ret_val) = ret_val {
-            varcall_return(ret_val, ret, err);
-        } else {
+    call_ctx: &CallContext,
+) -> CallResult<()> {
+    if let Ok(ret_val) = ret_val {
+        unsafe { varcall_return(ret_val, ret, err, call_ctx)? };
+    } else {
+        unsafe {
             *err = sys::default_call_error();
             (*err).error = sys::GDEXTENSION_CALL_ERROR_INVALID_ARGUMENT;
         }
     }
+    Ok(())
 }
 
 /// Moves `ret_val` into `ret`.
+///
+/// Uses [`ToGodot::__godot_try_into_godot_owned`] (via [`EngineToGodot`]) to check for unexpected (call-failing) `Result<T, E>` errors
+/// and produce the `Via` value in one consuming step. On error, returns `Err(CallError)` without writing to the return pointer.
+///
+/// Note that on the FFI level, ptrcalls have no `r_error` output parameter, so `Result<T, E>` resulting in failed calls (e.g. through
+/// `strat::Unexpected`) can't abort the calling GDScript function. Instead, this results in a Godot error print + default value.
 ///
 /// # Safety
 /// `ret_val`, `ret`, and `call_type` must follow the safety requirements as laid out in
@@ -433,16 +448,19 @@ pub(crate) unsafe fn varcall_return_checked<R: ToGodot>(
 unsafe fn ptrcall_return<R: EngineToGodot>(
     ret_val: R,
     ret: sys::GDExtensionTypePtr,
-    _call_ctx: &CallContext,
+    call_ctx: &CallContext,
     call_type: sys::PtrcallType,
-) {
-    unsafe {
-        // Needs a value (no ref) to be moved; can't use engine_to_godot() + to_ffi().
-        let val = ret_val.engine_to_godot_owned();
-        let ffi = val.into_ffi();
+) -> CallResult<()> {
+    // Consumes ret_val, checks for call-failing outcomes, and produces the Via value directly.
+    // For non-Result types this is a no-op (always Ok) equivalent to engine_to_godot_owned().
+    let val = ret_val.engine_try_into_godot_owned(call_ctx)?;
 
+    unsafe {
+        let ffi = val.into_ffi();
         ffi.move_return_ptr(ret, call_type);
     }
+
+    Ok(())
 }
 
 fn return_error<R>(call_ctx: &CallContext, err: ConvertError) -> ! {

--- a/godot-core/src/private.rs
+++ b/godot-core/src/private.rs
@@ -64,7 +64,7 @@ sys::plugin_registry!(pub __GODOT_DOCS_REGISTRY: DocsPlugin);
 //
 // When a Rust `#[func]` fails (returns Err), the error is stashed here so that Rust's `try_call()` can retrieve it
 // after the Godot round-trip. The varcall FFI callback simultaneously sets a *standard* Godot error code
-// (`GDEXTENSION_CALL_ERROR_INVALID_METHOD`) so that Godot's own GDScript VM recognizes the failure and aborts
+// (`GDEXTENSION_CALL_ERROR_INVALID_ARGUMENT`) so that Godot's own GDScript VM recognizes the failure and aborts
 // the calling script function.
 //
 // Thread-safety: varcall callbacks execute on the calling thread, and `try_call` reads the result on the same
@@ -432,10 +432,14 @@ pub fn handle_fallible_varcall<F, R>(
     F: FnOnce() -> CallResult<R> + std::panic::UnwindSafe,
 {
     if handle_fallible_call(call_ctx, code) {
-        // Use a standard Godot error code so the GDScript VM recognizes the failure and aborts the calling function.
-        // The rich CallError has been stashed in the thread-local for Rust try_call() to retrieve.
+        // Use a non-OK error code so the GDScript VM recognizes the failure and aborts the calling function.
+        // The Rust-side CallError has been stored in the thread-local, so that try_call() can retrieve it later.
+        //
+        // None of the existing call errors is great for this scenario, and all lead to misleading errors in the Godot console.
+        // For now we opted for custom code, which will result in "Bug: Invalid call error code 1337.". Note that INVALID_METHOD
+        // must not be used -- it signals that the method doesn't exist, which can be treated as a fatal static error by GDScript.
         *out_err = sys::GDExtensionCallError {
-            error: sys::GDEXTENSION_CALL_ERROR_INVALID_METHOD,
+            error: 1337 as sys::GDExtensionCallErrorType, // alternative: sys::GDEXTENSION_CALL_ERROR_INSTANCE_IS_NULL.
             argument: 0,
             expected: 0,
         };

--- a/godot/src/prelude.rs
+++ b/godot/src/prelude.rs
@@ -14,7 +14,7 @@ pub use super::global::{
     godot_error, godot_print, godot_print_rich, godot_script_error, godot_warn,
 };
 pub use super::init::{ExtensionLibrary, InitLevel, InitStage, gdextension};
-pub use super::meta::error::ConvertError;
+pub use super::meta::error::{ConvertError, func_bail, strat};
 pub use super::meta::{FromGodot, GodotConvert, ToGodot};
 pub use super::obj::{
     AsDyn, Base, DynGd, DynGdMut, DynGdRef, Gd, GdMut, GdRef, GodotClass, Inherits, InstanceId,

--- a/itest/godot/ManualFfiTests.gd
+++ b/itest/godot/ManualFfiTests.gd
@@ -624,3 +624,111 @@ func test_marshalling_continues_on_panic():
 
 	assert_eq(result, Vector3.ZERO, "Default value returned on failed function call")
 	mark_test_succeeded()
+
+# Verifies the ok path for varcall (untyped Variant) and Object.call() reflection.
+# Both go through varcall, so the return value should be the actual result.
+func test_strat_unexpected_ok_varcall():
+	var obj: Variant = FuncResulter.new()
+	assert_eq(obj.ok_int(), 42, "varcall ok path returns value")
+	assert_eq(obj.call("ok_int"), 42, "Object.call() ok path returns value")
+
+# Verifies the ok path for ptrcall (typed variable).
+func test_strat_unexpected_ok_ptrcall():
+	var obj: FuncResulter = FuncResulter.new()
+	var result: int = obj.ok_int()
+	assert_eq(result, 42, "ptrcall ok path returns value")
+
+# Verifies varcall error path: untyped Variant forces varcall, which aborts the calling GDScript
+# function in debug builds. In release builds, the error code is ignored and execution continues.
+func test_strat_unexpected_err_varcall():
+	var obj: Variant = FuncResulter.new()
+
+	if runs_release():
+		# In release builds, Godot ignores the GDExtension call-error code, so the calling function
+		# is NOT aborted. Execution continues and the return value is default (ret was never written).
+		var result = obj.err_bail()
+		assert_eq(result, null, "Release varcall: error returns null (ret unwritten)")
+	else:
+		expect_fail()
+		var _i = obj.err_bail()
+		assert_fail("err_bail() via varcall should abort calling function in debug")
+
+# Verifies ptrcall error path: typed object forces ptrcall, which has no r_error output parameter.
+# The error is logged but execution always continues with a default return value.
+func test_strat_unexpected_err_ptrcall():
+	mark_test_pending()
+
+	var obj: FuncResulter = FuncResulter.new()
+
+	Engine.print_error_messages = false
+	var result: int = obj.err_bail()
+	Engine.print_error_messages = true
+
+	assert_eq(result, 0, "ptrcall returns default value (0) on error")
+	mark_test_succeeded()
+
+# Verifies Object.call() error path: reflection always uses varcall regardless of obj's static type.
+# Behavior matches untyped Variant varcall.
+func test_strat_unexpected_err_reflection():
+	var obj: FuncResulter = FuncResulter.new()
+
+	if runs_release():
+		var result = obj.call("err_bail")
+		assert_eq(result, null, "Release Object.call(): error returns null (ret unwritten)")
+	else:
+		expect_fail()
+		var _i = obj.call("err_bail")
+		assert_fail("err_bail() via Object.call() should abort calling function in debug")
+
+# Verifies that a Result<(), Error> does NOT abort the calling function in either calling convention.
+# The error enum value is returned directly; execution continues normally.
+func test_strat_error_enum():
+	# Varcall path (untyped Variant).
+	var obj_v: Variant = FuncResulter.new()
+	assert_eq(obj_v.error_ok(), 0, "varcall: error_ok() should return Error.OK (0)")
+	assert_eq(obj_v.error_failed(), 1, "varcall: error_failed() should return Error.FAILED (1)")
+
+	# Ptrcall path (typed variable).
+	var obj_p: FuncResulter = FuncResulter.new()
+	var ok_result: int = obj_p.error_ok()
+	assert_eq(ok_result, 0, "ptrcall: error_ok() should return Error.OK (0)")
+	var err_result: int = obj_p.error_failed()
+	assert_eq(err_result, 1, "ptrcall: error_failed() should return Error.FAILED (1)")
+
+# Verifies that the object remains usable after an Err(Unexpected) via ptrcall.
+# Ptrcall does not abort the calling function, so we can verify recovery inline.
+func test_strat_unexpected_err_recovery_ptrcall():
+	mark_test_pending()
+
+	var obj: FuncResulter = FuncResulter.new()
+
+	# Trigger Unexpected error via ptrcall (does not abort *this* function, just logs error).
+	Engine.print_error_messages = false
+	var _fail: int = obj.err_bail()
+	Engine.print_error_messages = true
+
+	# Call a succeeding method -- the object should still work.
+	var result: int = obj.ok_int()
+	assert_eq(result, 42, "object should remain usable after error in previous ptrcall")
+	mark_test_succeeded()
+
+# Verifies that the object remains usable after an Err(Unexpected) via varcall.
+# Varcall aborts the calling function in debug, so recovery must be checked from a separate call.
+func test_strat_unexpected_err_recovery_varcall():
+	var obj: Variant = FuncResulter.new()
+
+	# Trigger the error. In debug, this aborts *_trigger_varcall_error*, not *this* function.
+	_trigger_varcall_error(obj)
+
+	# The object should still be usable after the failed call.
+	var result = obj.ok_int()
+	assert_eq(result, 42, "object should remain usable after error in previous varcall")
+
+# Helper: triggers an Unexpected error via varcall in a separate function scope,
+# so the abort (in debug builds) doesn't affect the caller's control flow.
+func _trigger_varcall_error(obj: Variant) -> void:
+	Engine.print_error_messages = false
+	var _i = obj.err_bail()
+	# In debug builds, this function is aborted here by the GDScript VM.
+	# In release builds, execution continues (error code ignored).
+	Engine.print_error_messages = true

--- a/itest/rust/src/register_tests/func_result_test.rs
+++ b/itest/rust/src/register_tests/func_result_test.rs
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use godot::builtin::VariantType;
+use godot::global::Error;
+use godot::meta::error::func_bail;
+use godot::prelude::*;
+
+use crate::framework::itest;
+
+#[derive(GodotClass)]
+#[class(init, base=RefCounted)]
+struct FuncResulter;
+
+#[godot_api]
+impl FuncResulter {
+    // ------------------------------------------------------------------------------------------------------------------------------------------
+    // Result<T, global::Error> -- recoverable enum
+
+    #[func]
+    fn error_ok(&self) -> Result<(), Error> {
+        Ok(())
+    }
+
+    #[func]
+    fn error_failed(&self) -> Result<(), Error> {
+        Err(Error::FAILED)
+    }
+
+    // ------------------------------------------------------------------------------------------------------------------------------------------
+    // Result<T, strat::Unexpected> -- fatal with ? ergonomics
+
+    #[func]
+    fn ok_int(&self) -> Result<i64, strat::Unexpected> {
+        // Simulates ? on std::num::ParseIntError.
+        let value = "42".parse::<i64>()?;
+        Ok(value)
+    }
+
+    #[func]
+    fn err_io(&self) -> Result<GString, strat::Unexpected> {
+        // std::io::Error auto-converts via From.
+        let _data = std::fs::read_to_string("/nonexistent/path")?;
+        unreachable!()
+    }
+
+    #[func]
+    fn err_bail(&self) -> Result<i64, strat::Unexpected> {
+        func_bail!("custom message");
+    }
+
+    #[func]
+    fn ok_unit(&self) -> Result<(), strat::Unexpected> {
+        Ok(())
+    }
+
+    #[func]
+    fn err_string(&self) -> Result<i64, strat::Unexpected> {
+        // String also converts via From (through Into<Box<dyn Error>>).
+        let err: String = "string error".into();
+        Err(err.into())
+    }
+
+    #[func]
+    fn err_parse(&self) -> Result<i64, strat::Unexpected> {
+        // ? converts ParseIntError into strat::Unexpected automatically.
+        let score = "not_a_number".parse::<i64>()?;
+        Ok(score)
+    }
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// Tests
+
+#[itest]
+fn func_result_ok_returns_value() {
+    let mut obj = FuncResulter::new_gd();
+
+    let result = obj.call("ok_int", &[]);
+    assert_eq!(result.get_type(), VariantType::INT);
+    assert_eq!(i64::from_variant(&result), 42);
+}
+
+#[itest]
+fn func_result_ok_unit_returns_nil() {
+    let mut obj = FuncResulter::new_gd();
+
+    let result = obj.call("ok_unit", &[]);
+    assert_eq!(result.get_type(), VariantType::NIL);
+}
+
+#[itest]
+fn func_result_try_call_ok_returns_value() {
+    let mut obj = FuncResulter::new_gd();
+
+    let result = obj.try_call("ok_int", &[]);
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap().to::<i64>(), 42);
+}
+
+#[itest]
+fn func_result_err_fails_call() {
+    let mut obj = FuncResulter::new_gd();
+
+    assert!(obj.try_call("err_io", &[]).is_err());
+    assert!(obj.try_call("err_bail", &[]).is_err());
+    assert!(obj.try_call("err_string", &[]).is_err());
+    assert!(obj.try_call("err_parse", &[]).is_err());
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// Other strategies (1 test per strategy)
+
+#[itest]
+fn global_error_returns_enum_value() {
+    let mut obj = FuncResulter::new_gd();
+
+    let ok = obj.call("error_ok", &[]);
+    assert_eq!(ok.get_type(), VariantType::INT);
+    assert_eq!(ok.to::<Error>(), Error::OK);
+
+    let err = obj.call("error_failed", &[]);
+    assert_eq!(err.get_type(), VariantType::INT);
+    assert_eq!(err.to::<Error>(), Error::FAILED);
+}

--- a/itest/rust/src/register_tests/mod.rs
+++ b/itest/rust/src/register_tests/mod.rs
@@ -8,6 +8,7 @@
 mod constant_test;
 mod conversion_test;
 mod derive_godotconvert_test;
+mod func_result_test;
 mod func_test;
 mod gdscript_ffi_test;
 mod multiple_impl_blocks_secondary;


### PR DESCRIPTION
Closes #425.

`Result<T, E>` can now be returned to Godot. The representation on Godot's side depends on `E` and can be tweaked with an `ErrorToGodot` trait.

For now, only a few `E` types are directly supported:
- `Result<T, Unexpected>` is converted as `T` to Godot. In the error case, the function call will print a Godot error. The calling code will either abort the function (in GDScript with varcall and Godot Debug builds) or receive a default value.
- `Result<T, ()>` returns a `Variant` which is either `T::to_variant()` or nil.
- `Result<(), global::Error>` returns the `global::Error` enum.

You could customize this with your own `E` types:
- `Result<T, MyGodotResult>` could return a custom class that requires checking for errors before accessing the value.
- `Result<Array<T>, MyGenericArray>` could emulate an `Option<T>` like type in Godot: `[]` on error, `[T]` on success. Typed but no error value.
- ...

Example usage:
```rs
#[godot_api]
impl PlayerCharacter {
    // Verifies that required nodes are present in the developer-authored scene tree.
    // Missing nodes are a scene setup bug, not an expected runtime condition.
    #[func]
    fn init_player(&mut self) -> Result<(), strat::Unexpected> {
        // Node missing = scene setup bug.
        let Some(hand) = self.base().try_get_node_as::<Node3D>("Skeleton3D/Hand") else {
            func_bail!("Player {}: 3D model is missing a hand", self.id);
        };

        // HashMap loaded at startup; missing or unparseable values are a code bug.
        let max_health = self.config_map
            .get("max_health")
            .ok_or("'max_health' key missing in config")?  // &str
            .parse::<i64>()?;                              // ParseIntError

        // Initialize self with hand + max_health...
        Ok(())
    }

    #[func]
    fn do_fallible_work(&self) -> Result<(), global::Error> {
        // ...
        Ok(())
    }
}
```

I'd like to keep this PR limited in scope, we can add more building blocks for common errors later. But it's important that we get the foundation somewhat right.

One thing that's not too nice is that some impls need an extra bound `ToGodot<Via: Clone>`. I should have made `GodotConvert::Via: Clone` an implied bound, but now that needs to wait until v0.6. Unless I add it directly on `GodotType`... :monocle_face: **Edit:** solved in #1545