### PR TITLE
Focused GDScript itests

### DIFF
--- a/itest/godot/InheritTests.gd
+++ b/itest/godot/InheritTests.gd
@@ -14,6 +14,9 @@ func reset_state():
 func is_test_failed() -> bool:
 	return test_suite.is_test_failed()
 
+func run_test(suite: RefCounted, method_name: String) -> GDScriptTestRunner.GDScriptTestCase:
+	return test_suite.run_test(suite, method_name)
+
 # In order to reproduce the behavior discovered in https://github.com/godot-rust/gdext/issues/138
 # we must inherit a Godot Node. Because of this we can't just inherit TesSuite like the rest of the tests.
 func assert_that(what: bool, message: String = "") -> bool:

--- a/itest/godot/TestRunner.gd
+++ b/itest/godot/TestRunner.gd
@@ -47,19 +47,13 @@ func _ready():
 		load("res://InheritTests.gd").new(),
 		load("res://ScriptInstanceTests.gd").new(),
 	]
-	
-	var gdscript_tests: Array = []
-	for suite in gdscript_suites:
-		for method in suite.get_method_list():
-			var method_name: String = method.name
-			if method_name.begins_with("test_"):
-				gdscript_tests.push_back(GDScriptExecutableTestCase.new(suite, method_name))
 
 	var special_case_test_suites: Array = [
 		load("res://SpecialTests.gd").new(),
 	]
 
-	for suite in special_case_test_suites:
+	var gdscript_tests: Array = []
+	for suite in gdscript_suites + special_case_test_suites:
 		for method in suite.get_method_list():
 			var method_name: String = method.name
 			if method_name.begins_with("test_"):

--- a/itest/godot/TestRunner.gd
+++ b/itest/godot/TestRunner.gd
@@ -46,18 +46,18 @@ func _ready():
 		load("res://gen/GenFfiTests.gd").new(),
 		load("res://InheritTests.gd").new(),
 		load("res://ScriptInstanceTests.gd").new(),
-	]
-
-	var special_case_test_suites: Array = [
 		load("res://SpecialTests.gd").new(),
 	]
 
+	var gdscript_focused_run := _has_focused_tests(gdscript_suites)
+	var prefix := "focus_test_" if gdscript_focused_run else "test_"
+
 	var gdscript_tests: Array = []
-	for suite in gdscript_suites + special_case_test_suites:
+	for suite in gdscript_suites:
 		for method in suite.get_method_list():
-			var method_name: String = method.name
-			if method_name.begins_with("test_"):
-				gdscript_tests.push_back(await suite.run_test(suite, method_name))
+			if method.name.begins_with(prefix):
+				# Always use `await` -- it does nothing on synchronous run_test() methods.
+				gdscript_tests.push_back(await suite.run_test(suite, method.name))
 
 	var property_tests = load("res://gen/GenPropertyTests.gd").new()
 
@@ -73,12 +73,20 @@ func _ready():
 		gdscript_tests,
 		gdscript_suites.size(),
 		allow_focus,
+		gdscript_focused_run,
 		self,
 		filters,
 		property_tests,
 		run_benchmarks
 	)
 
+
+func _has_focused_tests(suites: Array) -> bool:
+	for suite in suites:
+		for method in suite.get_method_list():
+			if method.name.begins_with("focus_test_"):
+				return true
+	return false
 
 
 class GDScriptTestCase:

--- a/itest/godot/TestSuite.gd
+++ b/itest/godot/TestSuite.gd
@@ -21,6 +21,9 @@ func reset_state() -> void:
 func is_test_failed() -> bool:
 	return _assertion_failed
 
+func run_test(suite: RefCounted, method_name: String) -> GDScriptTestRunner.GDScriptTestCase:
+	return GDScriptTestRunner.GDScriptExecutableTestCase.new(suite, method_name)
+
 # -----------------------------------------------------------------------------------------------------------------------------------------------
 # Protected API, called by individual test .gd files.
 

--- a/itest/rust/src/framework/mod.rs
+++ b/itest/rust/src/framework/mod.rs
@@ -32,18 +32,18 @@ sys::plugin_registry!(pub(crate) __GODOT_BENCH: RustBenchmark);
 fn collect_rust_tests(filters: &[String]) -> (Vec<RustTestCase>, HashSet<&str>, bool) {
     let mut all_files = HashSet::new();
     let mut tests: Vec<RustTestCase> = vec![];
-    let mut is_focus_run = false;
+    let mut is_focused_run = false;
 
     sys::plugin_foreach!(__GODOT_ITEST; |test: &RustTestCase| {
         // First time a focused test is encountered, switch to "focused" mode and throw everything away.
-        if !is_focus_run && test.focused {
+        if !is_focused_run && test.focused {
             tests.clear();
             all_files.clear();
-            is_focus_run = true;
+            is_focused_run = true;
         }
 
         // Only collect tests if normal mode, or focus mode and test is focused.
-        if (!is_focus_run || test.focused) && passes_filter(filters, test.name) {
+        if (!is_focused_run || test.focused) && passes_filter(filters, test.name) {
             all_files.insert(test.file);
             tests.push(*test);
         }
@@ -52,28 +52,28 @@ fn collect_rust_tests(filters: &[String]) -> (Vec<RustTestCase>, HashSet<&str>, 
     // Sort alphabetically for deterministic run order
     tests.sort_by_key(|test| test.file);
 
-    (tests, all_files, is_focus_run)
+    (tests, all_files, is_focused_run)
 }
 
 /// Finds all `#[itest(async)]` tests.
 fn collect_async_rust_tests(
     filters: &[String],
-    sync_focus_run: bool,
+    sync_focused_run: bool,
 ) -> (Vec<AsyncRustTestCase>, HashSet<&str>, bool) {
     let mut all_files = HashSet::new();
     let mut tests = vec![];
-    let mut is_focus_run = sync_focus_run;
+    let mut is_focused_run = sync_focused_run;
 
     sys::plugin_foreach!(__GODOT_ASYNC_ITEST; |test: &AsyncRustTestCase| {
         // First time a focused test is encountered, switch to "focused" mode and throw everything away.
-        if !is_focus_run && test.focused {
+        if !is_focused_run && test.focused {
             tests.clear();
             all_files.clear();
-            is_focus_run = true;
+            is_focused_run = true;
         }
 
         // Only collect tests if normal mode, or focus mode and test is focused.
-        if (!is_focus_run || test.focused) && passes_filter(filters, test.name) {
+        if (!is_focused_run || test.focused) && passes_filter(filters, test.name) {
             all_files.insert(test.file);
             tests.push(*test);
         }
@@ -82,7 +82,7 @@ fn collect_async_rust_tests(
     // Sort alphabetically for deterministic run order
     tests.sort_by_key(|test| test.file);
 
-    (tests, all_files, is_focus_run)
+    (tests, all_files, is_focused_run)
 }
 
 /// Finds all `#[bench]` benchmarks.

--- a/itest/rust/src/framework/runner.rs
+++ b/itest/rust/src/framework/runner.rs
@@ -30,7 +30,7 @@ struct TestStats {
 #[class(init)]
 pub struct IntegrationTests {
     stats: TestStats,
-    focus_run: bool,
+    focused_run: bool,
 }
 
 #[godot_api]
@@ -43,6 +43,7 @@ impl IntegrationTests {
         gdscript_tests: VarArray,
         gdscript_file_count: i64,
         allow_focus: bool,
+        gdscript_focused: bool,
         scene_tree: Gd<Node>,
         filters: VarArray,
         property_tests: Gd<Node>,
@@ -60,16 +61,31 @@ impl IntegrationTests {
 
         let rust_test_cases = collect_rust_tests(&filters);
 
-        // Print based on focus/not focus.
-        self.focus_run = rust_test_cases.focus_run;
-        if rust_test_cases.focus_run {
-            println!("  {FMT_CYAN}Focused run{FMT_END} -- execute only selected Rust tests.")
+        let rust_focused = rust_test_cases.focused_run;
+        let focused = rust_focused || gdscript_focused;
+        self.focused_run = focused;
+
+        // If the other side is focused (and this side is not), skip this side entirely.
+        let run_rust = !gdscript_focused || rust_focused;
+        let run_gdscript = !rust_focused || gdscript_focused;
+
+        // Print focus/count header.
+        let focus_which = match (rust_focused, gdscript_focused) {
+            (false, false) => None,
+            (true, false) => Some("Rust"),
+            (false, true) => Some("GDScript"),
+            (true, true) => Some("Rust and GDScript"),
+        };
+        if let Some(which) = focus_which {
+            println!("  {FMT_CYAN}Focused run{FMT_END} -- execute only selected {which} tests.");
         }
-        println!(
-            "  Rust: found {} tests in {} files.",
-            rust_test_cases.rust_test_count, rust_test_cases.rust_file_count
-        );
-        if !rust_test_cases.focus_run {
+        if run_rust {
+            println!(
+                "  Rust: found {} tests in {} files.",
+                rust_test_cases.rust_test_count, rust_test_cases.rust_file_count
+            );
+        }
+        if run_gdscript {
             println!(
                 "  GDScript: found {} tests in {} files.",
                 gdscript_tests.len(),
@@ -77,15 +93,17 @@ impl IntegrationTests {
             );
         }
 
+        let (rust_tests, async_rust_tests) = if run_rust {
+            (rust_test_cases.rust_tests, rust_test_cases.async_rust_tests)
+        } else {
+            (vec![], vec![])
+        };
+
         let clock = Instant::now();
-        self.run_rust_tests(
-            rust_test_cases.rust_tests,
-            scene_tree.clone(),
-            property_tests.clone(),
-        );
+        self.run_rust_tests(rust_tests, scene_tree.clone(), property_tests.clone());
         let rust_time = clock.elapsed();
 
-        let gdscript_time = if !rust_test_cases.focus_run {
+        let gdscript_time = if run_gdscript {
             let extra_duration = self.run_gdscript_tests(gdscript_tests);
             Some((clock.elapsed() - rust_time, extra_duration))
         } else {
@@ -109,6 +127,7 @@ impl IntegrationTests {
                     &stats,
                     rust_time + rust_async_time,
                     gdscript_time.map(|(elapsed, extra)| elapsed + extra),
+                    focused,
                     allow_focus,
                 );
 
@@ -118,7 +137,7 @@ impl IntegrationTests {
 
             Self::run_async_rust_tests(
                 stats,
-                rust_test_cases.async_rust_tests,
+                async_rust_tests,
                 scene_tree,
                 property_tests,
                 on_finalize_test,
@@ -135,7 +154,7 @@ impl IntegrationTests {
     #[allow(clippy::uninlined_format_args)]
     #[func]
     fn run_all_benchmarks(&mut self, scene_tree: Gd<Node>) {
-        if self.focus_run {
+        if self.focused_run {
             println!("  Benchmarks skipped (focused run).");
             return;
         }
@@ -303,6 +322,7 @@ impl IntegrationTests {
         stats: &TestStats,
         rust_time: Duration,
         gdscript_time: Option<Duration>,
+        focused_run: bool,
         allow_focus: bool,
     ) -> bool {
         let TestStats {
@@ -320,7 +340,6 @@ impl IntegrationTests {
 
         let rust_time = rust_time.as_secs_f32();
         let gdscript_time = gdscript_time.map(|t| t.as_secs_f32());
-        let focused_run = gdscript_time.is_none();
 
         let extra = if *skipped > 0 {
             format!(", {skipped} skipped")
@@ -583,16 +602,16 @@ struct RustTestCases {
     async_rust_tests: Vec<AsyncRustTestCase>,
     rust_test_count: usize,
     rust_file_count: usize,
-    focus_run: bool,
+    focused_run: bool,
 }
 
 fn collect_rust_tests(filters: &[String]) -> RustTestCases {
-    let (mut rust_tests, mut rust_files, focus_run) = super::collect_rust_tests(filters);
+    let (mut rust_tests, mut rust_files, focused_run) = super::collect_rust_tests(filters);
 
-    let (async_rust_tests, async_rust_files, async_focus_run) =
-        super::collect_async_rust_tests(filters, focus_run);
+    let (async_rust_tests, async_rust_files, async_focused_run) =
+        super::collect_async_rust_tests(filters, focused_run);
 
-    if !focus_run && async_focus_run {
+    if !focused_run && async_focused_run {
         rust_tests.clear();
         rust_files.clear();
     }
@@ -605,7 +624,7 @@ fn collect_rust_tests(filters: &[String]) -> RustTestCases {
         async_rust_tests,
         rust_test_count,
         rust_file_count,
-        focus_run: focus_run || async_focus_run,
+        focused_run: focused_run || async_focused_run,
     }
 }
 


### PR DESCRIPTION
GDScript test methods named `focus_test_*` are treated as focused, mirroring `#[itest(focus)]` in Rust.
If any such method exists, only focused tests will run and all other tests (Rust, GDScript) are skipped. 

`--disallow-focus` also enforces that focused changes don't pass at CI level.