### PR TITLE
Discourage use of `WeakRef` class

### DIFF
--- a/godot-codegen/src/generator/builtins.rs
+++ b/godot-codegen/src/generator/builtins.rs
@@ -11,7 +11,7 @@ use proc_macro2::{Ident, TokenStream};
 use quote::quote;
 
 use crate::context::Context;
-use crate::generator::functions_common::{FnCode, FnDefinition, FnDefinitions};
+use crate::generator::functions_common::{FnCode, FnDefinition, FnDefinitions, FnMeta};
 use crate::generator::method_tables::MethodTableKey;
 use crate::generator::{enums, functions_common};
 use crate::models::domain::{
@@ -322,6 +322,6 @@ fn make_builtin_method_definition(
             is_virtual_required: false,
             is_varcall_fallible: false,
         },
-        &TokenStream::new(),
+        &FnMeta::default(),
     )
 }

--- a/godot-codegen/src/generator/classes.rs
+++ b/godot-codegen/src/generator/classes.rs
@@ -11,7 +11,7 @@ use proc_macro2::{Ident, TokenStream};
 use quote::{format_ident, quote};
 
 use crate::context::{Context, NotificationEnum};
-use crate::generator::functions_common::{FnCode, FnDefinition, FnDefinitions};
+use crate::generator::functions_common::{FnCode, FnDefinition, FnDefinitions, FnMeta};
 use crate::generator::method_tables::MethodTableKey;
 use crate::generator::{
     constants, docs, enums, functions_common, notifications, signals, virtual_traits,
@@ -626,6 +626,7 @@ fn make_class_method_definition(
         )
     };
 
+    let cfg_attributes1 = cfg_attributes.clone();
     functions_common::make_function_definition(
         method,
         &FnCode {
@@ -635,6 +636,9 @@ fn make_class_method_definition(
             is_virtual_required: false,
             is_varcall_fallible: true,
         },
-        cfg_attributes,
+        &FnMeta {
+            cfg_attributes: cfg_attributes1,
+            specific_docs: TokenStream::new(),
+        },
     )
 }

--- a/godot-codegen/src/generator/default_parameters.rs
+++ b/godot-codegen/src/generator/default_parameters.rs
@@ -11,7 +11,7 @@ use quote::{format_ident, quote};
 
 use crate::generator::functions_common;
 use crate::generator::functions_common::{
-    FnArgExpr, FnCode, FnKind, FnParamDecl, make_arg_expr, make_param_or_field_type,
+    FnArgExpr, FnCode, FnKind, FnMeta, FnParamDecl, make_arg_expr, make_param_or_field_type,
 };
 use crate::models::domain::{FnParam, FnQualifier, Function, RustTy, TyName};
 use crate::util::{ident, safe_ident};
@@ -21,7 +21,7 @@ pub fn make_function_definition_with_defaults(
     sig: &dyn Function,
     code: &FnCode,
     full_fn_name: &Ident,
-    cfg_attributes: &TokenStream,
+    meta: &FnMeta,
 ) -> (TokenStream, TokenStream) {
     let (default_fn_params, required_fn_params): (Vec<_>, Vec<_>) = sig
         .params()
@@ -69,6 +69,8 @@ pub fn make_function_definition_with_defaults(
     let receiver_self = &code.receiver.self_prefix;
     let simple_receiver_param = &code.receiver.param;
     let extended_receiver_param = &code.receiver.param_lifetime_ex;
+    let cfg_attributes = &meta.cfg_attributes;
+    let maybe_specific_docs = &meta.specific_docs;
 
     let builders = quote! {
         #[doc = #builder_doc]
@@ -114,6 +116,7 @@ pub fn make_function_definition_with_defaults(
         // Lifetime is set if any parameter is a reference.
         #maybe_deprecated
         #maybe_expect_deprecated
+        #maybe_specific_docs
         #[doc = #default_parameter_usage]
         #[inline]
         #vis fn #simple_fn_name (
@@ -128,6 +131,7 @@ pub fn make_function_definition_with_defaults(
         // _ex() function:
         // Lifetime is set if any parameter is a reference OR if the method is not static/global (and thus can refer to self).
         #maybe_deprecated
+        #maybe_specific_docs
         #[inline]
         #vis fn #extended_fn_name<'ex> (
             #extended_receiver_param

--- a/godot-codegen/src/generator/docs.rs
+++ b/godot-codegen/src/generator/docs.rs
@@ -162,3 +162,8 @@ pub fn make_module_doc(class_name: &TyName) -> String {
         See also [Godot docs for `{godot_ty}` enums]({online_link}).\n\n"
     )
 }
+
+pub fn make_utility_fn_doc(function_name: &str) -> Option<String> {
+    let notes = special_cases::get_utility_fn_extra_docs(function_name)?;
+    Some(format!("\n\n# Specific notes for this function\n\n{notes}"))
+}

--- a/godot-codegen/src/generator/functions_common.rs
+++ b/godot-codegen/src/generator/functions_common.rs
@@ -47,6 +47,15 @@ pub struct FnCode {
     pub is_varcall_fallible: bool,
 }
 
+/// Item-level decoration for generated functions: conditional compilation and manual doc additions.
+#[derive(Default)]
+pub struct FnMeta {
+    /// `#[cfg(...)]` attributes gating compilation of the function (and related builder items).
+    pub cfg_attributes: TokenStream,
+    /// Extra `#[doc = "..."]` attributes appended to the Godot-provided documentation. Empty if no additions.
+    pub specific_docs: TokenStream,
+}
+
 pub struct FnDefinition {
     pub functions: TokenStream,
     pub builders: TokenStream,
@@ -100,11 +109,7 @@ pub struct FnParamTokens {
     pub arg_exprs: Vec<TokenStream>,
 }
 
-pub fn make_function_definition(
-    sig: &dyn Function,
-    code: &FnCode,
-    cfg_attributes: &TokenStream,
-) -> FnDefinition {
+pub fn make_function_definition(sig: &dyn Function, code: &FnCode, meta: &FnMeta) -> FnDefinition {
     let has_default_params = default_parameters::function_uses_default_params(sig);
     let vis = if has_default_params {
         // Public API mapped by separate function.
@@ -162,7 +167,7 @@ pub fn make_function_definition(
                 sig,
                 code,
                 &primary_fn_name,
-                cfg_attributes,
+                meta,
             );
     } else {
         primary_fn_name = rust_function_name.clone();
@@ -171,6 +176,7 @@ pub fn make_function_definition(
     };
 
     let (maybe_deprecated, _maybe_expect_deprecated) = make_deprecation_attribute(sig);
+    let maybe_specific_doc = &meta.specific_docs;
 
     let call_sig_decl = {
         let return_ty = &sig.return_value().type_tokens();
@@ -194,6 +200,7 @@ pub fn make_function_definition(
 
         quote! {
             #maybe_deprecated
+            #maybe_specific_doc
             #maybe_safety_doc
             #maybe_unsafe fn #primary_fn_name (
                 #receiver_param
@@ -210,6 +217,7 @@ pub fn make_function_definition(
         if !code.is_varcall_fallible {
             quote! {
                 #maybe_deprecated
+                #maybe_specific_doc
                 #maybe_safety_doc
                 #vis #maybe_unsafe fn #primary_fn_name (
                     #receiver_param
@@ -240,6 +248,7 @@ pub fn make_function_definition(
 
             quote! {
                 #maybe_deprecated
+                #maybe_specific_doc
                 /// # Panics
                 /// This is a _varcall_ method, meaning parameters and return values are passed as `Variant`.
                 /// It can detect call failures and will panic in such a case.
@@ -280,6 +289,7 @@ pub fn make_function_definition(
 
         quote! {
             #maybe_deprecated
+            #maybe_specific_doc
             #maybe_safety_doc
             #vis #maybe_unsafe fn #primary_fn_name  (
                 #receiver_param

--- a/godot-codegen/src/generator/utility_functions.rs
+++ b/godot-codegen/src/generator/utility_functions.rs
@@ -10,8 +10,8 @@ use std::path::Path;
 use proc_macro2::{Ident, TokenStream};
 use quote::quote;
 
-use crate::generator::functions_common;
-use crate::generator::functions_common::{FnCode, FnReceiver};
+use crate::generator::functions_common::{FnCode, FnMeta, FnReceiver};
+use crate::generator::{docs, functions_common};
 use crate::models::domain::{ExtensionApi, Function, UtilityFunction};
 use crate::{SubmitFn, util};
 
@@ -66,6 +66,10 @@ pub(crate) fn make_utility_function_definition(function: &UtilityFunction) -> To
         )
     };
 
+    let extra_docs = docs::make_utility_fn_doc(function_name_str)
+        .map(|note| quote! { #[doc = #note] })
+        .unwrap_or_default();
+
     let definition = functions_common::make_function_definition(
         function,
         &FnCode {
@@ -75,7 +79,10 @@ pub(crate) fn make_utility_function_definition(function: &UtilityFunction) -> To
             is_virtual_required: false,
             is_varcall_fallible: false,
         },
-        &TokenStream::new(),
+        &FnMeta {
+            cfg_attributes: TokenStream::new(),
+            specific_docs: extra_docs,
+        },
     );
 
     // Utility functions have no builders.

--- a/godot-codegen/src/generator/virtual_traits.rs
+++ b/godot-codegen/src/generator/virtual_traits.rs
@@ -11,7 +11,7 @@ use proc_macro2::{Ident, TokenStream};
 use quote::{ToTokens, quote};
 
 use crate::context::Context;
-use crate::generator::functions_common::FnCode;
+use crate::generator::functions_common::{FnCode, FnMeta};
 use crate::generator::{docs, functions_common};
 use crate::models::domain::{
     ApiView, Class, ClassLike, ClassMethod, FnQualifier, Function, TyName, VirtualMethodPresence,
@@ -241,7 +241,7 @@ fn make_virtual_method(
             is_virtual_required,
             is_varcall_fallible: true,
         },
-        &TokenStream::new(),
+        &FnMeta::default(),
     );
 
     // Virtual methods have no builders.

--- a/godot-codegen/src/special_cases/special_cases.rs
+++ b/godot-codegen/src/special_cases/special_cases.rs
@@ -101,7 +101,7 @@ pub fn get_class_method_deprecation(class_name: &TyName, method: &JsonClassMetho
 
         _ => return None,
     };
-    
+
     Some(deprecation_msg)
 }
 
@@ -771,7 +771,7 @@ pub fn is_class_method_const(class_name: &TyName, godot_method: &JsonClassMethod
         _ if !godot_method.is_const && !godot_method.is_static && !godot_method.is_virtual
             && ["get_", "is_", "has_"].iter().any(|p| godot_method.name.starts_with(p))
         => Some(true),
-        
+
         _ => None,
     }
 }
@@ -785,7 +785,7 @@ pub fn is_class_method_param_required(
     param: &Ident, // Don't use `&str` to avoid to_string() allocations for each check on call-site.
 ) -> bool {
     // Could possibly be unified with `meta=required` handling right at the JSON->domain mapping. Could then also apply to non-virtual fns.
-    
+
     // Note: for virtual methods, it's enough if a base class method is declared here; it will be picked up by derived classes.
 
     let param = param.to_string();
@@ -798,7 +798,7 @@ pub fn is_class_method_param_required(
         | ("Control", "_gui_input", "event")
 
         // https://docs.godotengine.org/en/stable/classes/class_collisionobject2d.html#class-collisionobject2d-private-method-input-event
-        | ("CollisionObject2D", "_input_event", "viewport" | "event") 
+        | ("CollisionObject2D", "_input_event", "viewport" | "event")
 
         // UI.
 
@@ -911,20 +911,30 @@ pub fn maybe_rename_virtual_method<'m>(
 //   or #[export(storage)] which is #[export] without editor UI.
 
 pub fn get_class_extra_docs(class_name: &TyName) -> Option<&'static str> {
-    match class_name.godot_ty.as_str() {
-        "FileAccess" => Some(
-            "The godot-rust library provides a higher-level abstraction, which should be preferred: [`GFile`][crate::tools::GFile].",
-        ),
-        "ScriptExtension" => {
-            Some("Use this in combination with the [`obj::script` module][crate::obj::script].")
+    let docs = match class_name.godot_ty.as_str() {
+        "FileAccess" => {
+            "The godot-rust library provides a higher-level abstraction, which should be preferred: [`GFile`][crate::tools::GFile]."
         }
-        "ResourceFormatLoader" => Some(
+        "ScriptExtension" => {
+            "Use this in combination with the [`obj::script` module][crate::obj::script]."
+        }
+        "ResourceFormatLoader" => {
             "Enable the `experimental-threads` feature when using custom `ResourceFormatLoader`s. \
             Otherwise the application will panic when the custom `ResourceFormatLoader` is used by Godot \
-            in a thread other than the main thread.",
-        ),
-        _ => None,
-    }
+            in a thread other than the main thread."
+        }
+        "WeakRef" => {
+            "It's almost never a good idea to use this class. You can use instance IDs as _weak references_, and upgrade to strong references \
+            through [`Gd::try_from_instance_id()`](crate::obj::Gd::try_from_instance_id). This works for both manually-managed and ref-counted \
+            classes. You can even build your own generic `WeakRef<T>` wrapper around `InstanceId` and achieve better type-safety and performance \
+            than Godot's `WeakRef` class, which carries the whole object overhead instead of an `i64`.\n\n\
+            The only reason to use `WeakRef` is when you need to interact with a third-party API that does so. Godot itself doesn't use it in \
+            any API outside of [`global::weakref()`][crate::global::weakref]."
+        }
+        _ => return None,
+    };
+
+    Some(docs)
 }
 
 pub fn get_interface_extra_docs(trait_name: &str) -> Option<&'static str> {
@@ -1182,7 +1192,7 @@ pub fn get_derived_virtual_method_presence(class_name: &TyName, godot_method_nam
 /// - **Scene level**: All singletons including `RenderingServer` are available.
 /// - **Editor level**: Editor-specific functionality is available.
 ///
-/// GDExtension singletons are generally not available during *any* level initialization, with the exception of a few core singletons 
+/// GDExtension singletons are generally not available during *any* level initialization, with the exception of a few core singletons
 /// (see above). This is different from how modules work, where servers are available at _Servers_ level.
 ///
 /// See also:
@@ -1217,7 +1227,7 @@ pub fn classify_codegen_level(class_name: &str) -> Option<ClassCodegenLevel> {
         | "PhysicsDirectBodyState2D" | "PhysicsDirectBodyState2DExtension" 
         | "PhysicsDirectSpaceState2D" | "PhysicsDirectSpaceState2DExtension" 
         | "PhysicsServer2D" | "PhysicsServer2DExtension" 
-        | "PhysicsServer2DManager" 
+        | "PhysicsServer2DManager"
         | "PhysicsDirectBodyState3D" | "PhysicsDirectBodyState3DExtension" 
         | "PhysicsDirectSpaceState3D" | "PhysicsDirectSpaceState3DExtension" 
         | "PhysicsServer3D" | "PhysicsServer3DExtension" 
@@ -1226,7 +1236,7 @@ pub fn classify_codegen_level(class_name: &str) -> Option<ClassCodegenLevel> {
         | "RenderData" | "RenderDataExtension"
         | "RenderSceneData" | "RenderSceneDataExtension"
         => ClassCodegenLevel::Servers,
-        
+
         // Declared final (un-inheritable) in Rust, but those are still servers.
         | "AudioServer" | "CameraServer" | "NavigationServer2D" | "NavigationServer3D" | "RenderingServer" | "TranslationServer" | "XRServer" | "DisplayServer"
         => ClassCodegenLevel::Servers,
@@ -1235,11 +1245,11 @@ pub fn classify_codegen_level(class_name: &str) -> Option<ClassCodegenLevel> {
         // https://github.com/godotengine/godot/issues/103867
         "OpenXRInteractionProfileEditorBase"
         | "OpenXRInteractionProfileEditor"
-        | "OpenXRBindingModifierEditor" if cfg!(before_api = "4.5") 
+        | "OpenXRBindingModifierEditor" if cfg!(before_api = "4.5")
         => ClassCodegenLevel::Editor,
-        
+
         // https://github.com/godotengine/godot/issues/86206
-        "ResourceImporterOggVorbis" | "ResourceImporterMP3" if cfg!(before_api = "4.3") 
+        "ResourceImporterOggVorbis" | "ResourceImporterMP3" if cfg!(before_api = "4.3")
         => ClassCodegenLevel::Editor,
 
         // No special-case override for this class.

--- a/godot-codegen/src/special_cases/special_cases.rs
+++ b/godot-codegen/src/special_cases/special_cases.rs
@@ -947,6 +947,18 @@ pub fn get_interface_extra_docs(trait_name: &str) -> Option<&'static str> {
     }
 }
 
+pub fn get_utility_fn_extra_docs(function_name: &str) -> Option<&'static str> {
+    let docs = match function_name {
+        "weakref" => {
+            "Use of `weakref()` is discouraged. See [`WeakRef`][crate::classes::WeakRef] for \
+            a detailed explanation and better alternatives."
+        }
+        _ => return None,
+    };
+
+    Some(docs)
+}
+
 #[cfg(before_api = "4.4")]
 pub fn is_virtual_method_required(class_name: &TyName, godot_method_name: &str) -> bool {
     // Do not call is_derived_virtual_method_required() here; that is handled in virtual_traits.rs.


### PR DESCRIPTION
Originally considered to add 31550081a09160e94185621428f62df1f6b38319, which would make `WeakRef` class nicer to use.

However it seems that this class is 100% useless. Every use case is already better handled by `InstanceId`, which needs 64 bits instead of a full-blown object (and ref-counted on top). When writing a wrapper `MyWeakRef<T>` around `InstanceId`, it can even be made trivially type-safe.

So this PR adds documentation that advises against `WeakRef` use. See also on RocketChat:
- https://chat.godotengine.org/channel/gdextension/thread/W6jg5j38zpMvdHZnH
- https://chat.godotengine.org/channel/gdextension/thread/w5pyFkwdKDduThB2u