### PR TITLE
Generate `gdextension_interface.json` out of Godot binary for Godot versions newer than latest/stable.

### DIFF
--- a/godot-bindings/src/godot_exe.rs
+++ b/godot-bindings/src/godot_exe.rs
@@ -7,6 +7,7 @@
 
 //! Commands related to Godot executable
 
+use std::borrow::Cow;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
@@ -47,6 +48,27 @@ pub fn load_extension_api_json(watch: &mut StopWatch) -> String {
 
     watch.record("read_api_json");
     result
+}
+
+pub fn load_gdextension_interface_json(watch: &mut StopWatch) -> Cow<'static, str> {
+    let godot_bin = locate_godot_binary();
+    rerun_on_changed(&godot_bin);
+    watch.record("locate_godot");
+
+    if read_godot_version(&godot_bin).is_newer_than_latest() {
+        watch.record("load_prebuilt_header_json");
+        return gdextension_api::load_gdextension_interface_json();
+    }
+
+    let out_dir = std::env::var("OUT_DIR").unwrap();
+    let json_path = format!("{out_dir}/gdextension_interface.json");
+    dump_header_json_file(&godot_bin, &json_path);
+    watch.record("dump_header_json");
+
+    let contents = fs::read_to_string(json_path)
+        .expect("failed to load freshly created gdextension_interface.json");
+
+    Cow::Owned(contents)
 }
 
 /*
@@ -145,6 +167,19 @@ pub(crate) fn locate_godot_binary() -> PathBuf {
              GDRUST_GODOT_BIN environment variable (with the path to the executable)."
         )
     }
+}
+
+fn dump_header_json_file<P: AsRef<Path>>(godot_bin: &PathBuf, path: &P) {
+    let cwd = path.as_ref().parent().unwrap();
+
+    fs::create_dir_all(cwd)
+        .unwrap_or_else(|_| panic!("failed to create directory '{}'", cwd.display()));
+    let mut cmd = Command::new(godot_bin);
+    cmd.current_dir(cwd)
+        .arg("--headless")
+        .arg("--dump-gdextension-interface-json");
+
+    execute(cmd, "dump Godot header file");
 }
 
 fn execute(cmd: Command, error_message: &str) -> Output {

--- a/godot-bindings/src/import.rs
+++ b/godot-bindings/src/import.rs
@@ -65,3 +65,11 @@ pub use gdextension_api::version_4_6 as prebuilt;
 //  [line] pub use gdextension_api::version_$snakeVersion as prebuilt;
 pub use gdextension_api::version_4_6 as prebuilt;
 // ]]
+
+// Latest API version, supported by the shipped prebuilt.
+// TODO - this info should be included in the `gdextension_api` library.
+// [version-sync] [[
+//  [include] current
+//  [line] pub const LATEST_API_VERSION: (u8, u8, u8) = $triple;
+pub const LATEST_API_VERSION: (u8, u8, u8) = (4, 6, 0);
+// ]]

--- a/godot-bindings/src/lib.rs
+++ b/godot-bindings/src/lib.rs
@@ -18,7 +18,7 @@ pub use watch::StopWatch;
 
 mod import;
 
-pub use import::MIN_SUPPORTED_VERSION;
+pub use import::{LATEST_API_VERSION, MIN_SUPPORTED_VERSION};
 
 #[derive(Eq, PartialEq, Debug)]
 pub struct GodotVersion {
@@ -41,19 +41,28 @@ pub struct GodotVersion {
 #[cfg(any(feature = "api-custom", feature = "api-custom-json"))]
 impl GodotVersion {
     pub(crate) fn validate_or_panic(self) -> Self {
+        let (min_major, min_minor) = MIN_SUPPORTED_VERSION;
+
         assert_eq!(
-            self.major, 4,
+            self.major, min_major,
             "Only Godot versions with major version 4 are supported; found version {}.",
             self.full_string
         );
 
         assert!(
-            self.minor > 0,
+            self.minor > min_minor,
             "Godot 4.0 is no longer supported by godot-rust; found version {}.",
             self.full_string
         );
 
         self
+    }
+
+    /// `True` if given godot version is newer than one included in the shipped prebuilt.
+    pub(crate) fn is_newer_than_latest(&self) -> bool {
+        let (_latest_major, latest_minor, _latest_patch): (u8, u8, u8) = LATEST_API_VERSION;
+
+        self.minor >= latest_minor
     }
 }
 
@@ -78,8 +87,7 @@ mod depend_on_custom {
     }
 
     pub fn load_gdextension_interface_json(watch: &mut StopWatch) -> Cow<'static, str> {
-        watch.record("load_interface_json");
-        gdextension_api::load_gdextension_interface_json()
+        godot_exe::load_gdextension_interface_json(watch)
     }
 
     pub(crate) fn get_godot_version() -> GodotVersion {


### PR DESCRIPTION
Does what it says on the tin.

tl;dr - currently `godot_exe` uses only latest gdextension header json which is an issue if we want to use/cover something added to it in a meanwhile (example: https://github.com/godot-rust/gdext/actions/runs/25080009521/job/73482557726 - fail because `classdb_construct_object3` has been present only since the Godot 4.7). Generating headers for nightly is rather silly waste of resources (ideally I should generate and test against them _before_ changes are merged).

It is debatable if we should use _latest or generated_ (forks might exist), but that's something we can adjust on someone's request (also, why would anybody fork Godot if they wouldn't set the major version to 404? That's obvious pun which shouldn't go under any forkmaster radar).

Closes #1571