### PR TITLE
Doc tags: use linear scanner instead of regex replacements

### DIFF
--- a/godot-codegen/Cargo.toml
+++ b/godot-codegen/Cargo.toml
@@ -28,7 +28,6 @@ heck = { workspace = true }
 nanoserde = { workspace = true }
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
-regex = { workspace = true }
 
 [build-dependencies]
 godot-bindings = { path = "../godot-bindings", version = "=0.5.2" } # emit_godot_version_cfg
@@ -52,4 +51,3 @@ rustc-args = ["--cfg", "published_docs"]
 #
 #[dev-dependencies]
 #criterion = "0.5"
-

--- a/godot-codegen/src/context.rs
+++ b/godot-codegen/src/context.rs
@@ -9,7 +9,6 @@ use std::collections::{HashMap, HashSet};
 
 use proc_macro2::{Ident, TokenStream};
 use quote::{ToTokens, format_ident};
-use regex::Regex;
 
 use crate::generator::method_tables::MethodTableKey;
 use crate::generator::notifications;
@@ -34,7 +33,6 @@ pub struct Context<'a> {
     notification_enum_names_by_class: HashMap<TyName, NotificationEnum>,
     method_table_indices: HashMap<MethodTableKey, usize>,
     method_table_next_index: HashMap<String, usize>,
-    import_regexes: ImportRegexes,
 }
 
 impl<'a> Context<'a> {
@@ -358,10 +356,6 @@ impl<'a> Context<'a> {
         let prev = self.cached_rust_types.insert(godot_ty, resolved);
         assert!(prev.is_none(), "no overwrites of RustTy");
     }
-
-    pub fn regexes(&self) -> &ImportRegexes {
-        &self.import_regexes
-    }
 }
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -453,63 +447,5 @@ impl InheritanceTree {
         }
 
         false
-    }
-}
-
-// ----------------------------------------------------------------------------------------------------------------------------------------------
-
-/// A collection of compiled regexes that are used when importing docs.
-pub struct ImportRegexes {
-    pub newlines: Regex,
-    pub bold_tags: Regex,
-    pub italic_tags: Regex,
-    pub code_tags: Regex,
-    // Keyboard shortcuts, e.g. "Ctrl + S".
-    pub kbd_tags: Regex,
-    pub url_tags: Regex,
-    pub codeblocks_tags: Regex,
-    pub codeblock_tags: Regex,
-    pub codeblock_lang_tags: Regex,
-    pub gdscript_tags: Regex,
-    pub csharp_tags: Regex,
-    pub type_links: Regex,
-    pub method_links: Regex,
-    pub unimplemented_links: Regex,
-    pub param_links: Regex,
-}
-
-impl Default for ImportRegexes {
-    fn default() -> Self {
-        fn regex(s: &str) -> Regex {
-            Regex::new(s).unwrap()
-        }
-
-        Self {
-            newlines: regex(r#"(\[codeblocks?( lang=.*?)?\](?:.|\n)*?\[\/codeblocks?\])|(\n)"#),
-            bold_tags: regex(r#"\[b\](.*?)\[\/b\]"#),
-            italic_tags: regex(r#"\[i\](.*?)\[\/i\]"#),
-            code_tags: regex(r#"\[code( skip-lint)?\](.*?)\[\/code\]"#),
-            kbd_tags: regex(r#"\[kbd\](.*?)\[\/kbd\]"#),
-            url_tags: regex(r#"\[url=(.*?)\](.*?)\[\/url\]"#),
-            codeblocks_tags: regex(r#"\[codeblocks\]([\s\S]*?)\[\/codeblocks\]"#),
-            codeblock_tags: regex(r#"\[codeblock\]([\s\S]*?)\[\/codeblock\]"#),
-            codeblock_lang_tags: regex(r#"\[codeblock lang=(.*?)\]([\s\S]*?)\[\/codeblock\]"#),
-            gdscript_tags: regex(r#"\[gdscript\]([\s\S]*?)\[\/gdscript\]"#),
-            csharp_tags: regex(r#"\[csharp\]([\s\S]*?)\[\/csharp\]"#),
-            // Matches a markdown code, codeblock tags, or a Godot type link. We need
-            // to match the code and codeblocks first to avoid matching type links inside the code
-            // Examples:
-            // - `code`
-            // - ```lang codeblock```
-            // - [Node]
-            type_links: regex(
-                r#"(\`[\s\S]*?\`)|(\`\`\`[a-zA-Z]*\s*[\s\S]*?\`\`\`)|\[([a-zA-Z0-9@]+?)\]"#,
-            ),
-            method_links: regex(r#"\[method ((([a-zA-Z0-9@]+?)\.)?([a-zA-Z0-9_]+?))\]"#),
-            unimplemented_links: regex(
-                r#"\[(annotation|constant|member|enum|constructor|signal)\s.*?\]"#,
-            ),
-            param_links: regex(r#"\[param ([a-zA-Z0-9_]+?)\]"#),
-        }
     }
 }

--- a/godot-codegen/src/generator/import_docs.rs
+++ b/godot-codegen/src/generator/import_docs.rs
@@ -5,7 +5,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::fmt::Write;
+use std::fmt::Write as _;
 
 use crate::context::Context;
 use crate::models::domain::{ApiView, Class, ClassLike, Function, TyName};
@@ -13,19 +13,20 @@ use crate::{conv, special_cases, util};
 
 type CowStr = std::borrow::Cow<'static, str>;
 
+/// Infallible `write!`.
+macro_rules! write_str {
+    ($out:expr, $($arg:tt)*) => {
+        write!($out, $($arg)*).expect("writing to String should not fail")
+    };
+}
+
 pub fn import_docs(
     description: &str,
     surrounding_class: Option<&Class>,
     ctx: &Context,
     view: &ApiView,
 ) -> String {
-    let mut result = replace_simple_tags(description, ctx);
-    result = replace_param_links(&result, ctx);
-    result = replace_type_links(&result, surrounding_class, ctx);
-    result = replace_method_links(&result, surrounding_class, ctx, view);
-    result = replace_unimplemented_links(&result, ctx);
-
-    result
+    DocImporter::new(description, surrounding_class, ctx, view).import()
 }
 
 pub fn import_function_docs(fun: &dyn Function, ctx: &Context, view: &ApiView) -> Option<String> {
@@ -40,91 +41,6 @@ pub fn import_function_docs(fun: &dyn Function, ctx: &Context, view: &ApiView) -
     Some(imported_doc)
 }
 
-fn replace_unimplemented_links(str: &str, ctx: &Context) -> String {
-    ctx.regexes()
-        .unimplemented_links
-        .replace_all(str, "\\$0")
-        .to_string()
-}
-
-fn replace_simple_tags(str: &str, ctx: &Context) -> String {
-    let re = ctx.regexes();
-
-    // Replace \n with \n\n everywhere except codeblock tags.
-    let result = re.newlines.replace_all(str, "$1$3$3");
-
-    let result = re.bold_tags.replace_all(&result, "**$1**");
-    let result = re.italic_tags.replace_all(&result, "_${1}_");
-    let result = re.code_tags.replace_all(&result, "`$2`");
-    let result = re.kbd_tags.replace_all(&result, "`$1`");
-    let result = re.url_tags.replace_all(&result, "[$2]($1)");
-    let result = re.codeblocks_tags.replace_all(&result, "$1");
-    let result = re.codeblock_tags.replace_all(&result, "```gdscript$1```");
-    let result = re.codeblock_lang_tags.replace_all(&result, "```$1$2```");
-    let result = re.gdscript_tags.replace_all(&result, "```gdscript$1```");
-    let result = re.csharp_tags.replace_all(&result, "```csharp$1```");
-
-    result.to_string()
-}
-
-fn replace_param_links(str: &str, ctx: &Context) -> String {
-    ctx.regexes()
-        .param_links
-        .replace_all(str, "`$1`")
-        .to_string()
-}
-
-fn replace_type_links(doc: &str, surrounding_class: Option<&Class>, ctx: &Context) -> String {
-    let mut result = String::new();
-    let mut previous = 0;
-    for captures in ctx.regexes().type_links.captures_iter(doc) {
-        let whole_match = captures.get(0).unwrap();
-        let start = whole_match.start();
-        let end = whole_match.end();
-        if doc[end..].starts_with("(http") {
-            continue;
-        }
-
-        // Type link regex captures markdown `code`, ```codeblock``` or Godot docs type link [Node],
-        // this is to prevent replacing what looks like a type link inside the code (`array[0]`, `dictionary[variable]`).
-        // This is why class name is a capture group 3.
-        // If there is no class name in the capture, in other words we matched a codeblock, not a type link, then we skip it.
-        let Some(class_name) = captures.get(3) else {
-            continue;
-        };
-
-        let class_name = class_name.as_str();
-        result.push_str(&doc[previous..start]);
-
-        // If we encounter a deleted or primitive type, or an ignored link,
-        // we insert it without any links or formatting.
-        if special_cases::is_godot_type_deleted(class_name)
-            || matches_primitive_type(class_name)
-            || matches_ignored_links(class_name)
-        {
-            write!(result, "{class_name}").unwrap();
-        } else if class_name == "@GlobalScope" {
-            write!(result, "[@GlobalScope][crate::global]").unwrap();
-        } else {
-            let path = get_class_rust_path(class_name, ctx);
-            let is_link_to_surrounding_class = surrounding_class.is_some_and(|class| {
-                let current_class_name = class.name().rust_ty.to_string();
-                current_class_name == conv::to_pascal_case(class_name)
-            });
-
-            // If a link points to the current class, then do not create a link tag in Markdown to reduce noise.
-            if is_link_to_surrounding_class {
-                write!(result, "`{class_name}`").unwrap();
-            } else {
-                write!(result, "[{class_name}][{path}]").unwrap();
-            }
-        }
-        previous = end;
-    }
-    result.push_str(&doc[previous..]);
-    result
-}
-
 fn matches_primitive_type(ty: &str) -> bool {
     matches!(ty, "int" | "float" | "bool")
 }
@@ -134,40 +50,408 @@ fn matches_ignored_links(class: &str) -> bool {
     class == "@GDScript"
 }
 
-fn replace_method_links(
-    doc: &str,
-    surrounding_class: Option<&Class>,
-    ctx: &Context,
-    view: &ApiView,
-) -> String {
-    let mut result = String::new();
-    let mut previous = 0;
+struct DocImporter<'d> {
+    doc: &'d str,
+    pos: usize,
+    surrounding_class: Option<&'d Class>,
+    // Pascal-case Rust name of the surrounding class, cached to avoid recomputing per type link.
+    surrounding_rust_name: Option<String>,
+    ctx: &'d Context<'d>,
+    view: &'d ApiView<'d>,
+}
 
-    for captures in ctx.regexes().method_links.captures_iter(doc) {
-        let whole_match = captures.get(0).unwrap();
-        let start = whole_match.start();
-        let end = whole_match.end();
-        if doc[end..].starts_with("(http") {
-            continue;
+impl<'d> DocImporter<'d> {
+    fn new(
+        doc: &'d str,
+        surrounding_class: Option<&'d Class>,
+        ctx: &'d Context<'d>,
+        view: &'d ApiView<'d>,
+    ) -> Self {
+        let surrounding_rust_name = surrounding_class.map(|c| c.name().rust_ty.to_string());
+        Self {
+            doc,
+            pos: 0,
+            surrounding_class,
+            surrounding_rust_name,
+            ctx,
+            view,
         }
-        result.push_str(&doc[previous..start]);
-        let method_path = captures.get(1).unwrap().as_str();
+    }
 
-        if let Some(method_path) = convert_to_method_path(method_path, surrounding_class, ctx, view)
+    fn import(mut self) -> String {
+        let mut out = String::with_capacity(self.doc.len());
+        let ok = self.parse_until(&mut out, None, true, true);
+        debug_assert!(ok, "top-level parse_until without closing tag must succeed");
+        out
+    }
+
+    // Parses the doc, writing rendered output into `out`.
+    // - If `closing_tag` is given, returns true when found and consumed.
+    // - On EOF without closing tag, rolls back `out` and `self.pos` and returns false.
+    // - With `closing_tag = None`, always succeeds at EOF.
+    fn parse_until(
+        &mut self,
+        out: &mut String,
+        closing_tag: Option<&str>,
+        double_newlines: bool,
+        allow_type_links: bool,
+    ) -> bool {
+        let start_pos = self.pos;
+        let start_len = out.len();
+
+        while self.pos < self.doc.len() {
+            if let Some(close) = closing_tag
+                && self.remaining().starts_with(close)
+            {
+                self.pos += close.len();
+                return true;
+            }
+
+            if self.remaining().starts_with('[')
+                && self.try_parse_tag(out, double_newlines, allow_type_links)
+            {
+                continue;
+            }
+
+            // SAFETY: loop guard ensures self.pos < self.doc.len(), so a char is present.
+            let ch = self.remaining().chars().next().unwrap();
+            self.pos += ch.len_utf8();
+            if ch == '\n' && double_newlines {
+                out.push_str("\n\n");
+            } else {
+                out.push(ch);
+            }
+        }
+
+        if closing_tag.is_none() {
+            true
+        } else {
+            out.truncate(start_len);
+            self.pos = start_pos;
+            false
+        }
+    }
+
+    fn try_parse_tag(
+        &mut self,
+        out: &mut String,
+        double_newlines: bool,
+        allow_type_links: bool,
+    ) -> bool {
+        // Dispatch by the byte after `[` to skip unrelated `starts_with()` checks.
+        // If nothing matches, fall through to Markdown and bracket-link parsing.
+        let after_bracket = self.doc.as_bytes().get(self.pos + 1).copied();
+        let matched = match after_bracket {
+            Some(b'b') => self.try_wrapped_tag(
+                out,
+                "[b]",
+                "[/b]",
+                "**",
+                "**",
+                double_newlines,
+                allow_type_links,
+            ),
+            Some(b'i') => self.try_wrapped_tag(
+                out,
+                "[i]",
+                "[/i]",
+                "_",
+                "_",
+                double_newlines,
+                allow_type_links,
+            ),
+            Some(b'k') => self.try_wrapped_tag(
+                out,
+                "[kbd]",
+                "[/kbd]",
+                "`",
+                "`",
+                double_newlines,
+                allow_type_links,
+            ),
+            Some(b'c') => {
+                self.try_wrapped_tag(out, "[code skip-lint]", "[/code]", "`", "`", false, false)
+                    || self.try_wrapped_tag(out, "[code]", "[/code]", "`", "`", false, false)
+                    || self.try_codeblocks_tag(out)
+                    || self.try_wrapped_tag(
+                        out,
+                        "[codeblock]",
+                        "[/codeblock]",
+                        "```gdscript",
+                        "```",
+                        false,
+                        false,
+                    )
+                    || self.try_codeblock_lang_tag(out)
+                    || self.try_wrapped_tag(
+                        out,
+                        "[csharp]",
+                        "[/csharp]",
+                        "```csharp",
+                        "```",
+                        double_newlines,
+                        false,
+                    )
+            }
+            Some(b'u') => self.try_url_tag(out, double_newlines, allow_type_links),
+            Some(b'g') => self.try_wrapped_tag(
+                out,
+                "[gdscript]",
+                "[/gdscript]",
+                "```gdscript",
+                "```",
+                double_newlines,
+                false,
+            ),
+            _ => false,
+        };
+
+        matched || self.try_markdown_link(out) || self.try_bracket_link(out, allow_type_links)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn try_wrapped_tag(
+        &mut self,
+        out: &mut String,
+        opening_tag: &str,
+        closing_tag: &str,
+        prefix: &str,
+        suffix: &str,
+        double_newlines: bool,
+        allow_type_links: bool,
+    ) -> bool {
+        if !self.remaining().starts_with(opening_tag) {
+            return false;
+        }
+
+        let start_pos = self.pos;
+        let start_len = out.len();
+        self.pos += opening_tag.len();
+        out.push_str(prefix);
+        // Only keep the wrapper if the matching closing tag exists.
+        if !self.parse_until(out, Some(closing_tag), double_newlines, allow_type_links) {
+            out.truncate(start_len);
+            self.pos = start_pos;
+            return false;
+        }
+        out.push_str(suffix);
+        true
+    }
+
+    fn try_url_tag(
+        &mut self,
+        out: &mut String,
+        double_newlines: bool,
+        allow_type_links: bool,
+    ) -> bool {
+        const PREFIX: &str = "[url=";
+        const SUFFIX: &str = "[/url]";
+
+        let remaining = self.remaining();
+        if !remaining.starts_with(PREFIX) {
+            return false;
+        }
+
+        // Assumes `]` does not occur inside the URL value (true for percent-encoded URLs).
+        let Some(end_of_opening_tag) = remaining.find(']') else {
+            return false;
+        };
+        let url = &remaining[PREFIX.len()..end_of_opening_tag];
+
+        let start_pos = self.pos;
+        let start_len = out.len();
+        self.pos += end_of_opening_tag + 1;
+        out.push('[');
+        if !self.parse_until(out, Some(SUFFIX), double_newlines, allow_type_links) {
+            out.truncate(start_len);
+            self.pos = start_pos;
+            return false;
+        }
+        write_str!(out, "]({url})");
+        true
+    }
+
+    fn try_codeblocks_tag(&mut self, out: &mut String) -> bool {
+        const OPENING_TAG: &str = "[codeblocks]";
+        const CLOSING_TAG: &str = "[/codeblocks]";
+
+        if !self.remaining().starts_with(OPENING_TAG) {
+            return false;
+        }
+
+        let start_pos = self.pos;
+        let start_len = out.len();
+        self.pos += OPENING_TAG.len();
+        // `[codeblocks]` is a container for nested language blocks, not a literal fence itself.
+        if !self.parse_until(out, Some(CLOSING_TAG), false, true) {
+            out.truncate(start_len);
+            self.pos = start_pos;
+            return false;
+        }
+        true
+    }
+
+    fn try_codeblock_lang_tag(&mut self, out: &mut String) -> bool {
+        const PREFIX: &str = "[codeblock lang=";
+        const SUFFIX: &str = "[/codeblock]";
+
+        let remaining = self.remaining();
+        if !remaining.starts_with(PREFIX) {
+            return false;
+        }
+
+        // Assumes `]` does not occur inside the lang attribute value.
+        let Some(end_of_opening_tag) = remaining.find(']') else {
+            return false;
+        };
+        let lang = &remaining[PREFIX.len()..end_of_opening_tag];
+
+        let start_pos = self.pos;
+        let start_len = out.len();
+        self.pos += end_of_opening_tag + 1;
+        out.push_str("```");
+        out.push_str(lang);
+        // The body is literal fenced code, so bracket roles should not be interpreted inside it.
+        if !self.parse_until(out, Some(SUFFIX), false, false) {
+            out.truncate(start_len);
+            self.pos = start_pos;
+            return false;
+        }
+        out.push_str("```");
+        true
+    }
+
+    fn try_markdown_link(&mut self, out: &mut String) -> bool {
+        let remaining = self.remaining();
+        if !remaining.starts_with('[') {
+            return false;
+        }
+
+        let Some(end_of_text) = remaining.find(']') else {
+            return false;
+        };
+        let after_text = &remaining[end_of_text + 1..];
+        // Preserve real inline Markdown links, but let `[Type](s)` fall back to type-link parsing.
+        if !after_text.starts_with("(http") {
+            return false;
+        }
+
+        let Some(end_of_target) = after_text.find(')') else {
+            return false;
+        };
+        let len = end_of_text + 1 + end_of_target + 1;
+        out.push_str(&remaining[..len]);
+        self.pos += len;
+        true
+    }
+
+    fn try_bracket_link(&mut self, out: &mut String, allow_type_links: bool) -> bool {
+        let remaining = self.remaining();
+        if !remaining.starts_with('[') {
+            return false;
+        }
+
+        let Some(end) = remaining.find(']') else {
+            return false;
+        };
+        let whole = &remaining[..=end];
+        let content = &remaining[1..end];
+
+        if let Some(param_name) = content.strip_prefix("param ")
+            && is_ident_like(param_name)
+        {
+            self.pos += whole.len();
+            write_str!(out, "`{param_name}`");
+            return true;
+        }
+
+        if let Some(method_path) = content.strip_prefix("method ") {
+            self.pos += whole.len();
+            self.write_method_link(out, whole, method_path);
+            return true;
+        }
+
+        // Escape unsupported roles so Rustdoc shows the original Godot syntax verbatim.
+        if is_unimplemented_role(content) {
+            self.pos += whole.len();
+            write_str!(out, "\\{whole}");
+            return true;
+        }
+
+        if allow_type_links && is_type_link(content) {
+            self.pos += whole.len();
+            self.write_type_link(out, content);
+            return true;
+        }
+
+        false
+    }
+
+    fn write_type_link(&self, out: &mut String, class_name: &str) {
+        if special_cases::is_godot_type_deleted(class_name)
+            || matches_primitive_type(class_name)
+            || matches_ignored_links(class_name)
+        {
+            out.push_str(class_name);
+        } else if class_name == "@GlobalScope" {
+            out.push_str("[@GlobalScope][crate::global]");
+        } else {
+            let is_link_to_surrounding_class = self
+                .surrounding_rust_name
+                .as_deref()
+                .is_some_and(|name| name == conv::to_pascal_case(class_name));
+
+            if is_link_to_surrounding_class {
+                // Avoid redundant self-links in docs for the class currently being generated.
+                write_str!(out, "`{class_name}`");
+            } else {
+                let path = get_class_rust_path(class_name, self.ctx);
+                write_str!(out, "[{class_name}][{path}]");
+            }
+        }
+    }
+
+    fn write_method_link(&self, out: &mut String, whole_match: &str, method_path: &str) {
+        if let Some(method_path) =
+            convert_to_method_path(method_path, self.surrounding_class, self.ctx, self.view)
         {
             let (_, method_name) = method_path
                 .rsplit_once("::")
                 .expect("rsplit_once should return a method name");
-            write!(result, "[{method_name}][`{method_path}`]").unwrap();
+            write_str!(out, "[{method_name}][`{method_path}`]");
         } else {
-            write!(result, "\\{}", whole_match.as_str()).unwrap();
+            write_str!(out, "\\{whole_match}");
         }
-
-        previous = end;
     }
-    result.push_str(&doc[previous..]);
 
-    result
+    fn remaining(&self) -> &'d str {
+        &self.doc[self.pos..]
+    }
+}
+
+fn is_ident_like(str: &str) -> bool {
+    !str.is_empty()
+        && str
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
+}
+
+fn is_type_link(str: &str) -> bool {
+    !str.is_empty()
+        && str
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || ch == '@')
+}
+
+fn is_unimplemented_role(str: &str) -> bool {
+    let Some((role, _)) = str.split_once(' ') else {
+        return false;
+    };
+
+    matches!(
+        role,
+        "annotation" | "constant" | "member" | "enum" | "constructor" | "signal"
+    )
 }
 
 fn convert_to_method_path(
@@ -195,6 +479,7 @@ fn convert_to_method_path(
 
     let link_godot_method = util::safe_ident(link_godot_method).to_string();
 
+    // These cover renamed helpers and special symbols that do not map 1:1 through the API view.
     if let (true, ret) = matches_hardcoded_method(link_godot_class, &link_godot_method) {
         return ret;
     }
@@ -658,6 +943,18 @@ mod tests {
         let actual = import_doc_for_test(description, None);
 
         assert_eq!(actual, "See [Node](https://example.com) for details.");
+    }
+
+    #[test]
+    fn type__followed_by_plural_suffix() {
+        let description = "Use [AnimationNode](s).";
+
+        let actual = import_doc_for_test(description, None);
+
+        assert_eq!(
+            actual,
+            "Use [AnimationNode][crate::classes::AnimationNode](s)."
+        );
     }
 
     // Sentinel test: an unclosed BBCode tag like `[b]` is currently rendered as a class link,

--- a/godot-codegen/src/generator/import_docs.rs
+++ b/godot-codegen/src/generator/import_docs.rs
@@ -291,3 +291,416 @@ fn get_class_rust_path(godot_class_name: &str, ctx: &Context) -> CowStr {
         format!("crate::classes::{rust_class_name}").into()
     }
 }
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// Unit tests
+
+#[cfg(test)]
+#[allow(non_snake_case)]
+mod tests {
+    use std::cell::OnceCell;
+
+    use super::*;
+    use crate::models::api_json::{JsonExtensionApi, load_extension_api};
+    use crate::models::domain::ExtensionApi;
+
+    // `JsonExtensionApi` and `ExtensionApi` are cached per thread; `Context`/`ApiView` are
+    // cheap to rebuild and need lifetimes tied to those owners, so we rebuild them per test.
+    // Using `thread_local` (rather than a global `OnceLock`) avoids needing a `Mutex`, since
+    // `ExtensionApi` contains `proc_macro2::TokenStream` and is therefore `!Sync`.
+    struct DocTestCache {
+        json: JsonExtensionApi,
+        api: ExtensionApi,
+    }
+
+    thread_local! {
+        static CACHE: OnceCell<DocTestCache> = const { OnceCell::new() };
+    }
+
+    fn import_doc_for_test(description: &str, surrounding_class_name: Option<&str>) -> String {
+        CACHE.with(|cell| {
+            let cache = cell.get_or_init(|| {
+                let mut watch = godot_bindings::StopWatch::start();
+                let json = load_extension_api(&mut watch);
+                let mut ctx = Context::build_from_api(&json);
+                let api = ExtensionApi::from_json(&json, &mut ctx);
+                DocTestCache { json, api }
+            });
+
+            let ctx = Context::build_from_api(&cache.json);
+            let view = ApiView::new(&cache.api);
+            let surrounding_class = surrounding_class_name
+                .and_then(|name| view.find_engine_class(&TyName::from_godot(name)));
+
+            import_docs(description, surrounding_class, &ctx, &view)
+        })
+    }
+
+    // TODO: Type links should render class names as code spans instead of Markdown links.
+    // Checks that bare Godot type links are imported as Rust doc links.
+    #[test]
+    fn type__engine_classes() {
+        let description = "Left side, usually used for [Control] or [StyleBox]-derived classes.";
+
+        let actual = import_doc_for_test(description, None);
+
+        assert_eq!(
+            actual,
+            "Left side, usually used for [Control][crate::classes::Control] or [StyleBox][crate::classes::StyleBox]-derived classes."
+        );
+    }
+
+    // TODO: Type links should render builtin type names with backticks inside links.
+    #[test]
+    fn type__builtin_and_member_role() {
+        let description = "Link [member Vector2.x] and [member Vector2.y] on [Vector2] or \
+            [Vector3]. Use [code]\"suffix:px/s\"[/code] for the editor unit suffix.";
+
+        let actual = import_doc_for_test(description, None);
+
+        assert_eq!(
+            actual,
+            "Link \\[member Vector2.x] and \\[member Vector2.y] on \
+            [Vector2][crate::builtin::Vector2] or [Vector3][crate::builtin::Vector3]. Use \
+            `\"suffix:px/s\"` for the editor unit suffix."
+        );
+    }
+
+    // TODO: Type links should render class names with backticks inside links.
+    // Existing Markdown links must stay untouched while later bare type links are still imported.
+    #[test]
+    fn type__preserves_markdown_link() {
+        let description = "See [reference](https://example.com) and [Node].";
+
+        let actual = import_doc_for_test(description, None);
+
+        assert_eq!(
+            actual,
+            "See [reference](https://example.com) and [Node][crate::classes::Node]."
+        );
+    }
+
+    #[test]
+    fn type__global_scope() {
+        let description = "Use [@GlobalScope].";
+
+        let actual = import_doc_for_test(description, None);
+
+        assert_eq!(actual, "Use [@GlobalScope][crate::global].");
+    }
+
+    // Sentinel test: @GDScript stays plain until there is a dedicated Rust target for it.
+    #[test]
+    fn type__gdscript__todo() {
+        let description = "See [@GDScript].";
+
+        let actual = import_doc_for_test(description, None);
+
+        assert_eq!(actual, "See @GDScript.");
+    }
+
+    // TODO: Primitive type links should render as code spans (backticks).
+    #[test]
+    fn type__primitive_links() {
+        let description = "Use [int], [float], and [bool].";
+
+        let actual = import_doc_for_test(description, None);
+
+        assert_eq!(actual, "Use int, float, and bool.");
+    }
+
+    // TODO: Non-surrounding class names should render as code spans (backticks).
+    // Links to the current class are rendered as code to avoid redundant Markdown links.
+    #[test]
+    fn type__surrounding_class() {
+        let description = "See [Node] and [Object].";
+
+        let actual = import_doc_for_test(description, Some("Node"));
+
+        assert_eq!(actual, "See `Node` and [Object][crate::classes::Object].");
+    }
+
+    #[test]
+    fn method__with_newlines_and_roles() {
+        let description = "Compare [code]LEFT[/code] and [code]RIGHT[/code] variants.\n\
+            Use [method InputEvent.is_match] with [constant KEY_LOCATION_UNSPECIFIED] or [enum KeyLocation].";
+
+        let actual = import_doc_for_test(description, None);
+
+        assert_eq!(
+            actual,
+            "Compare `LEFT` and `RIGHT` variants.\n\n\
+            Use [is_match][`crate::classes::InputEvent::is_match`] with \\[constant KEY_LOCATION_UNSPECIFIED] or \\[enum KeyLocation]."
+        );
+    }
+
+    #[test]
+    fn method__in_surrounding_class() {
+        let description = "Call [method get_node] to fetch a child.";
+
+        let actual = import_doc_for_test(description, Some("Node"));
+
+        assert_eq!(
+            actual,
+            "Call [get_node_as][`crate::classes::Node::get_node_as`] to fetch a child."
+        );
+    }
+
+    #[test]
+    fn code_block__preserves_contents() {
+        let description = "Bit mask used to remove modifiers before checking a keycode.\n\
+            [codeblock]\n\
+            var keycode = KEY_A | KEY_MASK_SHIFT\n\
+            keycode = keycode & KEY_CODE_MASK\n\
+            [/codeblock]";
+
+        let actual = import_doc_for_test(description, None);
+
+        assert_eq!(
+            actual,
+            "Bit mask used to remove modifiers before checking a keycode.\n\n\
+            ```gdscript\n\
+            var keycode = KEY_A | KEY_MASK_SHIFT\n\
+            keycode = keycode & KEY_CODE_MASK\n\
+            ```"
+        );
+    }
+
+    // Sentinel test: fenced code blocks must keep bracketed type-like text literal.
+    #[test]
+    fn code_block__type__todo() {
+        let description = "[codeblock]\n[Node]\n[/codeblock]";
+
+        let actual = import_doc_for_test(description, None);
+
+        assert_eq!(actual, "```gdscript\n[Node]\n```");
+    }
+
+    // Covers [codeblocks], [codeblock lang=...], [gdscript], and [csharp].
+    #[test]
+    fn code_block__other_variants() {
+        let codeblocks_description = "[codeblocks]alpha\nbeta[/codeblocks]";
+        let codeblock_lang_description = "[codeblock lang=text]\nalpha\nbeta\n[/codeblock]";
+        let gdscript_description = "[gdscript]\nprint(\"hi\")\n[/gdscript]";
+        let csharp_description = "[csharp]\nGD.Print(\"hi\");\n[/csharp]";
+
+        let codeblocks_actual = import_doc_for_test(codeblocks_description, None);
+        let codeblock_lang_actual = import_doc_for_test(codeblock_lang_description, None);
+        let gdscript_actual = import_doc_for_test(gdscript_description, None);
+        let csharp_actual = import_doc_for_test(csharp_description, None);
+
+        assert_eq!(codeblocks_actual, "alpha\nbeta");
+        assert_eq!(codeblock_lang_actual, "```text\nalpha\nbeta\n```");
+        assert_eq!(gdscript_actual, "```gdscript\n\nprint(\"hi\")\n\n```");
+        assert_eq!(csharp_actual, "```csharp\n\nGD.Print(\"hi\");\n\n```");
+    }
+
+    #[test]
+    fn codeblocks__nested_languages() {
+        let description = "[codeblocks]\n\
+            [gdscript]\n\
+            print(\"hi\")\n\
+            [/gdscript]\n\
+            [csharp]\n\
+            GD.Print(\"hi\");\n\
+            [/csharp]\n\
+            [/codeblocks]";
+
+        let actual = import_doc_for_test(description, None);
+
+        assert_eq!(
+            actual,
+            "\n\
+            ```gdscript\n\
+            print(\"hi\")\n\
+            ```\n\
+            ```csharp\n\
+            GD.Print(\"hi\");\n\
+            ```\n"
+        );
+    }
+
+    #[test]
+    fn code__skip_lint() {
+        let description =
+            "Use [code skip-lint]x[/code] and [code skip-lint][url=address]text[/url][/code].";
+
+        let actual = import_doc_for_test(description, None);
+
+        assert_eq!(actual, "Use `x` and `[text](address)`.");
+    }
+
+    // Guards the current regex order so unsupported roles inside [code] stay escaped.
+    #[test]
+    fn code__escapes_member_role() {
+        let description = "Literal [code][member Vector2.x][/code].";
+
+        let actual = import_doc_for_test(description, None);
+
+        assert_eq!(actual, "Literal `\\[member Vector2.x]`.");
+    }
+
+    // Sentinel test: inline code spans must keep bracketed type-like text literal.
+    #[test]
+    fn code__type__todo() {
+        let description = "Literal [code][Node][/code].";
+
+        let actual = import_doc_for_test(description, None);
+
+        assert_eq!(actual, "Literal `[Node]`.");
+    }
+
+    // Sentinel test: unresolved method links inside [code] stay escaped rather than turning into links.
+    #[test]
+    fn code__method__todo() {
+        let description = "Literal [code][method lerp][/code].";
+
+        let actual = import_doc_for_test(description, None);
+
+        assert_eq!(actual, "Literal `\\[method lerp]`.");
+    }
+
+    #[test]
+    fn bold__with_code_and_member_role() {
+        let description = "MIDI note release.\n\
+            [b]Note:[/b] Some devices send [constant MIDI_MESSAGE_NOTE_ON] with [member InputEventMIDI.velocity] = [code]0[/code].";
+
+        let actual = import_doc_for_test(description, None);
+
+        assert_eq!(
+            actual,
+            "MIDI note release.\n\n\
+            **Note:** Some devices send \\[constant MIDI_MESSAGE_NOTE_ON] with \
+            \\[member InputEventMIDI.velocity] = `0`."
+        );
+    }
+
+    #[test]
+    fn url__basic() {
+        let description = "Controller docs vary; see \
+            [url=https://example.com/spec]the spec[/url] for sliders, pedals, and similar inputs.";
+
+        let actual = import_doc_for_test(description, None);
+
+        assert_eq!(
+            actual,
+            "Controller docs vary; see [the spec](https://example.com/spec) for sliders, \
+            pedals, and similar inputs."
+        );
+    }
+
+    #[test]
+    fn italic__basic() {
+        let description = "The current instrument is often called [i]program[/i] or \
+            [i]preset[/i] in MIDI docs.";
+
+        let actual = import_doc_for_test(description, None);
+
+        assert_eq!(
+            actual,
+            "The current instrument is often called _program_ or _preset_ in MIDI docs."
+        );
+    }
+
+    #[test]
+    fn param__nested_in_bold() {
+        let description = "[b]Use [param count][/b].";
+
+        let actual = import_doc_for_test(description, None);
+
+        assert_eq!(actual, "**Use `count`**.");
+    }
+
+    #[test]
+    fn kbd__basic() {
+        let description = "Press [kbd]Ctrl + S[/kbd].";
+
+        let actual = import_doc_for_test(description, None);
+
+        assert_eq!(actual, "Press `Ctrl + S`.");
+    }
+
+    // Sentinel test: unsupported roles stay escaped until there is dedicated Markdown handling for them.
+    #[test]
+    fn signal___todo() {
+        let description = "Emit [signal pressed].";
+
+        let actual = import_doc_for_test(description, None);
+
+        assert_eq!(actual, "Emit \\[signal pressed].");
+    }
+
+    // Sentinel test: unsupported roles stay escaped until there is dedicated Markdown handling for them.
+    #[test]
+    fn annotation___todo() {
+        let description = "Use [annotation @GDScript.@rpc].";
+
+        let actual = import_doc_for_test(description, None);
+
+        assert_eq!(actual, "Use \\[annotation @GDScript.@rpc].");
+    }
+
+    // Sentinel test: unsupported roles stay escaped until there is dedicated Markdown handling for them.
+    #[test]
+    fn constructor___todo() {
+        let description = "Create [constructor Transform2D].";
+
+        let actual = import_doc_for_test(description, None);
+
+        assert_eq!(actual, "Create \\[constructor Transform2D].");
+    }
+
+    // A type-like bracket directly followed by `(http...)` must stay a Markdown link, not a Rust doc link.
+    #[test]
+    fn type__followed_by_http_url() {
+        let description = "See [Node](https://example.com) for details.";
+
+        let actual = import_doc_for_test(description, None);
+
+        assert_eq!(actual, "See [Node](https://example.com) for details.");
+    }
+
+    // Sentinel test: an unclosed BBCode tag like `[b]` is currently rendered as a class link,
+    // mirroring the prior regex behavior where `type_links` matched any bracketed alphanumeric
+    // identifier after `replace_simple_tags` had consumed properly closed `[b]...[/b]`.
+    #[test]
+    fn type__unclosed_bbcode__todo() {
+        let description = "[b]hello";
+
+        let actual = import_doc_for_test(description, None);
+
+        assert_eq!(actual, "[b][crate::classes::B]hello");
+    }
+
+    // Inline `[b]...[/b]` inside `[code]...[/code]` is rendered as bold, matching the prior regex
+    // order where `bold_tags` ran before `code_tags`.
+    #[test]
+    fn code__nested_bold() {
+        let description = "Use [code][b]x[/b][/code].";
+
+        let actual = import_doc_for_test(description, None);
+
+        assert_eq!(actual, "Use `**x**`.");
+    }
+
+    // Empty brackets `[]` are passed through untouched.
+    #[test]
+    fn empty_brackets() {
+        let description = "Edge case: [].";
+
+        let actual = import_doc_for_test(description, None);
+
+        assert_eq!(actual, "Edge case: [].");
+    }
+
+    // A `[param ...]` whose name is not an identifier (e.g. contains `-`) is left untouched,
+    // matching the old `param_links` regex which required `[a-zA-Z0-9_]+`.
+    #[test]
+    fn param__non_ident_left_literal() {
+        let description = "Bad name [param foo-bar].";
+
+        let actual = import_doc_for_test(description, None);
+
+        assert_eq!(actual, "Bad name [param foo-bar].");
+    }
+}


### PR DESCRIPTION
Follow-up to:
- https://github.com/godot-rust/gdext/pull/1552
- https://github.com/godot-rust/gdext/pull/1573

Migrates regex-based parsing of `[tags]` in Godot's documentation with a linear scanner. 
Massively speeds up compile times.
Removes the `regex` dependency from the entire project.

## Benchmarks

```rs
hyperfine --prepare 'cargo clean --workspace' 'cargo check -p godot'
```
```rs
// 5ed3468a88fe36e79643122a1820880c537054c9 (Apr 21), before method and class docs

Benchmark 1: cargo check -p godot
  Time (mean ± σ):     17.897 s ±  0.069 s    [User: 19.911 s, System: 1.531 s]
  Range (min … max):   17.787 s … 17.989 s    10 runs


// c79c972b6a92182a5c82dc56c9d52b4e3d7bf2f8 (Apr 30), after merging class docs, before method docs

Benchmark 1: cargo check -p godot
  Time (mean ± σ):     19.584 s ±  0.231 s    [User: 21.598 s, System: 1.633 s]
  Range (min … max):   19.263 s … 19.875 s    10 runs


// fda0a9611bf4f393051f365495560dca1fdf57e8 (Apr 30), after merging method docs

Benchmark 1: cargo check -p godot
  Time (mean ± σ):     37.291 s ±  0.211 s    [User: 39.244 s, System: 1.652 s]
  Range (min … max):   36.973 s … 37.626 s    10 runs


// this PR, after refactor

Benchmark 1: cargo check -p godot
  Time (mean ± σ):     19.480 s ±  0.301 s    [User: 21.380 s, System: 1.738 s]
  Range (min … max):   19.263 s … 20.312 s    10 runs
```

I have a few follow-ups to implement missing features, but I'll keep them separate from this PR.

We're also still losing significant build time with docs enabled: 19.480/17.897 - 1 = **8.84%**.
There are quite a few commits in between, so it might be something else, but we can also look into this.