### PR TITLE
Replace `GodotNullableFfi` with `GodotNullableType`

### DIFF
--- a/godot-core/src/meta/args/as_arg.rs
+++ b/godot-core/src/meta/args/as_arg.rs
@@ -7,7 +7,7 @@
 
 use crate::builtin::{Callable, GString, NodePath, Signal, StringName, Variant};
 use crate::meta::sealed::Sealed;
-use crate::meta::traits::{Element, GodotFfiVariant, GodotNullableFfi, PackedElement};
+use crate::meta::traits::{Element, GodotFfiVariant, GodotNullableType, PackedElement};
 use crate::meta::{CowArg, EngineToGodot, FfiArg, GodotType, ObjectArg, ToGodot};
 use crate::obj::{DynGd, Gd, GodotClass, Inherits};
 
@@ -722,8 +722,7 @@ pub enum ByOption<Via> {
 impl<Via> Sealed for ByOption<Via> {}
 impl<Via> ArgPassing for ByOption<Via>
 where
-    Via: GodotType,
-    for<'f> Via::ToFfi<'f>: GodotNullableFfi,
+    Via: GodotNullableType,
 {
     type Output<'r, T: 'r>
         = Option<&'r Via>
@@ -747,11 +746,13 @@ where
     fn ref_to_ffi<T>(value: &T) -> Self::FfiOutput<'_, T::Via>
     where
         T: EngineToGodot<Pass = Self>,
-        T::Via: GodotType,
     {
         // Reuse pattern from impl GodotType for Option<T>:
         // Convert Option<&Via> to Option<Via::ToFfi> and then flatten to Via::ToFfi with null handling.
-        GodotNullableFfi::flatten_option(value.engine_to_godot().map(|via_ref| via_ref.to_ffi()))
+        value
+            .engine_to_godot()
+            .map(|via_ref| via_ref.to_ffi())
+            .unwrap_or_else(Via::ffi_null_ref)
     }
 }
 

--- a/godot-core/src/meta/args/as_arg.rs
+++ b/godot-core/src/meta/args/as_arg.rs
@@ -567,8 +567,7 @@ pub trait ArgPassing: Sealed {
     #[doc(hidden)]
     fn ref_to_ffi<T>(value: &T) -> Self::FfiOutput<'_, T::Via>
     where
-        T: EngineToGodot<Pass = Self>,
-        T::Via: GodotType;
+        T: EngineToGodot<Pass = Self>;
 
     /// Convert to `Variant` in the most efficient way (move or borrow).
     #[doc(hidden)]
@@ -604,7 +603,6 @@ impl ArgPassing for ByValue {
     fn ref_to_ffi<T>(value: &T) -> Self::FfiOutput<'_, T::Via>
     where
         T: EngineToGodot<Pass = Self>,
-        T::Via: GodotType,
     {
         // For ByValue: engine_to_godot() returns owned T::Via, move directly to FFI.
         GodotType::into_ffi(value.engine_to_godot())
@@ -635,7 +633,6 @@ impl ArgPassing for ByRef {
     fn ref_to_ffi<T>(value: &T) -> <T::Via as GodotType>::ToFfi<'_>
     where
         T: EngineToGodot<Pass = Self>,
-        T::Via: GodotType,
     {
         // Use by-ref conversion if possible, avoiding unnecessary clones when passing to FFI.
         GodotType::to_ffi(value.engine_to_godot())
@@ -668,7 +665,6 @@ impl ArgPassing for ByVariant {
     fn ref_to_ffi<T>(value: &T) -> <T::Via as GodotType>::ToFfi<'_>
     where
         T: EngineToGodot<Pass = Self>,
-        T::Via: GodotType,
     {
         GodotType::to_ffi(value.engine_to_godot())
     }
@@ -700,7 +696,6 @@ impl ArgPassing for ByObject {
     fn ref_to_ffi<T>(value: &T) -> ObjectArg<'_>
     where
         T: EngineToGodot<Pass = Self>,
-        T::Via: GodotType,
     {
         let obj_ref: &T::Via = value.engine_to_godot(); // implements GodotType.
         obj_ref.as_object_arg()

--- a/godot-core/src/meta/args/cow_arg.rs
+++ b/godot-core/src/meta/args/cow_arg.rs
@@ -8,7 +8,7 @@
 use std::fmt;
 use std::ops::Deref;
 
-use godot_ffi::{ExtVariantType, GodotFfi, GodotNullableFfi, PtrcallType};
+use godot_ffi::{ExtVariantType, GodotFfi, PtrcallType};
 
 use crate::builtin::Variant;
 use crate::meta::error::ConvertError;
@@ -110,19 +110,6 @@ where
     }
 }
 
-impl<T> GodotNullableFfi for CowArg<'_, T>
-where
-    T: GodotNullableFfi,
-{
-    fn null() -> Self {
-        CowArg::Owned(T::null())
-    }
-
-    fn is_null(&self) -> bool {
-        self.cow_as_ref().is_null()
-    }
-}
-
 impl<T> Deref for CowArg<'_, T> {
     type Target = T;
 
@@ -136,22 +123,6 @@ impl<T> Deref for CowArg<'_, T> {
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // FfiArg implementations
-
-impl<T> GodotNullableFfi for FfiArg<'_, T>
-where
-    T: GodotNullableFfi,
-{
-    fn null() -> Self {
-        FfiArg::Cow(CowArg::Owned(T::null()))
-    }
-
-    fn is_null(&self) -> bool {
-        match self {
-            FfiArg::Cow(cow_arg) => cow_arg.is_null(),
-            FfiArg::FfiObject(obj_arg) => obj_arg.is_null(),
-        }
-    }
-}
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/godot-core/src/meta/args/object_arg.rs
+++ b/godot-core/src/meta/args/object_arg.rs
@@ -7,7 +7,7 @@
 
 use std::ptr;
 
-use godot_ffi::{ExtVariantType, GodotFfi, GodotNullableFfi, PtrcallType};
+use godot_ffi::{ExtVariantType, GodotFfi, PtrcallType};
 
 use crate::builtin::Variant;
 use crate::meta::error::ConvertError;
@@ -122,15 +122,5 @@ impl<'gd> GodotFfiVariant for ObjectArg<'gd> {
 
     fn ffi_from_variant(_variant: &Variant) -> Result<Self, ConvertError> {
         unreachable!("ObjectArg should only be passed *to* Godot, not *from*.")
-    }
-}
-
-impl<'gd> GodotNullableFfi for ObjectArg<'gd> {
-    fn null() -> Self {
-        Self::null()
-    }
-
-    fn is_null(&self) -> bool {
-        Self::is_null(self)
     }
 }

--- a/godot-core/src/meta/args/ref_arg.rs
+++ b/godot-core/src/meta/args/ref_arg.rs
@@ -7,7 +7,7 @@
 
 use std::fmt;
 
-use godot_ffi::{ExtVariantType, GodotFfi, GodotNullableFfi, PtrcallType};
+use godot_ffi::{ExtVariantType, GodotFfi, PtrcallType};
 
 use crate::builtin::Variant;
 use crate::meta::error::ConvertError;
@@ -22,7 +22,7 @@ use crate::sys;
 /// Private type. Cannot be `pub(crate)` because it's used in `#[doc(hidden)]` associate type `GodotType::ToFfi<'f>`, and `GodotType` is public.
 #[doc(hidden)]
 pub struct RefArg<'r, T> {
-    /// Only `None` if `T: GodotNullableFfi` and `T::is_null()` is true.
+    /// Only `None` for nullable types (`Option<Gd<...>>::None`).
     shared_ref: Option<&'r T>,
 }
 
@@ -34,6 +34,11 @@ impl<'r, T> RefArg<'r, T> {
         RefArg {
             shared_ref: Some(shared_ref),
         }
+    }
+
+    /// Creates a null `RefArg`, used for `Option<Gd<...>>::None`.
+    pub(crate) fn null_ref() -> Self {
+        RefArg { shared_ref: None }
     }
 
     // Note: the following APIs are not used by gdext itself, but exist for user convenience, since
@@ -48,15 +53,15 @@ impl<'r, T> RefArg<'r, T> {
         self.shared_ref.expect("RefArg is null")
     }
 
-    /// Returns the stored reference.
-    ///
-    /// Returns `None` if `T` is `Option<Gd<...>>::None`.
-    pub fn get_ref_or_none(&self) -> Option<&T>
+    /* Currently not needed, might be useful in future.
+    /// Returns the stored reference, or `None` if this represents a null object (`Option<Gd<...>>::None`).
+    pub(crate) fn get_ref_or_none(&self) -> Option<&T>
     where
-        T: GodotNullableFfi,
+        T: GodotNullableType,
     {
         self.shared_ref
     }
+    */
 
     /// Returns the stored reference.
     ///
@@ -201,18 +206,5 @@ where
 
     fn ffi_from_variant(_variant: &Variant) -> Result<Self, ConvertError> {
         wrong_direction!(ffi_from_variant)
-    }
-}
-
-impl<T> GodotNullableFfi for RefArg<'_, T>
-where
-    T: GodotNullableFfi,
-{
-    fn null() -> Self {
-        RefArg { shared_ref: None }
-    }
-
-    fn is_null(&self) -> bool {
-        self.shared_ref.is_none_or(T::is_null)
     }
 }

--- a/godot-core/src/meta/godot_convert/impls.rs
+++ b/godot-core/src/meta/godot_convert/impls.rs
@@ -9,7 +9,7 @@ use crate::builtin::{Array, Variant};
 use crate::meta;
 use crate::meta::error::{ConvertError, ErrorKind, FromFfiError};
 use crate::meta::shape::GodotShape;
-use crate::meta::{Element, FromGodot, GodotConvert, GodotNullableFfi, GodotType, ToGodot};
+use crate::meta::{Element, FromGodot, GodotConvert, GodotNullableType, GodotType, ToGodot};
 use crate::registry::info::ParamMetadata;
 
 // The following ToGodot/FromGodot/Convert impls are auto-generated for each engine type, co-located with their definitions:
@@ -19,26 +19,22 @@ use crate::registry::info::ParamMetadata;
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Option<T>
 
-impl<T> GodotType for Option<T>
-where
-    T: GodotType,
-    T::Ffi: GodotNullableFfi,
-    for<'f> T::ToFfi<'f>: GodotNullableFfi,
-{
+impl<T: GodotNullableType> GodotType for Option<T> {
     type Ffi = T::Ffi;
-
     type ToFfi<'f> = T::ToFfi<'f>;
 
     fn to_ffi(&self) -> Self::ToFfi<'_> {
-        GodotNullableFfi::flatten_option(self.as_ref().map(|t| t.to_ffi()))
+        self.as_ref()
+            .map(|t| t.to_ffi())
+            .unwrap_or_else(T::ffi_null_ref)
     }
 
     fn into_ffi(self) -> Self::Ffi {
-        GodotNullableFfi::flatten_option(self.map(|t| t.into_ffi()))
+        self.map(|t| t.into_ffi()).unwrap_or_else(T::ffi_null)
     }
 
     fn try_from_ffi(ffi: Self::Ffi) -> Result<Self, ConvertError> {
-        if ffi.is_null() {
+        if T::ffi_is_null(&ffi) {
             return Ok(None);
         }
 
@@ -46,7 +42,7 @@ where
     }
 
     fn from_ffi(ffi: Self::Ffi) -> Self {
-        if ffi.is_null() {
+        if T::ffi_is_null(&ffi) {
             return None;
         }
 
@@ -89,11 +85,7 @@ where
     // Currently limited to holding objects -> needed to establish to_godot() relation T::to_godot() = Option<&T::Via>.
     T: ToGodot<Pass = meta::ByObject>,
     // T::Via must be a Godot nullable type (to support the None case).
-    for<'f> T::Via: GodotType<
-            // Associated types need to be nullable.
-            Ffi: GodotNullableFfi,
-            ToFfi<'f>: GodotNullableFfi,
-        >,
+    T::Via: GodotNullableType,
     // Previously used bound, not needed right now but don't remove: Option<T::Via>: GodotType,
 {
     // Basically ByRef, but allows Option<T> -> Option<&T::Via> conversion.

--- a/godot-core/src/meta/mod.rs
+++ b/godot-core/src/meta/mod.rs
@@ -73,12 +73,10 @@ pub use args::*;
 pub use class_id::ClassId;
 pub use godot_convert::{EngineFromGodot, EngineToGodot, FromGodot, GodotConvert, ToGodot};
 pub use object_to_owned::ObjectToOwned;
-pub(crate) use param_tuple::TupleFromGodot;
 pub use param_tuple::{InParamTuple, OutParamTuple, ParamTuple};
 pub use raw_ptr::{FfiRawPointer, RawPtr};
 #[cfg(feature = "trace")]
 pub use signature::trace;
-pub(crate) use signature::{CallContext, Signature, varcall_return_checked};
 pub use signed_range::{SignedRange, wrapped};
 pub use traits::{Element, GodotImmutable, GodotType, PackedElement, element_variant_type};
 pub use uniform_object_deref::UniformObjectDeref;
@@ -89,10 +87,12 @@ pub use crate::arg_into_owned;
 #[doc(hidden)]
 pub use crate::arg_into_ref;
 
-// Crate-local re-exports.
+// Crate-local re-exports. Done like this to prevent rustfmt from mixing with public export.
 mod reexport_crate {
+    pub(crate) use super::param_tuple::TupleFromGodot;
+    pub(crate) use super::signature::{CallContext, Signature, varcall_return_checked};
     pub(crate) use super::traits::{
-        ExtVariantType, GodotFfiVariant, GodotNullableFfi, ffi_variant_type,
+        ExtVariantType, GodotFfiVariant, GodotNullableType, ffi_variant_type,
     };
     pub(crate) use crate::impl_godot_as_self;
     // Private imports for this module only.

--- a/godot-core/src/meta/sealed.rs
+++ b/godot-core/src/meta/sealed.rs
@@ -10,7 +10,7 @@
 // To ensure the user does not implement `GodotType` for their own types.
 use crate::builtin::*;
 use crate::meta;
-use crate::meta::traits::{Element, GodotNullableFfi, GodotType};
+use crate::meta::traits::{Element, GodotNullableType};
 use crate::obj::{DynGd, Gd, GodotClass, RawGd};
 
 pub trait Sealed {}
@@ -62,12 +62,7 @@ impl<T: GodotClass> Sealed for Gd<T> {}
 impl<T: GodotClass> Sealed for RawGd<T> {}
 impl<T: GodotClass, D: ?Sized> Sealed for DynGd<T, D> {}
 impl<T: GodotClass, D: ?Sized + 'static> Sealed for Option<DynGd<T, D>> {}
-impl<T> Sealed for Option<T>
-where
-    T: GodotType,
-    T::Ffi: GodotNullableFfi,
-{
-}
+impl<T: GodotNullableType> Sealed for Option<T> {}
 impl<T> Sealed for *mut T {} // FfiRawPointer.
 impl<T> Sealed for *const T {} // FfiRawPointer.
 impl<T1> Sealed for (T1,) {}

--- a/godot-core/src/meta/traits.rs
+++ b/godot-core/src/meta/traits.rs
@@ -15,7 +15,7 @@ use crate::registry::info::ParamMetadata;
 
 // Re-export sys traits in this module, so all are in one place.
 #[rustfmt::skip] // Do not reorder.
-pub use sys::{ExtVariantType, GodotFfi, GodotNullableFfi};
+pub use sys::{ExtVariantType, GodotFfi};
 
 pub use crate::builtin::meta_reexport::PackedElement;
 
@@ -88,7 +88,7 @@ pub trait GodotType: GodotConvert<Via = Self> + Clone + sealed::Sealed + Sized +
     ///
     /// Returning false only means that this is not a special case, not that it cannot be `None`. Regular checks are expected to run afterward.
     ///
-    /// This exists only for var-calls and serves a similar purpose as `GodotNullableFfi::is_null()` (although that handles general cases).
+    /// This exists only for var-calls and serves a similar purpose as `GodotNullableType::ffi_is_null()` (although that handles general cases).
     #[doc(hidden)]
     fn qualifies_as_special_none(_from_variant: &Variant) -> bool {
         false
@@ -109,6 +109,30 @@ pub trait GodotType: GodotConvert<Via = Self> + Clone + sealed::Sealed + Sized +
             std::any::type_name::<Self>()
         )
     }
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+
+/// Types representing nullable Godot objects (e.g., `Gd<T>`, `DynGd<T, D>`).
+///
+/// This trait enables blanket implementations for [`Option<T>`] across conversions and argument passing,
+/// without exposing internal FFI details in public where-clause bounds.
+///
+/// Implemented for `Gd<T>` directly. `DynGd<T, D>` benefits through `Via = Gd<T>`.
+pub(crate) trait GodotNullableType: GodotType {
+    /// Creates a null FFI owned value.
+    #[doc(hidden)]
+    fn ffi_null() -> Self::Ffi;
+
+    /// Creates a null borrowed FFI value.
+    #[doc(hidden)]
+    fn ffi_null_ref<'f>() -> Self::ToFfi<'f>
+    where
+        Self: 'f;
+
+    /// Checks whether an FFI value represents null.
+    #[doc(hidden)]
+    fn ffi_is_null(ffi: &Self::Ffi) -> bool;
 }
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------

--- a/godot-core/src/obj/casts.rs
+++ b/godot-core/src/obj/casts.rs
@@ -8,8 +8,6 @@
 use std::marker::PhantomData;
 use std::mem::ManuallyDrop;
 
-use godot_ffi::GodotNullableFfi;
-
 use crate::obj::{GodotClass, RawGd};
 use crate::sys;
 

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -15,7 +15,9 @@ use sys::{SysPtr as _, static_assert_eq_size_align};
 use crate::builtin::{Callable, NodePath, StringName, Variant};
 use crate::meta::error::{ConvertError, FromFfiError};
 use crate::meta::shape::GodotShape;
-use crate::meta::{AsArg, ClassId, Element, FromGodot, GodotConvert, GodotType, RefArg, ToGodot};
+use crate::meta::{
+    AsArg, ClassId, Element, FromGodot, GodotConvert, GodotNullableType, GodotType, RefArg, ToGodot,
+};
 use crate::obj::{
     Bounds, DynGd, GdDerefTarget, GdMut, GdRef, GodotClass, Inherits, InstanceId, OnEditor, RawGd,
     WithBaseField, WithSignals, bounds, cap,
@@ -1028,6 +1030,23 @@ impl<T: GodotClass> GodotType for Gd<T> {
 }
 
 impl<T: GodotClass> Element for Gd<T> {}
+
+impl<T: GodotClass> GodotNullableType for Gd<T> {
+    fn ffi_null() -> RawGd<T> {
+        RawGd::null()
+    }
+
+    fn ffi_null_ref<'f>() -> RefArg<'f, RawGd<T>>
+    where
+        Self: 'f,
+    {
+        RefArg::null_ref()
+    }
+
+    fn ffi_is_null(ffi: &RawGd<T>) -> bool {
+        ffi.is_null()
+    }
+}
 
 impl<T: GodotClass> Element for Option<Gd<T>> {}
 

--- a/godot-core/src/obj/on_editor.rs
+++ b/godot-core/src/obj/on_editor.rs
@@ -6,7 +6,7 @@
  */
 
 use crate::meta::shape::GodotShape;
-use crate::meta::{FromGodot, GodotConvert, GodotType};
+use crate::meta::{FromGodot, GodotConvert};
 use crate::registry::property::{BuiltinExport, Export, Var};
 
 /// Exported property that must be initialized in the editor (or associated code) before use.
@@ -346,7 +346,7 @@ impl<T> std::ops::DerefMut for OnEditor<T> {
 impl<T> GodotConvert for OnEditor<T>
 where
     T: GodotConvert,
-    T::Via: GodotType + BuiltinExport,
+    T::Via: BuiltinExport,
 {
     type Via = T::Via;
 

--- a/godot-core/src/obj/raw_gd.rs
+++ b/godot-core/src/obj/raw_gd.rs
@@ -8,7 +8,7 @@
 use std::{fmt, ptr};
 
 use godot_ffi as sys;
-use sys::{ExtVariantType, GodotFfi, GodotNullableFfi, PtrcallType, interface_fn};
+use sys::{ExtVariantType, GodotFfi, PtrcallType, interface_fn};
 
 use crate::builtin::{Variant, VariantType};
 #[cfg(safeguards_balanced)]
@@ -99,6 +99,15 @@ impl<T: GodotClass> RawGd<T> {
     /// This does not check if the object is dead. For that, use [`is_instance_valid()`](Self::is_instance_valid).
     pub(crate) fn is_null(&self) -> bool {
         self.obj.is_null() || self.cached_rtti.is_none()
+    }
+
+    /// Creates a null object pointer.
+    pub(crate) fn null() -> Self {
+        Self {
+            obj: ptr::null_mut(),
+            cached_rtti: None,
+            cached_storage_ptr: InstanceCache::null(),
+        }
     }
 
     pub(crate) fn instance_id_unchecked(&self) -> Option<InstanceId> {
@@ -720,21 +729,6 @@ impl<T: GodotClass> GodotFfiVariant for RawGd<T> {
             }
             .into_error(raw)
         })
-    }
-}
-
-impl<T: GodotClass> GodotNullableFfi for RawGd<T> {
-    /// Create a new object representing a null in Godot.
-    fn null() -> Self {
-        Self {
-            obj: ptr::null_mut(),
-            cached_rtti: None,
-            cached_storage_ptr: InstanceCache::null(),
-        }
-    }
-
-    fn is_null(&self) -> bool {
-        Self::is_null(self)
     }
 }
 

--- a/godot-core/src/registry/property/mod.rs
+++ b/godot-core/src/registry/property/mod.rs
@@ -7,9 +7,7 @@
 
 //! Registration support for property types.
 
-use godot_ffi::GodotNullableFfi;
-
-use crate::meta::{ClassId, FromGodot, GodotConvert, GodotType, ToGodot};
+use crate::meta::{ClassId, FromGodot, GodotConvert, GodotNullableType, ToGodot};
 
 mod phantom_var;
 
@@ -132,7 +130,7 @@ pub trait Export: Var {
 
 /// Marker trait to identify `GodotType`s that can be directly used with an `#[export]`.
 ///
-/// Implemented pretty much for all [`GodotType`]s that are not [`GodotClass`][crate::obj::GodotClass]es.
+/// Implemented pretty much for all [`GodotType`][crate::meta::GodotType]s that are not [`GodotClass`][crate::obj::GodotClass]es.
 /// By itself, this trait has no implications for the [`Var`] or [`Export`] traits.
 ///
 /// Types which don't implement the `BuiltinExport` trait can't be used directly as an `#[export]`
@@ -309,12 +307,7 @@ where
 {
 }
 
-impl<T> BuiltinExport for Option<T>
-where
-    T: GodotType,
-    T::Ffi: GodotNullableFfi,
-{
-}
+impl<T: GodotNullableType> BuiltinExport for Option<T> {}
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Export machinery

--- a/godot-ffi/src/godot_ffi.rs
+++ b/godot-ffi/src/godot_ffi.rs
@@ -99,24 +99,6 @@ pub unsafe trait GodotFfi {
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 
-/// Types that can represent null-values.
-///
-/// Used to blanket implement various conversions over `Option<T>`.
-///
-/// This is currently only implemented for `RawGd`.
-// TODO: Consider implementing for `Variant`.
-pub trait GodotNullableFfi: Sized + GodotFfi {
-    fn null() -> Self;
-
-    fn is_null(&self) -> bool;
-
-    fn flatten_option(opt: Option<Self>) -> Self {
-        opt.unwrap_or_else(Self::null)
-    }
-}
-
-// ----------------------------------------------------------------------------------------------------------------------------------------------
-
 /// Variant type that differentiates between `Variant` and `NIL` types.
 #[doc(hidden)]
 #[derive(Copy, Clone, Eq, PartialEq)]

--- a/godot-ffi/src/lib.rs
+++ b/godot-ffi/src/lib.rs
@@ -104,9 +104,7 @@ pub use init_level::*;
 pub use string_cache::StringCache;
 pub use toolbox::*;
 
-pub use crate::godot_ffi::{
-    ExtVariantType, GodotFfi, GodotNullableFfi, PrimitiveConversionError, PtrcallType,
-};
+pub use crate::godot_ffi::{ExtVariantType, GodotFfi, PrimitiveConversionError, PtrcallType};
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // API to access Godot via FFI


### PR DESCRIPTION
Remove the internal `GodotNullableFfi` trait and replace it with a high-level `GodotNullableType` trait. This keeps FFI details out of public bounds while centralizing null handling on the `Gd<T>` type.

Simplifies `T::ToFfi: GodotNullableFfi` -> `T: GodotNullableType`.

Particularly nice cleanup -- before:
```rs
impl<T> GodotType for Option<T>
where
    T: GodotType,
    T::Ffi: GodotNullableFfi,
    for<'f> T::ToFfi<'f>: GodotNullableFfi,
{
```
After:
```rs
impl<T: GodotNullableType> GodotType for Option<T> {
```