### PR TITLE
[codex] Validate gdext #[func] registration name conflicts

### DIFF
--- a/godot-core/src/obj/traits.rs
+++ b/godot-core/src/obj/traits.rs
@@ -913,6 +913,12 @@ pub mod cap {
         #[doc(hidden)]
         fn __register_constants();
         #[doc(hidden)]
+        fn __collect_method_metadata(
+            out: &mut Vec<crate::registry::class::MethodRegistrationMetadata>,
+        ) {
+            let _ = out;
+        }
+        #[doc(hidden)]
         fn __register_rpcs(_: &mut dyn Any) {}
     }
 

--- a/godot-core/src/private.rs
+++ b/godot-core/src/private.rs
@@ -32,6 +32,7 @@ mod reexport_pub {
     pub use crate::obj::rtti::ObjectRtti;
     pub use crate::obj::signal::priv_re_export::*;
     pub use crate::registry::callbacks;
+    pub use crate::registry::class::{MethodRegistrationMetadata, validate_method_name_conflicts};
     pub use crate::registry::plugin::{
         ClassPlugin, DynTraitImpl, ErasedDynGd, ErasedRegisterFn, ITraitImpl, InherentImpl,
         PluginItem, Struct,

--- a/godot-core/src/registry/callbacks.rs
+++ b/godot-core/src/registry/callbacks.rs
@@ -491,6 +491,14 @@ pub fn register_user_methods_constants<T: cap::ImplementsGodotApi>(_class_builde
     T::__register_constants();
 }
 
+pub fn collect_user_methods_metadata<T: cap::ImplementsGodotApi>(out: &mut dyn Any) {
+    let out = out
+        .downcast_mut::<Vec<crate::registry::class::MethodRegistrationMetadata>>()
+        .expect("bad type erasure");
+
+    T::__collect_method_metadata(out);
+}
+
 pub fn register_user_rpcs<T: cap::ImplementsGodotApi>(object: &mut dyn Any) {
     T::__register_rpcs(object);
 }

--- a/godot-core/src/registry/class.rs
+++ b/godot-core/src/registry/class.rs
@@ -5,7 +5,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::collections::HashMap;
+use std::collections::{HashMap, hash_map::Entry};
 use std::{any, ptr};
 
 use sys::{Global, GlobalGuard, GlobalLockError, interface_fn, out};
@@ -68,6 +68,28 @@ pub struct LoadedClass {
 // Currently empty, but should already work for per-class queries.
 pub struct ClassMetadata {}
 
+/// Internal metadata describing a method name exposed by `#[func]`.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MethodRegistrationMetadata {
+    pub rust_name: String,
+    pub godot_name: String,
+    pub is_script_virtual: bool,
+}
+
+impl MethodRegistrationMetadata {
+    pub fn new(
+        rust_name: impl Into<String>,
+        godot_name: impl Into<String>,
+        is_script_virtual: bool,
+    ) -> Self {
+        Self {
+            rust_name: rust_name.into(),
+            godot_name: godot_name.into(),
+            is_script_virtual,
+        }
+    }
+}
+
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 
 // This works as long as fields are called the same. May still need individual #[cfg]s for newer fields.
@@ -105,6 +127,8 @@ struct ClassRegistrationInfo {
 
     /// One entry for each `dyn Trait` implemented (and registered) for this class.
     dynify_fns_by_trait: HashMap<any::TypeId, DynTraitImpl>,
+
+    declared_method_metadata: Vec<MethodRegistrationMetadata>,
 
     /// Used to ensure that each component is only filled once.
     component_already_filled: [bool; 4],
@@ -184,6 +208,7 @@ pub(crate) fn register_class<
         component_already_filled: Default::default(), // [false; N]
         register_singleton_fn: None,
         unregister_singleton_fn: None,
+        declared_method_metadata: Vec::new(),
     });
 }
 
@@ -209,6 +234,7 @@ pub fn auto_register_classes(init_level: InitLevel) {
         let class_info = map
             .entry(name)
             .or_insert_with(|| default_registration_info(name));
+        class_info.init_level = elem.init_level;
 
         fill_class_info(elem.item.clone(), class_info);
     });
@@ -484,9 +510,14 @@ fn fill_class_info(item: PluginItem, c: &mut ClassRegistrationInfo) {
 
         PluginItem::InherentImpl(InherentImpl {
             register_methods_constants_fn,
+            collect_method_metadata_fn,
             register_rpcs_fn: _,
         }) => {
             c.register_methods_constants_fn = Some(register_methods_constants_fn);
+
+            let mut metadata = Vec::new();
+            (collect_method_metadata_fn.raw)(&mut metadata);
+            c.declared_method_metadata.extend(metadata);
         }
 
         PluginItem::ITraitImpl(ITraitImpl {
@@ -631,6 +662,82 @@ fn register_class_raw(mut info: ClassRegistrationInfo) {
 
 fn validate_class_constraints(_class: &ClassRegistrationInfo) {
     // TODO: if we add builder API, the proc-macro checks in parse_struct_attributes() etc. should be duplicated here.
+    validate_duplicate_method_names(_class.class_name, &_class.declared_method_metadata);
+
+    // Before Godot 4.7, ClassDB's full reflection API is only reliably available from Scene init onward.
+    if cfg!(since_api = "4.7") || _class.init_level >= InitLevel::Scene {
+        validate_inherited_method_name_conflicts(
+            _class.class_name,
+            _class.parent_class_name,
+            &_class.declared_method_metadata,
+        );
+    }
+}
+
+pub fn validate_method_name_conflicts(
+    class_name: ClassId,
+    parent_class_name: Option<ClassId>,
+    declared_methods: &[MethodRegistrationMetadata],
+) {
+    validate_duplicate_method_names(class_name, declared_methods);
+    validate_inherited_method_name_conflicts(class_name, parent_class_name, declared_methods);
+}
+
+fn validate_duplicate_method_names(
+    class_name: ClassId,
+    declared_methods: &[MethodRegistrationMetadata],
+) {
+    let mut first_method_by_godot_name = HashMap::<&str, &MethodRegistrationMetadata>::new();
+
+    for method in declared_methods {
+        match first_method_by_godot_name.entry(method.godot_name.as_str()) {
+            Entry::Vacant(entry) => {
+                entry.insert(method);
+            }
+            Entry::Occupied(entry) => {
+                let previous = entry.get();
+                panic!(
+                    "Godot class `{class_name}` has a same class method name conflict for `{godot_name}` between Rust methods `{previous_rust}` and `{current_rust}`. Use #[func(rename = ...)] to disambiguate.",
+                    class_name = class_name,
+                    godot_name = method.godot_name,
+                    previous_rust = previous.rust_name,
+                    current_rust = method.rust_name,
+                );
+            }
+        }
+    }
+}
+
+fn validate_inherited_method_name_conflicts(
+    class_name: ClassId,
+    parent_class_name: Option<ClassId>,
+    declared_methods: &[MethodRegistrationMetadata],
+) {
+    let Some(parent_class_name) = parent_class_name else {
+        return;
+    };
+
+    let parent_class_name_sname = parent_class_name.to_string_name();
+    let class_db = ClassDb::singleton();
+
+    for method in declared_methods {
+        if method.is_script_virtual {
+            continue;
+        }
+
+        let inherited_conflict = class_db
+            .class_has_method_ex(&parent_class_name_sname, &method.godot_name)
+            .done();
+
+        if inherited_conflict {
+            panic!(
+                "Godot class `{class_name}` has a base class method name conflict for `{godot_name}`: base class `{base_class}` already exposes that method. Use #[func(rename = ...)] to rename it. If you meant to override a virtual method, implement the corresponding interface trait instead of #[func].",
+                class_name = class_name,
+                godot_name = method.godot_name,
+                base_class = parent_class_name,
+            );
+        }
+    }
 }
 
 fn unregister_class_raw(class: LoadedClass) {
@@ -698,6 +805,7 @@ fn default_registration_info(class_name: ClassId) -> ClassRegistrationInfo {
         init_level: InitLevel::Scene,
         is_editor_plugin: false,
         dynify_fns_by_trait: HashMap::new(),
+        declared_method_metadata: Vec::new(),
         component_already_filled: Default::default(), // [false; N]
     }
 }

--- a/godot-core/src/registry/plugin.rs
+++ b/godot-core/src/registry/plugin.rs
@@ -309,6 +309,9 @@ pub struct InherentImpl {
     /// Always present since that's the entire point of this `impl` block.
     pub(crate) register_methods_constants_fn: ErasedRegisterFn,
 
+    /// Callback to library-generated function which collects metadata for registered `#[func]` methods in the `impl` block.
+    pub(crate) collect_method_metadata_fn: ErasedRegisterFn,
+
     /// Callback to library-generated function which calls [`Node::rpc_config`](crate::classes::Node::rpc_config) for each function annotated
     /// with `#[rpc]` on the `impl` block.
     ///
@@ -324,6 +327,9 @@ impl InherentImpl {
         Self {
             register_methods_constants_fn: ErasedRegisterFn {
                 raw: callbacks::register_user_methods_constants::<T>,
+            },
+            collect_method_metadata_fn: ErasedRegisterFn {
+                raw: callbacks::collect_user_methods_metadata::<T>,
             },
             register_rpcs_fn: Some(ErasedRegisterRpcsFn {
                 raw: callbacks::register_user_rpcs::<T>,

--- a/godot-macros/src/class/data_models/func.rs
+++ b/godot-macros/src/class/data_models/func.rs
@@ -55,6 +55,27 @@ impl FuncDefinition {
     }
 }
 
+pub fn make_method_metadata_registration(func_definition: &FuncDefinition) -> TokenStream {
+    let rust_name = func_definition.rust_ident().to_string();
+    let godot_name = func_definition.godot_name();
+    let is_script_virtual = func_definition.is_script_virtual;
+
+    let cfg_attrs = util::extract_cfg_attrs(&func_definition.external_attributes)
+        .into_iter()
+        .collect::<Vec<_>>();
+
+    quote! {
+        #(#cfg_attrs)*
+        {
+            out.push(::godot::private::MethodRegistrationMetadata::new(
+                #rust_name,
+                #godot_name,
+                #is_script_virtual,
+            ));
+        }
+    }
+}
+
 /// Returns a C function which acts as the callback when a virtual method of this instance is invoked.
 //
 // Virtual methods are non-static by their nature; so there's no support for static ones.

--- a/godot-macros/src/class/data_models/inherent_impl.rs
+++ b/godot-macros/src/class/data_models/inherent_impl.rs
@@ -138,6 +138,11 @@ pub fn transform_inherent_impl(
     #[cfg(not(feature = "codegen-full"))]
     let rpc_registrations = TokenStream::new();
 
+    let method_metadata_registrations: Vec<TokenStream> = funcs
+        .iter()
+        .map(crate::class::make_method_metadata_registration)
+        .collect();
+
     let method_registrations: Vec<TokenStream> = funcs
         .into_iter()
         .map(|func_def| make_method_registration(&class_name, func_def, None))
@@ -158,6 +163,10 @@ pub fn transform_inherent_impl(
                 guard.1.push(|| {
                     #constant_registration
                 });
+
+                guard.2.push(|out| {
+                    #( #method_metadata_registrations )*
+                });
             });
         }
     };
@@ -167,13 +176,20 @@ pub fn transform_inherent_impl(
 
         // Storage for registration functions from all `#[godot_api]` impl blocks (primary + secondary).
         // Accessed through the class type so secondary blocks in other modules can find it.
-        // Tuple: (method+signal registrations, constant registrations).
+        // Tuple: (method+signal registrations, constant registrations, method metadata collectors).
         let storage = quote! {
             impl #class_name {
                 #[doc(hidden)]
-                pub fn __registration_storage() -> &'static std::sync::Mutex<(Vec<fn()>, Vec<fn()>)> {
-                    static STORAGE: std::sync::Mutex<(Vec<fn()>, Vec<fn()>)>
-                        = std::sync::Mutex::new((Vec::new(), Vec::new()));
+                pub fn __registration_storage() -> &'static std::sync::Mutex<(
+                    Vec<fn()>,
+                    Vec<fn()>,
+                    Vec<fn(&mut Vec<::godot::private::MethodRegistrationMetadata>)>,
+                )> {
+                    static STORAGE: std::sync::Mutex<(
+                        Vec<fn()>,
+                        Vec<fn()>,
+                        Vec<fn(&mut Vec<::godot::private::MethodRegistrationMetadata>)>,
+                    )> = std::sync::Mutex::new((Vec::new(), Vec::new(), Vec::new()));
                     &STORAGE
                 }
             }
@@ -192,6 +208,15 @@ pub fn transform_inherent_impl(
                     let guard = #class_name::__registration_storage().lock().unwrap();
                     for f in guard.1.iter() {
                         f();
+                    }
+                }
+
+                fn __collect_method_metadata(
+                    out: &mut Vec<::godot::private::MethodRegistrationMetadata>,
+                ) {
+                    let guard = #class_name::__registration_storage().lock().unwrap();
+                    for f in guard.2.iter() {
+                        f(out);
                     }
                 }
 

--- a/itest/rust/src/register_tests/func_test.rs
+++ b/itest/rust/src/register_tests/func_test.rs
@@ -10,7 +10,9 @@
 
 use godot::builtin::vslice;
 use godot::classes::ClassDb;
+use godot::meta::ClassId;
 use godot::obj::Singleton;
+use godot::obj::cap::ImplementsGodotApi;
 use godot::prelude::*;
 
 use crate::framework::{expect_panic, itest};
@@ -459,6 +461,97 @@ fn cfg_removes_or_keeps_signals() {
     assert!(!class_has_signal::<GdSelfObj>("cfg_removes_signal"));
 }
 
+#[itest]
+fn cfg_removes_or_keeps_method_metadata() {
+    let metadata = collect_method_metadata::<GdSelfObj>();
+
+    assert!(metadata.iter().any(|method| {
+        method.godot_name == "func_recognized_with_simple_path_attribute_above_func_attr"
+    }));
+    assert!(metadata.iter().any(|method| {
+        method.godot_name == "func_recognized_with_simple_path_attribute_below_func_attr"
+    }));
+    assert!(
+        metadata
+            .iter()
+            .any(|method| method.godot_name == "cfg_removes_duplicate_function_impl")
+    );
+    assert!(
+        !metadata
+            .iter()
+            .any(|method| method.godot_name == "cfg_removes_function")
+    );
+}
+
+#[itest]
+fn validate_method_name_conflicts_detects_same_class_duplicates() {
+    let class_name = ClassId::new_dynamic("SameClassConflict");
+    let methods = vec![
+        godot::private::MethodRegistrationMetadata::new("foo_impl", "shared_name", false),
+        godot::private::MethodRegistrationMetadata::new("bar_impl", "shared_name", false),
+    ];
+
+    expect_panic(
+        "duplicate Godot method names in same class should panic",
+        || {
+            godot::private::validate_method_name_conflicts(
+                class_name,
+                Some(godot::classes::RefCounted::class_id()),
+                &methods,
+            );
+        },
+    );
+}
+
+#[itest]
+fn validate_method_name_conflicts_detects_rename_collisions() {
+    let class_name = ClassId::new_dynamic("RenameConflict");
+    let methods = vec![
+        godot::private::MethodRegistrationMetadata::new("shared_name", "shared_name", false),
+        godot::private::MethodRegistrationMetadata::new("renamed_impl", "shared_name", false),
+    ];
+
+    expect_panic("rename collisions should panic", || {
+        godot::private::validate_method_name_conflicts(
+            class_name,
+            Some(godot::classes::RefCounted::class_id()),
+            &methods,
+        );
+    });
+}
+
+#[itest]
+fn validate_method_name_conflicts_detects_base_class_collisions() {
+    let class_name = ClassId::new_dynamic("BaseClassConflict");
+    let methods = vec![godot::private::MethodRegistrationMetadata::new(
+        "get_class",
+        "get_class",
+        false,
+    )];
+
+    expect_panic("base class method collisions should panic", || {
+        godot::private::validate_method_name_conflicts(
+            class_name,
+            Some(godot::classes::Object::class_id()),
+            &methods,
+        );
+    });
+}
+
+#[itest]
+fn validate_method_name_conflicts_allows_script_virtual_methods() {
+    let class_name = ClassId::new_dynamic("VirtualOk");
+    let methods = vec![godot::private::MethodRegistrationMetadata::new(
+        "ready", "_ready", true,
+    )];
+
+    godot::private::validate_method_name_conflicts(
+        class_name,
+        Some(godot::classes::Node::class_id()),
+        &methods,
+    );
+}
+
 // No test for Gd::from_object(), as that simply moves the existing object without running user code.
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
@@ -475,4 +568,11 @@ fn class_has_method<T: GodotClass>(name: &str) -> bool {
 /// Checks at runtime if a class has a given signal through [ClassDb].
 fn class_has_signal<T: GodotClass>(name: &str) -> bool {
     ClassDb::singleton().class_has_signal(&T::class_id().to_string_name(), name)
+}
+
+fn collect_method_metadata<T: ImplementsGodotApi>()
+-> Vec<godot::private::MethodRegistrationMetadata> {
+    let mut metadata = Vec::new();
+    T::__collect_method_metadata(&mut metadata);
+    metadata
 }


### PR DESCRIPTION
## Summary
- add internal `#[func]` registration metadata plumbing from proc macros into class registration
- validate same-class method name duplicates and inherited `ClassDB` method collisions before registering methods
- add focused tests for duplicate names, `rename` collisions, inherited collisions, script virtual exceptions, and cfg-gated metadata collection

## Why
`gdext` currently registers user methods without validating whether the exposed Godot method name collides with another `#[func]` in the same class or with a method inherited from the base class. That turns a naming mistake into unclear runtime behavior instead of a clear startup-time error.

## Impact
This keeps the scope intentionally narrow to `#[func]` only. Properties, signals, and constants are left for follow-up work.

## Validation
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `GDRUST_MAIN_EXTENSION=IntegrationTests GDRUST_GODOT_BIN=/opt/homebrew/bin/godot /opt/homebrew/bin/bash ./check.sh itest -f func,classdb`