### PR TITLE
Rewrite `godot_ffi::toolbox::c_str()` to more properly check for a nul terminator

### DIFF
--- a/godot-ffi/src/toolbox.rs
+++ b/godot-ffi/src/toolbox.rs
@@ -98,10 +98,13 @@ where
 /// Returns a C `const char*` for a null-terminated byte string.
 #[inline]
 pub fn c_str(s: &[u8]) -> *const std::ffi::c_char {
+    let cstr_res = std::ffi::CStr::from_bytes_with_nul(s);
     // Ensure null-terminated
-    crate::strict_assert!(!s.is_empty() && s[s.len() - 1] == 0);
+    crate::strict_assert!(cstr_res.is_ok());
 
-    s.as_ptr() as *const std::ffi::c_char
+    // SAFETY: We just checked if the result is `Ok(_)`
+    let cstr = unsafe { cstr_res.unwrap_unchecked() };
+    cstr.as_ptr()
 }
 
 /// Returns a C `const char*` for a null-terminated string slice. UTF-8 encoded.


### PR DESCRIPTION
Whilst looking at logging code to see if I could make my log adapter work, I stumbled upon [`godot_ffi::toolbox::c_str_from_str()` and `godot_ffi::toolbox::c_str()`](https://github.com/godot-rust/gdext/blob/fae1db76c624976255175a720ca5a316aed3f332/godot-ffi/src/toolbox.rs#L98-L111).

I happened to notice the checks for a nul terminator are fairly simple - in fact, they can allow nul bytes in the middle of the slice. This feels like UB waiting to happen. (Or at least, potential memory corruption?)

This bothered me a bit, so I opted to replace this with a conversion that goes through [`std::ffi::CStr`](https://doc.rust-lang.org/1.95.0/std/ffi/struct.CStr.html) - which guarantees that it's a proper c-style string with a single nul terminator at the end, and no nul bytes in the middle.

CStr has two options for converting from a `&[u8]` to a `&CStr`:

* [`CStr::from_bytes_until_nul()`](https://doc.rust-lang.org/1.95.0/std/ffi/struct.CStr.html#method.from_bytes_until_nul), which checks if there's a nul terminator *anywhere* in the slice. If there is, a subslice is made from the beginning to that nul terminator, and a `CStr` is created from that subslice. 
* [`CStr::from_bytes_with_nul()`](https://doc.rust-lang.org/1.95.0/std/ffi/struct.CStr.html#method.from_bytes_with_nul), which checks if there's *only one* nul terminator *at the end* of the slice. If that's so, it creates a `CStr` from the entire slice.

I went with the "with_nul" version, as I felt that better represented the intent: To require a singular nul terminator, that exists at the end of the string. (Besides, having a nul terminator in the middle of the string will result in weird stuff anyways.)

However, if the "until_nul" version is preferred, let me know. (Or feel free to change it yourself - I allow edits by maintainers on my PRs.)

Side note: I don't have much experience benchmarking stuff, but running `check.sh` before and after this change seems to show negligible change in the benchmark results.