### PR TITLE
Use new initialization for Godot 4.7.

### DIFF
--- a/godot-core/src/classes/class_runtime.rs
+++ b/godot-core/src/classes/class_runtime.rs
@@ -240,7 +240,7 @@ where
 {
     let mut obj = unsafe {
         let object_ptr = sys::classdb_construct_object(T::class_id().string_sys());
-        Gd::<T>::from_obj_sys(object_ptr)
+        Gd::<T>::from_constructed_obj_sys(object_ptr)
     };
     #[cfg(since_api = "4.4")]
     obj.upcast_object_mut()

--- a/godot-core/src/obj/base.rs
+++ b/godot-core/src/obj/base.rs
@@ -5,51 +5,16 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-#[cfg(safeguards_balanced)]
-use std::cell::Cell;
-use std::cell::RefCell;
-use std::collections::HashMap;
-use std::collections::hash_map::Entry;
 use std::fmt::{Debug, Display, Formatter, Result as FmtResult};
 use std::mem::ManuallyDrop;
-#[cfg(safeguards_balanced)]
-use std::rc::Rc;
 
-use crate::builtin::Callable;
-use crate::obj::{Gd, GodotClass, InstanceId, PassiveGd, bounds};
+use crate::obj::base_init::{InitState, InitTracker};
+use crate::obj::{Gd, GodotClass, PassiveGd};
 use crate::{classes, sys};
 
-thread_local! {
-    /// Extra strong references for each instance ID, needed for [`Base::to_init_gd()`].
-    ///
-    /// At the moment, all Godot objects must be accessed from the main thread, because their deferred destruction (`Drop`) runs on the
-    /// main thread, too. This may be relaxed in the future, and a `sys::Global` could be used instead of a `thread_local!`.
-    static PENDING_STRONG_REFS: RefCell<HashMap<InstanceId, Gd<classes::RefCounted>>> = RefCell::new(HashMap::new());
-}
-
-/// Represents the initialization state of a `Base<T>` object.
-#[cfg(safeguards_balanced)] // TODO(v0.5 or v0.6): relax to strict state, once people are used to checks.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-enum InitState {
-    /// Object is being constructed (inside `I*::init()` or `Gd::from_init_fn()`).
-    ObjectConstructing,
-    /// Object construction is complete.
-    ObjectInitialized,
-    /// `ScriptInstance` context - always considered initialized (bypasses lifecycle checks).
-    Script,
-}
-
-#[cfg(safeguards_balanced)]
 macro_rules! base_from_obj {
     ($obj:expr_2021, $state:expr_2021) => {
         Base::from_obj($obj, $state)
-    };
-}
-
-#[cfg(not(safeguards_balanced))]
-macro_rules! base_from_obj {
-    ($obj:expr, $state:expr) => {
-        Base::from_obj($obj)
     };
 }
 
@@ -78,13 +43,9 @@ pub struct Base<T: GodotClass> {
     // When triggered by Rust (Gd::drop on last strong ref), it's as follows:
     // 1.   Gd<T>  -- triggers InstanceStorage destruction
     // 2.
-    obj: ManuallyDrop<Gd<T>>,
+    pub(super) obj: ManuallyDrop<Gd<T>>,
 
-    /// Tracks the initialization state of this `Base<T>` in Debug mode.
-    ///
-    /// Rc allows to "copy-construct" the base from an existing one, while still affecting the user-instance through the original `Base<T>`.
-    #[cfg(safeguards_balanced)]
-    init_state: Rc<Cell<InitState>>,
+    pub(super) init_state: InitTracker,
 }
 
 impl<T: GodotClass> Base<T> {
@@ -97,18 +58,58 @@ impl<T: GodotClass> Base<T> {
     /// If `base` is destroyed while the returned `Base<T>` is in use, that constitutes a logic error, not a safety issue.
     pub(crate) unsafe fn from_base(base: &Base<T>) -> Base<T> {
         sys::balanced_assert!(
-            base.obj.is_instance_valid(),
+            Base::is_valid(base),
             "Cannot construct Base; was object freed during initialization?"
         );
 
-        // SAFETY:
+        // SAFETY: See method docs.
         let obj = unsafe { Gd::from_obj_sys_weak(base.obj.obj_sys()) };
 
         Self {
             obj: ManuallyDrop::new(obj),
-            #[cfg(safeguards_balanced)]
-            init_state: Rc::clone(&base.init_state),
+            init_state: base.init_state.clone(),
         }
+    }
+
+    /// Checks if this base points to a live object.
+    pub(crate) fn is_valid(base: &Base<T>) -> bool {
+        base.obj.is_instance_valid()
+    }
+
+    /// Workaround for `base` being unitialized during object initialization and `NOTIFICATION_POSTINITIALIZE`
+    /// for Godot versions before 4.7.
+    ///
+    /// # Behaviour after Godot 4.7
+    ///
+    /// Since Godot 4.7 initialization layer receives fully-constructed object to work with – therefore in Godot 4.7 and later
+    /// this method simply returns a clone of a given instance.
+    ///
+    /// Use this method if you want to support Godot versions older than 4.7.
+    ///
+    /// # Behaviour before Godot 4.7
+    ///
+    /// Returns a [`Gd`] referencing the base object, for exclusive use during object initialization and `NOTIFICATION_POSTINITIALIZE`.
+    ///
+    /// Can be used during an initialization function [`I*::init()`][crate::classes::IObject::init] or [`Gd::from_init_fn()`], or [`POSTINITIALIZE`][crate::classes::notify::ObjectNotification::POSTINITIALIZE].
+    ///
+    /// The base pointer is only pointing to a base object; you cannot yet downcast it to the object being constructed.
+    /// The instance ID is the same as the one the in-construction object will have.
+    ///
+    /// ## Lifecycle for ref-counted classes
+    ///
+    /// If `T: Inherits<RefCounted>`, then the ref-counted object is not yet fully-initialized at the time of the `init` function and [`POSTINITIALIZE`][crate::classes::notify::ObjectNotification::POSTINITIALIZE] running.
+    /// Accessing the base object without further measures would be dangerous. Here, godot-rust employs a workaround: the `Base` object (which
+    /// holds a weak pointer to the actual instance) is temporarily upgraded to a strong pointer, preventing use-after-free.
+    ///
+    /// This additional reference is automatically dropped at an implementation-defined point in time (which may change, and technically delay
+    /// destruction of your object as soon as you use `Base::to_init_gd()`). Right now, this refcount-decrement is deferred to the next frame.
+    ///
+    /// Ref-counted bases can only use `to_init_gd()` on the main thread.
+    ///
+    /// ## Panics (Debug)
+    /// In Godot before 4.7, if called outside an initialization function, or for ref-counted objects on a non-main thread.
+    pub fn to_init_gd(&self) -> Gd<T> {
+        self.to_init_gd_inner()
     }
 
     /// Create base from existing object (used in script instances).
@@ -149,124 +150,11 @@ impl<T: GodotClass> Base<T> {
         base_from_obj!(obj, InitState::ObjectConstructing)
     }
 
-    #[cfg(safeguards_balanced)]
     fn from_obj(obj: Gd<T>, init_state: InitState) -> Self {
         Self {
             obj: ManuallyDrop::new(obj),
-            init_state: Rc::new(Cell::new(init_state)),
+            init_state: InitTracker::new(init_state),
         }
-    }
-
-    #[cfg(not(safeguards_balanced))]
-    fn from_obj(obj: Gd<T>) -> Self {
-        Self {
-            obj: ManuallyDrop::new(obj),
-        }
-    }
-
-    /// Returns a [`Gd`] referencing the base object, for exclusive use during object initialization and `NOTIFICATION_POSTINITIALIZE`.
-    ///
-    /// Can be used during an initialization function [`I*::init()`][crate::classes::IObject::init] or [`Gd::from_init_fn()`], or [`POSTINITIALIZE`][crate::classes::notify::ObjectNotification::POSTINITIALIZE].
-    ///
-    /// The base pointer is only pointing to a base object; you cannot yet downcast it to the object being constructed.
-    /// The instance ID is the same as the one the in-construction object will have.
-    ///
-    /// # Lifecycle for ref-counted classes
-    /// If `T: Inherits<RefCounted>`, then the ref-counted object is not yet fully-initialized at the time of the `init` function and [`POSTINITIALIZE`][crate::classes::notify::ObjectNotification::POSTINITIALIZE] running.
-    /// Accessing the base object without further measures would be dangerous. Here, godot-rust employs a workaround: the `Base` object (which
-    /// holds a weak pointer to the actual instance) is temporarily upgraded to a strong pointer, preventing use-after-free.
-    ///
-    /// This additional reference is automatically dropped at an implementation-defined point in time (which may change, and technically delay
-    /// destruction of your object as soon as you use `Base::to_init_gd()`). Right now, this refcount-decrement is deferred to the next frame.
-    ///
-    /// For now, ref-counted bases can only use `to_init_gd()` on the main thread.
-    ///
-    /// # Panics (Debug)
-    /// If called outside an initialization function, or for ref-counted objects on a non-main thread.
-    pub fn to_init_gd(&self) -> Gd<T> {
-        sys::balanced_assert!(
-            self.is_initializing(),
-            "Base::to_init_gd() can only be called during object initialization, inside I*::init() or Gd::from_init_fn()"
-        );
-
-        // For manually-managed objects, regular clone is fine.
-        // Only static type matters, because this happens immediately after initialization, so T is both static and dynamic type.
-        if !<T::Memory as bounds::Memory>::IS_REF_COUNTED {
-            return Gd::clone(&self.obj);
-        }
-
-        sys::balanced_assert!(
-            sys::is_main_thread(),
-            "Base::to_init_gd() can only be called on the main thread for ref-counted objects (for now)"
-        );
-
-        // First time handing out a Gd<T>, we need to take measures to temporarily upgrade the Base's weak pointer to a strong one.
-        // During the initialization phase (derived object being constructed), increment refcount by 1.
-        let instance_id = self.obj.instance_id();
-        PENDING_STRONG_REFS.with(|refs| {
-            let mut pending_refs = refs.borrow_mut();
-            if let Entry::Vacant(e) = pending_refs.entry(instance_id) {
-                let strong_ref: Gd<T> = unsafe { Gd::from_obj_sys(self.obj.obj_sys()) };
-
-                // We know that T: Inherits<RefCounted> due to check above, but don't it as a static bound for Gd::upcast().
-                // Thus fall back to low-level FFI cast on RawGd.
-                let strong_ref_raw = strong_ref.raw;
-                let raw = strong_ref_raw
-                    .ffi_cast::<classes::RefCounted>()
-                    .expect("Base must be RefCounted")
-                    .into_dest(strong_ref_raw);
-
-                e.insert(Gd { raw });
-            }
-        });
-
-        let name = format!("Base<{}> deferred unref", T::class_id());
-        let callable = Callable::from_once_fn(name, move |_args| {
-            Self::drop_strong_ref(instance_id);
-        });
-
-        // Use Callable::call_deferred() instead of Gd::apply_deferred(). The latter implicitly borrows &mut self,
-        // causing a "destroyed while bind was active" panic.
-        callable.call_deferred(&[]);
-
-        (*self.obj).clone()
-    }
-
-    /// Drops any extra strong references, possibly causing object destruction.
-    fn drop_strong_ref(instance_id: InstanceId) {
-        PENDING_STRONG_REFS.with(|refs| {
-            let mut pending_refs = refs.borrow_mut();
-            let strong_ref = pending_refs.remove(&instance_id);
-            sys::strict_assert!(
-                strong_ref.is_some(),
-                "Base unexpectedly had its strong ref rug-pulled"
-            );
-
-            // Editor creates instances of given class for various purposes (getting class docs, default values...)
-            // and frees them instantly before our callable can be executed.
-            // Perform "weak" drop instead of "strong" one iff our instance is no longer valid.
-            if !instance_id.lookup_validity() {
-                strong_ref.unwrap().drop_weak();
-            }
-
-            // Triggers RawGd::drop() -> dec-ref -> possibly object destruction.
-        });
-    }
-
-    /// Finalizes the initialization of this `Base<T>` and returns whether
-    pub(crate) fn mark_initialized(&mut self) {
-        #[cfg(safeguards_balanced)]
-        {
-            assert_eq!(
-                self.init_state.get(),
-                InitState::ObjectConstructing,
-                "Base<T> is already initialized, or holds a script instance"
-            );
-
-            self.init_state.set(InitState::ObjectInitialized);
-        }
-
-        // May return whether there is a "surplus" strong ref in the future, as self.extra_strong_ref.borrow().is_some().
     }
 
     /// Returns a [`Gd`] referencing the base object, for use in script contexts only.
@@ -291,31 +179,16 @@ impl<T: GodotClass> Base<T> {
 
     /// Returns a passive reference to the base object, for use in script contexts only.
     pub(crate) fn to_script_passive(&self) -> PassiveGd<T> {
-        #[cfg(safeguards_balanced)]
-        assert_eq!(
-            self.init_state.get(),
-            InitState::Script,
-            "to_script_passive() can only be called on script-context Base objects"
-        );
+        self.init_state.assert_script();
 
         // SAFETY: the object remains valid for script contexts as per the assertion above.
         unsafe { PassiveGd::from_strong_ref(&self.obj) }
     }
 
-    /// Returns `true` if this `Base<T>` is currently in the initializing state.
-    #[cfg(safeguards_balanced)]
-    fn is_initializing(&self) -> bool {
-        self.init_state.get() == InitState::ObjectConstructing
-    }
-
     /// Returns a [`Gd`] referencing the base object, assuming the derived object is fully constructed.
     #[doc(hidden)]
     pub fn __constructed_gd(&self) -> Gd<T> {
-        sys::balanced_assert!(
-            !self.is_initializing(),
-            "WithBaseField::to_gd(), base(), base_mut() can only be called on fully-constructed objects, after I*::init() or Gd::from_init_fn()"
-        );
-
+        self.init_state.assert_constructed();
         (*self.obj).clone()
     }
 
@@ -327,10 +200,7 @@ impl<T: GodotClass> Base<T> {
     /// # Safety
     /// Caller must ensure that the underlying object remains valid for the entire lifetime of the returned `PassiveGd`.
     pub(crate) unsafe fn constructed_passive(&self) -> PassiveGd<T> {
-        sys::balanced_assert!(
-            !self.is_initializing(),
-            "WithBaseField::base(), base_mut() can only be called on fully-constructed objects, after I*::init() or Gd::from_init_fn()"
-        );
+        self.init_state.assert_constructed();
 
         // SAFETY: object pointer is valid and remains valid as long as self is alive (per safety precondition of this fn).
         unsafe { PassiveGd::from_obj_sys(self.obj.obj_sys()) }

--- a/godot-core/src/obj/base_init.rs
+++ b/godot-core/src/obj/base_init.rs
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+//! Before Godot 4.7 initialization layers – be it an engine module or gdextension – was working with not yet fully initialized
+//! object (i.e. RefCounted with reference count `0`). Increasing and decreasing RefCount anyhow (by, for example,
+//! passing it to one of the Godot APIs) was resulting in freeing the Object.
+//! Additionally, initializing freshly constructed instance was caller responsibility.
+//!
+//! Since Godot 4.7 initialization layer receives (and yields) fully initialized object.
+//!
+//! `base_weak_initialization` contains implementation for safe workaround around this issue (deffered init) for Godot < 4.7.
+//! `base_strong_initialization` contains placeholders for Godot >= 4.7.
+//!
+//! For more information see also [`Base::to_init_gd`].
+
+#[cfg(since_api = "4.7")]
+pub(super) use super::base_strong_initialization::InitTracker;
+#[cfg(before_api = "4.7")]
+pub(super) use super::base_weak_initialization::InitTracker;
+
+/// Represents the initialization state of a `Base<T>` object.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum InitState {
+    /// Object is being constructed (inside `I*::init()` or `Gd::from_init_fn()`).
+    ObjectConstructing,
+    /// Object construction is complete.
+    ObjectInitialized,
+    /// `ScriptInstance` context - always considered initialized (bypasses lifecycle checks).
+    Script,
+}

--- a/godot-core/src/obj/base_strong_initialization.rs
+++ b/godot-core/src/obj/base_strong_initialization.rs
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use crate::obj::base_init::InitState;
+use crate::obj::{Base, Gd, GodotClass};
+
+/// Tracks the initialization state of this `Base<T>`.
+///
+/// ZST for Godot >= 4.7, where tracking initialization state is no longer necressary.
+#[derive(Clone)]
+pub struct InitTracker;
+
+impl<T: GodotClass> Base<T> {
+    /// Since Godot 4.7 initialization layer receives fully-constructed base to work with – therefore it simply returns a clone of a given instance.
+    #[doc(hidden)]
+    pub(crate) fn to_init_gd_inner(&self) -> Gd<T> {
+        self.__constructed_gd()
+    }
+}
+
+impl InitTracker {
+    pub fn new(_state: InitState) -> Self {
+        Self
+    }
+    pub fn assert_constructed(&self) {}
+    pub fn assert_script(&self) {}
+}

--- a/godot-core/src/obj/base_weak_initialization.rs
+++ b/godot-core/src/obj/base_weak_initialization.rs
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+use crate::builtin::Callable;
+use crate::obj::base_init::InitState;
+use crate::obj::{Base, Gd, GodotClass, InstanceId};
+use crate::{classes, sys};
+
+thread_local! {
+    /// Extra strong references for each instance ID, needed for [`Base::to_init_gd()`].
+    ///
+    /// At the moment, all Godot objects must be accessed from the main thread, because their deferred destruction (`Drop`) runs on the
+    /// main thread, too. This may be relaxed in the future, and a `sys::Global` could be used instead of a `thread_local!`.
+    static PENDING_STRONG_REFS: RefCell<HashMap<InstanceId, Gd<classes::RefCounted>>> = RefCell::new(HashMap::new());
+}
+
+impl<T: GodotClass> Base<T> {
+    #[doc(hidden)]
+    pub(crate) fn to_init_gd_inner(&self) -> Gd<T> {
+        sys::balanced_assert!(
+            self.init_state.is_initializing(),
+            "Base::to_init_gd() can only be called during object initialization, inside I*::init() or Gd::from_init_fn()"
+        );
+
+        // For manually-managed objects, regular clone is fine.
+        // Only static type matters, because this happens immediately after initialization, so T is both static and dynamic type.
+        if !<T::Memory as crate::obj::bounds::Memory>::IS_REF_COUNTED {
+            return Gd::clone(&self.obj);
+        }
+
+        sys::balanced_assert!(
+            sys::is_main_thread(),
+            "Base::to_init_gd() can only be called on the main thread for ref-counted objects (for now)"
+        );
+
+        // First time handing out a Gd<T>, we need to take measures to temporarily upgrade the Base's weak pointer to a strong one.
+        // During the initialization phase (derived object being constructed), increment refcount by 1.
+        let instance_id = self.obj.instance_id();
+        PENDING_STRONG_REFS.with(|refs| {
+            let mut pending_refs = refs.borrow_mut();
+            if let std::collections::hash_map::Entry::Vacant(e) = pending_refs.entry(instance_id) {
+                let strong_ref: Gd<T> = unsafe { Gd::from_obj_sys(self.obj.obj_sys()) };
+
+                // We know that T: Inherits<RefCounted> due to check above, but don't it as a static bound for Gd::upcast().
+                // Thus fall back to low-level FFI cast on RawGd.
+                let strong_ref_raw = strong_ref.raw;
+                let raw = strong_ref_raw
+                    .ffi_cast::<classes::RefCounted>()
+                    .expect("Base must be RefCounted")
+                    .into_dest(strong_ref_raw);
+
+                e.insert(Gd { raw });
+            }
+        });
+
+        let name = format!("Base<{}> deferred unref", T::class_id());
+        let callable = Callable::from_once_fn(name, move |_args| {
+            Self::drop_strong_ref(instance_id);
+        });
+
+        // Use Callable::call_deferred() instead of Gd::apply_deferred(). The latter implicitly borrows &mut self,
+        // causing a "destroyed while bind was active" panic.
+        callable.call_deferred(&[]);
+
+        (*self.obj).clone()
+    }
+
+    /// Drops any extra strong references, possibly causing object destruction.
+    fn drop_strong_ref(instance_id: InstanceId) {
+        PENDING_STRONG_REFS.with(|refs| {
+            let mut pending_refs = refs.borrow_mut();
+            let strong_ref = pending_refs.remove(&instance_id);
+            sys::strict_assert!(
+                strong_ref.is_some(),
+                "Base unexpectedly had its strong ref rug-pulled"
+            );
+
+            // Editor creates instances of given class for various purposes (getting class docs, default values...)
+            // and frees them instantly before our callable can be executed.
+            // Perform "weak" drop instead of "strong" one iff our instance is no longer valid.
+            if !instance_id.lookup_validity() {
+                strong_ref.unwrap().drop_weak();
+            }
+
+            // Triggers RawGd::drop() -> dec-ref -> possibly object destruction.
+        });
+    }
+
+    /// Finalizes the initialization of this `Base<T>`.
+    pub(crate) fn mark_initialized(&mut self) {
+        self.init_state.mark_initialized();
+    }
+}
+
+pub use implementation::*;
+
+#[cfg(safeguards_balanced)]
+mod implementation {
+    use std::cell::Cell;
+    use std::rc::Rc;
+
+    use super::*;
+
+    /// Tracks the initialization state of this `Base<T>`.
+    ///
+    /// Rc allows to "copy-construct" the base from an existing one, while still affecting the user-instance through the original `Base<T>`.
+    #[derive(Clone, Debug)]
+    pub struct InitTracker {
+        init_state: Rc<Cell<InitState>>,
+    }
+
+    impl InitTracker {
+        pub fn new(state: InitState) -> Self {
+            Self {
+                init_state: Rc::new(Cell::new(state)),
+            }
+        }
+
+        pub fn is_initializing(&self) -> bool {
+            self.init_state.get() == InitState::ObjectConstructing
+        }
+
+        /// Finalizes the initialization of this `Base<T>`.
+        pub fn mark_initialized(&self) {
+            assert_eq!(
+                self.init_state.get(),
+                InitState::ObjectConstructing,
+                "Base<T> is already initialized, or holds a script instance"
+            );
+            self.init_state.set(InitState::ObjectInitialized);
+        }
+
+        // Asserts live here so call sites don't need cfg.
+        pub fn assert_constructed(&self) {
+            sys::balanced_assert!(
+                !self.is_initializing(),
+                "WithBaseField::base(), base_mut(), to_gd() can only be called on \
+                  fully-constructed objects, after I*::init() or Gd::from_init_fn()"
+            );
+        }
+
+        pub fn assert_script(&self) {
+            sys::balanced_assert!(
+                self.init_state.get() == InitState::Script,
+                "to_script_passive() can only be called on script-context Base objects"
+            );
+        }
+    }
+}
+
+#[cfg(not(safeguards_balanced))]
+mod implementation {
+    use super::InitState;
+
+    /// Tracks the initialization state of this `Base<T>`.
+    ///
+    /// Rc allows to "copy-construct" the base from an existing one, while still affecting the user-instance through the original `Base<T>`.
+    #[derive(Clone)]
+    pub struct InitTracker;
+
+    impl InitTracker {
+        pub fn new(_state: InitState) -> Self {
+            Self
+        }
+        pub fn is_initializing(&self) -> bool {
+            false
+        }
+        pub fn mark_initialized(&self) {}
+        pub fn assert_constructed(&self) {}
+        pub fn assert_script(&self) {}
+    }
+}

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -160,7 +160,7 @@ where
         let object_ptr = callbacks::create_custom(init, true) // or propagate panic.
             .unwrap_or_else(|payload| PanicPayload::repanic(payload));
 
-        unsafe { Gd::from_obj_sys(object_ptr) }
+        unsafe { Gd::from_constructed_obj_sys(object_ptr) }
     }
 
     /// Moves a user-created object into this smart pointer, submitting ownership to the Godot engine.
@@ -539,7 +539,7 @@ impl<T: GodotClass> Gd<T> {
             #[cfg(before_api = "4.4")]
             let object_ptr = callbacks::create::<T>(std::ptr::null_mut());
 
-            Gd::from_obj_sys(object_ptr)
+            Gd::from_constructed_obj_sys(object_ptr)
         }
     }
 
@@ -595,6 +595,32 @@ impl<T: GodotClass> Gd<T> {
         F: 'static + FnMut(&[&Variant]) -> R,
     {
         Callable::from_linked_fn(method_name, self, rust_function)
+    }
+
+    /// Used by caller to transform pointer of freshly created instance into `Gd<T>`. This is default in most initializations from FFI.
+    ///
+    /// Before 4.7 Godot (including GDExtension layer) returns not fully-initialized instance and initializing it is a caller
+    /// responsibility, which is done with [`Self::from_obj_sys`].
+    ///
+    /// After 4.7 Godot (and GDExtension layer too) returns fully-initialized instance to the caller, and [`Self::from_obj_sys_weak`]
+    /// is used instead.
+    ///
+    /// In other words, before 4.7 it was something along the lines of:
+    /// construct base -> do init/postinit -> CALLER initializes instance
+    ///
+    /// While afterwards we ended with:
+    /// construct initialized base -> do init/postinit -> CALLER receives initialized instance.
+    ///
+    /// # Safety
+    /// `ptr` must point to a valid object of this type.
+    pub(crate) unsafe fn from_constructed_obj_sys(ptr: sys::GDExtensionObjectPtr) -> Self {
+        #[cfg(before_api = "4.7")]
+        let obj = unsafe { Gd::<T>::from_obj_sys(ptr) };
+
+        #[cfg(since_api = "4.7")]
+        let obj = unsafe { Gd::<T>::from_obj_sys_weak(ptr) };
+
+        obj
     }
 
     pub(crate) unsafe fn from_obj_sys_or_none(

--- a/godot-core/src/obj/mod.rs
+++ b/godot-core/src/obj/mod.rs
@@ -24,6 +24,11 @@ mod passive_gd;
 mod raw_gd;
 mod traits;
 
+mod base_init;
+#[cfg(since_api = "4.7")]
+mod base_strong_initialization;
+#[cfg(before_api = "4.7")]
+mod base_weak_initialization;
 pub(crate) mod rtti;
 pub mod signal;
 

--- a/godot-core/src/registry/callbacks.rs
+++ b/godot-core/src/registry/callbacks.rs
@@ -105,8 +105,15 @@ where
         #[cfg(since_api = "4.4")]
         if notify_postinitialize {
             // Should notify it with a weak pointer, during `NOTIFICATION_POSTINITIALIZE`, ref-counted object is not yet fully-initialized.
+            #[cfg(before_api = "4.7")]
             let mut obj = unsafe { Gd::<Object>::from_obj_sys_weak(base_ptr) };
+
+            // Since 4.7 base comes in fully initialized.
+            #[cfg(since_api = "4.7")]
+            let mut obj = unsafe { Gd::<Object>::from_obj_sys(base_ptr) };
+
             obj.notify(crate::classes::notify::ObjectNotification::POSTINITIALIZE);
+            #[cfg(before_api = "4.7")]
             obj.drop_weak();
         }
     };
@@ -153,7 +160,13 @@ where
     // Print shouldn't be necessary as panic itself is printed. If this changes, re-enable in error case:
     // godot_error!("failed to create instance of {class_name}; Rust init() panicked");
 
+    #[cfg(before_api = "4.7")]
     let mut base_copy = unsafe { Base::from_base(&base) };
+    #[cfg(all(since_api = "4.7", safeguards_balanced))]
+    sys::balanced_assert!(
+        Base::is_valid(&base),
+        "Unable to construct instance – Base was freed during initialization"
+    );
 
     let instance = InstanceStorage::<T>::construct(user_instance, base);
     let instance_rust_ptr = instance.into_raw();
@@ -173,6 +186,7 @@ where
     postinit(base_ptr);
 
     // Mark initialization as complete, now that user constructor has finished.
+    #[cfg(before_api = "4.7")]
     base_copy.mark_initialized();
 
     // No std::mem::forget(base_copy) here, since Base may stores other fields that need deallocation.

--- a/godot-core/src/registry/class.rs
+++ b/godot-core/src/registry/class.rs
@@ -75,8 +75,10 @@ pub struct ClassMetadata {}
 type GodotCreationInfo = sys::GDExtensionClassCreationInfo2;
 #[cfg(all(since_api = "4.3", before_api = "4.4"))]
 type GodotCreationInfo = sys::GDExtensionClassCreationInfo3;
-#[cfg(since_api = "4.4")]
+#[cfg(all(since_api = "4.4", before_api = "4.7"))]
 type GodotCreationInfo = sys::GDExtensionClassCreationInfo4;
+#[cfg(since_api = "4.7")]
+type GodotCreationInfo = sys::GDExtensionClassCreationInfo6;
 
 #[cfg(before_api = "4.4")]
 pub(crate) type GodotGetVirtual = <sys::GDExtensionClassGetVirtual as sys::Inner>::FnPtr;
@@ -583,8 +585,11 @@ fn register_class_raw(mut info: ClassRegistrationInfo) {
         #[cfg(all(since_api = "4.3", before_api = "4.4"))]
         let register_fn = interface_fn!(classdb_register_extension_class3);
 
-        #[cfg(since_api = "4.4")]
+        #[cfg(all(since_api = "4.4", before_api = "4.7"))]
         let register_fn = interface_fn!(classdb_register_extension_class4);
+
+        #[cfg(since_api = "4.7")]
+        let register_fn = interface_fn!(classdb_register_extension_class6);
 
         let _: () = register_fn(
             sys::get_library(),
@@ -759,11 +764,40 @@ fn default_creation_info() -> sys::GDExtensionClassCreationInfo3 {
     }
 }
 
-#[cfg(since_api = "4.4")]
+#[cfg(all(since_api = "4.4", before_api = "4.7"))]
 fn default_creation_info() -> sys::GDExtensionClassCreationInfo4 {
     sys::GDExtensionClassCreationInfo4 {
-        is_virtual: false as u8,
-        is_abstract: false as u8,
+        is_virtual: sys::conv::SYS_FALSE,
+        is_abstract: sys::conv::SYS_FALSE,
+        is_exposed: sys::conv::SYS_TRUE,
+        is_runtime: sys::conv::SYS_TRUE,
+        icon_path: ptr::null(),
+        set_func: None,
+        get_func: None,
+        get_property_list_func: None,
+        free_property_list_func: None,
+        property_can_revert_func: None,
+        property_get_revert_func: None,
+        validate_property_func: None,
+        notification_func: None,
+        to_string_func: None,
+        reference_func: None,
+        unreference_func: None,
+        create_instance_func: None,
+        free_instance_func: None,
+        recreate_instance_func: None,
+        get_virtual_func: None,
+        get_virtual_call_data_func: None,
+        call_virtual_with_data_func: None,
+        class_userdata: ptr::null_mut(),
+    }
+}
+
+#[cfg(since_api = "4.7")]
+fn default_creation_info() -> sys::GDExtensionClassCreationInfo6 {
+    sys::GDExtensionClassCreationInfo6 {
+        is_virtual: sys::conv::SYS_FALSE,
+        is_abstract: sys::conv::SYS_FALSE,
         is_exposed: sys::conv::SYS_TRUE,
         is_runtime: sys::conv::SYS_TRUE,
         icon_path: ptr::null(),

--- a/godot-ffi/src/lib.rs
+++ b/godot-ffi/src/lib.rs
@@ -646,8 +646,11 @@ pub unsafe fn classdb_construct_object(
     #[cfg(before_api = "4.4")]
     let f = interface_fn!(classdb_construct_object);
 
-    #[cfg(since_api = "4.4")]
+    #[cfg(all(since_api = "4.4", before_api = "4.7"))]
     let f = interface_fn!(classdb_construct_object2);
+
+    #[cfg(since_api = "4.7")]
+    let f = interface_fn!(classdb_construct_object3);
 
     // SAFETY: function pointer is valid since binding is initialized; class_name validity is upheld by caller.
     unsafe { f(class_name) }

--- a/itest/rust/src/object_tests/base_init_test.rs
+++ b/itest/rust/src/object_tests/base_init_test.rs
@@ -10,7 +10,7 @@ use godot::builtin::real_consts::FRAC_PI_3;
 use godot::classes::notify::ObjectNotification;
 use godot::classes::{ClassDb, IRefCounted, RefCounted};
 use godot::meta::ToGodot;
-use godot::obj::{Base, Gd, InstanceId, NewGd, Singleton, WithBaseField};
+use godot::obj::{Base, Gd, NewGd, Singleton, WithBaseField};
 use godot::register::{GodotClass, godot_api};
 use godot::task::TaskHandle;
 
@@ -97,83 +97,124 @@ fn base_init_refcounted_simple() {
     });
 }
 
-// Tests that the auto-decrement of surplus references also works when instantiated through the engine.
-#[itest(async)]
-fn base_init_refcounted_from_engine() -> TaskHandle {
-    let db = ClassDb::singleton();
-    let obj = db.instantiate("RefcBased").to::<Gd<RefcBased>>();
+#[cfg(before_api = "4.7")]
+mod refcount_tests {
+    use godot::obj::InstanceId;
 
-    assert_eq!(obj.get_reference_count(), 2);
-    next_frame(move || assert_eq!(obj.get_reference_count(), 1, "eventual dec-ref happens"))
-}
+    use super::*;
 
-#[itest(async)]
-fn base_init_refcounted_from_rust() -> TaskHandle {
-    let obj = RefcBased::new_gd();
+    // Tests that the auto-decrement of surplus references also works when instantiated through the engine.
+    #[itest(async)]
+    fn base_init_refcounted_from_engine() -> TaskHandle {
+        let db = ClassDb::singleton();
+        let obj = db.instantiate("RefcBased").to::<Gd<RefcBased>>();
 
-    assert_eq!(obj.get_reference_count(), 2);
-    next_frame(move || assert_eq!(obj.get_reference_count(), 1, "eventual dec-ref happens"))
-}
+        assert_eq!(obj.get_reference_count(), 2);
+        next_frame(move || assert_eq!(obj.get_reference_count(), 1, "eventual dec-ref happens"))
+    }
 
-#[itest(async)]
-fn base_init_refcounted_complex() -> TaskHandle {
-    // Instantiate with multiple Gd<T> references.
-    let id_simple = verify_complex_init(RefcBased::split_simple());
-    let id_intermixed = verify_complex_init(RefcBased::split_intermixed());
+    #[itest(async)]
+    fn base_init_refcounted_from_rust() -> TaskHandle {
+        let obj = RefcBased::new_gd();
 
-    next_frame(move || {
-        assert!(!id_simple.lookup_validity(), "object destroyed eventually");
-        assert!(
-            !id_intermixed.lookup_validity(),
-            "object destroyed eventually"
-        );
-    })
-}
+        assert_eq!(obj.get_reference_count(), 2);
+        next_frame(move || assert_eq!(obj.get_reference_count(), 1, "eventual dec-ref happens"))
+    }
 
-fn verify_complex_init((obj, base): (Gd<RefcBased>, Gd<RefCounted>)) -> InstanceId {
-    let id = obj.instance_id();
+    #[itest(async)]
+    fn base_init_refcounted_complex() -> TaskHandle {
+        // Instantiate with multiple Gd<T> references.
+        let id_simple = verify_complex_init(RefcBased::split_simple());
+        let id_intermixed = verify_complex_init(RefcBased::split_intermixed());
 
-    assert_eq!(obj.instance_id(), base.instance_id());
-    assert_eq!(base.get_reference_count(), 3);
-    assert_eq!(obj.get_reference_count(), 3);
+        next_frame(move || {
+            assert!(!id_simple.lookup_validity(), "object destroyed eventually");
+            assert!(
+                !id_intermixed.lookup_validity(),
+                "object destroyed eventually"
+            );
+        })
+    }
 
-    drop(base);
-    assert_eq!(obj.get_reference_count(), 2);
-    assert_eq!(obj.get_reference_count(), 2);
-    drop(obj);
+    fn verify_complex_init((obj, base): (Gd<RefcBased>, Gd<RefCounted>)) -> InstanceId {
+        let id = obj.instance_id();
 
-    // Not dead yet.
-    assert!(id.lookup_validity(), "object retained (dec-ref deferred)");
-    id
-}
+        assert_eq!(obj.instance_id(), base.instance_id());
+        assert_eq!(base.get_reference_count(), 3);
+        assert_eq!(obj.get_reference_count(), 3);
 
-#[cfg(safeguards_strict)]
-#[itest]
-fn base_init_outside_init() {
-    use godot::obj::NewAlloc;
-    let mut obj = Based::new_alloc();
+        drop(base);
+        assert_eq!(obj.get_reference_count(), 2);
+        assert_eq!(obj.get_reference_count(), 2);
+        drop(obj);
 
-    expect_panic("to_init_gd() outside init() function", || {
-        let guard = obj.bind_mut();
-        let _gd = guard.base.to_init_gd(); // Panics in strict safeguard mode.
-    });
+        // Not dead yet.
+        assert!(id.lookup_validity(), "object retained (dec-ref deferred)");
+        id
+    }
 
-    obj.free();
-}
+    #[cfg(safeguards_strict)]
+    #[itest]
+    fn base_init_outside_init() {
+        use godot::obj::NewAlloc;
+        let mut obj = Based::new_alloc();
 
-#[cfg(safeguards_strict)]
-#[itest]
-fn base_init_to_gd() {
-    expect_panic("WithBaseField::to_gd() inside init() function", || {
-        let _obj = Gd::<Based>::from_init_fn(|base| {
-            let temp_obj = Based { base, i: 999 };
-
-            // Call to self.to_gd() during initialization should panic in strict safeguard mode.
-            let _gd = godot::obj::WithBaseField::to_gd(&temp_obj);
-
-            temp_obj
+        expect_panic("to_init_gd() outside init() function", || {
+            let guard = obj.bind_mut();
+            let _gd = guard.base.to_init_gd(); // Panics in strict safeguard mode.
         });
-    });
+
+        obj.free();
+    }
+
+    #[cfg(safeguards_strict)]
+    #[itest]
+    fn base_init_to_gd() {
+        expect_panic("WithBaseField::to_gd() inside init() function", || {
+            let _obj = Gd::<Based>::from_init_fn(|base| {
+                let temp_obj = Based { base, i: 999 };
+
+                // Call to self.to_gd() during initialization should panic in strict safeguard mode.
+                let _gd = godot::obj::WithBaseField::to_gd(&temp_obj);
+
+                temp_obj
+            });
+        });
+    }
+}
+
+#[cfg(since_api = "4.7")]
+mod refcount_tests {
+    use super::*;
+
+    #[itest(async)]
+    fn base_init_refcounted_from_engine() -> TaskHandle {
+        let db = ClassDb::singleton();
+        let obj = db.instantiate("RefcBased").to::<Gd<RefcBased>>();
+
+        assert_eq!(obj.get_reference_count(), 1);
+        let instance_id = obj.instance_id();
+        next_frame(move || {
+            assert!(
+                !instance_id.lookup_validity(),
+                "properly freed at this point"
+            )
+        })
+    }
+
+    #[itest(async)]
+    fn base_init_refcounted_from_rust() -> TaskHandle {
+        let obj = RefcBased::new_gd();
+
+        assert_eq!(obj.get_reference_count(), 1);
+        let instance_id = obj.instance_id();
+        next_frame(move || {
+            assert!(
+                !instance_id.lookup_validity(),
+                "properly freed at this point"
+            )
+        })
+    }
 }
 
 #[derive(GodotClass)]
@@ -193,7 +234,7 @@ impl IRefCounted for RefcPostinit {
     }
 }
 
-#[cfg(since_api = "4.4")]
+#[cfg(all(since_api = "4.4", before_api = "4.7"))]
 #[itest(async)]
 fn base_postinit_refcounted() -> TaskHandle {
     let obj = RefcPostinit::new_gd();

--- a/itest/rust/src/object_tests/base_test.rs
+++ b/itest/rust/src/object_tests/base_test.rs
@@ -186,6 +186,20 @@ fn base_refcounted_weak_reference() {
     );
 }
 
+#[itest]
+#[cfg(since_api = "4.7")]
+fn base_can_be_used_in_init() {
+    // Before Godot 4.7 our RefCounted `base` was coming in uninitialized.
+    // Increasing and decreasing refcount was resulting in freeing an instance.
+    let obj = Gd::from_init_fn(|base| {
+        let instance = RefcBased { base };
+        drop(instance.base().clone());
+        instance
+    });
+    // Since Godot 4.7 such operations are totally legal :).
+    assert!(obj.is_instance_valid());
+}
+
 fn create_object_with_extracted_base() -> (Gd<Baseless>, Base<Node2D>) {
     let mut extracted_base = None;
     let obj = Baseless::smuggle_out(&mut extracted_base);
@@ -298,7 +312,10 @@ impl RefcBased {
     pub fn create_one() -> Gd<Self> {
         Gd::from_init_fn(|base| Self { base })
     }
+}
 
+#[cfg(before_api = "4.7")]
+impl RefcBased {
     /// Used in `base_init_test.rs` to test that a base pointer can be extracted during initialization.
     pub fn split_simple() -> (Gd<Self>, Gd<RefCounted>) {
         let mut moved_out = None;


### PR DESCRIPTION
Migrates gdext with API >= 4.7 to use `classdb_construct_object3` `classdb_register_extension_class6`: https://github.com/godotengine/godot/pull/118214.

Tl;dr:
- In Godot 4.7 initialization layer receives fully initialized base to work with.
- In Godot 4.7 initializing constructed object is no longer a caller responsibility.

I ran tests against 4.7 && 4.7 + 4.6 API && 4.6 + 4.6 API, all seems to works fine.

I abstracted most stuff so it won't get into way or confuse people - I moved whole `init_gd` workaround into separate inner module (I think we won't work on it anymore), and added extra function which yield strong/weak pointer of freshly constructed instance from pointer to object. (The former is responsible for 2\3 changes in this PR lmao)