### PR TITLE
Fix version check in `godot_exe`.

### DIFF
--- a/godot-bindings/src/godot_exe.rs
+++ b/godot-bindings/src/godot_exe.rs
@@ -55,7 +55,7 @@ pub fn load_gdextension_interface_json(watch: &mut StopWatch) -> Cow<'static, st
     rerun_on_changed(&godot_bin);
     watch.record("locate_godot");
 
-    if read_godot_version(&godot_bin).is_newer_than_latest() {
+    if !read_godot_version(&godot_bin).is_newer_than_latest() {
         watch.record("load_prebuilt_header_json");
         return gdextension_api::load_gdextension_interface_json();
     }

--- a/godot-bindings/src/lib.rs
+++ b/godot-bindings/src/lib.rs
@@ -62,7 +62,7 @@ impl GodotVersion {
     pub(crate) fn is_newer_than_latest(&self) -> bool {
         let (_latest_major, latest_minor, _latest_patch): (u8, u8, u8) = LATEST_API_VERSION;
 
-        self.minor >= latest_minor
+        self.minor > latest_minor
     }
 }
 


### PR DESCRIPTION
I forget to test it properly after refactor :grimacing:.

<details>

<summary> after / before </summary>

```rs
$ cargo build --features api-custom
   Compiling godot-bindings v0.5.2 (/home/irwin/apps/godot/opensource-contr/missing_docs/gdext/godot-bindings)
   Compiling godot-codegen v0.5.2 (/home/irwin/apps/godot/opensource-contr/missing_docs/gdext/godot-codegen)
   Compiling godot-macros v0.5.2 (/home/irwin/apps/godot/opensource-contr/missing_docs/gdext/godot-macros)
   Compiling godot-ffi v0.5.2 (/home/irwin/apps/godot/opensource-contr/missing_docs/gdext/godot-ffi)
   Compiling godot-core v0.5.2 (/home/irwin/apps/godot/opensource-contr/missing_docs/gdext/godot-core)
   Compiling itest v0.0.0 (/home/irwin/apps/godot/opensource-contr/missing_docs/gdext/itest/rust)
   Compiling godot v0.5.2 (/home/irwin/apps/godot/opensource-contr/missing_docs/gdext/godot)
   Compiling itest-dependency v0.0.0 (/home/irwin/apps/godot/opensource-contr/missing_docs/gdext/itest/itest-dependency)
   Compiling hot-reload v0.1.0 (/home/irwin/apps/godot/opensource-contr/missing_docs/gdext/itest/hot-reload/rust)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 37.56s

$ git checkout master

$ cargo build --features api-custom
   Compiling godot-bindings v0.5.2 (/home/irwin/apps/godot/opensource-contr/missing_docs/gdext/godot-bindings)
   Compiling godot-codegen v0.5.2 (/home/irwin/apps/godot/opensource-contr/missing_docs/gdext/godot-codegen)
   Compiling godot-macros v0.5.2 (/home/irwin/apps/godot/opensource-contr/missing_docs/gdext/godot-macros)
   Compiling godot-ffi v0.5.2 (/home/irwin/apps/godot/opensource-contr/missing_docs/gdext/godot-ffi)
   Compiling godot-core v0.5.2 (/home/irwin/apps/godot/opensource-contr/missing_docs/gdext/godot-core)
   Compiling itest v0.0.0 (/home/irwin/apps/godot/opensource-contr/missing_docs/gdext/itest/rust)
error[E0609]: no field `classdb_construct_object3` on type `&'static gdextension_interface::GDExtensionInterface`
   --> godot-ffi/src/lib.rs:653:27
    |
653 |     let f = interface_fn!(classdb_construct_object3);
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^ unknown field
    |
    = note: available fields are: `get_godot_version`, `get_godot_version2`, `mem_alloc`, `mem_realloc`, `mem_free` ... and 95 others

For more information about this error, try `rustc --explain E0609`.
error: could not compile `godot-ffi` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
irwin@fedora:~/apps/godot/opensource-contr/missing_docs/gdext$ git push
```

</details>