### PR TITLE
`GodotConvert::Via: Clone` is now implied

### DIFF
--- a/godot-core/src/builtin/collections/array.rs
+++ b/godot-core/src/builtin/collections/array.rs
@@ -1166,10 +1166,7 @@ impl<T: Element> ToGodot for Array<T> {
         self
     }
 
-    fn to_godot_owned(&self) -> Self::Via
-    where
-        Self::Via: Clone,
-    {
+    fn to_godot_owned(&self) -> Self::Via {
         // Overridden, because default clone() validates that before/after element types are equal, which doesn't matter when we pass to FFI.
         // This may however be an issue if to_godot_owned() is used by the user directly.
         unsafe { self.clone_unchecked() }

--- a/godot-core/src/meta/args/as_arg.rs
+++ b/godot-core/src/meta/args/as_arg.rs
@@ -561,8 +561,7 @@ pub trait ArgPassing: Sealed {
     #[doc(hidden)]
     fn ref_to_owned_via<T>(value: &T) -> T::Via
     where
-        T: EngineToGodot<Pass = Self>,
-        T::Via: Clone;
+        T: EngineToGodot<Pass = Self>;
 
     /// Convert to FFI repr in the most efficient way (move or borrow).
     #[doc(hidden)]
@@ -598,7 +597,6 @@ impl ArgPassing for ByValue {
     fn ref_to_owned_via<T>(value: &T) -> T::Via
     where
         T: EngineToGodot<Pass = Self>,
-        T::Via: Clone,
     {
         value.engine_to_godot()
     }
@@ -629,7 +627,6 @@ impl ArgPassing for ByRef {
     fn ref_to_owned_via<T>(value: &T) -> T::Via
     where
         T: EngineToGodot<Pass = Self>,
-        T::Via: Clone,
     {
         // For ByRef types, clone the reference to get owned value.
         value.engine_to_godot().clone()
@@ -664,7 +661,6 @@ impl ArgPassing for ByVariant {
     fn ref_to_owned_via<T>(value: &T) -> T::Via
     where
         T: EngineToGodot<Pass = Self>,
-        T::Via: Clone,
     {
         value.engine_to_godot().clone()
     }
@@ -696,7 +692,6 @@ impl ArgPassing for ByObject {
     fn ref_to_owned_via<T>(value: &T) -> T::Via
     where
         T: EngineToGodot<Pass = Self>,
-        T::Via: Clone,
     {
         // For ByObject types, do like ByRef: clone the reference to get owned value.
         value.engine_to_godot().clone()
@@ -745,7 +740,6 @@ where
     fn ref_to_owned_via<T>(value: &T) -> T::Via
     where
         T: EngineToGodot<Pass = Self>,
-        T::Via: Clone,
     {
         value.engine_to_godot_owned()
     }

--- a/godot-core/src/meta/args/cow_arg.rs
+++ b/godot-core/src/meta/args/cow_arg.rs
@@ -90,10 +90,7 @@ where
         self.cow_as_ref().to_godot()
     }
 
-    fn to_godot_owned(&self) -> Self::Via
-    where
-        Self::Via: Clone,
-    {
+    fn to_godot_owned(&self) -> Self::Via {
         // Default implementation calls underlying T::to_godot().clone(), which is wrong.
         // Some to_godot_owned() calls are specialized/overridden, we need to honor that.
 

--- a/godot-core/src/meta/args/ref_arg.rs
+++ b/godot-core/src/meta/args/ref_arg.rs
@@ -104,10 +104,7 @@ where
         shared_ref.to_godot()
     }
 
-    fn to_godot_owned(&self) -> Self::Via
-    where
-        Self::Via: Clone,
-    {
+    fn to_godot_owned(&self) -> Self::Via {
         // Default implementation calls underlying T::to_godot().clone(), which is wrong.
         // Some to_godot_owned() calls are specialized/overridden, we need to honor that.
 

--- a/godot-core/src/meta/godot_convert/impls.rs
+++ b/godot-core/src/meta/godot_convert/impls.rs
@@ -88,8 +88,6 @@ impl<T> ToGodot for Option<T>
 where
     // Currently limited to holding objects -> needed to establish to_godot() relation T::to_godot() = Option<&T::Via>.
     T: ToGodot<Pass = meta::ByObject>,
-    // Extra Clone bound for to_godot_owned(); might be extracted in the future.
-    T::Via: Clone,
     // T::Via must be a Godot nullable type (to support the None case).
     for<'f> T::Via: GodotType<
             // Associated types need to be nullable.
@@ -105,10 +103,7 @@ where
         self.as_ref().map(T::to_godot)
     }
 
-    fn to_godot_owned(&self) -> Option<T::Via>
-    where
-        Self::Via: Clone,
-    {
+    fn to_godot_owned(&self) -> Option<T::Via> {
         self.as_ref().map(T::to_godot_owned)
     }
 

--- a/godot-core/src/meta/godot_convert/mod.rs
+++ b/godot-core/src/meta/godot_convert/mod.rs
@@ -90,12 +90,7 @@ pub trait ToGodot: Sized + GodotConvert {
     /// Converts this type to owned Godot representation.
     ///
     /// Always returns `Self::Via`, cloning if necessary for ByRef types.
-    // Future: could potentially split into separate ToGodotOwned trait, which has a blanket impl for T: Clone, while requiring
-    // manual implementation for non-Clone types. This would remove the Via: Clone bound, which can be restrictive.
-    fn to_godot_owned(&self) -> Self::Via
-    where
-        Self::Via: Clone,
-    {
+    fn to_godot_owned(&self) -> Self::Via {
         Self::Pass::ref_to_owned_via(self)
     }
 
@@ -177,10 +172,7 @@ pub trait EngineToGodot: Sized + GodotConvert {
     fn engine_to_godot(&self) -> ToArg<'_, Self::Via, Self::Pass>;
 
     /// Converts this type to owned Godot representation.
-    fn engine_to_godot_owned(&self) -> Self::Via
-    where
-        Self::Via: Clone,
-    {
+    fn engine_to_godot_owned(&self) -> Self::Via {
         Self::Pass::ref_to_owned_via(self)
     }
 
@@ -195,10 +187,7 @@ impl<T: ToGodot> EngineToGodot for T {
         <T as ToGodot>::to_godot(self)
     }
 
-    fn engine_to_godot_owned(&self) -> Self::Via
-    where
-        Self::Via: Clone,
-    {
+    fn engine_to_godot_owned(&self) -> Self::Via {
         <T as ToGodot>::to_godot_owned(self)
     }
 

--- a/godot-core/src/meta/param_tuple/impls.rs
+++ b/godot-core/src/meta/param_tuple/impls.rs
@@ -135,7 +135,7 @@ macro_rules! unsafe_impl_param_tuple {
             }
         }
 
-        impl<$($P),*> OutParamTuple for ($($P,)*) where $($P: EngineToGodot<Via: Clone> + fmt::Debug,)* {
+        impl<$($P),*> OutParamTuple for ($($P,)*) where $($P: EngineToGodot + fmt::Debug,)* {
             fn with_variants<F, R>(self, f: F) -> R
             where
                 F: FnOnce(&[Variant]) -> R,

--- a/godot-core/src/meta/signature.rs
+++ b/godot-core/src/meta/signature.rs
@@ -62,7 +62,7 @@ impl<Params: ParamTuple, Ret: GodotConvert> Signature<Params, Ret> {
 impl<Params, Ret> Signature<Params, Ret>
 where
     Params: InParamTuple,
-    Ret: EngineToGodot<Via: Clone>,
+    Ret: EngineToGodot,
 {
     /// Receive a varcall from Godot, and return the value in `ret` as a variant pointer.
     ///
@@ -429,7 +429,7 @@ pub(crate) unsafe fn varcall_return_checked<R: ToGodot>(
 /// # Safety
 /// `ret_val`, `ret`, and `call_type` must follow the safety requirements as laid out in
 /// [`GodotFuncMarshal::try_return`](sys::GodotFuncMarshal::try_return).
-unsafe fn ptrcall_return<R: EngineToGodot<Via: Clone>>(
+unsafe fn ptrcall_return<R: EngineToGodot>(
     ret_val: R,
     ret: sys::GDExtensionTypePtr,
     _call_ctx: &CallContext,

--- a/godot-core/src/meta/traits.rs
+++ b/godot-core/src/meta/traits.rs
@@ -38,7 +38,7 @@ pub trait GodotFfiVariant: Sized + GodotFfi {
 // type. For instance [`i32`] does not implement `GodotFfi` because it cannot represent all values of
 // Godot's `int` type, however it does implement `GodotType` because we can set the meta-data of values with
 // this type to indicate that they are 32 bits large.
-pub trait GodotType: GodotConvert<Via = Self> + sealed::Sealed + Sized + 'static
+pub trait GodotType: GodotConvert<Via = Self> + Clone + sealed::Sealed + Sized + 'static
 // 'static is not technically required, but it simplifies a few things (limits e.g. `ObjectArg`).
 {
     // Value type for this type's FFI representation.

--- a/godot-core/src/registry/property/mod.rs
+++ b/godot-core/src/registry/property/mod.rs
@@ -81,7 +81,6 @@ pub trait SimpleVar: ToGodot + FromGodot + Clone {}
 impl<T> Var for T
 where
     T: SimpleVar,
-    T::Via: Clone,
 {
     type PubType = Self;
 


### PR DESCRIPTION
`GodotType` now has `Clone` as a supertrait. This is non-breaking since the former is sealed. This change allows to get rid of 18 clauses of the style `where T::Via: Clone`, that cluttered trait definitions without much value.

The limitation is that all future `GodotType`s need indeed be cloneable. This is already the case currently, and given that these typically also implement `ToGodot`/`FromGodot`, a `Clone` is likely to be feasible -- semantically in the worst case as `to_godot()` + `from_godot()` roundtrips.