### PR TITLE
Codegen directly uses correct module path for global enums

### DIFF
--- a/godot-codegen/src/conv/type_conversions.rs
+++ b/godot-codegen/src/conv/type_conversions.rs
@@ -15,7 +15,7 @@ use quote::{ToTokens, quote};
 use crate::context::Context;
 use crate::conv;
 use crate::models::domain::{ArgPassing, FlowDirection, GodotTy, ModName, RustTy, TyName};
-use crate::special_cases::is_builtin_type_scalar;
+use crate::special_cases::{get_global_enum_rust_path, is_builtin_type_scalar};
 use crate::util::ident;
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
@@ -345,10 +345,11 @@ pub(crate) fn to_enum_type_uncached(enum_or_bitfield: &str, is_bitfield: bool) -
         to_class_enum_uncached("Resource", enum_or_bitfield, is_bitfield)
     } else {
         // Global enum or bitfield.
+        let path = get_global_enum_rust_path(enum_or_bitfield);
         let enum_or_bitfield_name = conv::make_enum_name(enum_or_bitfield);
 
         RustTy::EngineEnum {
-            tokens: quote! { crate::global::#enum_or_bitfield_name },
+            tokens: quote! { #path::#enum_or_bitfield_name },
             surrounding_class: None,
             is_bitfield,
         }

--- a/godot-codegen/src/special_cases/special_cases.rs
+++ b/godot-codegen/src/special_cases/special_cases.rs
@@ -29,7 +29,8 @@
 
 use std::borrow::Cow;
 
-use proc_macro2::Ident;
+use proc_macro2::{Ident, TokenStream};
+use quote::quote;
 
 use crate::Context;
 use crate::conv::to_enum_type_uncached;
@@ -1265,6 +1266,15 @@ pub fn is_enum_private(class_name: Option<&TyName>, enum_name: &str) -> bool {
         | (None, "MethodFlags")
 
         => true, _ => false
+    }
+}
+
+/// Returns the Rust module path of a global Godot enum (instead of `crate::global::EnumName`).
+pub fn get_global_enum_rust_path(enum_name: &str) -> TokenStream {
+    match enum_name {
+        "PropertyHint" | "PropertyUsageFlags" | "MethodFlags" => quote! { crate::registry::info },
+        "Corner" | "EulerOrder" | "Side" => quote! { crate::builtin },
+        _ => quote! { crate::global },
     }
 }
 

--- a/godot-core/src/global/mod.rs
+++ b/godot-core/src/global/mod.rs
@@ -25,16 +25,16 @@
 //!
 //! - Color: [`ColorChannelOrder`][crate::builtin::ColorChannelOrder]
 //! - Projection: [`ProjectionEye`][crate::builtin::ProjectionEye], [`ProjectionPlane`][crate::builtin::ProjectionPlane]
-//! - Rectangle: [`Side`], [`Corner`] <sub>(godot-generated)</sub>
-//! - Rotation: [`EulerOrder`] <sub>(godot-generated)</sub>
+//! - Rectangle: [`Side`][crate::builtin::Side], [`Corner`][crate::builtin::Corner] <sub>(godot-generated)</sub>
+//! - Rotation: [`EulerOrder`][crate::builtin::EulerOrder] <sub>(godot-generated)</sub>
 //! - Variant: [`VariantType`][crate::builtin::VariantType], [`VariantOperator`][crate::builtin::VariantOperator]
 //! - Vector: [`Vector2Axis`][crate::builtin::Vector2Axis], [`Vector3Axis`][crate::builtin::Vector3Axis], [`Vector4Axis`][crate::builtin::Vector4Axis]
 //!
 //! Some enums are closely related to property/method registration and are located in [`godot::register::info`][crate::registry::info]:
 //!
-//! - [`PropertyHint`] <sub>(godot-generated)</sub>
-//! - [`PropertyUsageFlags`] <sub>(godot-generated)</sub>
-//! - [`MethodFlags`] <sub>(godot-generated)</sub>
+//! - [`PropertyHint`][crate::registry::info::PropertyHint] <sub>(godot-generated)</sub>
+//! - [`PropertyUsageFlags`][crate::registry::info::PropertyUsageFlags] <sub>(godot-generated)</sub>
+//! - [`MethodFlags`][crate::registry::info::MethodFlags] <sub>(godot-generated)</sub>
 
 // Doc aliases are also available in dedicated APIs, but directing people here may give them a bit more context.
 #![doc(
@@ -52,17 +52,8 @@ pub use crate::{
     godot_error, godot_print, godot_print_rich, godot_script_error, godot_str, godot_warn,
 };
 
-// ----------------------------------------------------------------------------------------------------------------------------------------------
-// Internal re-exports
-
-// This is needed for generated classes to find symbols, even those that have been moved to crate::builtin.
-#[allow(unused_imports)] // micromanaging imports for generated code is not fun
-#[rustfmt::skip] // Do not reorder.
-pub(crate) use crate::builtin::{Corner, EulerOrder, Side};
-
-// This is needed for generated code to find symbols that have been moved to crate::registry::info.
-#[allow(unused_imports)]
-pub(crate) use crate::registry::info::{MethodFlags, PropertyHint, PropertyUsageFlags};
+// Some enums that are global in Godot are moved to different Rust modules. Codegen takes care of it by adjusting their path accordingly.
+// See get_global_enum_rust_path() in special_cases.rs.
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Deprecations


### PR DESCRIPTION
Some Godot enums aren't located in `crate::global` but another Rust module. Previously privately re-exported, the library now directly emits the correct path.