### PR TITLE
Reorganize `meta` module, move parts to `godot::private`

### DIFF
--- a/godot-codegen/src/util.rs
+++ b/godot-codegen/src/util.rs
@@ -25,7 +25,8 @@ pub fn make_imports() -> TokenStream {
     quote! {
         use godot_ffi as sys;
         use crate::builtin::*;
-        use crate::meta::{AsArg, ClassId, CowArg, InParamTuple, OutParamTuple, ParamTuple, RawPtr, RefArg, Signature};
+        use crate::meta::{AsArg, ClassId, CowArg, InParamTuple, OutParamTuple, ParamTuple, RawPtr, RefArg};
+        use crate::private::Signature;
         use crate::classes::native::*;
         use crate::classes::Object;
         use crate::obj::Gd;

--- a/godot-core/src/builtin/variant/mod.rs
+++ b/godot-core/src/builtin/variant/mod.rs
@@ -30,7 +30,7 @@ mod impls;
 ///
 /// # Conversions
 ///
-/// For type conversions, please read the [`godot::meta` module docs][crate::meta].
+/// For type conversions, please read the [`godot::meta` module docs](../meta/index.html).
 ///
 /// # Godot docs
 ///

--- a/godot-core/src/classes/class_runtime.rs
+++ b/godot-core/src/classes/class_runtime.rs
@@ -23,7 +23,7 @@ mod strict {
 
 #[cfg(safeguards_balanced)]
 mod balanced {
-    pub use crate::meta::CallContext;
+    pub(crate) use crate::meta::CallContext;
 }
 
 #[cfg(safeguards_balanced)]

--- a/godot-core/src/meta/godot_convert/mod.rs
+++ b/godot-core/src/meta/godot_convert/mod.rs
@@ -21,7 +21,7 @@ use crate::meta::{ArgPassing, GodotType, ToArg};
 /// [`GodotType`] is a stronger bound than [`GodotConvert`], since it expresses that a type is _directly_ representable
 /// in Godot (without intermediate "via"). Every `GodotType` also implements `GodotConvert` with `Via = Self`.
 ///
-/// Please read the [`godot::meta` module docs][crate::meta] for further information about conversions.
+/// Please read the [`godot::meta` module docs](index.html) for further information about conversions.
 ///
 /// # u64
 /// The type `u64` is **not** supported by `ToGodot` and `FromGodot` traits. You can thus not pass it in `#[func]` parameters/return types.
@@ -52,7 +52,7 @@ pub trait GodotConvert {
 ///
 /// Violating these assumptions is safe but will give unexpected results.
 ///
-/// Please read the [`godot::meta` module docs][crate::meta] for further information about conversions.
+/// Please read the [`godot::meta` module docs](index.html) for further information about conversions.
 ///
 /// This trait can be derived using the [`#[derive(GodotConvert)]`](../register/derive.GodotConvert.html) macro.
 #[diagnostic::on_unimplemented(
@@ -115,7 +115,7 @@ pub trait ToGodot: Sized + GodotConvert {
 ///
 /// Violating these assumptions is safe but will give unexpected results.
 ///
-/// Please read the [`godot::meta` module docs][crate::meta] for further information about conversions.
+/// Please read the [`godot::meta` module docs](index.html) for further information about conversions.
 ///
 /// This trait can be derived using the [`#[derive(GodotConvert)]`](../register/derive.GodotConvert.html) macro.
 #[diagnostic::on_unimplemented(

--- a/godot-core/src/meta/mod.rs
+++ b/godot-core/src/meta/mod.rs
@@ -55,6 +55,13 @@ mod uniform_object_deref;
 
 pub(crate) mod sealed;
 
+/// Re-exports for proc-macros and generated code. Not part of the public API.
+#[doc(hidden)]
+pub mod private_reexport {
+    pub use super::param_tuple::TupleFromGodot;
+    pub use super::signature::{CallContext, Signature, ensure_func_bounds};
+}
+
 pub mod conv;
 pub mod error;
 pub mod inspect;
@@ -66,18 +73,20 @@ pub use args::*;
 pub use class_id::ClassId;
 pub use godot_convert::{EngineFromGodot, EngineToGodot, FromGodot, GodotConvert, ToGodot};
 pub use object_to_owned::ObjectToOwned;
-pub use param_tuple::{InParamTuple, OutParamTuple, ParamTuple, TupleFromGodot};
+pub(crate) use param_tuple::TupleFromGodot;
+pub use param_tuple::{InParamTuple, OutParamTuple, ParamTuple};
 pub use raw_ptr::{FfiRawPointer, RawPtr};
 #[cfg(feature = "trace")]
 pub use signature::trace;
-#[doc(hidden)]
-pub use signature::*;
+pub(crate) use signature::{CallContext, Signature, varcall_return_checked};
 pub use signed_range::{SignedRange, wrapped};
 pub use traits::{Element, GodotImmutable, GodotType, PackedElement, element_variant_type};
 pub use uniform_object_deref::UniformObjectDeref;
 
 // Macro re-exports (used as `meta::arg_into_owned!` etc.).
+#[doc(hidden)]
 pub use crate::arg_into_owned;
+#[doc(hidden)]
 pub use crate::arg_into_ref;
 
 // Crate-local re-exports.

--- a/godot-core/src/meta/signature.rs
+++ b/godot-core/src/meta/signature.rs
@@ -14,9 +14,10 @@ use sys::GodotFfi;
 
 use crate::builtin::Variant;
 use crate::meta::error::{CallError, CallResult, ConvertError};
+use crate::meta::param_tuple::TupleFromGodot;
 use crate::meta::{
     EngineFromGodot, EngineToGodot, FromGodot, GodotConvert, GodotType, InParamTuple,
-    MethodParamOrReturnInfo, OutParamTuple, ParamTuple, ToGodot, TupleFromGodot,
+    MethodParamOrReturnInfo, OutParamTuple, ParamTuple, ToGodot,
 };
 use crate::obj::{GodotClass, ValidatedObject};
 

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -89,7 +89,7 @@ use crate::{classes, meta, out};
 ///
 /// # Conversions
 ///
-/// For type conversions, please read the [`godot::meta` module docs][crate::meta].
+/// For type conversions, please read the [`godot::meta` module docs](../meta/index.html).
 ///
 /// # Exporting
 ///

--- a/godot-core/src/private.rs
+++ b/godot-core/src/private.rs
@@ -13,7 +13,6 @@ use std::sync::atomic;
 use sys::Global;
 
 use crate::global::godot_error;
-use crate::meta::CallContext;
 use crate::meta::error::{CallError, CallResult};
 use crate::obj::Gd;
 use crate::registry::property::Var;
@@ -23,12 +22,14 @@ use crate::{classes, sys};
 // Public re-exports
 
 mod reexport_pub {
+    pub use crate::arg_into_owned;
     #[cfg(all(since_api = "4.3", feature = "register-docs"))]
     pub use crate::docs::{DocsItem, DocsPlugin, InherentImplDocs, StructDocs};
     pub use crate::r#gen::classes::class_macros;
     pub use crate::r#gen::virtuals; // virtual fn names, hashes, signatures
+    pub use crate::meta::private_reexport::*;
     #[cfg(feature = "trace")]
-    pub use crate::meta::trace;
+    pub use crate::meta::{CowArg, FfiArg, trace};
     pub use crate::obj::rtti::ObjectRtti;
     pub use crate::obj::signal::priv_re_export::*;
     pub use crate::registry::callbacks;

--- a/godot-macros/src/class/data_models/func.rs
+++ b/godot-macros/src/class/data_models/func.rs
@@ -172,7 +172,7 @@ pub fn make_method_registration(
         let sig_ret_span = signature_info.params_span; // Alternative: sig_ret's span (first token).
 
         quote_spanned! { sig_ret_span=>
-            ::godot::meta::ensure_func_bounds::<CallParams, CallRet>();
+            ::godot::private::ensure_func_bounds::<CallParams, CallRet>();
         }
     };
 
@@ -688,7 +688,7 @@ fn make_ptrcall_invocation(wrapped_method: &TokenStream, is_virtual: bool) -> To
     };
 
     quote! {
-        ::godot::meta::Signature::<CallParams, CallRet>::in_ptrcall(
+        ::godot::private::Signature::<CallParams, CallRet>::in_ptrcall(
             instance_ptr,
             &call_ctx,
             args_ptr,
@@ -707,7 +707,7 @@ fn make_varcall_invocation(
     quote! {
         {
             let defaults = #default_parameters;
-            ::godot::meta::Signature::<CallParams, CallRet>::in_varcall(
+            ::godot::private::Signature::<CallParams, CallRet>::in_varcall(
                 instance_ptr,
                 &call_ctx,
                 args_ptr,
@@ -723,7 +723,7 @@ fn make_varcall_invocation(
 
 fn make_call_context(class_name_str: &str, method_name_str: &str) -> TokenStream {
     quote! {
-        ::godot::meta::CallContext::func(#class_name_str, #method_name_str)
+        ::godot::private::CallContext::func(#class_name_str, #method_name_str)
     }
 }
 

--- a/godot-macros/src/class/data_models/inherent_impl.rs
+++ b/godot-macros/src/class/data_models/inherent_impl.rs
@@ -506,7 +506,7 @@ fn add_virtual_script_call(
             type CallRet = #call_ret;
             let args = (#( #arg_names, )*);
             unsafe {
-                ::godot::meta::Signature::<CallParams, CallRet>::out_script_virtual_call(
+                ::godot::private::Signature::<CallParams, CallRet>::out_script_virtual_call(
                     #class_name_str,
                     #method_name_str,
                     method_sname_ptr,

--- a/godot-macros/src/class/data_models/signal.rs
+++ b/godot-macros/src/class/data_models/signal.rs
@@ -397,7 +397,7 @@ fn make_signal_individual_struct(details: &SignalDetails) -> TokenStream {
             pub fn emit(&mut self, #emit_params) {
                 use ::godot::meta::AsArg;
                 #(
-                    ::godot::meta::arg_into_owned!(infer #param_names);
+                    ::godot::private::arg_into_owned!(infer #param_names);
                     //let #param_names = #param_names.into_arg();
                 )*
 

--- a/godot/src/lib.rs
+++ b/godot/src/lib.rs
@@ -253,32 +253,15 @@ pub mod init {
 
 /// Meta-information about Godot types, their properties and conversions between them.
 pub mod meta {
-    // Submodules.
-    // Derive macro (moved from `register`).
-    pub use godot_core::meta::ClassId;
-    #[doc(hidden)]
-    pub use godot_core::meta::arg_into_owned;
-    #[cfg(feature = "__trace")]
-    #[doc(hidden)]
-    pub use godot_core::meta::trace;
-    // Argument conversions that stay in flat `meta`.
-    pub use godot_core::meta::{AsArg, ObjectArg, ToArg, owned_into_arg, ref_to_arg};
-    // Hidden internal items for proc-macros and generated code.
-    #[doc(hidden)]
-    pub use godot_core::meta::{CallContext, Signature, ensure_func_bounds};
-    #[cfg(feature = "__trace")]
-    #[doc(hidden)]
-    pub use godot_core::meta::{CowArg, FfiArg};
-    // Type traits.
     pub use godot_core::meta::{
-        Element, GodotImmutable, GodotType, PackedElement, element_variant_type,
+        AsArg, ClassId, Element, EngineFromGodot, EngineToGodot, FromGodot, GodotConvert,
+        GodotImmutable, GodotType, ObjectArg, PackedElement, SignedRange, ToArg, ToGodot,
+        element_variant_type, owned_into_arg, ref_to_arg, wrapped,
     };
-    // Conversion traits.
-    pub use godot_core::meta::{EngineFromGodot, EngineToGodot, FromGodot, GodotConvert, ToGodot};
-    // Range utilities.
-    pub use godot_core::meta::{SignedRange, wrapped};
     #[doc(inline)]
     pub use godot_core::meta::{conv, error, inspect, shape};
+    // TODO(v0.6): this re-export prevents `godot::meta` from being a module alias `#[doc(inline)] pub use godot_core::meta`.
+    // If resolved by moving macro, search for "meta/index.html" (or just "index.html") and revert those links to `[...][crate::meta]`.
     pub use godot_macros::GodotConvert;
 }
 

--- a/itest/rust/src/builtin_tests/convert_test.rs
+++ b/itest/rust/src/builtin_tests/convert_test.rs
@@ -10,10 +10,10 @@ use godot::builtin::{
     array, iarray, vdict,
 };
 use godot::classes::{Node, Resource};
-use godot::meta;
 use godot::meta::error::ConvertError;
-use godot::meta::{AsArg, CowArg, FromGodot, GodotConvert, ToGodot};
+use godot::meta::{AsArg, FromGodot, GodotConvert, ToGodot};
 use godot::obj::{Gd, NewAlloc};
+use godot::private::CowArg;
 
 use crate::framework::itest;
 
@@ -376,6 +376,8 @@ fn strings_as_arg() {
 
 #[itest]
 fn to_arg_helpers() {
+    use godot::meta;
+
     let i: i8 = 3;
     let mut ints = iarray![1, 2];
     ints.push(meta::ref_to_arg(&i));


### PR DESCRIPTION
Hidden items only used by proc-macros and generated code are removed from the public `godot::meta` module and re-exported via `godot::private`, instead through a new `godot_core::meta::private_reexport` submodule.

The `godot::meta` module retains all legitimately public API items.

Also fixes doc links to `meta` (which need to be HTML right now -- we cannot re-export `godot_core::meta` as-is because `godot::meta` also contains a derive macro, and godot-core doesn't depend on godot-macros).