### PR TITLE
Import Godot documentation for methods

### DIFF
--- a/godot-codegen/src/context.rs
+++ b/godot-codegen/src/context.rs
@@ -475,6 +475,7 @@ pub struct ImportRegexes {
     pub type_links: Regex,
     pub method_links: Regex,
     pub unimplemented_links: Regex,
+    pub param_links: Regex,
 }
 
 impl Default for ImportRegexes {
@@ -495,11 +496,20 @@ impl Default for ImportRegexes {
             codeblock_lang_tags: regex(r#"\[codeblock lang=(.*?)\]([\s\S]*?)\[\/codeblock\]"#),
             gdscript_tags: regex(r#"\[gdscript\]([\s\S]*?)\[\/gdscript\]"#),
             csharp_tags: regex(r#"\[csharp\]([\s\S]*?)\[\/csharp\]"#),
-            type_links: regex(r#"\[([a-zA-Z0-9@]+?)\]"#),
+            // Matches a markdown code, codeblock tags, or a Godot type link. We need
+            // to match the code and codeblocks first to avoid matching type links inside the code
+            // Examples:
+            // - `code`
+            // - ```lang codeblock```
+            // - [Node]
+            type_links: regex(
+                r#"(\`[\s\S]*?\`)|(\`\`\`[a-zA-Z]*\s*[\s\S]*?\`\`\`)|\[([a-zA-Z0-9@]+?)\]"#,
+            ),
             method_links: regex(r#"\[method ((([a-zA-Z0-9@]+?)\.)?([a-zA-Z0-9_]+?))\]"#),
             unimplemented_links: regex(
-                r#"\[(annotation|constant|member|enum|param|constructor|signal)\s.*?\]"#,
+                r#"\[(annotation|constant|member|enum|constructor|signal)\s.*?\]"#,
             ),
+            param_links: regex(r#"\[param ([a-zA-Z0-9_]+?)\]"#),
         }
     }
 }

--- a/godot-codegen/src/generator/builtins.rs
+++ b/godot-codegen/src/generator/builtins.rs
@@ -15,8 +15,8 @@ use crate::generator::functions_common::{FnCode, FnDefinition, FnDefinitions, Fn
 use crate::generator::method_tables::MethodTableKey;
 use crate::generator::{enums, functions_common};
 use crate::models::domain::{
-    BuiltinClass, BuiltinMethod, ClassLike, ExtensionApi, FlowDirection, FnDirection, Function,
-    ModName, RustTy, TyName,
+    ApiView, BuiltinClass, BuiltinMethod, ClassLike, ExtensionApi, FlowDirection, FnDirection,
+    Function, ModName, RustTy, TyName,
 };
 use crate::{SubmitFn, conv, util};
 
@@ -36,6 +36,7 @@ pub struct GeneratedBuiltinModule {
 pub fn generate_builtin_class_files(
     api: &ExtensionApi,
     ctx: &mut Context,
+    view: &ApiView,
     gen_path: &Path,
     submit_fn: &mut SubmitFn,
 ) {
@@ -52,7 +53,7 @@ pub fn generate_builtin_class_files(
         let module_name = class.mod_name();
 
         let variant_shout_name = util::ident(variant.godot_shout_name());
-        let generated_builtin = make_builtin_class(class, &variant_shout_name, ctx);
+        let generated_builtin = make_builtin_class(class, &variant_shout_name, view, ctx);
         let file_contents = generated_builtin.code;
 
         let out_path = gen_path.join(format!("{}.rs", module_name.rust_mod));
@@ -105,6 +106,7 @@ pub fn make_builtin_module_file(classes_and_modules: Vec<GeneratedBuiltinModule>
 fn make_builtin_class(
     class: &BuiltinClass,
     variant_shout_name: &Ident,
+    view: &ApiView,
     ctx: &mut Context,
 ) -> GeneratedBuiltin {
     let godot_name = &class.name().godot_ty;
@@ -127,7 +129,7 @@ fn make_builtin_class(
     let (
         FnDefinitions { functions: inner_methods, builders: inner_builders },
         FnDefinitions { functions: outer_methods, builders: outer_builders },
-    ) = make_builtin_methods(class, variant_shout_name, &class.methods, ctx);
+    ) = make_builtin_methods(class, variant_shout_name, &class.methods, view, ctx);
 
     let imports = util::make_imports();
     let enums = enums::make_enums(&class.enums, &TokenStream::new());
@@ -190,6 +192,7 @@ fn make_builtin_methods(
     builtin_class: &BuiltinClass,
     variant_shout_name: &Ident,
     methods: &[BuiltinMethod],
+    view: &ApiView,
     ctx: &mut Context,
 ) -> (FnDefinitions, FnDefinitions) {
     // Can't use partition() without allocating new vectors. It can also not be used after map() since condition is lost at that point.
@@ -198,7 +201,7 @@ fn make_builtin_methods(
         .iter()
         .filter(|&method| !method.is_exposed_in_outer)
         .map(|method| {
-            make_builtin_method_definition(builtin_class, variant_shout_name, method, ctx)
+            make_builtin_method_definition(builtin_class, variant_shout_name, method, view, ctx)
         });
     let inner_defs = FnDefinitions::expand(inner_defs);
 
@@ -206,7 +209,7 @@ fn make_builtin_methods(
         .iter()
         .filter(|&method| method.is_exposed_in_outer)
         .map(|method| {
-            make_builtin_method_definition(builtin_class, variant_shout_name, method, ctx)
+            make_builtin_method_definition(builtin_class, variant_shout_name, method, view, ctx)
         });
     let outer_defs = FnDefinitions::expand(outer_defs);
 
@@ -249,6 +252,7 @@ fn make_builtin_method_definition(
     builtin_class: &BuiltinClass,
     variant_shout_name: &Ident,
     method: &BuiltinMethod,
+    view: &ApiView,
     ctx: &mut Context,
 ) -> FnDefinition {
     let FnDirection::Outbound { hash } = method.direction() else {
@@ -323,5 +327,7 @@ fn make_builtin_method_definition(
             is_varcall_fallible: false,
         },
         &FnMeta::default(),
+        view,
+        ctx,
     )
 }

--- a/godot-codegen/src/generator/classes.rs
+++ b/godot-codegen/src/generator/classes.rs
@@ -114,7 +114,7 @@ fn make_class(class: &Class, ctx: &mut Context, view: &ApiView) -> GeneratedClas
         && !description.is_empty()
     {
         extended_class_doc.push_str("\n# Godot docs\n");
-        let imported_doc = super::import_docs::import_class_docs(description, class, ctx, view);
+        let imported_doc = super::import_docs::import_docs(description, Some(class), ctx, view);
         extended_class_doc.push_str(&imported_doc);
     }
 
@@ -147,7 +147,7 @@ fn make_class(class: &Class, ctx: &mut Context, view: &ApiView) -> GeneratedClas
     let FnDefinitions {
         functions: methods,
         builders,
-    } = make_class_methods(class, &class.methods, &cfg_attributes, ctx);
+    } = make_class_methods(class, &class.methods, &cfg_attributes, view, ctx);
 
     let signals::SignalCodegen {
         signal_code,
@@ -560,12 +560,13 @@ fn make_class_methods(
     class: &Class,
     methods: &[ClassMethod],
     cfg_attributes: &TokenStream,
+    view: &ApiView,
     ctx: &mut Context,
 ) -> FnDefinitions {
     let get_method_table = class.api_level.table_global_getter();
 
     let definitions = methods.iter().map(|method| {
-        make_class_method_definition(class, method, &get_method_table, cfg_attributes, ctx)
+        make_class_method_definition(class, method, &get_method_table, cfg_attributes, view, ctx)
     });
 
     FnDefinitions::expand(definitions)
@@ -576,6 +577,7 @@ fn make_class_method_definition(
     method: &ClassMethod,
     get_method_table: &Ident,
     cfg_attributes: &TokenStream,
+    view: &ApiView,
     ctx: &mut Context,
 ) -> FnDefinition {
     let FnDirection::Outbound { hash } = method.direction() else {
@@ -648,5 +650,7 @@ fn make_class_method_definition(
             cfg_attributes: cfg_attributes1,
             specific_docs: TokenStream::new(),
         },
+        view,
+        ctx,
     )
 }

--- a/godot-codegen/src/generator/default_parameters.rs
+++ b/godot-codegen/src/generator/default_parameters.rs
@@ -9,11 +9,12 @@ use functions_common as fns;
 use proc_macro2::{Ident, TokenStream};
 use quote::{format_ident, quote};
 
-use crate::generator::functions_common;
+use crate::context::Context;
 use crate::generator::functions_common::{
     FnArgExpr, FnCode, FnKind, FnMeta, FnParamDecl, make_arg_expr, make_param_or_field_type,
 };
-use crate::models::domain::{FnParam, FnQualifier, Function, RustTy, TyName};
+use crate::generator::{functions_common, import_docs};
+use crate::models::domain::{ApiView, FnParam, FnQualifier, Function, RustTy, TyName};
 use crate::util::{ident, safe_ident};
 use crate::{conv, special_cases};
 
@@ -22,6 +23,8 @@ pub fn make_function_definition_with_defaults(
     code: &FnCode,
     full_fn_name: &Ident,
     meta: &FnMeta,
+    view: &ApiView,
+    ctx: &Context,
 ) -> (TokenStream, TokenStream) {
     let (default_fn_params, required_fn_params): (Vec<_>, Vec<_>) = sig
         .params()
@@ -72,6 +75,11 @@ pub fn make_function_definition_with_defaults(
     let cfg_attributes = &meta.cfg_attributes;
     let maybe_specific_docs = &meta.specific_docs;
 
+    let mut maybe_godot_doc = TokenStream::new();
+    if let Some(doc) = import_docs::import_function_docs(sig, ctx, view) {
+        maybe_godot_doc = quote! { #[doc = #doc] };
+    }
+
     let builders = quote! {
         #[doc = #builder_doc]
         #[must_use]
@@ -118,6 +126,7 @@ pub fn make_function_definition_with_defaults(
         #maybe_expect_deprecated
         #maybe_specific_docs
         #[doc = #default_parameter_usage]
+        #maybe_godot_doc
         #[inline]
         #vis fn #simple_fn_name (
             #simple_receiver_param
@@ -132,6 +141,7 @@ pub fn make_function_definition_with_defaults(
         // Lifetime is set if any parameter is a reference OR if the method is not static/global (and thus can refer to self).
         #maybe_deprecated
         #maybe_specific_docs
+        #maybe_godot_doc
         #[inline]
         #vis fn #extended_fn_name<'ex> (
             #extended_receiver_param

--- a/godot-codegen/src/generator/functions_common.rs
+++ b/godot-codegen/src/generator/functions_common.rs
@@ -8,8 +8,9 @@
 use proc_macro2::{Ident, TokenStream};
 use quote::{format_ident, quote};
 
-use crate::generator::default_parameters;
-use crate::models::domain::{ArgPassing, FnParam, FnQualifier, Function, RustTy};
+use crate::context::Context;
+use crate::generator::{default_parameters, import_docs};
+use crate::models::domain::{ApiView, ArgPassing, FnParam, FnQualifier, Function, RustTy};
 use crate::special_cases;
 use crate::util::lifetime;
 
@@ -109,7 +110,14 @@ pub struct FnParamTokens {
     pub arg_exprs: Vec<TokenStream>,
 }
 
-pub fn make_function_definition(sig: &dyn Function, code: &FnCode, meta: &FnMeta) -> FnDefinition {
+pub fn make_function_definition(
+    sig: &dyn Function,
+    code: &FnCode,
+    meta: &FnMeta,
+    // TODO(v0.6): Consider removing these two arguments, because they are only needed for importing docs.
+    view: &ApiView,
+    ctx: &Context,
+) -> FnDefinition {
     let has_default_params = default_parameters::function_uses_default_params(sig);
     let vis = if has_default_params {
         // Public API mapped by separate function.
@@ -168,6 +176,8 @@ pub fn make_function_definition(sig: &dyn Function, code: &FnCode, meta: &FnMeta
                 code,
                 &primary_fn_name,
                 meta,
+                view,
+                ctx,
             );
     } else {
         primary_fn_name = rust_function_name.clone();
@@ -177,6 +187,11 @@ pub fn make_function_definition(sig: &dyn Function, code: &FnCode, meta: &FnMeta
 
     let (maybe_deprecated, _maybe_expect_deprecated) = make_deprecation_attribute(sig);
     let maybe_specific_doc = &meta.specific_docs;
+
+    let mut maybe_godot_doc = TokenStream::new();
+    if let Some(doc) = import_docs::import_function_docs(sig, ctx, view) {
+        maybe_godot_doc = quote! { #[doc = #doc] };
+    }
 
     let call_sig_decl = {
         let return_ty = &sig.return_value().type_tokens();
@@ -201,6 +216,7 @@ pub fn make_function_definition(sig: &dyn Function, code: &FnCode, meta: &FnMeta
         quote! {
             #maybe_deprecated
             #maybe_specific_doc
+            #maybe_godot_doc
             #maybe_safety_doc
             #maybe_unsafe fn #primary_fn_name (
                 #receiver_param
@@ -218,6 +234,7 @@ pub fn make_function_definition(sig: &dyn Function, code: &FnCode, meta: &FnMeta
             quote! {
                 #maybe_deprecated
                 #maybe_specific_doc
+                #maybe_godot_doc
                 #maybe_safety_doc
                 #vis #maybe_unsafe fn #primary_fn_name (
                     #receiver_param
@@ -249,6 +266,7 @@ pub fn make_function_definition(sig: &dyn Function, code: &FnCode, meta: &FnMeta
             quote! {
                 #maybe_deprecated
                 #maybe_specific_doc
+                #maybe_godot_doc
                 /// # Panics
                 /// This is a _varcall_ method, meaning parameters and return values are passed as `Variant`.
                 /// It can detect call failures and will panic in such a case.
@@ -290,6 +308,7 @@ pub fn make_function_definition(sig: &dyn Function, code: &FnCode, meta: &FnMeta
         quote! {
             #maybe_deprecated
             #maybe_specific_doc
+            #maybe_godot_doc
             #maybe_safety_doc
             #vis #maybe_unsafe fn #primary_fn_name  (
                 #receiver_param

--- a/godot-codegen/src/generator/import_docs.rs
+++ b/godot-codegen/src/generator/import_docs.rs
@@ -9,22 +9,35 @@ use std::fmt::Write;
 
 use crate::context::Context;
 use crate::models::domain::{ApiView, Class, ClassLike, Function, TyName};
-use crate::{special_cases, util};
+use crate::{conv, special_cases, util};
 
 type CowStr = std::borrow::Cow<'static, str>;
 
-pub fn import_class_docs(
+pub fn import_docs(
     description: &str,
-    class: &Class,
+    surrounding_class: Option<&Class>,
     ctx: &Context,
     view: &ApiView,
 ) -> String {
     let mut result = replace_simple_tags(description, ctx);
-    result = replace_type_links(&result, class, ctx);
-    result = replace_method_links(&result, class, ctx, view);
+    result = replace_param_links(&result, ctx);
+    result = replace_type_links(&result, surrounding_class, ctx);
+    result = replace_method_links(&result, surrounding_class, ctx, view);
     result = replace_unimplemented_links(&result, ctx);
 
     result
+}
+
+pub fn import_function_docs(fun: &dyn Function, ctx: &Context, view: &ApiView) -> Option<String> {
+    let doc = fun.common().description.as_ref()?;
+    if doc.is_empty() {
+        return None;
+    }
+    let surrounding_class_name = fun.surrounding_class();
+    let surrounding_class = surrounding_class_name.and_then(|name| view.find_engine_class(name));
+    let imported_doc = import_docs(doc, surrounding_class, ctx, view);
+    let imported_doc = format!("\n# Godot docs\n{imported_doc}");
+    Some(imported_doc)
 }
 
 fn replace_unimplemented_links(str: &str, ctx: &Context) -> String {
@@ -54,7 +67,14 @@ fn replace_simple_tags(str: &str, ctx: &Context) -> String {
     result.to_string()
 }
 
-fn replace_type_links(doc: &str, class: &Class, ctx: &Context) -> String {
+fn replace_param_links(str: &str, ctx: &Context) -> String {
+    ctx.regexes()
+        .param_links
+        .replace_all(str, "`$1`")
+        .to_string()
+}
+
+fn replace_type_links(doc: &str, surrounding_class: Option<&Class>, ctx: &Context) -> String {
     let mut result = String::new();
     let mut previous = 0;
     for captures in ctx.regexes().type_links.captures_iter(doc) {
@@ -64,22 +84,36 @@ fn replace_type_links(doc: &str, class: &Class, ctx: &Context) -> String {
         if doc[end..].starts_with("(http") {
             continue;
         }
-        let class_name = captures.get(1).unwrap();
+
+        // Type link regex captures markdown `code`, ```codeblock``` or Godot docs type link [Node],
+        // this is to prevent replacing what looks like a type link inside the code (`array[0]`, `dictionary[variable]`).
+        // This is why class name is a capture group 3.
+        // If there is no class name in the capture, in other words we matched a codeblock, not a type link, then we skip it.
+        let Some(class_name) = captures.get(3) else {
+            continue;
+        };
+
         let class_name = class_name.as_str();
         result.push_str(&doc[previous..start]);
 
-        // If we encounter a deleted or primitive type, or an ignored link, we insert it without any links or formatting.
+        // If we encounter a deleted or primitive type, or an ignored link,
+        // we insert it without any links or formatting.
         if special_cases::is_godot_type_deleted(class_name)
             || matches_primitive_type(class_name)
             || matches_ignored_links(class_name)
         {
             write!(result, "{class_name}").unwrap();
+        } else if class_name == "@GlobalScope" {
+            write!(result, "[@GlobalScope][crate::global]").unwrap();
         } else {
             let path = get_class_rust_path(class_name, ctx);
-            let current_class_name = class.name().rust_ty.to_string();
+            let is_link_to_surrounding_class = surrounding_class.is_some_and(|class| {
+                let current_class_name = class.name().rust_ty.to_string();
+                current_class_name == conv::to_pascal_case(class_name)
+            });
 
             // If a link points to the current class, then do not create a link tag in Markdown to reduce noise.
-            if current_class_name == class_name {
+            if is_link_to_surrounding_class {
                 write!(result, "`{class_name}`").unwrap();
             } else {
                 write!(result, "[{class_name}][{path}]").unwrap();
@@ -100,7 +134,12 @@ fn matches_ignored_links(class: &str) -> bool {
     class == "@GDScript"
 }
 
-fn replace_method_links(doc: &str, class: &Class, ctx: &Context, view: &ApiView) -> String {
+fn replace_method_links(
+    doc: &str,
+    surrounding_class: Option<&Class>,
+    ctx: &Context,
+    view: &ApiView,
+) -> String {
     let mut result = String::new();
     let mut previous = 0;
 
@@ -114,7 +153,8 @@ fn replace_method_links(doc: &str, class: &Class, ctx: &Context, view: &ApiView)
         result.push_str(&doc[previous..start]);
         let method_path = captures.get(1).unwrap().as_str();
 
-        if let Some(method_path) = convert_to_method_path(method_path, class, ctx, view) {
+        if let Some(method_path) = convert_to_method_path(method_path, surrounding_class, ctx, view)
+        {
             let (_, method_name) = method_path
                 .rsplit_once("::")
                 .expect("rsplit_once should return a method name");
@@ -132,20 +172,26 @@ fn replace_method_links(doc: &str, class: &Class, ctx: &Context, view: &ApiView)
 
 fn convert_to_method_path(
     class_method: &str,
-    class: &Class,
+    surrounding_class: Option<&Class>,
     ctx: &Context,
     view: &ApiView,
 ) -> Option<CowStr> {
-    // Get the class name from the link if it has one, otherwise, use the current class's name.
+    // Get the class name from the link if it has one, otherwise, use the surrounding class's name.
     // For example, if we are generating docs for the `CanvasItem` class and see an "Object._notification" link
     // take "Object" as the class name and "_notification" as the method name. But if we see a "queue_redraw"
-    // link, take the current class's name(in our case it's "CanvasItem") as the class that owns the method.
+    // link, take the surrounding class's name(in our case it's "CanvasItem") as the class that owns the method.
     let (link_godot_class, link_godot_method) =
         if let Some((class_name, method_name)) = class_method.split_once('.') {
             (class_name, method_name)
-        } else {
+        } else if let Some(class) = surrounding_class {
             (class.name().godot_ty.as_str(), class_method)
+        } else {
+            return None;
         };
+
+    if special_cases::is_godot_type_deleted(link_godot_class) {
+        return None;
+    }
 
     let link_godot_method = util::safe_ident(link_godot_method).to_string();
 
@@ -159,8 +205,10 @@ fn convert_to_method_path(
             .iter()
             .find(|method| method.godot_name() == link_godot_method)
     {
-        let godot_method_name = link_godot_method.trim_start_matches("_");
-        if method.is_private() {
+        let rust_method_name = method.name();
+
+        // Skip links to private methods.
+        if method.is_private_in_final_api() {
             return None;
         }
         if method.is_virtual() {
@@ -171,7 +219,7 @@ fn convert_to_method_path(
                 let path = format!(
                     "crate::classes::{}::{}",
                     class.name().virtual_trait_name(),
-                    godot_method_name
+                    rust_method_name
                 );
                 return Some(path.into());
             }
@@ -189,7 +237,26 @@ fn matches_hardcoded_method(godot_class: &str, godot_method: &str) -> (bool, Opt
         ("Object", "get_instance_id") => "crate::obj::Gd::instance_id".into(),
         ("Object", "notification") => "crate::classes::Object::notify".into(),
         ("Object", "_notification") => "crate::classes::IObject::on_notification".into(),
+        ("Object", "_init") => "crate::classes::IObject::init".into(),
+        ("Object", "_validate_property") => "crate::classes::IObject::on_validate_property".into(),
+        ("Object", "_get_property_list") => "crate::classes::IObject::on_get_property_list".into(),
+        ("Object", "_get") => "crate::classes::IObject::on_get".into(),
+        ("Object", "_set") => "crate::classes::IObject::on_set".into(),
         ("GDScript", "new") => "crate::obj::NewGd::new_gd".into(),
+        ("String", "length") => "crate::builtin::GString::len".into(),
+        ("String", "match_") => "crate::builtin::GString::match_glob".into(),
+        ("Dictionary", "size") => "crate::builtin::Dictionary::len".into(),
+        ("Array", "size") => "crate::builtin::AnyArray::len".into(),
+        ("PackedByteArray", "size") => "crate::builtin::PackedByteArray::len".into(),
+        ("Vector2", "min") => "crate::builtin::Vector2::coord_min".into(),
+        ("Vector2", "max") => "crate::builtin::Vector2::coord_max".into(),
+        ("Vector3", "min") => "crate::builtin::Vector3::coord_min".into(),
+        ("Vector3", "max") => "crate::builtin::Vector3::coord_max".into(),
+        ("Vector4", "min") => "crate::builtin::Vector4::coord_min".into(),
+        ("Vector4", "max") => "crate::builtin::Vector4::coord_max".into(),
+        ("Transform2D", "get_scale") => "crate::builtin::Transform2D::scale".into(),
+        ("Node", "get_node") => "crate::classes::Node::get_node_as".into(),
+        ("Color", "is_equal_approx") => "crate::builtin::math::ApproxEq::approx_eq".into(),
         ("@GlobalScope", "instance_from_id") => "crate::obj::Gd::from_instance_id".into(),
         ("@GlobalScope", "is_instance_valid") => "crate::obj::Gd::is_instance_valid".into(),
         ("@GDScript", "load") => "crate::tools::load".into(),

--- a/godot-codegen/src/generator/utility_functions.rs
+++ b/godot-codegen/src/generator/utility_functions.rs
@@ -10,13 +10,16 @@ use std::path::Path;
 use proc_macro2::{Ident, TokenStream};
 use quote::quote;
 
+use crate::context::Context;
 use crate::generator::functions_common::{FnCode, FnMeta, FnReceiver};
 use crate::generator::{docs, functions_common};
-use crate::models::domain::{ExtensionApi, Function, UtilityFunction};
+use crate::models::domain::{ApiView, ExtensionApi, Function, UtilityFunction};
 use crate::{SubmitFn, util};
 
 pub(crate) fn generate_utilities_file(
     api: &ExtensionApi,
+    ctx: &Context,
+    view: &ApiView,
     gen_path: &Path,
     submit_fn: &mut SubmitFn,
 ) {
@@ -24,7 +27,7 @@ pub(crate) fn generate_utilities_file(
     let utility_fn_defs = api
         .utility_functions
         .iter()
-        .map(make_utility_function_definition);
+        .map(|fun| make_utility_function_definition(fun, view, ctx));
 
     let imports = util::make_imports();
 
@@ -41,7 +44,11 @@ pub(crate) fn make_utility_function_ptr_name(function: &dyn Function) -> Ident {
     function.name_ident()
 }
 
-pub(crate) fn make_utility_function_definition(function: &UtilityFunction) -> TokenStream {
+pub(crate) fn make_utility_function_definition(
+    function: &UtilityFunction,
+    view: &ApiView,
+    ctx: &Context,
+) -> TokenStream {
     let function_ident = make_utility_function_ptr_name(function);
     let function_name_str = function.name();
 
@@ -83,6 +90,8 @@ pub(crate) fn make_utility_function_definition(function: &UtilityFunction) -> To
             cfg_attributes: TokenStream::new(),
             specific_docs: extra_docs,
         },
+        view,
+        ctx,
     );
 
     // Utility functions have no builders.

--- a/godot-codegen/src/generator/virtual_traits.rs
+++ b/godot-codegen/src/generator/virtual_traits.rs
@@ -31,7 +31,8 @@ pub fn make_virtual_methods_trait(
     let trait_name_str = class.name().virtual_trait_name();
     let trait_name = ident(&trait_name_str);
 
-    let (mut virtual_methods, extra_docs) = make_all_virtual_methods(class, all_base_names, view);
+    let (mut virtual_methods, extra_docs) =
+        make_all_virtual_methods(class, all_base_names, view, ctx);
     virtual_methods.extend(make_special_virtual_methods(notification_enum_name));
     virtual_methods.sort_by_key(|m| m.order_in_trait);
 
@@ -213,6 +214,8 @@ fn make_special_virtual_methods(notification_enum_name: &Ident) -> Vec<OrderedVi
 fn make_virtual_method(
     method: &ClassMethod,
     presence: VirtualMethodPresence,
+    view: &ApiView,
+    ctx: &Context,
 ) -> Option<OrderedVirtual> {
     if !method.is_virtual() {
         return None;
@@ -242,6 +245,8 @@ fn make_virtual_method(
             is_varcall_fallible: true,
         },
         &FnMeta::default(),
+        view,
+        ctx,
     );
 
     // Virtual methods have no builders.
@@ -253,6 +258,7 @@ fn make_all_virtual_methods(
     class: &Class,
     all_base_names: &[TyName],
     view: &ApiView,
+    ctx: &Context,
 ) -> (Vec<OrderedVirtual>, String) {
     let mut all_methods = Vec::new();
 
@@ -262,7 +268,7 @@ fn make_all_virtual_methods(
         let presence =
             special_cases::get_derived_virtual_method_presence(class.name(), method.godot_name());
 
-        if let Some(ordered) = make_virtual_method(method, presence) {
+        if let Some(ordered) = make_virtual_method(method, presence, view, ctx) {
             all_methods.push(ordered);
         }
     }
@@ -299,7 +305,7 @@ fn make_all_virtual_methods(
                 .unwrap();
             }
 
-            if let Some(ordered) = make_virtual_method(method, derived_presence) {
+            if let Some(ordered) = make_virtual_method(method, derived_presence, view, ctx) {
                 all_methods.push(ordered);
             }
         }

--- a/godot-codegen/src/lib.rs
+++ b/godot-codegen/src/lib.rs
@@ -178,6 +178,7 @@ pub fn generate_core_files(core_gen_path: &Path) {
     generate_builtin_class_files(
         &api,
         &mut ctx,
+        &view,
         &core_gen_path.join("builtin_classes"),
         &mut submit_fn,
     );
@@ -197,7 +198,7 @@ pub fn generate_core_files(core_gen_path: &Path) {
     generate_core_central_file(&api, &mut ctx, core_gen_path, &mut submit_fn);
     watch.record("generate_central_file");
 
-    generate_utilities_file(&api, core_gen_path, &mut submit_fn);
+    generate_utilities_file(&api, &ctx, &view, core_gen_path, &mut submit_fn);
     watch.record("generate_utilities_file");
 
     // From 4.4 onward, generate table that maps all virtual methods to their known hashes.

--- a/godot-codegen/src/models/api_json.rs
+++ b/godot-codegen/src/models/api_json.rs
@@ -205,6 +205,7 @@ pub struct JsonUtilityFunction {
     pub is_vararg: bool,
     pub hash: i64,
     pub arguments: Option<Vec<JsonMethodArg>>,
+    pub description: Option<String>,
 }
 
 #[derive(DeJson)]
@@ -216,6 +217,7 @@ pub struct JsonBuiltinMethod {
     pub is_static: bool,
     pub hash: Option<i64>,
     pub arguments: Option<Vec<JsonMethodArg>>,
+    pub description: Option<String>,
 }
 
 #[derive(DeJson, Clone)]
@@ -230,6 +232,7 @@ pub struct JsonClassMethod {
     pub hash: Option<i64>,
     pub return_value: Option<JsonMethodReturn>,
     pub arguments: Option<Vec<JsonMethodArg>>,
+    pub description: Option<String>,
 }
 
 // Example: set_point_weight_scale ->

--- a/godot-codegen/src/models/domain.rs
+++ b/godot-codegen/src/models/domain.rs
@@ -17,9 +17,9 @@ use proc_macro2::{Ident, Literal, TokenStream};
 use quote::{ToTokens, format_ident, quote};
 
 use crate::context::Context;
-use crate::conv;
 use crate::models::api_json::{JsonBuiltinClass, JsonMethodArg, JsonMethodReturn};
 use crate::util::{ident, option_as_slice, safe_ident};
+use crate::{conv, special_cases};
 
 mod enums;
 
@@ -294,6 +294,7 @@ pub struct FunctionCommon {
     pub direction: FnDirection,
     /// Deprecation message, if the method is deprecated.
     pub deprecation_msg: Option<&'static str>,
+    pub description: Option<String>,
 }
 
 pub trait Function: fmt::Display {
@@ -331,6 +332,19 @@ pub trait Function: fmt::Display {
 
     fn is_private(&self) -> bool {
         self.common().is_private
+    }
+
+    fn is_private_in_final_api(&self) -> bool {
+        let replaced_with_type_safe = self
+            .surrounding_class()
+            .map(|class_name| {
+                special_cases::is_class_method_replaced_with_type_safe(
+                    class_name,
+                    self.godot_name(),
+                )
+            })
+            .unwrap_or(false);
+        self.is_private() && !replaced_with_type_safe
     }
 
     fn is_virtual(&self) -> bool {

--- a/godot-codegen/src/models/domain_mapping.rs
+++ b/godot-codegen/src/models/domain_mapping.rs
@@ -419,6 +419,9 @@ impl BuiltinMethod {
             }
         };
 
+        // TODO(v0.6): find a better way than cloning (borrow, swap, ...).
+        let description = method.description.clone();
+
         Some(Self {
             common: FunctionCommon {
                 // Fill in these fields
@@ -434,6 +437,7 @@ impl BuiltinMethod {
                     hash: method.hash.expect("hash absent for builtin method"),
                 },
                 deprecation_msg: None, // Builtin methods are not deprecated yet.
+                description,
             },
             qualifier: FnQualifier::from_const_static(method.is_const, method.is_static),
             surrounding_class,
@@ -602,6 +606,9 @@ impl ClassMethod {
 
         let deprecation_msg = special_cases::get_class_method_deprecation(class_name, method);
 
+        // TODO(v0.6): find a better way than cloning (borrow, swap, ...).
+        let description = method.description.clone();
+
         Some(Self {
             common: FunctionCommon {
                 name: rust_method_name,
@@ -614,6 +621,7 @@ impl ClassMethod {
                 is_unsafe,
                 direction,
                 deprecation_msg,
+                description,
             },
             qualifier,
             surrounding_class: class_name.clone(),
@@ -693,6 +701,9 @@ impl UtilityFunction {
         let godot_method_name = function.name.clone();
         let rust_method_name = godot_method_name.clone(); // No change for now.
 
+        // TODO(v0.6): find a better way than cloning (borrow, swap, ...).
+        let description = function.description.clone();
+
         Some(Self {
             common: FunctionCommon {
                 name: rust_method_name,
@@ -707,6 +718,7 @@ impl UtilityFunction {
                     hash: function.hash,
                 },
                 deprecation_msg: None, // Utility functions are not deprecated.
+                description,
             },
         })
     }

--- a/godot-codegen/src/special_cases/special_cases.rs
+++ b/godot-codegen/src/special_cases/special_cases.rs
@@ -442,7 +442,7 @@ pub fn is_method_private(class_or_builtin_ty: &TyName, godot_method_name: &str) 
 ///
 /// See also [`get_class_method_enum_param_replacement()`] for a more automated approach specifically for enum parameters.
 #[rustfmt::skip]
-fn is_class_method_replaced_with_type_safe(class_ty: &TyName, godot_method_name: &str) -> bool {
+pub fn is_class_method_replaced_with_type_safe(class_ty: &TyName, godot_method_name: &str) -> bool {
     match (class_ty.godot_ty.as_str(), godot_method_name) {
         // Variant -> Option<Gd<Script>>
         | ("Object", "get_script")


### PR DESCRIPTION
This PR adds support for importing Godot documentation for methods and free‑standing functions. Setters/getters are not included.

What have been added:

- Import documentation for class methods, builtin class methods and utility functions
- Escape param tags(`[param x]` -> `` `x` `` )

What have been fixed:

- Links to self class were still present in cases when the class name inside a link differs from the surrounding class's Rust name only in casing (e.g. `OpenXrExtensionWrapper` vs `OpenXRExtensionWrapper`)
- Links to methods that were replaced with a type-safe variant were ignored (e.g. `Object.set_script`, `Node.get_tree`)

I'm not sure about the "Godot docs" header. For almost every method, it's the first thing that comes in the documentation. While it tells us that what follows is imported from Godot docs, it can lead to useless summaries like in `godot::global` functions. We can remove the header if the method doesn't have any other documentation, but it could confuse later where that doc comes from.