### PR TITLE
`Result<T, E>` returned from `#[func]` no longer implements `ToGodot`

### DIFF
--- a/godot-core/src/meta/error/error_to_godot.rs
+++ b/godot-core/src/meta/error/error_to_godot.rs
@@ -13,8 +13,7 @@ use crate::meta::ToGodot;
 
 /// Defines how `Result<T, E>` returned by `#[func]` is mapped to Godot.
 ///
-/// When implemented for a type `E`, this trait enables `Result<T, E>` return types
-/// [through a blanket impl](../trait.ToGodot.html#impl-ToGodot-for-Result%3CT,+E%3E).
+/// When implemented for a type `E`, this trait enables `Result<T, E>` return types in `#[func]` methods.
 ///
 /// # Implementing the trait
 /// The associated type [`Mapped`][Self::Mapped] determines what GDScript sees as the function's return type. This type
@@ -37,7 +36,7 @@ use crate::meta::ToGodot;
 /// # use godot::prelude::*;
 /// use godot::builtin::Array;
 /// use godot::meta::error::{CallOutcome, ErrorToGodot};
-/// use godot::meta::{Element, ref_to_arg};
+/// use godot::meta::{Element, owned_into_arg};
 ///
 /// struct MyError(String);
 ///
@@ -45,10 +44,10 @@ use crate::meta::ToGodot;
 ///     // GDScript sees Array[T] as the #[func]'s return type.
 ///     type Mapped = Array<T>;
 ///
-///     fn result_to_godot(result: Result<&T, &Self>) -> CallOutcome<Array<T>> {
+///     fn result_to_godot(result: Result<T, Self>) -> CallOutcome<Array<T>> {
 ///         // Construct [elem] or [].
 ///         let array = match result {
-///             Ok(elem) => array![ref_to_arg(elem)],
+///             Ok(elem) => array![owned_into_arg(elem)],
 ///             Err(_) => Array::new(),
 ///         };
 ///
@@ -66,12 +65,21 @@ use crate::meta::ToGodot;
 /// else:
 ///     var value := result.front()  # typed!
 /// ```
+//
+// Potential expansion: ToGodot for Result<T, E> for infallible strategies (e.g. (), global::Error).
+// Backwards-compatible. By-ref needed for ToGodot taking &self. Rough sketch:
+//
+//     pub trait ErrorToGodotInfallible<T: ToGodot>: ErrorToGodot<T> {
+//         fn result_to_godot_ref(r: Result<&T, &Self>) -> Self::Mapped;
+//     }
+//     impl<T, E> ToGodot for Result<T, E> where E: ErrorToGodotInfallible<T> { ... }
+//
 pub trait ErrorToGodot<T: ToGodot>: Sized {
     /// The type to which `Result<T, Self>` is mapped on Godot side.
     type Mapped: ToGodot;
 
-    /// Map a `Result<T, Self>` to a Godot return value or an unexpected-error message.
-    fn result_to_godot(result: Result<&T, &Self>) -> CallOutcome<Self::Mapped>;
+    /// Map an owned `Result` to a Godot return value or an unexpected-error message.
+    fn result_to_godot(result: Result<T, Self>) -> CallOutcome<Self::Mapped>;
 }
 
 /// Outcome of mapping a `Result<T, E>` for a `#[func]` return value.

--- a/godot-core/src/meta/error/strat/mod.rs
+++ b/godot-core/src/meta/error/strat/mod.rs
@@ -16,7 +16,7 @@
 //!
 //! | Strategy                                       | `Mapped` type                       | Ok path            | Err path                  | GDScript ergonomics                     |
 //! |------------------------------------------------|-------------------------------------|--------------------|---------------------------|-----------------------------------------|
-//! | [`strat::Unexpected`]<br>Unexpected errors     | `T`                                 | `val.clone()`      | Default or<br>failed call | Sees `T`; `?` works with any `Error`    |
+//! | [`strat::Unexpected`]<br>Unexpected errors     | `T`                                 | `val`              | Default or<br>failed call | Sees `T`; `?` works with any `Error`    |
 //! | `()`<br>Nil on error                           | `Variant`                           | `val.to_variant()` | `null`                    | `if val == null`                        |
 //! | [`global::Error`]<br>Godot error enum          | `global::Error`                     | `OK` constant      | `ERR_*` constant          | `val == OK`                             |
 //! | _(not provided)_<br>`Variant`                  | `Variant`                           | `val.to_variant()` | `err.to_variant()`        | Must check type/value                   |
@@ -29,6 +29,7 @@ mod unexpected;
 pub use unexpected::*;
 
 use super::{CallOutcome, ErrorToGodot};
+use crate::builtin::Variant;
 use crate::global;
 use crate::meta::ToGodot;
 #[expect(unused)] // for docs.
@@ -54,8 +55,8 @@ use crate::meta::error::strat;
 ///     // Returns the high score from a save file, or null if absent or unreadable.
 ///     // A missing file is normal for new players -- GDScript handles null gracefully.
 ///     #[func]
-///     fn load_high_score(&self, save_path: GString) -> Result<i64, ()> {
-///         let text = std::fs::read_to_string(save_path.to_string()).map_err(|_| ())?;
+///     fn load_high_score(&self, save_path: String) -> Result<i64, ()> {
+///         let text = std::fs::read_to_string(save_path).map_err(|_| ())?;
 ///         text.trim().parse::<i64>().map_err(|_| ())
 ///     }
 /// }
@@ -63,17 +64,17 @@ use crate::meta::error::strat;
 ///
 /// GDScript usage:
 /// ```gdscript
-/// var score = player.load_high_score("user://save.dat")
+/// var score = player.load_high_score("user://highscore.dat")
 /// if score == null:
-///     score = 0  # New player, no save file yet.
+///     # New player, no save file yet.
 /// ```
 impl<T: ToGodot> ErrorToGodot<T> for () {
-    type Mapped = crate::builtin::Variant;
+    type Mapped = Variant;
 
-    fn result_to_godot(result: Result<&T, &Self>) -> CallOutcome<crate::builtin::Variant> {
+    fn result_to_godot(result: Result<T, Self>) -> CallOutcome<Variant> {
         match result {
             Ok(val) => CallOutcome::Return(val.to_variant()),
-            Err(()) => CallOutcome::Return(crate::builtin::Variant::nil()),
+            Err(()) => CallOutcome::Return(Variant::nil()),
         }
     }
 }
@@ -86,10 +87,10 @@ impl<T: ToGodot> ErrorToGodot<T> for () {
 impl<T: ToGodot> ErrorToGodot<T> for global::Error {
     type Mapped = global::Error;
 
-    fn result_to_godot(result: Result<&T, &Self>) -> CallOutcome<global::Error> {
+    fn result_to_godot(result: Result<T, Self>) -> CallOutcome<global::Error> {
         match result {
             Ok(_) => CallOutcome::Return(global::Error::OK),
-            Err(&e) => CallOutcome::Return(e),
+            Err(e) => CallOutcome::Return(e),
         }
     }
 }

--- a/godot-core/src/meta/error/strat/unexpected.rs
+++ b/godot-core/src/meta/error/strat/unexpected.rs
@@ -140,12 +140,12 @@ impl<E: Into<Box<dyn Error + Send + Sync + 'static>>> From<E> for Unexpected {
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // ErrorToGodot impl -- unexpected mode
 
-impl<T: ToGodot + Clone> ErrorToGodot<T> for Unexpected {
+impl<T: ToGodot> ErrorToGodot<T> for Unexpected {
     type Mapped = T;
 
-    fn result_to_godot(result: Result<&T, &Self>) -> CallOutcome<T> {
+    fn result_to_godot(result: Result<T, Self>) -> CallOutcome<T> {
         match result {
-            Ok(val) => CallOutcome::Return(val.clone()),
+            Ok(val) => CallOutcome::Return(val),
             Err(e) => CallOutcome::CallFailed(format!("Err(Unexpected) in #[func]: {e}")),
         }
     }

--- a/godot-core/src/meta/godot_convert/impls.rs
+++ b/godot-core/src/meta/godot_convert/impls.rs
@@ -11,7 +11,9 @@ use crate::meta::error::{
     CallError, CallOutcome, ConvertError, ErrorKind, ErrorToGodot, FromFfiError,
 };
 use crate::meta::shape::GodotShape;
-use crate::meta::{Element, FromGodot, GodotConvert, GodotNullableType, GodotType, ToGodot};
+use crate::meta::{
+    Element, EngineToGodot, FromGodot, GodotConvert, GodotNullableType, GodotType, ToGodot,
+};
 use crate::registry::info::ParamMetadata;
 
 // The following ToGodot/FromGodot/Convert impls are auto-generated for each engine type, co-located with their definitions:
@@ -163,50 +165,54 @@ where
     }
 }
 
-impl<T, E> ToGodot for Result<T, E>
+impl<T, E> EngineToGodot for Result<T, E>
 where
     T: ToGodot,
     E: ErrorToGodot<T>,
 {
     type Pass = meta::ByValue;
 
-    fn to_godot(&self) -> Self::Via {
-        // Two cases of result_to_godot():
-        // * Return -- pass forward.
-        // * CallFailed -- misuse: #[func] Result<T, E> is mapped in a separate code path; this is only for users
-        //   calling to_godot() manually, so panic.
-        //
-        // Exception safety (see to_variant() comment): this panic is safe because Result<T, E> does not implement Element.
-        // Array::resize() is thus never at risk of calling to_variant() on a Result and leaving the array in an inconsistent state.
-        match E::result_to_godot(self.as_ref()) {
-            CallOutcome::Return(mapped) => mapped.to_godot_owned(),
-            CallOutcome::CallFailed(msg) => panic!("Result::to_godot() called on Err: {msg}"),
-        }
+    fn engine_to_godot(&self) -> meta::ToArg<'_, Self::Via, Self::Pass> {
+        panic_non_consuming()
     }
 
-    // Two __godot_try* overrides are required: one for each calling convention. They can't be merged without sacrificing perf in one of the paths:
-    // - varcall writes a Variant to a GDExtensionVariantPtr. __godot_try_into_variant produces it directly; going through Via first would add
-    //   an intermediate clone for ByRef types.
-    // - ptrcall writes Via to a typed GDExtensionTypePtr. __godot_try_into_godot_owned produces Via directly; going through Variant first
-    //   would require a Variant→Via round-trip.
-    // Both methods also propagate unexpected errors as CallError instead of panicking.
+    fn engine_to_godot_owned(&self) -> Self::Via {
+        panic_non_consuming()
+    }
 
-    fn __godot_try_into_variant(self, call_ctx: &meta::CallContext) -> Result<Variant, CallError> {
-        match E::result_to_godot(self.as_ref()) {
+    fn engine_to_variant(&self) -> Variant {
+        panic_non_consuming()
+    }
+
+    // Varcall and ptrcall each need their own override; merging them would force an extra conversion in one direction.
+    //
+    // Varcall writes a Variant, so engine_try_into_variant produces one directly -- routing through Via first would add a clone for ByRef types.
+    // Ptrcall writes Via, so engine_try_into_godot_owned produces it directly -- routing through Variant would cost a Variant→Via round-trip.
+    //
+    // Both methods also report unexpected errors as CallError rather than panicking.
+
+    fn engine_try_into_variant(self, call_ctx: &meta::CallContext) -> Result<Variant, CallError> {
+        match E::result_to_godot(self) {
             CallOutcome::Return(mapped) => Ok(mapped.to_variant()),
             CallOutcome::CallFailed(msg) => Err(CallError::failed_by_user_result(call_ctx, msg)),
         }
     }
 
-    fn __godot_try_into_godot_owned(
+    fn engine_try_into_godot_owned(
         self,
         call_ctx: &meta::CallContext,
     ) -> Result<Self::Via, CallError> {
-        match E::result_to_godot(self.as_ref()) {
+        match E::result_to_godot(self) {
             CallOutcome::Return(mapped) => Ok(mapped.to_godot_owned()),
             CallOutcome::CallFailed(msg) => Err(CallError::failed_by_user_result(call_ctx, msg)),
         }
     }
+}
+
+fn panic_non_consuming() -> ! {
+    panic!(
+        "Result<T, E> is only valid as a #[func] return value; non-owned conversions unsupported"
+    )
 }
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------

--- a/godot-core/src/meta/godot_convert/mod.rs
+++ b/godot-core/src/meta/godot_convert/mod.rs
@@ -55,6 +55,15 @@ pub trait GodotConvert {
 /// Please read the [`godot::meta` module docs](index.html) for further information about conversions.
 ///
 /// This trait can be derived using the [`#[derive(GodotConvert)]`](../register/derive.GodotConvert.html) macro.
+///
+/// # `Result<T, E>`
+/// It is possible to return `Result<T, E>` from `#[func]`, when `T: ToGodot` and [`E: ErrorToGodot`][crate::meta::error::ErrorToGodot].
+/// However, `Result<T, E>` currently does not implement `ToGodot` itself, as it is not generally infallible.
+///
+/// # Panics
+/// Currently, the methods `to_godot()`, `to_godot_owned()` and `to_variant()` are infallible and never panic, i.e. you can convert every value
+/// to a Godot representation. If new types are supported in the future that may not satisfy this (example: `Result<T, E>`), it's possible
+/// that panics are introduced _only for those new types_.
 #[diagnostic::on_unimplemented(
     message = "passing type `{Self}` to Godot requires `ToGodot` trait, which is usually provided by the library",
     note = "ToGodot is implemented for built-in types (i32, Vector2, GString, …). For objects, use Gd<T> instead of T.",
@@ -85,53 +94,19 @@ pub trait ToGodot: Sized + GodotConvert {
     /// # Return type
     /// - For `Pass = ByValue`, returns owned `Self::Via`.
     /// - For `Pass = ByRef`, returns borrowed `&Self::Via`.
-    ///
-    /// # Panics
-    /// Generally never panics, except for the `Result<T, E>` impl in case of `Err(E)`.
     fn to_godot(&self) -> ToArg<'_, Self::Via, Self::Pass>;
 
     /// Converts this type to owned Godot representation.
     ///
     /// Always returns `Self::Via`, cloning if necessary for ByRef types.
-    ///
-    /// # Panics
-    /// See [`to_godot()`][Self::to_godot].
     fn to_godot_owned(&self) -> Self::Via {
         Self::Pass::ref_to_owned_via(self)
     }
 
     /// Converts this type to a [Variant].
-    ///
-    /// # Panics
-    /// See [`to_godot()`][Self::to_godot].
-    // Exception safety: must not panic apart from exceptional circumstances (Nov 2024: only u64).
-    // This has invariant implications, e.g. in Array::resize().
+    // Exception safety: introducing a panic would have invariant implications, e.g. in Array::resize().
     fn to_variant(&self) -> Variant {
         Self::Pass::ref_to_variant(self)
-    }
-
-    /// Consuming conversion to `Variant` for `#[func]` varcall return values.
-    ///
-    /// Defaults to infallible [`to_variant()`][Self::to_variant]. Overridden for `Result<T, E>`
-    /// to propagate unexpected errors as [`CallError`][crate::meta::error::CallError] instead of panicking.
-    #[doc(hidden)]
-    fn __godot_try_into_variant(
-        self,
-        _call_ctx: &crate::meta::CallContext,
-    ) -> Result<Variant, crate::meta::error::CallError> {
-        Ok(self.to_variant())
-    }
-
-    /// Consuming conversion to the Godot `Via` type for `#[func]` ptrcall return values.
-    ///
-    /// Defaults to infallible [`to_godot_owned()`][Self::to_godot_owned]. Overridden for `Result<T, E>`
-    /// to propagate unexpected errors as [`CallError`][crate::meta::error::CallError] instead of panicking.
-    #[doc(hidden)]
-    fn __godot_try_into_godot_owned(
-        self,
-        _call_ctx: &crate::meta::CallContext,
-    ) -> Result<Self::Via, crate::meta::error::CallError> {
-        Ok(self.to_godot_owned())
     }
 }
 
@@ -256,16 +231,16 @@ impl<T: ToGodot> EngineToGodot for T {
 
     fn engine_try_into_variant(
         self,
-        call_ctx: &crate::meta::CallContext,
+        _call_ctx: &crate::meta::CallContext,
     ) -> Result<Variant, crate::meta::error::CallError> {
-        T::__godot_try_into_variant(self, call_ctx)
+        Ok(self.to_variant())
     }
 
     fn engine_try_into_godot_owned(
         self,
-        call_ctx: &crate::meta::CallContext,
+        _call_ctx: &crate::meta::CallContext,
     ) -> Result<Self::Via, crate::meta::error::CallError> {
-        T::__godot_try_into_godot_owned(self, call_ctx)
+        Ok(self.to_godot_owned())
     }
 }
 
@@ -348,5 +323,4 @@ macro_rules! impl_godot_as_self {
             }
         }
     };
-
 }

--- a/godot-core/src/meta/mod.rs
+++ b/godot-core/src/meta/mod.rs
@@ -59,7 +59,7 @@ pub(crate) mod sealed;
 #[doc(hidden)]
 pub mod private_reexport {
     pub use super::param_tuple::TupleFromGodot;
-    pub use super::signature::{CallContext, Signature, ensure_func_bounds};
+    pub use super::signature::{CallContext, FuncReturn, Signature, ensure_func_bounds};
 }
 
 pub mod conv;

--- a/godot-core/src/meta/signature.rs
+++ b/godot-core/src/meta/signature.rs
@@ -13,7 +13,7 @@ use godot_ffi as sys;
 use sys::GodotFfi;
 
 use crate::builtin::Variant;
-use crate::meta::error::{CallError, CallResult, ConvertError};
+use crate::meta::error::{CallError, CallResult, ConvertError, ErrorToGodot};
 use crate::meta::param_tuple::TupleFromGodot;
 use crate::meta::{
     EngineFromGodot, EngineToGodot, FromGodot, GodotConvert, GodotType, InParamTuple,
@@ -21,18 +21,36 @@ use crate::meta::{
 };
 use crate::obj::{GodotClass, ValidatedObject};
 
-/// Checks for `#[func]` expansions that all parameters implement `FromGodot` and the return type implements `ToGodot`
-/// (or `Result<T: ToGodot, E: ErrorToGodot>`).
+/// Marker trait for types valid as `#[func]` return values.
+///
+/// Separates user-facing `#[func]` return types from internal engine types (e.g. `u64`, which implements
+/// [`EngineToGodot`] but not [`ToGodot`] and thus not `FuncReturn`).
+///
+/// Implemented for all [`ToGodot`] types and for `Result<T, E>` where `E: ErrorToGodot<T>`.
+#[doc(hidden)]
+pub trait FuncReturn: EngineToGodot {}
+
+impl<T: ToGodot> FuncReturn for T {}
+
+impl<T, E> FuncReturn for Result<T, E>
+where
+    T: ToGodot,
+    E: ErrorToGodot<T>,
+{
+}
+
+/// Checks for `#[func]` expansions that all parameters implement `FromGodot` and the return type implements [`FuncReturn`]
+/// (which covers all [`ToGodot`] types and `Result<T, E: ErrorToGodot<T>>`).
 ///
 /// [`Signature`] itself only requires `EngineFromGodot` and `EngineToGodot` for out-calls.
 #[inline(always)]
 #[doc(hidden)]
-pub fn ensure_func_bounds<Params: TupleFromGodot, Ret: ToGodot>() {}
+pub fn ensure_func_bounds<Params: TupleFromGodot, Ret: FuncReturn>() {}
 
 /// A full signature for a function.
 ///
 /// For in-calls (that is, calls from the Godot engine to Rust code) `Params` will implement [`InParamTuple`] and `Ret`
-/// will implement [`ToGodot`].
+/// will implement [`FuncReturn`] (which covers all [`ToGodot`] types and `Result<T, E: ErrorToGodot<T>>`).
 ///
 /// For out-calls (that is calls from Rust code to the Godot engine) `Params` will implement [`OutParamTuple`] and `Ret`
 /// will implement [`FromGodot`].
@@ -394,7 +412,7 @@ impl<Params: OutParamTuple, Ret: EngineFromGodot> Signature<Params, Ret> {
 
 /// Moves `ret_val` into `ret`.
 ///
-/// Uses [`ToGodot::__godot_try_into_variant`] (via [`EngineToGodot`]) to support `Result<T, E>` without panicking.
+/// Uses [`EngineToGodot::engine_try_into_variant`] to support `Result<T, E>` without panicking.
 ///
 /// # Safety
 /// - `ret` must be a pointer to an initialized `Variant`.
@@ -439,7 +457,7 @@ pub(crate) unsafe fn varcall_return_checked<R: ToGodot>(
 
 /// Moves `ret_val` into `ret`.
 ///
-/// Uses [`ToGodot::__godot_try_into_godot_owned`] (via [`EngineToGodot`]) to check for unexpected (call-failing) `Result<T, E>` errors
+/// Uses [`EngineToGodot::engine_try_into_godot_owned`] to check for unexpected (call-failing) `Result<T, E>` errors
 /// and produce the `Via` value in one consuming step. On error, returns `Err(CallError)` without writing to the return pointer.
 ///
 /// Note that on the FFI level, ptrcalls have no `r_error` output parameter, so `Result<T, E>` resulting in failed calls (e.g. through


### PR DESCRIPTION
Follow-up to #1544.

Problem is that `Result` with its "call failed" semantics stretches the invariants of `ToGodot` quite a bit, for example `to_godot`/`to_variant` not panicking.

`ErrorToGodot::result_to_godot()` now also takes the `Result` by value, which is more
natural and doesn't require `Clone` (which may not be available for all error types).

Instead, use an internal trait `FuncReturn`. We can possibly still allow `ToGodot` in the future, or only allow it for non-fallible `EngineToGodot` strategies. But this doesn't commit to a public API yet, while still allowing the `#[func]` return.