### PR TITLE
Import Godot docs for classes 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ rust-version = "1.94"
 # regular dependencies. Sort alphabetically within each section; comments about a dependency come on the section header.
 [workspace.dependencies]
 # Related to godot-rust.
-gdextension-api = { version = "0.3.3", git = "https://github.com/godot-rust/godot4-prebuilt", branch = "release-v0.3" }
+gdextension-api = { version = "0.4.0", git = "https://github.com/godot-rust/godot4-prebuilt", branch = "release-v0.4" }
 
 # Main library features.
 glam = { version = "0.32", features = ["debug-glam-assert"] }

--- a/godot-bindings/src/godot_exe.rs
+++ b/godot-bindings/src/godot_exe.rs
@@ -155,7 +155,9 @@ fn dump_extension_api(godot_bin: &Path, out_file: &Path) {
     let mut cmd = Command::new(godot_bin);
     cmd.current_dir(cwd)
         .arg("--headless")
-        .arg("--dump-extension-api");
+        // Available since Godot 4.2
+        // See: https://github.com/godotengine/godot/pull/82331
+        .arg("--dump-extension-api-with-docs");
 
     execute(cmd, "dump Godot JSON file");
     println!("Generated {}/extension_api.json.", cwd.display());

--- a/godot-codegen/src/context.rs
+++ b/godot-codegen/src/context.rs
@@ -9,6 +9,7 @@ use std::collections::{HashMap, HashSet};
 
 use proc_macro2::{Ident, TokenStream};
 use quote::{ToTokens, format_ident};
+use regex::Regex;
 
 use crate::generator::method_tables::MethodTableKey;
 use crate::generator::notifications;
@@ -33,6 +34,7 @@ pub struct Context<'a> {
     notification_enum_names_by_class: HashMap<TyName, NotificationEnum>,
     method_table_indices: HashMap<MethodTableKey, usize>,
     method_table_next_index: HashMap<String, usize>,
+    import_regexes: ImportRegexes,
 }
 
 impl<'a> Context<'a> {
@@ -356,6 +358,10 @@ impl<'a> Context<'a> {
         let prev = self.cached_rust_types.insert(godot_ty, resolved);
         assert!(prev.is_none(), "no overwrites of RustTy");
     }
+
+    pub fn regexes(&self) -> &ImportRegexes {
+        &self.import_regexes
+    }
 }
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -447,5 +453,53 @@ impl InheritanceTree {
         }
 
         false
+    }
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+
+/// A collection of compiled regexes that are used when importing docs.
+pub struct ImportRegexes {
+    pub newlines: Regex,
+    pub bold_tags: Regex,
+    pub italic_tags: Regex,
+    pub code_tags: Regex,
+    // Keyboard shortcuts, e.g. "Ctrl + S".
+    pub kbd_tags: Regex,
+    pub url_tags: Regex,
+    pub codeblocks_tags: Regex,
+    pub codeblock_tags: Regex,
+    pub codeblock_lang_tags: Regex,
+    pub gdscript_tags: Regex,
+    pub csharp_tags: Regex,
+    pub type_links: Regex,
+    pub method_links: Regex,
+    pub unimplemented_links: Regex,
+}
+
+impl Default for ImportRegexes {
+    fn default() -> Self {
+        fn regex(s: &str) -> Regex {
+            Regex::new(s).unwrap()
+        }
+
+        Self {
+            newlines: regex(r#"(\[codeblocks?( lang=.*?)?\](?:.|\n)*?\[\/codeblocks?\])|(\n)"#),
+            bold_tags: regex(r#"\[b\](.*?)\[\/b\]"#),
+            italic_tags: regex(r#"\[i\](.*?)\[\/i\]"#),
+            code_tags: regex(r#"\[code( skip-lint)?\](.*?)\[\/code\]"#),
+            kbd_tags: regex(r#"\[kbd\](.*?)\[\/kbd\]"#),
+            url_tags: regex(r#"\[url=(.*?)\](.*?)\[\/url\]"#),
+            codeblocks_tags: regex(r#"\[codeblocks\]([\s\S]*?)\[\/codeblocks\]"#),
+            codeblock_tags: regex(r#"\[codeblock\]([\s\S]*?)\[\/codeblock\]"#),
+            codeblock_lang_tags: regex(r#"\[codeblock lang=(.*?)\]([\s\S]*?)\[\/codeblock\]"#),
+            gdscript_tags: regex(r#"\[gdscript\]([\s\S]*?)\[\/gdscript\]"#),
+            csharp_tags: regex(r#"\[csharp\]([\s\S]*?)\[\/csharp\]"#),
+            type_links: regex(r#"\[([a-zA-Z0-9@]+?)\]"#),
+            method_links: regex(r#"\[method ((([a-zA-Z0-9@]+?)\.)?([a-zA-Z0-9_]+?))\]"#),
+            unimplemented_links: regex(
+                r#"\[(annotation|constant|member|enum|param|constructor|signal)\s.*?\]"#,
+            ),
+        }
     }
 }

--- a/godot-codegen/src/generator/classes.rs
+++ b/godot-codegen/src/generator/classes.rs
@@ -110,6 +110,14 @@ fn make_class(class: &Class, ctx: &mut Context, view: &ApiView) -> GeneratedClas
     let mut extended_class_doc = construct_doc.replace("Self", &class_name.rust_ty.to_string());
     extended_class_doc.push_str(final_doc.unwrap_or_default());
 
+    if let Some(description) = &class.description
+        && !description.is_empty()
+    {
+        extended_class_doc.push_str("\n# Godot docs\n");
+        let imported_doc = super::import_docs::import_class_docs(description, class, ctx, view);
+        extended_class_doc.push_str(&imported_doc);
+    }
+
     let api_level = class.api_level;
     let init_level = api_level.to_init_level();
 

--- a/godot-codegen/src/generator/import_docs.rs
+++ b/godot-codegen/src/generator/import_docs.rs
@@ -1,0 +1,226 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use std::fmt::Write;
+
+use crate::context::Context;
+use crate::models::domain::{ApiView, Class, ClassLike, Function, TyName};
+use crate::{special_cases, util};
+
+type CowStr = std::borrow::Cow<'static, str>;
+
+pub fn import_class_docs(
+    description: &str,
+    class: &Class,
+    ctx: &Context,
+    view: &ApiView,
+) -> String {
+    let mut result = replace_simple_tags(description, ctx);
+    result = replace_type_links(&result, class, ctx);
+    result = replace_method_links(&result, class, ctx, view);
+    result = replace_unimplemented_links(&result, ctx);
+
+    result
+}
+
+fn replace_unimplemented_links(str: &str, ctx: &Context) -> String {
+    ctx.regexes()
+        .unimplemented_links
+        .replace_all(str, "\\$0")
+        .to_string()
+}
+
+fn replace_simple_tags(str: &str, ctx: &Context) -> String {
+    let re = ctx.regexes();
+
+    // Replace \n with \n\n everywhere except codeblock tags.
+    let result = re.newlines.replace_all(str, "$1$3$3");
+
+    let result = re.bold_tags.replace_all(&result, "**$1**");
+    let result = re.italic_tags.replace_all(&result, "_${1}_");
+    let result = re.code_tags.replace_all(&result, "`$2`");
+    let result = re.kbd_tags.replace_all(&result, "`$1`");
+    let result = re.url_tags.replace_all(&result, "[$2]($1)");
+    let result = re.codeblocks_tags.replace_all(&result, "$1");
+    let result = re.codeblock_tags.replace_all(&result, "```gdscript$1```");
+    let result = re.codeblock_lang_tags.replace_all(&result, "```$1$2```");
+    let result = re.gdscript_tags.replace_all(&result, "```gdscript$1```");
+    let result = re.csharp_tags.replace_all(&result, "```csharp$1```");
+
+    result.to_string()
+}
+
+fn replace_type_links(doc: &str, class: &Class, ctx: &Context) -> String {
+    let mut result = String::new();
+    let mut previous = 0;
+    for captures in ctx.regexes().type_links.captures_iter(doc) {
+        let whole_match = captures.get(0).unwrap();
+        let start = whole_match.start();
+        let end = whole_match.end();
+        if doc[end..].starts_with("(http") {
+            continue;
+        }
+        let class_name = captures.get(1).unwrap();
+        let class_name = class_name.as_str();
+        result.push_str(&doc[previous..start]);
+
+        // If we encounter a deleted or primitive type, or an ignored link, we insert it without any links or formatting.
+        if special_cases::is_godot_type_deleted(class_name)
+            || matches_primitive_type(class_name)
+            || matches_ignored_links(class_name)
+        {
+            write!(result, "{class_name}").unwrap();
+        } else {
+            let path = get_class_rust_path(class_name, ctx);
+            let current_class_name = class.name().rust_ty.to_string();
+
+            // If a link points to the current class, then do not create a link tag in Markdown to reduce noise.
+            if current_class_name == class_name {
+                write!(result, "`{class_name}`").unwrap();
+            } else {
+                write!(result, "[{class_name}][{path}]").unwrap();
+            }
+        }
+        previous = end;
+    }
+    result.push_str(&doc[previous..]);
+    result
+}
+
+fn matches_primitive_type(ty: &str) -> bool {
+    matches!(ty, "int" | "float" | "bool")
+}
+
+fn matches_ignored_links(class: &str) -> bool {
+    // We don't have a single place to point @GDScript to.
+    class == "@GDScript"
+}
+
+fn replace_method_links(doc: &str, class: &Class, ctx: &Context, view: &ApiView) -> String {
+    let mut result = String::new();
+    let mut previous = 0;
+
+    for captures in ctx.regexes().method_links.captures_iter(doc) {
+        let whole_match = captures.get(0).unwrap();
+        let start = whole_match.start();
+        let end = whole_match.end();
+        if doc[end..].starts_with("(http") {
+            continue;
+        }
+        result.push_str(&doc[previous..start]);
+        let method_path = captures.get(1).unwrap().as_str();
+
+        if let Some(method_path) = convert_to_method_path(method_path, class, ctx, view) {
+            let (_, method_name) = method_path
+                .rsplit_once("::")
+                .expect("rsplit_once should return a method name");
+            write!(result, "[{method_name}][`{method_path}`]").unwrap();
+        } else {
+            write!(result, "\\{}", whole_match.as_str()).unwrap();
+        }
+
+        previous = end;
+    }
+    result.push_str(&doc[previous..]);
+
+    result
+}
+
+fn convert_to_method_path(
+    class_method: &str,
+    class: &Class,
+    ctx: &Context,
+    view: &ApiView,
+) -> Option<CowStr> {
+    // Get the class name from the link if it has one, otherwise, use the current class's name.
+    // For example, if we are generating docs for the `CanvasItem` class and see an "Object._notification" link
+    // take "Object" as the class name and "_notification" as the method name. But if we see a "queue_redraw"
+    // link, take the current class's name(in our case it's "CanvasItem") as the class that owns the method.
+    let (link_godot_class, link_godot_method) =
+        if let Some((class_name, method_name)) = class_method.split_once('.') {
+            (class_name, method_name)
+        } else {
+            (class.name().godot_ty.as_str(), class_method)
+        };
+
+    let link_godot_method = util::safe_ident(link_godot_method).to_string();
+
+    if let (true, ret) = matches_hardcoded_method(link_godot_class, &link_godot_method) {
+        return ret;
+    }
+
+    if let Some(class) = view.find_engine_class(&TyName::from_godot(link_godot_class))
+        && let Some(method) = class
+            .methods
+            .iter()
+            .find(|method| method.godot_name() == link_godot_method)
+    {
+        let godot_method_name = link_godot_method.trim_start_matches("_");
+        if method.is_private() {
+            return None;
+        }
+        if method.is_virtual() {
+            if class.is_final {
+                // Final classes don't have an associated trait with virtual methods.
+                return None;
+            } else {
+                let path = format!(
+                    "crate::classes::{}::{}",
+                    class.name().virtual_trait_name(),
+                    godot_method_name
+                );
+                return Some(path.into());
+            }
+        }
+    }
+
+    let godot_method_name = link_godot_method.trim_start_matches("_");
+    let rust_class_path = get_class_rust_path(link_godot_class, ctx);
+    Some(format!("{rust_class_path}::{godot_method_name}").into())
+}
+
+fn matches_hardcoded_method(godot_class: &str, godot_method: &str) -> (bool, Option<CowStr>) {
+    let path = match (godot_class, godot_method) {
+        ("Object", "free") => "crate::obj::Gd::free".into(),
+        ("Object", "get_instance_id") => "crate::obj::Gd::instance_id".into(),
+        ("Object", "notification") => "crate::classes::Object::notify".into(),
+        ("Object", "_notification") => "crate::classes::IObject::on_notification".into(),
+        ("GDScript", "new") => "crate::obj::NewGd::new_gd".into(),
+        ("@GlobalScope", "instance_from_id") => "crate::obj::Gd::from_instance_id".into(),
+        ("@GlobalScope", "is_instance_valid") => "crate::obj::Gd::is_instance_valid".into(),
+        ("@GDScript", "load") => "crate::tools::load".into(),
+        ("@GDScript", "save") => "crate::tools::save".into(),
+        ("@GlobalScope", _) => format!("crate::global::{}", godot_method).into(),
+        ("@GDScript", _) => return (true, None),
+        _ => return (false, None),
+    };
+
+    (true, Some(path))
+}
+
+fn convert_builtin_types(type_name: &str) -> Option<&'static str> {
+    match type_name {
+        "String" => Some("crate::builtin::GString"),
+        "Array" => Some("crate::builtin::Array"),
+        "Dictionary" => Some("crate::builtin::Dictionary"),
+        _ => None,
+    }
+}
+
+fn get_class_rust_path(godot_class_name: &str, ctx: &Context) -> CowStr {
+    if let Some(hardcoded_builtin_type) = convert_builtin_types(godot_class_name) {
+        return hardcoded_builtin_type.into();
+    }
+
+    let is_builtin = ctx.is_builtin(godot_class_name);
+    let rust_class_name = crate::conv::to_pascal_case(godot_class_name);
+    if is_builtin {
+        format!("crate::builtin::{rust_class_name}").into()
+    } else {
+        format!("crate::classes::{rust_class_name}").into()
+    }
+}

--- a/godot-codegen/src/generator/mod.rs
+++ b/godot-codegen/src/generator/mod.rs
@@ -23,6 +23,7 @@ pub mod enums;
 pub mod extension_interface;
 pub mod functions_common;
 pub mod gdext_build_struct;
+pub mod import_docs;
 pub mod lifecycle_builtins;
 pub mod method_tables;
 pub mod native_structures;

--- a/godot-codegen/src/models/domain.rs
+++ b/godot-codegen/src/models/domain.rs
@@ -67,6 +67,10 @@ impl<'a> ApiView<'a> {
             .get(ty)
             .unwrap_or_else(|| panic!("specified type `{}` is not an engine class", ty.godot_ty))
     }
+
+    pub fn find_engine_class(&self, ty: &TyName) -> Option<&'a Class> {
+        self.class_by_ty.get(ty).cloned()
+    }
 }
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
@@ -169,6 +173,7 @@ pub struct Class {
     pub enums: Vec<Enum>,
     pub methods: Vec<ClassMethod>,
     pub signals: Vec<ClassSignal>,
+    pub description: Option<String>,
 }
 
 impl ClassLike for Class {

--- a/godot-codegen/src/models/domain_mapping.rs
+++ b/godot-codegen/src/models/domain_mapping.rs
@@ -135,6 +135,9 @@ impl Class {
             .as_ref()
             .map(|godot_name| TyName::from_godot(godot_name));
 
+        // TODO(v0.6): find a better way than cloning (borrow, swap, ...).
+        let description = json.description.clone();
+
         Some(Self {
             common: ClassCommons {
                 name: ty_name,
@@ -150,6 +153,7 @@ impl Class {
             enums,
             methods,
             signals,
+            description,
         })
     }
 }

--- a/godot-codegen/src/models/json.rs
+++ b/godot-codegen/src/models/json.rs
@@ -81,6 +81,8 @@ pub struct JsonClass {
     pub methods: Option<Vec<JsonClassMethod>>,
     // pub properties: Option<Vec<Property>>,
     pub signals: Option<Vec<JsonSignal>>,
+    // Not all extensions declare a description field.
+    pub description: Option<String>,
 }
 
 #[derive(DeJson)]


### PR DESCRIPTION
This PR adds importing Godot docs for classes that are in `godot::classes`. 

This PR only affects class documentation (no method, setter/getter, signal docs etc).

A few points to discuss:

1. Should we add a class name to the method link if the method belongs to another class (not the current one) ? `CanvasItem` docs mention `Object::notification`, this could improve readability. Instead of showing `notification` show `Object::notification` in the docs.
2. Currently the path to classes is hardcoded (`crate::classes::`), would be good to use some singular method to get a rust path to the mapped Godot class (or I just missed one?).
3. I made it so if a link can't be converted then it will be inserted as is, this removes warnings related to some edge cases (e.g missing rust mirror entity of Godot entity) and for cases where existence of a struct depends on a cargo feature. For example `Skeleton2D` docs mention `SkeletonModificationStack2D` type which doesn't exist without `experimental-godot-api` feature. This could become a problem later if we change something and links would stop converting properly and we wouldn't even know.

If points above doesn't require a solution in the current PR then it can be merged.