### PR TITLE
Doc parser: improve mappings + refactor

### DIFF
--- a/godot-codegen/src/context.rs
+++ b/godot-codegen/src/context.rs
@@ -31,6 +31,9 @@ pub struct Context<'a> {
     notifications_by_class: HashMap<TyName, Vec<(Ident, i32)>>,
     classes_with_signals: HashSet<TyName>,
     notification_enum_names_by_class: HashMap<TyName, NotificationEnum>,
+    /// Maps a Godot notification constant name (e.g. `"NOTIFICATION_READY"`) to (declaring-class enum ident, variant ident)
+    /// (e.g. `(NodeNotification, READY)`).
+    notification_constants_index: HashMap<String, (Ident, Ident)>,
     method_table_indices: HashMap<MethodTableKey, usize>,
     method_table_next_index: HashMap<String, usize>,
 }
@@ -172,6 +175,12 @@ impl<'a> Context<'a> {
 
                     has_notifications = true;
                 }
+
+                let decl_enum_name = format_ident!("{}Notification", class_name.rust_ty);
+                ctx.notification_constants_index.insert(
+                    constant.name.clone(),
+                    (decl_enum_name, rust_constant.clone()),
+                );
 
                 ctx.notifications_by_class
                     .get_mut(class_name)
@@ -350,6 +359,17 @@ impl<'a> Context<'a> {
             .get(class_name)
             .unwrap_or_else(|| panic!("class {} has no notification enum name", class_name.rust_ty))
             .clone()
+    }
+
+    /// Look up a notification constant by its Godot name (e.g. `"NOTIFICATION_READY"`).
+    ///
+    /// Returns `(declaring_class_enum_ident, variant_ident)`, e.g. `(NodeNotification, READY)`.
+    /// The declaring-class enum is a fallback; callers with a surrounding class should prefer
+    /// [`Self::notification_enum_name`] for that class instead.
+    pub fn find_notification_constant(&self, godot_name: &str) -> Option<(&Ident, &Ident)> {
+        self.notification_constants_index
+            .get(godot_name)
+            .map(|(e, v)| (e, v))
     }
 
     pub fn insert_rust_type(&mut self, godot_ty: GodotTy, resolved: RustTy) {

--- a/godot-codegen/src/generator/default_parameters.rs
+++ b/godot-codegen/src/generator/default_parameters.rs
@@ -34,7 +34,8 @@ pub fn make_function_definition_with_defaults(
     let simple_fn_name = safe_ident(sig.name());
     let extended_fn_name = format_ident!("{}_ex", simple_fn_name);
     let default_parameter_usage = format!(
-        "To set the default parameters, use [`Self::{extended_fn_name}`] and its builder methods.  See [the book](https://godot-rust.github.io/book/godot-api/functions.html#default-parameters) for detailed usage instructions."
+        "To set the default parameters, use [`{extended_fn_name}`][Self::{extended_fn_name}] and its builder methods.  \
+        See [the book](https://godot-rust.github.io/book/godot-api/functions.html#default-parameters) for detailed usage instructions."
     );
     let vis = functions_common::make_vis(sig.is_private());
 

--- a/godot-codegen/src/generator/functions_common.rs
+++ b/godot-codegen/src/generator/functions_common.rs
@@ -188,8 +188,16 @@ pub fn make_function_definition(
     let (maybe_deprecated, _maybe_expect_deprecated) = make_deprecation_attribute(sig);
     let maybe_specific_doc = &meta.specific_docs;
 
+    // If a sectioned doc precedes the Godot doc (`# Safety` from unsafe pointers, `# Specific notes for this function` from utility-fn extra
+    // docs), prefix the Godot doc with its own `# Godot docs` heading so the sections don't visually merge. Standalone, no heading.
     let mut maybe_godot_doc = TokenStream::new();
     if let Some(doc) = import_docs::import_function_docs(sig, ctx, view) {
+        let has_preceding_section = sig.common().is_unsafe || !meta.specific_docs.is_empty();
+        let doc = if has_preceding_section {
+            format!("\n# Godot docs\n{doc}")
+        } else {
+            doc
+        };
         maybe_godot_doc = quote! { #[doc = #doc] };
     }
 

--- a/godot-codegen/src/generator/import_docs.rs
+++ b/godot-codegen/src/generator/import_docs.rs
@@ -435,30 +435,31 @@ impl<'d> DocImporter<'d> {
     }
 
     /// Emit Markdown for `[Foo]`. Branches:
-    /// - deleted/`@GDScript` → plain text;
-    /// - `int`/`float`/`bool` → `` `int` `` (no link target);
-    /// - hardcoded specials (`@GlobalScope`) → fixed link;
-    /// - link to surrounding class → `` `Self` ``-style code span (avoid self-link);
-    /// - else → `` [`Foo`][crate::classes::Foo] `` Rustdoc reference link.
+    /// - `@GDScript` -> plain text (no dedicated Rust module target);
+    /// - deleted/disabled class -> `` `Foo` `` code span (class exists but has no Rust binding);
+    /// - `int`/`float`/`bool` -> `` `int` `` (no link target);
+    /// - hardcoded specials (`@GlobalScope`) -> fixed link;
+    /// - link to surrounding class -> `` `Self` ``-style code span (avoid self-link);
+    /// - else -> `` [`Foo`][crate::classes::Foo] `` Rustdoc reference link.
     fn write_type_link(&self, out: &mut String, ty_name: &str) {
-        if special_cases::is_godot_type_deleted(ty_name) || matches_ignored_links(ty_name) {
+        if matches_ignored_links(ty_name) {
             out.push_str(ty_name);
         } else if matches_primitive_type(ty_name) {
             write_code_span(out, ty_name);
         } else if let Some(hardcoded) = matches_hardcoded_type(ty_name) {
             out.push_str(hardcoded);
-        } else {
+        } else if !self.ctx.is_builtin(ty_name) && special_cases::is_class_deleted_str(ty_name) {
+            // Engine class excluded from codegen (or genuinely deleted): no link target. Builtins are always available, so skip the check.
+            write_code_span(out, ty_name);
+        } else if self
+            .surrounding_class
+            .is_some_and(|c| c.name().godot_ty == ty_name)
+        {
             // Compare on the Godot name to skip the per-link `to_pascal_case` allocation.
-            let is_link_to_surrounding_class = self
-                .surrounding_class
-                .is_some_and(|c| c.name().godot_ty == ty_name);
-
-            if is_link_to_surrounding_class {
-                write_code_span(out, ty_name);
-            } else {
-                let path = get_class_rust_path(ty_name, self.ctx);
-                write_code_link(out, ty_name, &path);
-            }
+            write_code_span(out, ty_name);
+        } else {
+            let path = get_class_rust_path(ty_name, self.ctx);
+            write_code_link(out, ty_name, &path);
         }
     }
 
@@ -583,8 +584,7 @@ impl<'d> DocImporter<'d> {
     ) -> Option<(&'d Class, &'d Enum, &'d Enumerator)> {
         let mut current = starting_class;
         loop {
-            if let Some((enum_, enumerator)) = find_enumerator_in_class(current, const_godot_name)
-            {
+            if let Some((enum_, enumerator)) = find_enumerator_in_class(current, const_godot_name) {
                 return Some((current, enum_, enumerator));
             }
             let base_name = current.base_class.as_ref()?;
@@ -692,25 +692,40 @@ fn convert_to_method_path(
             return None;
         };
 
-    if special_cases::is_godot_type_deleted(link_godot_class) {
-        return None;
-    }
-
     let link_godot_method = util::safe_ident(link_godot_method).to_string();
 
     // These cover renamed helpers and special symbols that do not map 1:1 through the API view.
+    // Run before the deletion check, so hardcoded mappings (e.g. `@GlobalScope.*`) keep working.
     match matches_hardcoded_method(link_godot_class, &link_godot_method) {
         Hardcoded::Mapped(path) => return Some(path),
         Hardcoded::Suppressed => return None,
         Hardcoded::NotMatched => {}
     }
 
-    if let Some(class) = view.find_engine_class(&TyName::from_godot(link_godot_class))
-        && let Some(method) = class
+    // Skip for builtins (Vector2, Transform2D, ...): they are always available and the exclusion list doesn't apply to them.
+    if !ctx.is_builtin(link_godot_class) && special_cases::is_class_deleted_str(link_godot_class) {
+        return None;
+    }
+
+    if let Some(class) = view.find_engine_class(&TyName::from_godot(link_godot_class)) {
+        let Some(method) = class
             .methods
             .iter()
             .find(|method| method.godot_name() == link_godot_method)
-    {
+        else {
+            // Class is in the API view but the method isn't (excluded from default codegen, or shadowed by an `_ex` builder).
+            // Fabricating a path would yield a broken link.
+            return None;
+        };
+
+        // Type-safe replacements (e.g. `Object.get_script`): the codegen-generated method has a `raw_` prefix and is `pub(crate)`;
+        // the public Rust replacement keeps the original Godot name. Link to the public replacement.
+        if special_cases::is_class_method_replaced_with_type_safe(class.name(), &link_godot_method)
+        {
+            let rust_class_path = get_class_rust_path(link_godot_class, ctx);
+            return Some(format!("{rust_class_path}::{link_godot_method}").into());
+        }
+
         let rust_method_name = method.name();
 
         // Skip links to private methods.
@@ -732,13 +747,13 @@ fn convert_to_method_path(
         }
 
         // Use the Rust name; covers `special_cases::maybe_rename_class_method`.
-        // Examples: `Object.get_script` -> `raw_get_script`, `GDScript.new` -> `instantiate`.
+        // Example: `GDScript.new` -> `instantiate`.
         let rust_class_path = get_class_rust_path(link_godot_class, ctx);
         return Some(format!("{rust_class_path}::{rust_method_name}").into());
     }
 
-    // Fallback when class/method is not in the API view (e.g. unknown class link): strip the leading underscore
-    // as a best-effort guess at the Rust name.
+    // Fallback for classes not represented in the engine API view: builtins (Vector2, Transform2D, ...) whose methods are not captured in
+    // ApiView. Strip the leading underscore as a best-effort guess at the Rust name.
     let godot_method_name = link_godot_method.trim_start_matches("_");
     let rust_class_path = get_class_rust_path(link_godot_class, ctx);
     Some(format!("{rust_class_path}::{godot_method_name}").into())
@@ -868,15 +883,16 @@ mod tests {
     }
 
     // Bare Godot type links become Rustdoc links with code-formatted labels.
+    // Uses classes always present in default codegen (`Node`, `Resource`); excluded classes resolve to a code span instead.
     #[test]
     fn type__engine_classes() {
-        let description = "Left side, usually used for [Control] or [StyleBox]-derived classes.";
+        let description = "Inherits from [Node] or [Resource], depending on use case.";
 
         let actual = import_doc_for_test(description, None);
 
         assert_eq!(
             actual,
-            "Left side, usually used for [`Control`][crate::classes::Control] or [`StyleBox`][crate::classes::StyleBox]-derived classes."
+            "Inherits from [`Node`][crate::classes::Node] or [`Resource`][crate::classes::Resource], depending on use case."
         );
     }
 
@@ -927,6 +943,17 @@ mod tests {
         assert_eq!(actual, "See @GDScript.");
     }
 
+    // Deleted/disabled classes (e.g. Android-only) become a backtick code span, not a broken link.
+    #[test]
+    #[cfg(not(target_os = "android"))]
+    fn type__deleted_class_backtick() {
+        let description = "See [JavaClass].";
+
+        let actual = import_doc_for_test(description, None);
+
+        assert_eq!(actual, "See `JavaClass`.");
+    }
+
     #[test]
     fn type__primitive_links() {
         let description = "Use [int], [float], and [bool].";
@@ -973,17 +1000,16 @@ mod tests {
         );
     }
 
-    // Regression: methods renamed via `special_cases::maybe_rename_class_method` must use the Rust name in the link.
-    // Here type-safe replacement: `Object.get_script` -> `raw_get_script`.
+    // Type-safe replacements link to the public Rust method (which keeps the original Godot name), not the `pub(crate) raw_*` codegen variant.
     #[test]
-    fn method__renamed_via_special_case() {
+    fn method__type_safe_replacement() {
         let description = "See [method Object.get_script].";
 
         let actual = import_doc_for_test(description, None);
 
         assert_eq!(
             actual,
-            "See [`raw_get_script`][`crate::classes::Object::raw_get_script`]."
+            "See [`get_script`][`crate::classes::Object::get_script`]."
         );
     }
 
@@ -1309,14 +1335,11 @@ mod tests {
 
     #[test]
     fn type__followed_by_plural_suffix() {
-        let description = "Use [AnimationNode](s).";
+        let description = "Use [Node](s).";
 
         let actual = import_doc_for_test(description, None);
 
-        assert_eq!(
-            actual,
-            "Use [`AnimationNode`][crate::classes::AnimationNode](s)."
-        );
+        assert_eq!(actual, "Use [`Node`][crate::classes::Node](s).");
     }
 
     // Unterminated BBCode stays literal instead of falling through into type-link parsing.

--- a/godot-codegen/src/generator/import_docs.rs
+++ b/godot-codegen/src/generator/import_docs.rs
@@ -78,8 +78,8 @@ impl ParseMode {
     ///
     /// Formatting tags (`[b]`, `[i]`, `[kbd]`) inherit the outer mode so nested links/tags work.
     /// Code tags switch to [`Self::CODE`] so brackets inside code stay literal.
-    fn inherit_for(self, tag: &WrappedTag) -> Self {
-        if tag.allow_inner {
+    fn inherit_for(self, allow_inner: bool) -> Self {
+        if allow_inner {
             Self {
                 double_newlines: self.double_newlines,
                 allow_type_links: self.allow_type_links,
@@ -91,35 +91,53 @@ impl ParseMode {
     }
 }
 
-/// BBCode tag with a fixed opener/closer and a literal Markdown wrapping.
+/// BBCode tag with a fixed opener/closer.
 ///
 /// Used for tags whose opener has no dynamic attribute. Tags with attributes
 /// (`[url=...]`, `[codeblock lang=...]`) are handled by separate parsers.
-struct WrappedTag {
-    /// BBCode opener, e.g. `"[b]"`.
-    open: &'static str,
-    /// BBCode closer, e.g. `"[/b]"`.
-    close: &'static str,
-    /// Markdown to emit before inner content, e.g. `"**"` or `"```gdscript"`.
-    prefix: &'static str,
-    /// Markdown to emit after inner content, e.g. `"**"` or `"```"`.
-    suffix: &'static str,
-    /// If true, inner content is parsed with the outer mode (formatting tags like `[b]`, `[i]`, `[kbd]`).
-    /// If false, inner content is parsed in [`ParseMode::CODE`] (fenced/inline code blocks).
-    allow_inner: bool,
+enum WrappedTag {
+    /// Tag and its content are emitted, wrapped in Markdown.
+    Render {
+        /// BBCode opener, e.g. `"[b]"`.
+        open: &'static str,
+        /// BBCode closer, e.g. `"[/b]"`.
+        close: &'static str,
+        /// Markdown to emit before inner content, e.g. `"**"` or `"```gdscript"`.
+        prefix: &'static str,
+        /// Markdown to emit after inner content, e.g. `"**"` or `"```"`.
+        suffix: &'static str,
+        /// If true, inner content is parsed with the outer mode (formatting tags like `[b]`, `[i]`, `[kbd]`).
+        /// If false, inner content is parsed in [`ParseMode::CODE`] (fenced/inline code blocks).
+        allow_inner: bool,
+    },
+    /// Tag and its content are dropped entirely. One trailing `\n` already in the output is also consumed,
+    /// so the surrounding block doesn't gain a blank line.
+    Skip {
+        open: &'static str,
+        close: &'static str,
+    },
+}
+
+impl WrappedTag {
+    fn open(&self) -> &'static str {
+        match self {
+            Self::Render { open, .. } | Self::Skip { open, .. } => open,
+        }
+    }
 }
 
 // Order matters: longer prefix first when prefixes overlap (`[code skip-lint]` before `[code]`).
 #[rustfmt::skip]
 const WRAPPED_TAGS: &[WrappedTag] = &[
-    WrappedTag { open: "[b]",              close: "[/b]",         prefix: "**",            suffix: "**",  allow_inner: true  },
-    WrappedTag { open: "[i]",              close: "[/i]",         prefix: "_",             suffix: "_",   allow_inner: true  },
-    WrappedTag { open: "[kbd]",            close: "[/kbd]",       prefix: "`",             suffix: "`",   allow_inner: true  },
-    WrappedTag { open: "[code skip-lint]", close: "[/code]",      prefix: "`",             suffix: "`",   allow_inner: false },
-    WrappedTag { open: "[code]",           close: "[/code]",      prefix: "`",             suffix: "`",   allow_inner: false },
-    WrappedTag { open: "[codeblock]",      close: "[/codeblock]", prefix: "```gdscript",   suffix: "```", allow_inner: false },
-    WrappedTag { open: "[gdscript]",       close: "[/gdscript]",  prefix: "```gdscript",   suffix: "```", allow_inner: false },
-    WrappedTag { open: "[csharp]",         close: "[/csharp]",    prefix: "```csharp",     suffix: "```", allow_inner: false },
+    WrappedTag::Render { open: "[b]",              close: "[/b]",         prefix: "**",          suffix: "**",  allow_inner: true  },
+    WrappedTag::Render { open: "[i]",              close: "[/i]",         prefix: "_",           suffix: "_",   allow_inner: true  },
+    WrappedTag::Render { open: "[kbd]",            close: "[/kbd]",       prefix: "`",           suffix: "`",   allow_inner: true  },
+    WrappedTag::Render { open: "[code skip-lint]", close: "[/code]",      prefix: "`",           suffix: "`",   allow_inner: false },
+    WrappedTag::Render { open: "[code]",           close: "[/code]",      prefix: "`",           suffix: "`",   allow_inner: false },
+    WrappedTag::Render { open: "[codeblock]",      close: "[/codeblock]", prefix: "```gdscript", suffix: "```", allow_inner: false },
+    WrappedTag::Render { open: "[gdscript]",       close: "[/gdscript]",  prefix: "```gdscript", suffix: "```", allow_inner: false },
+    // C# blocks usually just duplicate the adjacent `[gdscript]` block, and we have no C# audience in Rust docs.
+    WrappedTag::Skip   { open: "[csharp]",         close: "[/csharp]" },
 ];
 
 struct DocImporter<'d> {
@@ -241,18 +259,43 @@ impl<'d> DocImporter<'d> {
     }
 
     fn try_wrapped_tag(&mut self, out: &mut String, tag: &WrappedTag, mode: ParseMode) -> bool {
-        if !self.remaining().starts_with(tag.open) {
+        if !self.remaining().starts_with(tag.open()) {
             return false;
         }
 
         let cp = self.checkpoint(out);
-        self.pos += tag.open.len();
-        out.push_str(tag.prefix);
-        if !self.parse_until(out, Some(tag.close), mode.inherit_for(tag)) {
-            self.rollback(out, cp);
-            return false;
+        self.pos += tag.open().len();
+
+        match *tag {
+            WrappedTag::Render {
+                close,
+                prefix,
+                suffix,
+                allow_inner,
+                ..
+            } => {
+                out.push_str(prefix);
+                if !self.parse_until(out, Some(close), mode.inherit_for(allow_inner)) {
+                    self.rollback(out, cp);
+                    return false;
+                }
+                out.push_str(suffix);
+            }
+            WrappedTag::Skip { close, .. } => {
+                // Drop the tag and its body. Content is discarded into a scratch buffer so `parse_until`'s
+                // close-tag matching still works. On EOF without close, roll back to leave the opener literal.
+                let mut scratch = String::new();
+                if !self.parse_until(&mut scratch, Some(close), ParseMode::CODE) {
+                    self.rollback(out, cp);
+                    return false;
+                }
+
+                // Consume one trailing `\n` already in `out`, so the dropped block doesn't leave a blank line behind it.
+                if out.ends_with('\n') {
+                    out.pop();
+                }
+            }
         }
-        out.push_str(tag.suffix);
         true
     }
 
@@ -657,7 +700,7 @@ fn is_type_link(str: &str) -> bool {
 /// True if `str` begins with a recognized BBCode opener. Used by [`DocImporter::try_parse_tag`]
 /// to emit unterminated known openers as-is, instead of letting the bracket-link parser reinterpret them.
 fn starts_with_known_tag(str: &str) -> bool {
-    WRAPPED_TAGS.iter().any(|t| str.starts_with(t.open))
+    WRAPPED_TAGS.iter().any(|t| str.starts_with(t.open()))
         || str.starts_with("[url=")
         || str.starts_with("[codeblocks]")
         || str.starts_with("[codeblock lang=")
@@ -1155,7 +1198,8 @@ mod tests {
         assert_eq!(codeblocks_actual, "alpha\nbeta");
         assert_eq!(codeblock_lang_actual, "```text\nalpha\nbeta\n```");
         assert_eq!(gdscript_actual, "```gdscript\nprint(\"hi\")\n```");
-        assert_eq!(csharp_actual, "```csharp\nGD.Print(\"hi\");\n```");
+        assert_eq!(csharp_actual, ""); // C# is currently hidden from Rust docs; it often just duplicates GDScript.
+        // assert_eq!(csharp_actual, "```csharp\nGD.Print(\"hi\");\n```");
     }
 
     #[test]
@@ -1176,10 +1220,7 @@ mod tests {
             "\n\
             ```gdscript\n\
             print(\"hi\")\n\
-            ```\n\
-            ```csharp\n\
-            GD.Print(\"hi\");\n\
-            ```\n"
+            ```\n" // C# is currently hidden from Rust docs; it often just duplicates GDScript.
         );
     }
 

--- a/godot-codegen/src/generator/import_docs.rs
+++ b/godot-codegen/src/generator/import_docs.rs
@@ -679,10 +679,9 @@ fn convert_to_method_path(
     ctx: &Context,
     view: &ApiView,
 ) -> Option<CowStr> {
-    // Get the class name from the link if it has one, otherwise, use the surrounding class's name.
-    // For example, if we are generating docs for the `CanvasItem` class and see an "Object._notification" link
-    // take "Object" as the class name and "_notification" as the method name. But if we see a "queue_redraw"
-    // link, take the surrounding class's name(in our case it's "CanvasItem") as the class that owns the method.
+    // Get the class name from the link if it has one, otherwise use the surrounding class's name.
+    // For example, in `CanvasItem` docs the link `[method Object.notification]` is owned by `Object`, while bare `[method queue_redraw]`
+    // resolves against the surrounding `CanvasItem`.
     let (link_godot_class, link_godot_method) =
         if let Some((class_name, method_name)) = class_method.split_once('.') {
             (class_name, method_name)
@@ -707,56 +706,47 @@ fn convert_to_method_path(
         return None;
     }
 
-    if let Some(class) = view.find_engine_class(&TyName::from_godot(link_godot_class)) {
-        let Some(method) = class
-            .methods
-            .iter()
-            .find(|method| method.godot_name() == link_godot_method)
-        else {
-            // Class is in the API view but the method isn't (excluded from default codegen, or shadowed by an `_ex` builder).
-            // Fabricating a path would yield a broken link.
-            return None;
-        };
+    let rust_class_path = get_class_rust_path(link_godot_class, ctx);
 
-        // Type-safe replacements (e.g. `Object.get_script`): the codegen-generated method has a `raw_` prefix and is `pub(crate)`;
-        // the public Rust replacement keeps the original Godot name. Link to the public replacement.
-        if special_cases::is_class_method_replaced_with_type_safe(class.name(), &link_godot_method)
-        {
-            let rust_class_path = get_class_rust_path(link_godot_class, ctx);
-            return Some(format!("{rust_class_path}::{link_godot_method}").into());
-        }
+    let Some(class) = view.find_engine_class(&TyName::from_godot(link_godot_class)) else {
+        // Builtins (Vector2, Transform2D, ...) are not engine classes in the API view; their methods aren't captured here, so we trust the link.
+        return Some(format!("{rust_class_path}::{link_godot_method}").into());
+    };
 
-        let rust_method_name = method.name();
+    let Some(method) = class
+        .methods
+        .iter()
+        .find(|method| method.godot_name() == link_godot_method)
+    else {
+        // Class is in the API view but the method isn't (excluded from default codegen, or shadowed by an `_ex` builder).
+        // Fabricating a path would yield a broken link.
+        return None;
+    };
 
-        // Skip links to private methods.
-        if method.is_private_in_final_api() {
-            return None;
-        }
-        if method.is_virtual() {
-            return if class.is_final {
-                // Final classes don't have an associated trait with virtual methods.
-                None
-            } else {
-                let path = format!(
-                    "crate::classes::{}::{}",
-                    class.name().virtual_trait_name(),
-                    rust_method_name
-                );
-                Some(path.into())
-            };
-        }
-
-        // Use the Rust name; covers `special_cases::maybe_rename_class_method`.
-        // Example: `GDScript.new` -> `instantiate`.
-        let rust_class_path = get_class_rust_path(link_godot_class, ctx);
-        return Some(format!("{rust_class_path}::{rust_method_name}").into());
+    // Type-safe replacements (e.g. `Object.get_script`): the codegen-generated method has a `raw_` prefix and is `pub(crate)`;
+    // the public Rust replacement keeps the original Godot name. Link to the public replacement.
+    if special_cases::is_class_method_replaced_with_type_safe(class.name(), &link_godot_method) {
+        return Some(format!("{rust_class_path}::{link_godot_method}").into());
     }
 
-    // Fallback for classes not represented in the engine API view: builtins (Vector2, Transform2D, ...) whose methods are not captured in
-    // ApiView. Strip the leading underscore as a best-effort guess at the Rust name.
-    let godot_method_name = link_godot_method.trim_start_matches("_");
-    let rust_class_path = get_class_rust_path(link_godot_class, ctx);
-    Some(format!("{rust_class_path}::{godot_method_name}").into())
+    if method.is_private_in_final_api() {
+        return None;
+    }
+
+    if method.is_virtual() {
+        // Final classes don't have an associated trait with virtual methods.
+        return (!class.is_final).then(|| {
+            format!(
+                "crate::classes::{}::{}",
+                class.name().virtual_trait_name(),
+                method.name()
+            )
+            .into()
+        });
+    }
+
+    // Use the Rust name; covers `special_cases::maybe_rename_class_method`. Example: `GDScript.new` -> `instantiate`.
+    Some(format!("{rust_class_path}::{}", method.name()).into())
 }
 
 fn matches_hardcoded_type(godot_class: &str) -> Option<&'static str> {

--- a/godot-codegen/src/generator/import_docs.rs
+++ b/godot-codegen/src/generator/import_docs.rs
@@ -8,7 +8,7 @@
 use std::fmt::Write as _;
 
 use crate::context::Context;
-use crate::models::domain::{ApiView, Class, ClassLike, Function, TyName};
+use crate::models::domain::{ApiView, Class, ClassLike, Enum, Enumerator, Function, TyName};
 use crate::{conv, special_cases, util};
 
 type CowStr = std::borrow::Cow<'static, str>;
@@ -37,7 +37,6 @@ pub fn import_function_docs(fun: &dyn Function, ctx: &Context, view: &ApiView) -
     let surrounding_class_name = fun.surrounding_class();
     let surrounding_class = surrounding_class_name.and_then(|name| view.find_engine_class(name));
     let imported_doc = import_docs(doc, surrounding_class, ctx, view);
-    // let imported_doc = format!("\n# Godot docs\n{imported_doc}"); -- no title at the moment.
     Some(imported_doc)
 }
 
@@ -222,7 +221,7 @@ impl<'d> DocImporter<'d> {
         // Try the static table of wrapped tags first. An unterminated real opener is emitted as-is,
         // not reinterpreted by the bracket-link parser below.
         for tag in WRAPPED_TAGS {
-            if self.remaining().starts_with(tag.open) && self.try_wrapped_tag(out, tag, mode) {
+            if self.try_wrapped_tag(out, tag, mode) {
                 return true;
             }
         }
@@ -408,7 +407,7 @@ impl<'d> DocImporter<'d> {
 
         if let Some(constant) = content.strip_prefix("constant ") {
             self.pos += whole.len();
-            write_code_span(out, constant);
+            self.write_constant_link(out, constant);
             return true;
         }
 
@@ -478,6 +477,121 @@ impl<'d> DocImporter<'d> {
         }
     }
 
+    /// Emit a link for `[constant X]` or `[constant ClassName.X]`.
+    ///
+    /// Lookup order for **bare** references (`[constant X]`, no dot):
+    /// 1. Notification constants (`NOTIFICATION_*`) -- link to `crate::classes::notify::XyzNotification::X`, using the surrounding class's
+    ///    notification enum when available, or the declaring class's otherwise.
+    /// 2. Enum constants from the surrounding class's hierarchy (walks up via `base_class`) -- link to the sidecar module of the class in the
+    ///    chain that declares the enum.
+    /// 3. Global enum enumerators (e.g. `MIDI_MESSAGE_NOTE_ON`) -- link to `crate::global::MyEnum::XYZ`.
+    /// 4. Fallback to a plain code span.
+    ///
+    /// For **class-scoped** references (`[constant ClassName.X]`, dot present):
+    /// 1. Class enums (via [`Self::find_class_enum_constant`]).
+    /// 2. Notification constants for the specified class.
+    /// 3. Fallback to a plain code span.
+    fn write_constant_link(&self, out: &mut String, godot_const_ref: &str) {
+        if let Some((class_godot_name, const_godot_name)) = godot_const_ref.split_once('.') {
+            // Class-scoped reference: e.g. "Node.NOTIFICATION_READY" or "Object.CONNECT_DEFERRED".
+            if let Some((class, enum_, enumerator)) =
+                self.find_class_enum_constant(class_godot_name, const_godot_name)
+            {
+                let module = format!("crate::classes::{}", class.mod_name().rust_mod);
+                write_enum_const_link(out, &module, &enum_.name, &enumerator.name);
+                return;
+            }
+
+            // Notification constant for the explicitly-specified class (e.g. "Node.NOTIFICATION_READY").
+            if !class_godot_name.starts_with('@')
+                && let Some((_decl_enum, variant)) =
+                    self.ctx.find_notification_constant(const_godot_name)
+            {
+                let class_ty = TyName::from_godot(class_godot_name);
+                if self.view.find_engine_class(&class_ty).is_some() {
+                    let enum_name = self.ctx.notification_enum_name(&class_ty).name;
+                    write_enum_const_link(out, "crate::classes::notify", &enum_name, &variant);
+                    return;
+                }
+            }
+        } else {
+            // Global-scope reference -- try notifications, then class hierarchy, then global enums.
+
+            // Notification constants (e.g. "NOTIFICATION_READY" -> "NodeNotification::READY").
+            if let Some((decl_enum_ident, variant)) =
+                self.ctx.find_notification_constant(godot_const_ref)
+            {
+                let enum_ident = self
+                    .surrounding_class
+                    .map(|c| self.ctx.notification_enum_name(c.name()).name)
+                    .unwrap_or_else(|| decl_enum_ident.clone());
+                write_enum_const_link(out, "crate::classes::notify", &enum_ident, &variant);
+                return;
+            }
+
+            // Enum constant from the surrounding class or one of its base classes.
+            if let Some(surrounding_class) = self.surrounding_class
+                && let Some((class, enum_, enumerator)) =
+                    self.find_class_enum_constant_in_hierarchy(surrounding_class, godot_const_ref)
+            {
+                let module = format!("crate::classes::{}", class.mod_name().rust_mod);
+                write_enum_const_link(out, &module, &enum_.name, &enumerator.name);
+                return;
+            }
+
+            // Global enum enumerator (e.g. "MIDI_MESSAGE_NOTE_ON").
+            if let Some((enum_, enumerator)) = self.view.find_global_enum_constant(godot_const_ref)
+            {
+                let module = special_cases::get_global_enum_module_path(&enum_.godot_name);
+                write_enum_const_link(out, module, &enum_.name, &enumerator.name);
+                return;
+            }
+        }
+
+        // Fallback: render as a code span when the constant cannot be resolved.
+        write_code_span(out, godot_const_ref);
+    }
+
+    /// Look up a class-scoped enum enumerator by the Godot class and enumerator names.
+    ///
+    /// Finds the class in O(1) via [`ApiView`], then searches within that class's enums. The
+    /// search within a single class is bounded in practice (classes typically have few enums).
+    fn find_class_enum_constant(
+        &self,
+        class_godot_name: &str,
+        const_godot_name: &str,
+    ) -> Option<(&'d Class, &'d Enum, &'d Enumerator)> {
+        // Names like `@GlobalScope` are not valid Rust identifiers and are not engine classes.
+        if class_godot_name.starts_with('@') {
+            return None;
+        }
+        let class = self
+            .view
+            .find_engine_class(&TyName::from_godot(class_godot_name))?;
+        let (enum_, enumerator) = find_enumerator_in_class(class, const_godot_name)?;
+        Some((class, enum_, enumerator))
+    }
+
+    /// Walk from `starting_class` up the inheritance chain, searching each class's enums for an
+    /// enumerator matching `const_godot_name`.
+    ///
+    /// Returns the first match as `(declaring_class, enum, enumerator)`, or `None`.
+    fn find_class_enum_constant_in_hierarchy(
+        &self,
+        starting_class: &'d Class,
+        const_godot_name: &str,
+    ) -> Option<(&'d Class, &'d Enum, &'d Enumerator)> {
+        let mut current = starting_class;
+        loop {
+            if let Some((enum_, enumerator)) = find_enumerator_in_class(current, const_godot_name)
+            {
+                return Some((current, enum_, enumerator));
+            }
+            let base_name = current.base_class.as_ref()?;
+            current = self.view.find_engine_class(base_name)?;
+        }
+    }
+
     fn remaining(&self) -> &'d str {
         &self.doc[self.pos..]
     }
@@ -485,20 +599,38 @@ impl<'d> DocImporter<'d> {
 
 /// Emit `` `text` ``.
 fn write_code_span(out: &mut String, text: &str) {
-    out.push('`');
-    out.push_str(text);
-    out.push('`');
+    write_str!(out, "`{text}`");
+}
+
+/// Search a single class's enums for an enumerator with the given Godot name.
+fn find_enumerator_in_class<'a>(
+    class: &'a Class,
+    const_godot_name: &str,
+) -> Option<(&'a Enum, &'a Enumerator)> {
+    class.enums.iter().find_map(|e| {
+        e.enumerators
+            .iter()
+            .find(|en| en.godot_name == const_godot_name)
+            .map(|en| (e, en))
+    })
 }
 
 /// Emit a Rustdoc reference link `` [`label`][path] ``.
 fn write_code_link(out: &mut String, label: &str, path: &str) {
-    out.push('[');
-    out.push('`');
-    out.push_str(label);
-    out.push('`');
-    out.push_str("][");
-    out.push_str(path);
-    out.push(']');
+    write_str!(out, "[`{label}`][{path}]");
+}
+
+/// Emit `` [`Enum::Variant`][`module::Enum::Variant`] ``, the form used for class- and global-enum links.
+fn write_enum_const_link(
+    out: &mut String,
+    module_path: &str,
+    enum_name: &dyn std::fmt::Display,
+    variant: &dyn std::fmt::Display,
+) {
+    write_str!(
+        out,
+        "[`{enum_name}::{variant}`][`{module_path}::{enum_name}::{variant}`]"
+    );
 }
 
 /// Bracketed name acceptable as a parameter/identifier (ASCII alphanumeric + underscore).
@@ -531,7 +663,7 @@ fn starts_with_known_tag(str: &str) -> bool {
         || str.starts_with("[codeblock lang=")
 }
 
-/// Roles we recognize but cannot resolve to a Rust target — emit them as escaped literal `\[role X]`
+/// Roles we recognize but cannot resolve to a Rust target -- emit them as escaped literal `\[role X]`
 /// so Markdown does not interpret them as links. Accepts both `[role arg]` and bare `[role]`.
 fn is_escaped_role(str: &str) -> bool {
     let role = str.split_once(' ').map(|(r, _)| r).unwrap_or(str);
@@ -622,7 +754,7 @@ fn matches_hardcoded_type(godot_class: &str) -> Option<&'static str> {
 enum Hardcoded {
     /// Matched a special-cased mapping; use this Rust path.
     Mapped(CowStr),
-    /// Matched, but link should be dropped (no Rust target — e.g. arbitrary `@GDScript` symbols).
+    /// Matched, but link should be dropped (no Rust target -- e.g. arbitrary `@GDScript` symbols).
     Suppressed,
     /// No special case; fall through to the regular API-view lookup.
     NotMatched,
@@ -824,7 +956,8 @@ mod tests {
         assert_eq!(
             actual,
             "Compare `LEFT` and `RIGHT` variants.\n\n\
-            Use [`is_match`][`crate::classes::InputEvent::is_match`] with `KEY_LOCATION_UNSPECIFIED` or \\[enum KeyLocation]."
+            Use [`is_match`][`crate::classes::InputEvent::is_match`] with \
+            [`KeyLocation::UNSPECIFIED`][`crate::global::KeyLocation::UNSPECIFIED`] or \\[enum KeyLocation]."
         );
     }
 
@@ -854,14 +987,110 @@ mod tests {
         );
     }
 
-    // `[constant X]` is rendered as code, since we have no Rust target for arbitrary constants.
+    // `[constant X]` falls back to a code span when the name doesn't resolve to any known constant.
+    // Here, `CONNECT_DEFERRED` is a class-scoped constant that requires surrounding-class context,
+    // which is absent, so it cannot be resolved.
     #[test]
     fn constant__code_fallback() {
+        let description = "See [constant CONNECT_DEFERRED].";
+
+        let actual = import_doc_for_test(description, None);
+
+        assert_eq!(actual, "See `CONNECT_DEFERRED`.");
+    }
+
+    // `[constant NOTIFICATION_X]` without a surrounding class links to the declaring class's enum.
+    #[test]
+    fn constant__notification_link_no_class() {
         let description = "See [constant NOTIFICATION_ENTER_TREE].";
 
         let actual = import_doc_for_test(description, None);
 
-        assert_eq!(actual, "See `NOTIFICATION_ENTER_TREE`.");
+        assert_eq!(
+            actual,
+            "See [`NodeNotification::ENTER_TREE`][`crate::classes::notify::NodeNotification::ENTER_TREE`]."
+        );
+    }
+
+    // `[constant NOTIFICATION_X]` with a surrounding class links to that class's notification enum.
+    #[test]
+    fn constant__notification_link_with_class() {
+        let description = "See [constant NOTIFICATION_READY].";
+
+        let actual = import_doc_for_test(description, Some("Node"));
+
+        assert_eq!(
+            actual,
+            "See [`NodeNotification::READY`][`crate::classes::notify::NodeNotification::READY`]."
+        );
+    }
+
+    // An inherited notification constant uses the surrounding class's (not declaring class's) enum.
+    // `NOTIFICATION_POSTINITIALIZE` is declared by `Object`, but in `Node` docs it links to `NodeNotification`.
+    #[test]
+    fn constant__notification_link_inherited() {
+        let description = "See [constant NOTIFICATION_POSTINITIALIZE].";
+
+        let actual = import_doc_for_test(description, Some("Node"));
+
+        assert_eq!(
+            actual,
+            "See [`NodeNotification::POSTINITIALIZE`][`crate::classes::notify::NodeNotification::POSTINITIALIZE`]."
+        );
+    }
+
+    // A class enum constant referenced without a dot is resolved via the surrounding class hierarchy.
+    // `CONNECT_DEFERRED` is in `Object::ConnectFlags`; accessed from a `Node`-surrounding context it
+    // walks up to `Object` and links to the sidecar module.
+    #[test]
+    fn constant__class_enum_via_hierarchy() {
+        let description = "See [constant CONNECT_DEFERRED].";
+
+        let actual = import_doc_for_test(description, Some("Node"));
+
+        assert_eq!(
+            actual,
+            "See [`ConnectFlags::DEFERRED`][`crate::classes::object::ConnectFlags::DEFERRED`]."
+        );
+    }
+
+    // `[constant ClassName.X]` with a dot resolves via the named class's sidecar enum.
+    #[test]
+    fn constant__dot_class_enum_link() {
+        let description = "See [constant Object.CONNECT_DEFERRED].";
+
+        let actual = import_doc_for_test(description, None);
+
+        assert_eq!(
+            actual,
+            "See [`ConnectFlags::DEFERRED`][`crate::classes::object::ConnectFlags::DEFERRED`]."
+        );
+    }
+
+    // `[constant ClassName.NOTIFICATION_X]` with a dot resolves to that class's notification enum.
+    #[test]
+    fn constant__dot_notification_link() {
+        let description = "See [constant Node.NOTIFICATION_READY].";
+
+        let actual = import_doc_for_test(description, None);
+
+        assert_eq!(
+            actual,
+            "See [`NodeNotification::READY`][`crate::classes::notify::NodeNotification::READY`]."
+        );
+    }
+
+    // `[constant X]` for a global enum enumerator emits a Rustdoc link to the Rust variant.
+    #[test]
+    fn constant__global_enum_link() {
+        let description = "See [constant MIDI_MESSAGE_NOTE_ON].";
+
+        let actual = import_doc_for_test(description, None);
+
+        assert_eq!(
+            actual,
+            "See [`MidiMessage::NOTE_ON`][`crate::global::MidiMessage::NOTE_ON`]."
+        );
     }
 
     #[test]
@@ -988,7 +1217,7 @@ mod tests {
         assert_eq!(
             actual,
             "MIDI note release.\n\n\
-            **Note:** Some devices send `MIDI_MESSAGE_NOTE_ON` with \
+            **Note:** Some devices send [`MidiMessage::NOTE_ON`][`crate::global::MidiMessage::NOTE_ON`] with \
             \\[member InputEventMIDI.velocity] = `0`."
         );
     }

--- a/godot-codegen/src/generator/import_docs.rs
+++ b/godot-codegen/src/generator/import_docs.rs
@@ -80,7 +80,7 @@ impl<'d> DocImporter<'d> {
 
     fn import(mut self) -> String {
         let mut out = String::with_capacity(self.doc.len());
-        let ok = self.parse_until(&mut out, None, true, true);
+        let ok = self.parse_until(&mut out, None, true, true, true);
         debug_assert!(ok, "top-level parse_until without closing tag must succeed");
         out
     }
@@ -95,6 +95,7 @@ impl<'d> DocImporter<'d> {
         closing_tag: Option<&str>,
         double_newlines: bool,
         allow_type_links: bool,
+        allow_tags: bool,
     ) -> bool {
         let start_pos = self.pos;
         let start_len = out.len();
@@ -107,7 +108,8 @@ impl<'d> DocImporter<'d> {
                 return true;
             }
 
-            if self.remaining().starts_with('[')
+            if allow_tags
+                && self.remaining().starts_with('[')
                 && self.try_parse_tag(out, double_newlines, allow_type_links)
             {
                 continue;
@@ -138,8 +140,8 @@ impl<'d> DocImporter<'d> {
         double_newlines: bool,
         allow_type_links: bool,
     ) -> bool {
-        // Dispatch by the byte after `[` to skip unrelated `starts_with()` checks.
-        // If nothing matches, fall through to Markdown and bracket-link parsing.
+        // Dispatch by the byte after `[` to avoid repeated `starts_with()` checks.
+        // If a real opener is unterminated, leave it literal instead of falling through into bracket-link parsing.
         let after_bracket = self.doc.as_bytes().get(self.pos + 1).copied();
         let matched = match after_bracket {
             Some(b'b') => self.try_wrapped_tag(
@@ -150,6 +152,7 @@ impl<'d> DocImporter<'d> {
                 "**",
                 double_newlines,
                 allow_type_links,
+                true,
             ),
             Some(b'i') => self.try_wrapped_tag(
                 out,
@@ -159,6 +162,7 @@ impl<'d> DocImporter<'d> {
                 "_",
                 double_newlines,
                 allow_type_links,
+                true,
             ),
             Some(b'k') => self.try_wrapped_tag(
                 out,
@@ -168,10 +172,19 @@ impl<'d> DocImporter<'d> {
                 "`",
                 double_newlines,
                 allow_type_links,
+                true,
             ),
             Some(b'c') => {
-                self.try_wrapped_tag(out, "[code skip-lint]", "[/code]", "`", "`", false, false)
-                    || self.try_wrapped_tag(out, "[code]", "[/code]", "`", "`", false, false)
+                self.try_wrapped_tag(
+                    out,
+                    "[code skip-lint]",
+                    "[/code]",
+                    "`",
+                    "`",
+                    false,
+                    false,
+                    false,
+                ) || self.try_wrapped_tag(out, "[code]", "[/code]", "`", "`", false, false, false)
                     || self.try_codeblocks_tag(out)
                     || self.try_wrapped_tag(
                         out,
@@ -179,6 +192,7 @@ impl<'d> DocImporter<'d> {
                         "[/codeblock]",
                         "```gdscript",
                         "```",
+                        false,
                         false,
                         false,
                     )
@@ -191,9 +205,10 @@ impl<'d> DocImporter<'d> {
                         "```",
                         double_newlines,
                         false,
+                        false,
                     )
             }
-            Some(b'u') => self.try_url_tag(out, double_newlines, allow_type_links),
+            Some(b'u') => self.try_url_tag(out, double_newlines, allow_type_links, true),
             Some(b'g') => self.try_wrapped_tag(
                 out,
                 "[gdscript]",
@@ -202,11 +217,20 @@ impl<'d> DocImporter<'d> {
                 "```",
                 double_newlines,
                 false,
+                false,
             ),
             _ => false,
         };
 
-        matched || self.try_markdown_link(out) || self.try_bracket_link(out, allow_type_links)
+        if matched {
+            return true;
+        }
+
+        if starts_with_known_tag(self.remaining()) {
+            return false;
+        }
+
+        self.try_markdown_link(out) || self.try_bracket_link(out, allow_type_links)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -219,6 +243,7 @@ impl<'d> DocImporter<'d> {
         suffix: &str,
         double_newlines: bool,
         allow_type_links: bool,
+        allow_tags: bool,
     ) -> bool {
         if !self.remaining().starts_with(opening_tag) {
             return false;
@@ -228,8 +253,13 @@ impl<'d> DocImporter<'d> {
         let start_len = out.len();
         self.pos += opening_tag.len();
         out.push_str(prefix);
-        // Only keep the wrapper if the matching closing tag exists.
-        if !self.parse_until(out, Some(closing_tag), double_newlines, allow_type_links) {
+        if !self.parse_until(
+            out,
+            Some(closing_tag),
+            double_newlines,
+            allow_type_links,
+            allow_tags,
+        ) {
             out.truncate(start_len);
             self.pos = start_pos;
             return false;
@@ -243,6 +273,7 @@ impl<'d> DocImporter<'d> {
         out: &mut String,
         double_newlines: bool,
         allow_type_links: bool,
+        allow_tags: bool,
     ) -> bool {
         const PREFIX: &str = "[url=";
         const SUFFIX: &str = "[/url]";
@@ -262,7 +293,13 @@ impl<'d> DocImporter<'d> {
         let start_len = out.len();
         self.pos += end_of_opening_tag + 1;
         out.push('[');
-        if !self.parse_until(out, Some(SUFFIX), double_newlines, allow_type_links) {
+        if !self.parse_until(
+            out,
+            Some(SUFFIX),
+            double_newlines,
+            allow_type_links,
+            allow_tags,
+        ) {
             out.truncate(start_len);
             self.pos = start_pos;
             return false;
@@ -283,7 +320,7 @@ impl<'d> DocImporter<'d> {
         let start_len = out.len();
         self.pos += OPENING_TAG.len();
         // `[codeblocks]` is a container for nested language blocks, not a literal fence itself.
-        if !self.parse_until(out, Some(CLOSING_TAG), false, true) {
+        if !self.parse_until(out, Some(CLOSING_TAG), false, true, true) {
             out.truncate(start_len);
             self.pos = start_pos;
             return false;
@@ -312,7 +349,7 @@ impl<'d> DocImporter<'d> {
         out.push_str("```");
         out.push_str(lang);
         // The body is literal fenced code, so bracket roles should not be interpreted inside it.
-        if !self.parse_until(out, Some(SUFFIX), false, false) {
+        if !self.parse_until(out, Some(SUFFIX), false, false, false) {
             out.truncate(start_len);
             self.pos = start_pos;
             return false;
@@ -371,8 +408,27 @@ impl<'d> DocImporter<'d> {
             return true;
         }
 
-        // Escape unsupported roles so Rustdoc shows the original Godot syntax verbatim.
-        if is_unimplemented_role(content) {
+        if let Some(signal_name) = content.strip_prefix("signal ") {
+            self.pos += whole.len();
+            write_code_span(out, signal_name);
+            return true;
+        }
+
+        if let Some(annotation) = content.strip_prefix("annotation ") {
+            self.pos += whole.len();
+            write_code_span(out, annotation);
+            return true;
+        }
+
+        if let Some(ty_name) = content.strip_prefix("constructor ") {
+            self.pos += whole.len();
+            out.push('`');
+            out.push_str(ty_name);
+            out.push_str("()`");
+            return true;
+        }
+
+        if is_escaped_role(content) {
             self.pos += whole.len();
             write_str!(out, "\\{whole}");
             return true;
@@ -387,26 +443,24 @@ impl<'d> DocImporter<'d> {
         false
     }
 
-    fn write_type_link(&self, out: &mut String, class_name: &str) {
-        if special_cases::is_godot_type_deleted(class_name)
-            || matches_primitive_type(class_name)
-            || matches_ignored_links(class_name)
-        {
-            out.push_str(class_name);
-        } else if class_name == "@GlobalScope" {
+    fn write_type_link(&self, out: &mut String, ty_name: &str) {
+        if special_cases::is_godot_type_deleted(ty_name) || matches_ignored_links(ty_name) {
+            out.push_str(ty_name);
+        } else if matches_primitive_type(ty_name) {
+            write_code_span(out, ty_name);
+        } else if ty_name == "@GlobalScope" {
             out.push_str("[@GlobalScope][crate::global]");
         } else {
             let is_link_to_surrounding_class = self
                 .surrounding_rust_name
                 .as_deref()
-                .is_some_and(|name| name == conv::to_pascal_case(class_name));
+                .is_some_and(|name| name == conv::to_pascal_case(ty_name));
 
             if is_link_to_surrounding_class {
-                // Avoid redundant self-links in docs for the class currently being generated.
-                write_str!(out, "`{class_name}`");
+                write_code_span(out, ty_name);
             } else {
-                let path = get_class_rust_path(class_name, self.ctx);
-                write_str!(out, "[{class_name}][{path}]");
+                let path = get_class_rust_path(ty_name, self.ctx);
+                write_code_link(out, ty_name, &path);
             }
         }
     }
@@ -429,6 +483,22 @@ impl<'d> DocImporter<'d> {
     }
 }
 
+fn write_code_span(out: &mut String, text: &str) {
+    out.push('`');
+    out.push_str(text);
+    out.push('`');
+}
+
+fn write_code_link(out: &mut String, label: &str, path: &str) {
+    out.push('[');
+    out.push('`');
+    out.push_str(label);
+    out.push('`');
+    out.push_str("][");
+    out.push_str(path);
+    out.push(']');
+}
+
 fn is_ident_like(str: &str) -> bool {
     !str.is_empty()
         && str
@@ -443,15 +513,26 @@ fn is_type_link(str: &str) -> bool {
             .all(|ch| ch.is_ascii_alphanumeric() || ch == '@')
 }
 
-fn is_unimplemented_role(str: &str) -> bool {
+fn starts_with_known_tag(str: &str) -> bool {
+    str.starts_with("[b]")
+        || str.starts_with("[i]")
+        || str.starts_with("[kbd]")
+        || str.starts_with("[code skip-lint]")
+        || str.starts_with("[code]")
+        || str.starts_with("[codeblocks]")
+        || str.starts_with("[codeblock]")
+        || str.starts_with("[codeblock lang=")
+        || str.starts_with("[csharp]")
+        || str.starts_with("[gdscript]")
+        || str.starts_with("[url=")
+}
+
+fn is_escaped_role(str: &str) -> bool {
     let Some((role, _)) = str.split_once(' ') else {
         return false;
     };
 
-    matches!(
-        role,
-        "annotation" | "constant" | "member" | "enum" | "constructor" | "signal"
-    )
+    matches!(role, "constant" | "member" | "enum")
 }
 
 fn convert_to_method_path(
@@ -621,8 +702,7 @@ mod tests {
         })
     }
 
-    // TODO: Type links should render class names as code spans instead of Markdown links.
-    // Checks that bare Godot type links are imported as Rust doc links.
+    // Bare Godot type links become Rustdoc links with code-formatted labels.
     #[test]
     fn type__engine_classes() {
         let description = "Left side, usually used for [Control] or [StyleBox]-derived classes.";
@@ -631,11 +711,10 @@ mod tests {
 
         assert_eq!(
             actual,
-            "Left side, usually used for [Control][crate::classes::Control] or [StyleBox][crate::classes::StyleBox]-derived classes."
+            "Left side, usually used for [`Control`][crate::classes::Control] or [`StyleBox`][crate::classes::StyleBox]-derived classes."
         );
     }
 
-    // TODO: Type links should render builtin type names with backticks inside links.
     #[test]
     fn type__builtin_and_member_role() {
         let description = "Link [member Vector2.x] and [member Vector2.y] on [Vector2] or \
@@ -646,12 +725,11 @@ mod tests {
         assert_eq!(
             actual,
             "Link \\[member Vector2.x] and \\[member Vector2.y] on \
-            [Vector2][crate::builtin::Vector2] or [Vector3][crate::builtin::Vector3]. Use \
+            [`Vector2`][crate::builtin::Vector2] or [`Vector3`][crate::builtin::Vector3]. Use \
             `\"suffix:px/s\"` for the editor unit suffix."
         );
     }
 
-    // TODO: Type links should render class names with backticks inside links.
     // Existing Markdown links must stay untouched while later bare type links are still imported.
     #[test]
     fn type__preserves_markdown_link() {
@@ -661,7 +739,7 @@ mod tests {
 
         assert_eq!(
             actual,
-            "See [reference](https://example.com) and [Node][crate::classes::Node]."
+            "See [reference](https://example.com) and [`Node`][crate::classes::Node]."
         );
     }
 
@@ -674,9 +752,9 @@ mod tests {
         assert_eq!(actual, "Use [@GlobalScope][crate::global].");
     }
 
-    // Sentinel test: @GDScript stays plain until there is a dedicated Rust target for it.
+    // Bare `@GDScript` stays plain until there is a dedicated Rust target for it.
     #[test]
-    fn type__gdscript__todo() {
+    fn type__gdscript_plain_text() {
         let description = "See [@GDScript].";
 
         let actual = import_doc_for_test(description, None);
@@ -684,17 +762,15 @@ mod tests {
         assert_eq!(actual, "See @GDScript.");
     }
 
-    // TODO: Primitive type links should render as code spans (backticks).
     #[test]
     fn type__primitive_links() {
         let description = "Use [int], [float], and [bool].";
 
         let actual = import_doc_for_test(description, None);
 
-        assert_eq!(actual, "Use int, float, and bool.");
+        assert_eq!(actual, "Use `int`, `float`, and `bool`.");
     }
 
-    // TODO: Non-surrounding class names should render as code spans (backticks).
     // Links to the current class are rendered as code to avoid redundant Markdown links.
     #[test]
     fn type__surrounding_class() {
@@ -702,7 +778,7 @@ mod tests {
 
         let actual = import_doc_for_test(description, Some("Node"));
 
-        assert_eq!(actual, "See `Node` and [Object][crate::classes::Object].");
+        assert_eq!(actual, "See `Node` and [`Object`][crate::classes::Object].");
     }
 
     #[test]
@@ -751,9 +827,9 @@ mod tests {
         );
     }
 
-    // Sentinel test: fenced code blocks must keep bracketed type-like text literal.
+    // Fenced code blocks keep bracketed type-like text literal.
     #[test]
-    fn code_block__type__todo() {
+    fn code_block__type_literal() {
         let description = "[codeblock]\n[Node]\n[/codeblock]";
 
         let actual = import_doc_for_test(description, None);
@@ -812,22 +888,22 @@ mod tests {
 
         let actual = import_doc_for_test(description, None);
 
-        assert_eq!(actual, "Use `x` and `[text](address)`.");
+        assert_eq!(actual, "Use `x` and `[url=address]text[/url]`.");
     }
 
-    // Guards the current regex order so unsupported roles inside [code] stay escaped.
+    // Inline code keeps bracket roles literal.
     #[test]
-    fn code__escapes_member_role() {
+    fn code__member_literal() {
         let description = "Literal [code][member Vector2.x][/code].";
 
         let actual = import_doc_for_test(description, None);
 
-        assert_eq!(actual, "Literal `\\[member Vector2.x]`.");
+        assert_eq!(actual, "Literal `[member Vector2.x]`.");
     }
 
-    // Sentinel test: inline code spans must keep bracketed type-like text literal.
+    // Inline code spans keep bracketed type-like text literal.
     #[test]
-    fn code__type__todo() {
+    fn code__type_literal() {
         let description = "Literal [code][Node][/code].";
 
         let actual = import_doc_for_test(description, None);
@@ -835,14 +911,14 @@ mod tests {
         assert_eq!(actual, "Literal `[Node]`.");
     }
 
-    // Sentinel test: unresolved method links inside [code] stay escaped rather than turning into links.
+    // Inline code keeps method roles literal.
     #[test]
-    fn code__method__todo() {
+    fn code__method_literal() {
         let description = "Literal [code][method lerp][/code].";
 
         let actual = import_doc_for_test(description, None);
 
-        assert_eq!(actual, "Literal `\\[method lerp]`.");
+        assert_eq!(actual, "Literal `[method lerp]`.");
     }
 
     #[test]
@@ -905,34 +981,34 @@ mod tests {
         assert_eq!(actual, "Press `Ctrl + S`.");
     }
 
-    // Sentinel test: unsupported roles stay escaped until there is dedicated Markdown handling for them.
+    // Signal roles fall back to code-formatted text.
     #[test]
-    fn signal___todo() {
+    fn signal__code_fallback() {
         let description = "Emit [signal pressed].";
 
         let actual = import_doc_for_test(description, None);
 
-        assert_eq!(actual, "Emit \\[signal pressed].");
+        assert_eq!(actual, "Emit `pressed`.");
     }
 
-    // Sentinel test: unsupported roles stay escaped until there is dedicated Markdown handling for them.
+    // Annotation roles fall back to code-formatted text.
     #[test]
-    fn annotation___todo() {
+    fn annotation__code_fallback() {
         let description = "Use [annotation @GDScript.@rpc].";
 
         let actual = import_doc_for_test(description, None);
 
-        assert_eq!(actual, "Use \\[annotation @GDScript.@rpc].");
+        assert_eq!(actual, "Use `@GDScript.@rpc`.");
     }
 
-    // Sentinel test: unsupported roles stay escaped until there is dedicated Markdown handling for them.
+    // Constructor roles fall back to code-formatted text.
     #[test]
-    fn constructor___todo() {
+    fn constructor__code_fallback() {
         let description = "Create [constructor Transform2D].";
 
         let actual = import_doc_for_test(description, None);
 
-        assert_eq!(actual, "Create \\[constructor Transform2D].");
+        assert_eq!(actual, "Create `Transform2D()`.");
     }
 
     // A type-like bracket directly followed by `(http...)` must stay a Markdown link, not a Rust doc link.
@@ -953,31 +1029,28 @@ mod tests {
 
         assert_eq!(
             actual,
-            "Use [AnimationNode][crate::classes::AnimationNode](s)."
+            "Use [`AnimationNode`][crate::classes::AnimationNode](s)."
         );
     }
 
-    // Sentinel test: an unclosed BBCode tag like `[b]` is currently rendered as a class link,
-    // mirroring the prior regex behavior where `type_links` matched any bracketed alphanumeric
-    // identifier after `replace_simple_tags` had consumed properly closed `[b]...[/b]`.
+    // Unterminated BBCode stays literal instead of falling through into type-link parsing.
     #[test]
-    fn type__unclosed_bbcode__todo() {
+    fn bbcode__unclosed_tag_literal() {
         let description = "[b]hello";
 
         let actual = import_doc_for_test(description, None);
 
-        assert_eq!(actual, "[b][crate::classes::B]hello");
+        assert_eq!(actual, "[b]hello");
     }
 
-    // Inline `[b]...[/b]` inside `[code]...[/code]` is rendered as bold, matching the prior regex
-    // order where `bold_tags` ran before `code_tags`.
+    // Inline code keeps nested BBCode literal.
     #[test]
     fn code__nested_bold() {
         let description = "Use [code][b]x[/b][/code].";
 
         let actual = import_doc_for_test(description, None);
 
-        assert_eq!(actual, "Use `**x**`.");
+        assert_eq!(actual, "Use `[b]x[/b]`.");
     }
 
     // Empty brackets `[]` are passed through untouched.
@@ -990,8 +1063,7 @@ mod tests {
         assert_eq!(actual, "Edge case: [].");
     }
 
-    // A `[param ...]` whose name is not an identifier (e.g. contains `-`) is left untouched,
-    // matching the old `param_links` regex which required `[a-zA-Z0-9_]+`.
+    // A `[param ...]` whose name is not an identifier, such as `foo-bar`, is left untouched.
     #[test]
     fn param__non_ident_left_literal() {
         let description = "Bad name [param foo-bar].";

--- a/godot-codegen/src/generator/import_docs.rs
+++ b/godot-codegen/src/generator/import_docs.rs
@@ -37,7 +37,7 @@ pub fn import_function_docs(fun: &dyn Function, ctx: &Context, view: &ApiView) -
     let surrounding_class_name = fun.surrounding_class();
     let surrounding_class = surrounding_class_name.and_then(|name| view.find_engine_class(name));
     let imported_doc = import_docs(doc, surrounding_class, ctx, view);
-    let imported_doc = format!("\n# Godot docs\n{imported_doc}");
+    // let imported_doc = format!("\n# Godot docs\n{imported_doc}"); -- no title at the moment.
     Some(imported_doc)
 }
 
@@ -50,12 +50,83 @@ fn matches_ignored_links(class: &str) -> bool {
     class == "@GDScript"
 }
 
+/// Flags controlling how a parse region is rendered.
+#[derive(Copy, Clone)]
+struct ParseMode {
+    /// Convert single `\n` in source to `\n\n` (Markdown paragraph break).
+    double_newlines: bool,
+    /// Turn `[Type]` brackets into Rustdoc links; off inside code regions.
+    allow_type_links: bool,
+    /// Recurse into BBCode tags; off inside code regions where content is literal.
+    allow_tags: bool,
+}
+
+impl ParseMode {
+    /// Top-level prose: paragraph breaks, type links, BBCode all enabled.
+    const TOP: Self = Self {
+        double_newlines: true,
+        allow_type_links: true,
+        allow_tags: true,
+    };
+    /// Inside fenced/inline code: keep content literal, no paragraph breaks, no recursion.
+    const CODE: Self = Self {
+        double_newlines: false,
+        allow_type_links: false,
+        allow_tags: false,
+    };
+
+    /// Derive inner-content mode for a wrapped tag.
+    ///
+    /// Formatting tags (`[b]`, `[i]`, `[kbd]`) inherit the outer mode so nested links/tags work.
+    /// Code tags switch to [`Self::CODE`] so brackets inside code stay literal.
+    fn inherit_for(self, tag: &WrappedTag) -> Self {
+        if tag.allow_inner {
+            Self {
+                double_newlines: self.double_newlines,
+                allow_type_links: self.allow_type_links,
+                allow_tags: true,
+            }
+        } else {
+            Self::CODE
+        }
+    }
+}
+
+/// BBCode tag with a fixed opener/closer and a literal Markdown wrapping.
+///
+/// Used for tags whose opener has no dynamic attribute. Tags with attributes
+/// (`[url=...]`, `[codeblock lang=...]`) are handled by separate parsers.
+struct WrappedTag {
+    /// BBCode opener, e.g. `"[b]"`.
+    open: &'static str,
+    /// BBCode closer, e.g. `"[/b]"`.
+    close: &'static str,
+    /// Markdown to emit before inner content, e.g. `"**"` or `"```gdscript"`.
+    prefix: &'static str,
+    /// Markdown to emit after inner content, e.g. `"**"` or `"```"`.
+    suffix: &'static str,
+    /// If true, inner content is parsed with the outer mode (formatting tags like `[b]`, `[i]`, `[kbd]`).
+    /// If false, inner content is parsed in [`ParseMode::CODE`] (fenced/inline code blocks).
+    allow_inner: bool,
+}
+
+// Order matters: longer prefix first when prefixes overlap (`[code skip-lint]` before `[code]`).
+#[rustfmt::skip]
+const WRAPPED_TAGS: &[WrappedTag] = &[
+    WrappedTag { open: "[b]",              close: "[/b]",         prefix: "**",            suffix: "**",  allow_inner: true  },
+    WrappedTag { open: "[i]",              close: "[/i]",         prefix: "_",             suffix: "_",   allow_inner: true  },
+    WrappedTag { open: "[kbd]",            close: "[/kbd]",       prefix: "`",             suffix: "`",   allow_inner: true  },
+    WrappedTag { open: "[code skip-lint]", close: "[/code]",      prefix: "`",             suffix: "`",   allow_inner: false },
+    WrappedTag { open: "[code]",           close: "[/code]",      prefix: "`",             suffix: "`",   allow_inner: false },
+    WrappedTag { open: "[codeblock]",      close: "[/codeblock]", prefix: "```gdscript",   suffix: "```", allow_inner: false },
+    WrappedTag { open: "[gdscript]",       close: "[/gdscript]",  prefix: "```gdscript",   suffix: "```", allow_inner: false },
+    WrappedTag { open: "[csharp]",         close: "[/csharp]",    prefix: "```csharp",     suffix: "```", allow_inner: false },
+];
+
 struct DocImporter<'d> {
     doc: &'d str,
     pos: usize,
     surrounding_class: Option<&'d Class>,
-    // Pascal-case Rust name of the surrounding class, cached to avoid recomputing per type link.
-    surrounding_rust_name: Option<String>,
     ctx: &'d Context<'d>,
     view: &'d ApiView<'d>,
 }
@@ -67,22 +138,34 @@ impl<'d> DocImporter<'d> {
         ctx: &'d Context<'d>,
         view: &'d ApiView<'d>,
     ) -> Self {
-        let surrounding_rust_name = surrounding_class.map(|c| c.name().rust_ty.to_string());
         Self {
             doc,
             pos: 0,
             surrounding_class,
-            surrounding_rust_name,
             ctx,
             view,
         }
     }
 
     fn import(mut self) -> String {
-        let mut out = String::with_capacity(self.doc.len());
-        let ok = self.parse_until(&mut out, None, true, true, true);
+        // Output grows ~3-4x when type links expand to `[`Foo`][crate::classes::Foo]`; reserve up front.
+        let mut out = String::with_capacity(self.doc.len() * 4);
+        let ok = self.parse_until(&mut out, None, ParseMode::TOP);
         debug_assert!(ok, "top-level parse_until without closing tag must succeed");
         out
+    }
+
+    /// Snapshot of `(self.pos, out.len())` for transactional rollback on failed sub-parses.
+    fn checkpoint(&self, out: &str) -> (usize, usize) {
+        (self.pos, out.len())
+    }
+
+    /// Restore both input position and output length from a [`Self::checkpoint`].
+    /// Used when a sub-parser starts emitting then fails (e.g. unterminated tag) and must
+    /// leave the source byte-for-byte for the fallback parser to consume.
+    fn rollback(&mut self, out: &mut String, cp: (usize, usize)) {
+        self.pos = cp.0;
+        out.truncate(cp.1);
     }
 
     // Parses the doc, writing rendered output into `out`.
@@ -93,12 +176,9 @@ impl<'d> DocImporter<'d> {
         &mut self,
         out: &mut String,
         closing_tag: Option<&str>,
-        double_newlines: bool,
-        allow_type_links: bool,
-        allow_tags: bool,
+        mode: ParseMode,
     ) -> bool {
-        let start_pos = self.pos;
-        let start_len = out.len();
+        let cp = self.checkpoint(out);
 
         while self.pos < self.doc.len() {
             if let Some(close) = closing_tag
@@ -108,17 +188,15 @@ impl<'d> DocImporter<'d> {
                 return true;
             }
 
-            if allow_tags
-                && self.remaining().starts_with('[')
-                && self.try_parse_tag(out, double_newlines, allow_type_links)
+            if mode.allow_tags && self.remaining().starts_with('[') && self.try_parse_tag(out, mode)
             {
                 continue;
             }
 
-            // SAFETY: loop guard ensures self.pos < self.doc.len(), so a char is present.
+            // unwrap(): loop guard ensures self.pos < self.doc.len(), so a char is present.
             let ch = self.remaining().chars().next().unwrap();
             self.pos += ch.len_utf8();
-            if ch == '\n' && double_newlines {
+            if ch == '\n' && mode.double_newlines {
                 out.push_str("\n\n");
             } else {
                 out.push(ch);
@@ -128,101 +206,31 @@ impl<'d> DocImporter<'d> {
         if closing_tag.is_none() {
             true
         } else {
-            out.truncate(start_len);
-            self.pos = start_pos;
+            self.rollback(out, cp);
             false
         }
     }
 
-    fn try_parse_tag(
-        &mut self,
-        out: &mut String,
-        double_newlines: bool,
-        allow_type_links: bool,
-    ) -> bool {
-        // Dispatch by the byte after `[` to avoid repeated `starts_with()` checks.
-        // If a real opener is unterminated, leave it literal instead of falling through into bracket-link parsing.
-        let after_bracket = self.doc.as_bytes().get(self.pos + 1).copied();
-        let matched = match after_bracket {
-            Some(b'b') => self.try_wrapped_tag(
-                out,
-                "[b]",
-                "[/b]",
-                "**",
-                "**",
-                double_newlines,
-                allow_type_links,
-                true,
-            ),
-            Some(b'i') => self.try_wrapped_tag(
-                out,
-                "[i]",
-                "[/i]",
-                "_",
-                "_",
-                double_newlines,
-                allow_type_links,
-                true,
-            ),
-            Some(b'k') => self.try_wrapped_tag(
-                out,
-                "[kbd]",
-                "[/kbd]",
-                "`",
-                "`",
-                double_newlines,
-                allow_type_links,
-                true,
-            ),
-            Some(b'c') => {
-                self.try_wrapped_tag(
-                    out,
-                    "[code skip-lint]",
-                    "[/code]",
-                    "`",
-                    "`",
-                    false,
-                    false,
-                    false,
-                ) || self.try_wrapped_tag(out, "[code]", "[/code]", "`", "`", false, false, false)
-                    || self.try_codeblocks_tag(out)
-                    || self.try_wrapped_tag(
-                        out,
-                        "[codeblock]",
-                        "[/codeblock]",
-                        "```gdscript",
-                        "```",
-                        false,
-                        false,
-                        false,
-                    )
-                    || self.try_codeblock_lang_tag(out)
-                    || self.try_wrapped_tag(
-                        out,
-                        "[csharp]",
-                        "[/csharp]",
-                        "```csharp",
-                        "```",
-                        double_newlines,
-                        false,
-                        false,
-                    )
+    /// Dispatch a `[...]` opener to the matching parser.
+    ///
+    /// Tries parsers in order:
+    /// 1. Static [`WRAPPED_TAGS`] table.
+    /// 2. Attribute-bearing tags: `[url=...]`, `[codeblocks]`, `[codeblock lang=...]`.
+    /// 3. If a known BBCode opener is unterminated, return `false` -> the caller emits the bracket literally.
+    /// 4. Generic Markdown link or type-link role.
+    fn try_parse_tag(&mut self, out: &mut String, mode: ParseMode) -> bool {
+        // Try the static table of wrapped tags first. An unterminated real opener is emitted as-is,
+        // not reinterpreted by the bracket-link parser below.
+        for tag in WRAPPED_TAGS {
+            if self.remaining().starts_with(tag.open) && self.try_wrapped_tag(out, tag, mode) {
+                return true;
             }
-            Some(b'u') => self.try_url_tag(out, double_newlines, allow_type_links, true),
-            Some(b'g') => self.try_wrapped_tag(
-                out,
-                "[gdscript]",
-                "[/gdscript]",
-                "```gdscript",
-                "```",
-                double_newlines,
-                false,
-                false,
-            ),
-            _ => false,
-        };
+        }
 
-        if matched {
+        if self.try_url_tag(out, mode)
+            || self.try_codeblocks_tag(out)
+            || self.try_codeblock_lang_tag(out)
+        {
             return true;
         }
 
@@ -230,78 +238,54 @@ impl<'d> DocImporter<'d> {
             return false;
         }
 
-        self.try_markdown_link(out) || self.try_bracket_link(out, allow_type_links)
+        self.try_markdown_link(out) || self.try_bracket_link(out, mode.allow_type_links)
     }
 
-    #[allow(clippy::too_many_arguments)]
-    fn try_wrapped_tag(
-        &mut self,
-        out: &mut String,
-        opening_tag: &str,
-        closing_tag: &str,
-        prefix: &str,
-        suffix: &str,
-        double_newlines: bool,
-        allow_type_links: bool,
-        allow_tags: bool,
-    ) -> bool {
-        if !self.remaining().starts_with(opening_tag) {
+    fn try_wrapped_tag(&mut self, out: &mut String, tag: &WrappedTag, mode: ParseMode) -> bool {
+        if !self.remaining().starts_with(tag.open) {
             return false;
         }
 
-        let start_pos = self.pos;
-        let start_len = out.len();
-        self.pos += opening_tag.len();
-        out.push_str(prefix);
-        if !self.parse_until(
-            out,
-            Some(closing_tag),
-            double_newlines,
-            allow_type_links,
-            allow_tags,
-        ) {
-            out.truncate(start_len);
-            self.pos = start_pos;
+        let cp = self.checkpoint(out);
+        self.pos += tag.open.len();
+        out.push_str(tag.prefix);
+        if !self.parse_until(out, Some(tag.close), mode.inherit_for(tag)) {
+            self.rollback(out, cp);
             return false;
         }
-        out.push_str(suffix);
+        out.push_str(tag.suffix);
         true
     }
 
-    fn try_url_tag(
-        &mut self,
-        out: &mut String,
-        double_newlines: bool,
-        allow_type_links: bool,
-        allow_tags: bool,
-    ) -> bool {
+    // Consume an opener of the form `<prefix>VALUE]`. Advances `self.pos` past the `]`.
+    // Returns the slice between `<prefix>` and `]` (the attribute value), or None if no match.
+    //
+    // Shortcoming: searches for the first `]` in the remaining input, so an attribute value containing `]` (e.g. `[url=https://x/a]b]`)
+    // would truncate. Godot's docs should not produce such values in practice, so this is accepted.
+    fn try_consume_attr_opener(&mut self, prefix: &str) -> Option<&'d str> {
+        let remaining = self.remaining();
+        if !remaining.starts_with(prefix) {
+            return None;
+        }
+        let end = remaining.find(']')?;
+        let value = &remaining[prefix.len()..end];
+        self.pos += end + 1;
+        Some(value)
+    }
+
+    fn try_url_tag(&mut self, out: &mut String, mode: ParseMode) -> bool {
         const PREFIX: &str = "[url=";
         const SUFFIX: &str = "[/url]";
 
-        let remaining = self.remaining();
-        if !remaining.starts_with(PREFIX) {
-            return false;
-        }
-
-        // Assumes `]` does not occur inside the URL value (true for percent-encoded URLs).
-        let Some(end_of_opening_tag) = remaining.find(']') else {
+        let cp = self.checkpoint(out);
+        let Some(url) = self.try_consume_attr_opener(PREFIX) else {
             return false;
         };
-        let url = &remaining[PREFIX.len()..end_of_opening_tag];
+        let url = url.to_owned(); // detach borrow from `self` before recursing.
 
-        let start_pos = self.pos;
-        let start_len = out.len();
-        self.pos += end_of_opening_tag + 1;
         out.push('[');
-        if !self.parse_until(
-            out,
-            Some(SUFFIX),
-            double_newlines,
-            allow_type_links,
-            allow_tags,
-        ) {
-            out.truncate(start_len);
-            self.pos = start_pos;
+        if !self.parse_until(out, Some(SUFFIX), mode) {
+            self.rollback(out, cp);
             return false;
         }
         write_str!(out, "]({url})");
@@ -316,13 +300,16 @@ impl<'d> DocImporter<'d> {
             return false;
         }
 
-        let start_pos = self.pos;
-        let start_len = out.len();
+        let cp = self.checkpoint(out);
         self.pos += OPENING_TAG.len();
         // `[codeblocks]` is a container for nested language blocks, not a literal fence itself.
-        if !self.parse_until(out, Some(CLOSING_TAG), false, true, true) {
-            out.truncate(start_len);
-            self.pos = start_pos;
+        let inner = ParseMode {
+            double_newlines: false,
+            allow_type_links: true,
+            allow_tags: true,
+        };
+        if !self.parse_until(out, Some(CLOSING_TAG), inner) {
+            self.rollback(out, cp);
             return false;
         }
         true
@@ -332,32 +319,27 @@ impl<'d> DocImporter<'d> {
         const PREFIX: &str = "[codeblock lang=";
         const SUFFIX: &str = "[/codeblock]";
 
-        let remaining = self.remaining();
-        if !remaining.starts_with(PREFIX) {
-            return false;
-        }
-
-        // Assumes `]` does not occur inside the lang attribute value.
-        let Some(end_of_opening_tag) = remaining.find(']') else {
+        let cp = self.checkpoint(out);
+        let Some(lang) = self.try_consume_attr_opener(PREFIX) else {
             return false;
         };
-        let lang = &remaining[PREFIX.len()..end_of_opening_tag];
+        let lang = lang.to_owned(); // detach borrow from `self` before recursing.
 
-        let start_pos = self.pos;
-        let start_len = out.len();
-        self.pos += end_of_opening_tag + 1;
-        out.push_str("```");
-        out.push_str(lang);
+        write_str!(out, "```{lang}");
         // The body is literal fenced code, so bracket roles should not be interpreted inside it.
-        if !self.parse_until(out, Some(SUFFIX), false, false, false) {
-            out.truncate(start_len);
-            self.pos = start_pos;
+        if !self.parse_until(out, Some(SUFFIX), ParseMode::CODE) {
+            self.rollback(out, cp);
             return false;
         }
         out.push_str("```");
         true
     }
 
+    /// Pass-through for inline Markdown links `[text](http(s)://...)` already present in source.
+    /// Bare `[Type](suffix)` (no `http`) is left for [`Self::try_bracket_link`] to handle.
+    ///
+    /// Shortcoming: scans for the first `]` and `)`, so nested brackets in link text (e.g. `[a [Node] b](http://x)`) would mis-parse.
+    /// Not produced by Godot in practice.
     fn try_markdown_link(&mut self, out: &mut String) -> bool {
         let remaining = self.remaining();
         if !remaining.starts_with('[') {
@@ -382,6 +364,10 @@ impl<'d> DocImporter<'d> {
         true
     }
 
+    /// Handle role-prefixed brackets (`[param X]`, `[method Class.fn]`, `[signal X]`,
+    /// `[annotation X]`, `[constructor Type]`), bare type links (`[Node]`), and
+    /// "escaped" roles whose target we cannot resolve (`[member X.y]`, `[constant X]`, ...).
+    /// Unrecognized brackets return `false` so the caller emits them literally.
     fn try_bracket_link(&mut self, out: &mut String, allow_type_links: bool) -> bool {
         let remaining = self.remaining();
         if !remaining.starts_with('[') {
@@ -420,6 +406,12 @@ impl<'d> DocImporter<'d> {
             return true;
         }
 
+        if let Some(constant) = content.strip_prefix("constant ") {
+            self.pos += whole.len();
+            write_code_span(out, constant);
+            return true;
+        }
+
         if let Some(ty_name) = content.strip_prefix("constructor ") {
             self.pos += whole.len();
             out.push('`');
@@ -443,18 +435,24 @@ impl<'d> DocImporter<'d> {
         false
     }
 
+    /// Emit Markdown for `[Foo]`. Branches:
+    /// - deleted/`@GDScript` → plain text;
+    /// - `int`/`float`/`bool` → `` `int` `` (no link target);
+    /// - hardcoded specials (`@GlobalScope`) → fixed link;
+    /// - link to surrounding class → `` `Self` ``-style code span (avoid self-link);
+    /// - else → `` [`Foo`][crate::classes::Foo] `` Rustdoc reference link.
     fn write_type_link(&self, out: &mut String, ty_name: &str) {
         if special_cases::is_godot_type_deleted(ty_name) || matches_ignored_links(ty_name) {
             out.push_str(ty_name);
         } else if matches_primitive_type(ty_name) {
             write_code_span(out, ty_name);
-        } else if ty_name == "@GlobalScope" {
-            out.push_str("[@GlobalScope][crate::global]");
+        } else if let Some(hardcoded) = matches_hardcoded_type(ty_name) {
+            out.push_str(hardcoded);
         } else {
+            // Compare on the Godot name to skip the per-link `to_pascal_case` allocation.
             let is_link_to_surrounding_class = self
-                .surrounding_rust_name
-                .as_deref()
-                .is_some_and(|name| name == conv::to_pascal_case(ty_name));
+                .surrounding_class
+                .is_some_and(|c| c.name().godot_ty == ty_name);
 
             if is_link_to_surrounding_class {
                 write_code_span(out, ty_name);
@@ -465,6 +463,8 @@ impl<'d> DocImporter<'d> {
         }
     }
 
+    /// Emit Markdown for `[method Class.fn]` or `[method fn]` (latter resolved against surrounding class).
+    /// Falls back to escaping the original `[method ...]` literal if the target cannot be resolved.
     fn write_method_link(&self, out: &mut String, whole_match: &str, method_path: &str) {
         if let Some(method_path) =
             convert_to_method_path(method_path, self.surrounding_class, self.ctx, self.view)
@@ -472,7 +472,7 @@ impl<'d> DocImporter<'d> {
             let (_, method_name) = method_path
                 .rsplit_once("::")
                 .expect("rsplit_once should return a method name");
-            write_str!(out, "[{method_name}][`{method_path}`]");
+            write_str!(out, "[`{method_name}`][`{method_path}`]");
         } else {
             write_str!(out, "\\{whole_match}");
         }
@@ -483,12 +483,14 @@ impl<'d> DocImporter<'d> {
     }
 }
 
+/// Emit `` `text` ``.
 fn write_code_span(out: &mut String, text: &str) {
     out.push('`');
     out.push_str(text);
     out.push('`');
 }
 
+/// Emit a Rustdoc reference link `` [`label`][path] ``.
 fn write_code_link(out: &mut String, label: &str, path: &str) {
     out.push('[');
     out.push('`');
@@ -499,6 +501,7 @@ fn write_code_link(out: &mut String, label: &str, path: &str) {
     out.push(']');
 }
 
+/// Bracketed name acceptable as a parameter/identifier (ASCII alphanumeric + underscore).
 fn is_ident_like(str: &str) -> bool {
     !str.is_empty()
         && str
@@ -506,33 +509,36 @@ fn is_ident_like(str: &str) -> bool {
             .all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
 }
 
+/// Bracketed name shaped like a Godot class link: ASCII alphanumeric, optionally prefixed with `@`
+/// for global namespaces (`@GlobalScope`, `@GDScript`). `@` only allowed at position 0.
 fn is_type_link(str: &str) -> bool {
-    !str.is_empty()
-        && str
-            .chars()
-            .all(|ch| ch.is_ascii_alphanumeric() || ch == '@')
-}
-
-fn starts_with_known_tag(str: &str) -> bool {
-    str.starts_with("[b]")
-        || str.starts_with("[i]")
-        || str.starts_with("[kbd]")
-        || str.starts_with("[code skip-lint]")
-        || str.starts_with("[code]")
-        || str.starts_with("[codeblocks]")
-        || str.starts_with("[codeblock]")
-        || str.starts_with("[codeblock lang=")
-        || str.starts_with("[csharp]")
-        || str.starts_with("[gdscript]")
-        || str.starts_with("[url=")
-}
-
-fn is_escaped_role(str: &str) -> bool {
-    let Some((role, _)) = str.split_once(' ') else {
+    let mut chars = str.chars();
+    let Some(first) = chars.next() else {
         return false;
     };
+    if !first.is_ascii_alphanumeric() && first != '@' {
+        return false;
+    }
+    chars.all(|ch| ch.is_ascii_alphanumeric())
+}
 
-    matches!(role, "constant" | "member" | "enum")
+/// True if `str` begins with a recognized BBCode opener. Used by [`DocImporter::try_parse_tag`]
+/// to emit unterminated known openers as-is, instead of letting the bracket-link parser reinterpret them.
+fn starts_with_known_tag(str: &str) -> bool {
+    WRAPPED_TAGS.iter().any(|t| str.starts_with(t.open))
+        || str.starts_with("[url=")
+        || str.starts_with("[codeblocks]")
+        || str.starts_with("[codeblock lang=")
+}
+
+/// Roles we recognize but cannot resolve to a Rust target — emit them as escaped literal `\[role X]`
+/// so Markdown does not interpret them as links. Accepts both `[role arg]` and bare `[role]`.
+fn is_escaped_role(str: &str) -> bool {
+    let role = str.split_once(' ').map(|(r, _)| r).unwrap_or(str);
+    matches!(
+        role,
+        "constant" | "member" | "enum" | "signal" | "annotation" | "constructor"
+    )
 }
 
 fn convert_to_method_path(
@@ -561,8 +567,10 @@ fn convert_to_method_path(
     let link_godot_method = util::safe_ident(link_godot_method).to_string();
 
     // These cover renamed helpers and special symbols that do not map 1:1 through the API view.
-    if let (true, ret) = matches_hardcoded_method(link_godot_class, &link_godot_method) {
-        return ret;
+    match matches_hardcoded_method(link_godot_class, &link_godot_method) {
+        Hardcoded::Mapped(path) => return Some(path),
+        Hardcoded::Suppressed => return None,
+        Hardcoded::NotMatched => {}
     }
 
     if let Some(class) = view.find_engine_class(&TyName::from_godot(link_godot_class))
@@ -578,27 +586,50 @@ fn convert_to_method_path(
             return None;
         }
         if method.is_virtual() {
-            if class.is_final {
+            return if class.is_final {
                 // Final classes don't have an associated trait with virtual methods.
-                return None;
+                None
             } else {
                 let path = format!(
                     "crate::classes::{}::{}",
                     class.name().virtual_trait_name(),
                     rust_method_name
                 );
-                return Some(path.into());
-            }
+                Some(path.into())
+            };
         }
+
+        // Use the Rust name; covers `special_cases::maybe_rename_class_method`.
+        // Examples: `Object.get_script` -> `raw_get_script`, `GDScript.new` -> `instantiate`.
+        let rust_class_path = get_class_rust_path(link_godot_class, ctx);
+        return Some(format!("{rust_class_path}::{rust_method_name}").into());
     }
 
+    // Fallback when class/method is not in the API view (e.g. unknown class link): strip the leading underscore
+    // as a best-effort guess at the Rust name.
     let godot_method_name = link_godot_method.trim_start_matches("_");
     let rust_class_path = get_class_rust_path(link_godot_class, ctx);
     Some(format!("{rust_class_path}::{godot_method_name}").into())
 }
 
-fn matches_hardcoded_method(godot_class: &str, godot_method: &str) -> (bool, Option<CowStr>) {
-    let path = match (godot_class, godot_method) {
+fn matches_hardcoded_type(godot_class: &str) -> Option<&'static str> {
+    match godot_class {
+        "@GlobalScope" => Some("[@GlobalScope][crate::global]"),
+        _ => None,
+    }
+}
+
+enum Hardcoded {
+    /// Matched a special-cased mapping; use this Rust path.
+    Mapped(CowStr),
+    /// Matched, but link should be dropped (no Rust target — e.g. arbitrary `@GDScript` symbols).
+    Suppressed,
+    /// No special case; fall through to the regular API-view lookup.
+    NotMatched,
+}
+
+fn matches_hardcoded_method(godot_class: &str, godot_method: &str) -> Hardcoded {
+    let path: CowStr = match (godot_class, godot_method) {
         ("Object", "free") => "crate::obj::Gd::free".into(),
         ("Object", "get_instance_id") => "crate::obj::Gd::instance_id".into(),
         ("Object", "notification") => "crate::classes::Object::notify".into(),
@@ -627,12 +658,12 @@ fn matches_hardcoded_method(godot_class: &str, godot_method: &str) -> (bool, Opt
         ("@GlobalScope", "is_instance_valid") => "crate::obj::Gd::is_instance_valid".into(),
         ("@GDScript", "load") => "crate::tools::load".into(),
         ("@GDScript", "save") => "crate::tools::save".into(),
-        ("@GlobalScope", _) => format!("crate::global::{}", godot_method).into(),
-        ("@GDScript", _) => return (true, None),
-        _ => return (false, None),
+        ("@GlobalScope", _) => format!("crate::global::{godot_method}").into(),
+        ("@GDScript", _) => return Hardcoded::Suppressed,
+        _ => return Hardcoded::NotMatched,
     };
 
-    (true, Some(path))
+    Hardcoded::Mapped(path)
 }
 
 fn convert_builtin_types(type_name: &str) -> Option<&'static str> {
@@ -644,13 +675,15 @@ fn convert_builtin_types(type_name: &str) -> Option<&'static str> {
     }
 }
 
+// Optimization: results could be memoized via `HashMap<&str, CowStr>` on `Context` to avoid re-formatting the same `crate::classes::MyClass`
+// path per type link. Only worthwhile if doc import shows up in codegen profiles.
 fn get_class_rust_path(godot_class_name: &str, ctx: &Context) -> CowStr {
     if let Some(hardcoded_builtin_type) = convert_builtin_types(godot_class_name) {
         return hardcoded_builtin_type.into();
     }
 
     let is_builtin = ctx.is_builtin(godot_class_name);
-    let rust_class_name = crate::conv::to_pascal_case(godot_class_name);
+    let rust_class_name = conv::to_pascal_case(godot_class_name);
     if is_builtin {
         format!("crate::builtin::{rust_class_name}").into()
     } else {
@@ -791,7 +824,7 @@ mod tests {
         assert_eq!(
             actual,
             "Compare `LEFT` and `RIGHT` variants.\n\n\
-            Use [is_match][`crate::classes::InputEvent::is_match`] with \\[constant KEY_LOCATION_UNSPECIFIED] or \\[enum KeyLocation]."
+            Use [`is_match`][`crate::classes::InputEvent::is_match`] with `KEY_LOCATION_UNSPECIFIED` or \\[enum KeyLocation]."
         );
     }
 
@@ -803,8 +836,32 @@ mod tests {
 
         assert_eq!(
             actual,
-            "Call [get_node_as][`crate::classes::Node::get_node_as`] to fetch a child."
+            "Call [`get_node_as`][`crate::classes::Node::get_node_as`] to fetch a child."
         );
+    }
+
+    // Regression: methods renamed via `special_cases::maybe_rename_class_method` must use the Rust name in the link.
+    // Here type-safe replacement: `Object.get_script` -> `raw_get_script`.
+    #[test]
+    fn method__renamed_via_special_case() {
+        let description = "See [method Object.get_script].";
+
+        let actual = import_doc_for_test(description, None);
+
+        assert_eq!(
+            actual,
+            "See [`raw_get_script`][`crate::classes::Object::raw_get_script`]."
+        );
+    }
+
+    // `[constant X]` is rendered as code, since we have no Rust target for arbitrary constants.
+    #[test]
+    fn constant__code_fallback() {
+        let description = "See [constant NOTIFICATION_ENTER_TREE].";
+
+        let actual = import_doc_for_test(description, None);
+
+        assert_eq!(actual, "See `NOTIFICATION_ENTER_TREE`.");
     }
 
     #[test]
@@ -852,8 +909,8 @@ mod tests {
 
         assert_eq!(codeblocks_actual, "alpha\nbeta");
         assert_eq!(codeblock_lang_actual, "```text\nalpha\nbeta\n```");
-        assert_eq!(gdscript_actual, "```gdscript\n\nprint(\"hi\")\n\n```");
-        assert_eq!(csharp_actual, "```csharp\n\nGD.Print(\"hi\");\n\n```");
+        assert_eq!(gdscript_actual, "```gdscript\nprint(\"hi\")\n```");
+        assert_eq!(csharp_actual, "```csharp\nGD.Print(\"hi\");\n```");
     }
 
     #[test]
@@ -931,7 +988,7 @@ mod tests {
         assert_eq!(
             actual,
             "MIDI note release.\n\n\
-            **Note:** Some devices send \\[constant MIDI_MESSAGE_NOTE_ON] with \
+            **Note:** Some devices send `MIDI_MESSAGE_NOTE_ON` with \
             \\[member InputEventMIDI.velocity] = `0`."
         );
     }

--- a/godot-codegen/src/models/domain.rs
+++ b/godot-codegen/src/models/domain.rs
@@ -53,13 +53,32 @@ impl ExtensionApi {
 
 pub struct ApiView<'a> {
     class_by_ty: HashMap<TyName, &'a Class>,
+
+    /// Maps Godot enumerator name -> (enum, enumerator) for global-scope enums.
+    ///
+    /// Global enumerator names are unique; they carry the enum name as prefix (e.g. `MIDI_MESSAGE_NOTE_ON` for `MidiMessage`).
+    /// Key is `godot_name` from [`Enumerator`], so lookup is O(1) without iterating all enums.
+    global_enum_constants: HashMap<&'a str, (&'a Enum, &'a Enumerator)>,
 }
 
 impl<'a> ApiView<'a> {
     pub fn new(api: &'a ExtensionApi) -> ApiView<'a> {
         let class_by_ty = api.classes.iter().map(|c| (c.name().clone(), c)).collect();
 
-        Self { class_by_ty }
+        let global_enum_constants = api
+            .global_enums
+            .iter()
+            .flat_map(|e| {
+                e.enumerators
+                    .iter()
+                    .map(move |enumerator| (enumerator.godot_name.as_str(), (e, enumerator)))
+            })
+            .collect();
+
+        Self {
+            class_by_ty,
+            global_enum_constants,
+        }
     }
 
     pub fn get_engine_class(&self, ty: &TyName) -> &'a Class {
@@ -70,6 +89,17 @@ impl<'a> ApiView<'a> {
 
     pub fn find_engine_class(&self, ty: &TyName) -> Option<&'a Class> {
         self.class_by_ty.get(ty).cloned()
+    }
+
+    /// Look up a global enum enumerator by its Godot name, e.g. `"MIDI_MESSAGE_NOTE_ON"`.
+    ///
+    /// Returns the containing [`Enum`] and the matching [`Enumerator`] (both carrying the already-renamed
+    /// Rust identifiers), or `None` if the name does not belong to any global enum.
+    pub fn find_global_enum_constant(
+        &self,
+        godot_name: &str,
+    ) -> Option<(&'a Enum, &'a Enumerator)> {
+        self.global_enum_constants.get(godot_name).copied()
     }
 }
 

--- a/godot-codegen/src/special_cases/special_cases.rs
+++ b/godot-codegen/src/special_cases/special_cases.rs
@@ -1293,11 +1293,20 @@ pub fn is_enum_private(class_name: Option<&TyName>, enum_name: &str) -> bool {
     }
 }
 
+/// Returns the Rust module path of a global Godot enum as a string (instead of `crate::global`).
+pub fn get_global_enum_module_path(enum_name: &str) -> &'static str {
+    match enum_name {
+        "PropertyHint" | "PropertyUsageFlags" | "MethodFlags" => "crate::registry::info",
+        "Corner" | "EulerOrder" | "Side" => "crate::builtin",
+        _ => "crate::global",
+    }
+}
+
 /// Returns the Rust module path of a global Godot enum (instead of `crate::global::EnumName`).
 pub fn get_global_enum_rust_path(enum_name: &str) -> TokenStream {
-    match enum_name {
-        "PropertyHint" | "PropertyUsageFlags" | "MethodFlags" => quote! { crate::registry::info },
-        "Corner" | "EulerOrder" | "Side" => quote! { crate::builtin },
+    match get_global_enum_module_path(enum_name) {
+        "crate::registry::info" => quote! { crate::registry::info },
+        "crate::builtin" => quote! { crate::builtin },
         _ => quote! { crate::global },
     }
 }

--- a/godot-codegen/src/special_cases/special_cases.rs
+++ b/godot-codegen/src/special_cases/special_cases.rs
@@ -109,8 +109,12 @@ pub fn get_class_method_deprecation(class_name: &TyName, method: &JsonClassMetho
 }
 
 pub fn is_class_deleted(class_name: &TyName) -> bool {
-    codegen_special_cases::is_class_excluded(&class_name.godot_ty)
-        || is_godot_type_deleted(&class_name.godot_ty)
+    is_class_deleted_str(&class_name.godot_ty)
+}
+
+pub fn is_class_deleted_str(godot_class_name: &str) -> bool {
+    codegen_special_cases::is_class_excluded(godot_class_name)
+        || is_godot_type_deleted(godot_class_name)
 }
 
 /// Native-struct types excluded in minimal codegen, because they hold codegen-excluded classes as fields.
@@ -135,7 +139,7 @@ pub fn get_native_struct_definition(struct_name: &str) -> Option<&'static str> {
 }
 
 #[rustfmt::skip]
-pub fn is_godot_type_deleted(godot_ty: &str) -> bool {
+pub(super) fn is_godot_type_deleted(godot_ty: &str) -> bool {
     // Note: parameter can be a class or builtin name, but also something like "enum::AESContext.Mode".
 
     // Exclude experimental APIs unless opted-in.
@@ -1297,7 +1301,8 @@ pub fn is_enum_private(class_name: Option<&TyName>, enum_name: &str) -> bool {
 pub fn get_global_enum_module_path(enum_name: &str) -> &'static str {
     match enum_name {
         "PropertyHint" | "PropertyUsageFlags" | "MethodFlags" => "crate::registry::info",
-        "Corner" | "EulerOrder" | "Side" => "crate::builtin",
+        // Godot's JSON spells `VariantType` as `Variant.Type`; accept both since callers may pass either form.
+        "Corner" | "EulerOrder" | "Side" | "VariantType" | "Variant.Type" => "crate::builtin",
         _ => "crate::global",
     }
 }


### PR DESCRIPTION
After initial perf improvements in #1580, this PR does some refactoring and implements missing cases in doc conversions.

The previous _sentinel tests_ marking incomplete implementation are now passing.

Unfortunately the new features added again quite a bit of compile-time, I'll need to investigate this.
```rs
// After PR #1580
Benchmark 1: cargo check -p godot
  Time (mean ± σ):     19.480 s ±  0.301 s    [User: 21.380 s, System: 1.738 s]
  Range (min … max):   19.263 s … 20.312 s    10 runs

// After this PR
Benchmark 1: cargo check -p godot
  Time (mean ± σ):     21.277 s ±  0.534 s    [User: 22.258 s, System: 2.777 s]
  Range (min … max):   20.740 s … 22.152 s    10 runs
```