### PR TITLE
Optimize JSON -> Domain mapping + some doc-imports

### DIFF
--- a/godot-codegen/src/context.rs
+++ b/godot-codegen/src/context.rs
@@ -20,10 +20,10 @@ use crate::util::option_as_slice;
 use crate::{JsonExtensionApi, special_cases, util};
 
 #[derive(Default)]
-pub struct Context<'a> {
-    builtin_types: HashSet<&'a str>,
-    native_structures_types: HashSet<&'a str>,
-    singletons: HashSet<&'a str>,
+pub struct Context {
+    builtin_types: HashSet<String>,
+    native_structures_types: HashSet<String>,
+    singletons: HashSet<String>,
     inheritance_tree: InheritanceTree,
     /// Which interface traits are generated (`false` for "Godot-abstract"/final classes).
     classes_final: HashMap<TyName, bool>,
@@ -38,17 +38,17 @@ pub struct Context<'a> {
     method_table_next_index: HashMap<String, usize>,
 }
 
-impl<'a> Context<'a> {
-    pub fn build_from_api(api: &'a JsonExtensionApi) -> Self {
+impl Context {
+    pub fn build_from_api(api: &JsonExtensionApi) -> Self {
         let mut ctx = Self::default();
 
         for class in api.singletons.iter() {
-            ctx.singletons.insert(class.name.as_str());
+            ctx.singletons.insert(class.name.clone());
         }
 
-        ctx.builtin_types.insert("Variant"); // not part of builtin_classes
+        ctx.builtin_types.insert("Variant".to_string()); // not part of builtin_classes
         for builtin in api.builtin_classes.iter() {
-            let ty_name = builtin.name.as_str();
+            let ty_name = builtin.name.clone();
             ctx.builtin_types.insert(ty_name);
 
             Self::populate_builtin_class_table_indices(
@@ -59,7 +59,7 @@ impl<'a> Context<'a> {
         }
 
         for structure in api.native_structures.iter() {
-            let ty_name = structure.name.as_str();
+            let ty_name = structure.name.clone();
             ctx.native_structures_types.insert(ty_name);
         }
 
@@ -328,7 +328,7 @@ impl<'a> Context<'a> {
         &self.inheritance_tree
     }
 
-    pub fn find_rust_type(&'a self, ty: &GodotTy) -> Option<&'a RustTy> {
+    pub fn find_rust_type(&self, ty: &GodotTy) -> Option<&RustTy> {
         self.cached_rust_types.get(ty)
     }
 
@@ -350,7 +350,7 @@ impl<'a> Context<'a> {
         panic!("Object (root) should always have signals")
     }
 
-    pub fn notification_constants(&'a self, class_name: &TyName) -> Option<&'a Vec<(Ident, i32)>> {
+    pub fn notification_constants(&self, class_name: &TyName) -> Option<&Vec<(Ident, i32)>> {
         self.notifications_by_class.get(class_name)
     }
 

--- a/godot-codegen/src/generator/import_docs.rs
+++ b/godot-codegen/src/generator/import_docs.rs
@@ -5,6 +5,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+use std::collections::HashMap;
 use std::fmt::Write as _;
 
 use crate::context::Context;
@@ -146,6 +147,9 @@ struct DocImporter<'d> {
     surrounding_class: Option<&'d Class>,
     ctx: &'d Context<'d>,
     view: &'d ApiView<'d>,
+    /// Cache of Godot class name -> Rust crate path (e.g. `"Node"` -> `"crate::classes::Node"`).
+    /// Lives for the duration of one doc-string import; avoids repeated `to_pascal_case` + `format!` per link.
+    path_cache: HashMap<String, String>,
 }
 
 impl<'d> DocImporter<'d> {
@@ -161,6 +165,7 @@ impl<'d> DocImporter<'d> {
             surrounding_class,
             ctx,
             view,
+            path_cache: HashMap::new(),
         }
     }
 
@@ -183,6 +188,16 @@ impl<'d> DocImporter<'d> {
     fn rollback(&mut self, out: &mut String, cp: (usize, usize)) {
         self.pos = cp.0;
         out.truncate(cp.1);
+    }
+
+    /// Advance `self.pos` past `target` without writing anything to output. Returns `true` if `target` was found.
+    fn skip_past(&mut self, target: &str) -> bool {
+        if let Some(offset) = self.doc[self.pos..].find(target) {
+            self.pos += offset + target.len();
+            true
+        } else {
+            false
+        }
     }
 
     // Parses the doc, writing rendered output into `out`.
@@ -282,10 +297,8 @@ impl<'d> DocImporter<'d> {
                 out.push_str(suffix);
             }
             WrappedTag::Skip { close, .. } => {
-                // Drop the tag and its body. Content is discarded into a scratch buffer so `parse_until`'s
-                // close-tag matching still works. On EOF without close, roll back to leave the opener literal.
-                let mut scratch = String::new();
-                if !self.parse_until(&mut scratch, Some(close), ParseMode::CODE) {
+                // Drop the tag and its body. On EOF without close, roll back to leave the opener literal.
+                if !self.skip_past(close) {
                     self.rollback(out, cp);
                     return false;
                 }
@@ -300,19 +313,21 @@ impl<'d> DocImporter<'d> {
     }
 
     // Consume an opener of the form `<prefix>VALUE]`. Advances `self.pos` past the `]`.
-    // Returns the slice between `<prefix>` and `]` (the attribute value), or None if no match.
+    // Returns (start, end) byte offsets within `self.doc` instead of `&str`, so callers can keep parsing with `&mut self`
+    // and reconstruct the slice later without allocating a temporary `String`.
     //
     // Shortcoming: searches for the first `]` in the remaining input, so an attribute value containing `]` (e.g. `[url=https://x/a]b]`)
     // would truncate. Godot's docs should not produce such values in practice, so this is accepted.
-    fn try_consume_attr_opener(&mut self, prefix: &str) -> Option<&'d str> {
+    fn try_consume_attr_opener(&mut self, prefix: &str) -> Option<(usize, usize)> {
         let remaining = self.remaining();
         if !remaining.starts_with(prefix) {
             return None;
         }
         let end = remaining.find(']')?;
-        let value = &remaining[prefix.len()..end];
+        let value_start = self.pos + prefix.len();
+        let value_end = self.pos + end;
         self.pos += end + 1;
-        Some(value)
+        Some((value_start, value_end))
     }
 
     fn try_url_tag(&mut self, out: &mut String, mode: ParseMode) -> bool {
@@ -320,17 +335,17 @@ impl<'d> DocImporter<'d> {
         const SUFFIX: &str = "[/url]";
 
         let cp = self.checkpoint(out);
-        let Some(url) = self.try_consume_attr_opener(PREFIX) else {
+        let Some((url_start, url_end)) = self.try_consume_attr_opener(PREFIX) else {
             return false;
         };
-        let url = url.to_owned(); // detach borrow from `self` before recursing.
 
         out.push('[');
         if !self.parse_until(out, Some(SUFFIX), mode) {
             self.rollback(out, cp);
             return false;
         }
-        write_str!(out, "]({url})");
+        // Re-slice after parse_until: storing offsets avoids borrowing self.doc across the `&mut self` call and a `to_owned()`.
+        write_str!(out, "]({})", &self.doc[url_start..url_end]);
         true
     }
 
@@ -362,12 +377,15 @@ impl<'d> DocImporter<'d> {
         const SUFFIX: &str = "[/codeblock]";
 
         let cp = self.checkpoint(out);
-        let Some(lang) = self.try_consume_attr_opener(PREFIX) else {
+        let Some((lang_start, lang_end)) = self.try_consume_attr_opener(PREFIX) else {
             return false;
         };
-        let lang = lang.to_owned(); // detach borrow from `self` before recursing.
 
-        write_str!(out, "```{lang}");
+        // Write the fence opener first; storing offsets keeps the borrow local so parse_until can still take `&mut self`.
+        {
+            let lang = &self.doc[lang_start..lang_end];
+            write_str!(out, "```{lang}");
+        }
         // The body is literal fenced code, so bracket roles should not be interpreted inside it.
         if !self.parse_until(out, Some(SUFFIX), ParseMode::CODE) {
             self.rollback(out, cp);
@@ -484,7 +502,7 @@ impl<'d> DocImporter<'d> {
     /// - hardcoded specials (`@GlobalScope`) -> fixed link;
     /// - link to surrounding class -> `` `Self` ``-style code span (avoid self-link);
     /// - else -> `` [`Foo`][crate::classes::Foo] `` Rustdoc reference link.
-    fn write_type_link(&self, out: &mut String, ty_name: &str) {
+    fn write_type_link(&mut self, out: &mut String, ty_name: &str) {
         if matches_ignored_links(ty_name) {
             out.push_str(ty_name);
         } else if matches_primitive_type(ty_name) {
@@ -498,19 +516,18 @@ impl<'d> DocImporter<'d> {
             .surrounding_class
             .is_some_and(|c| c.name().godot_ty == ty_name)
         {
-            // Compare on the Godot name to skip the per-link `to_pascal_case` allocation.
             write_code_span(out, ty_name);
         } else {
-            let path = get_class_rust_path(ty_name, self.ctx);
-            write_code_link(out, ty_name, &path);
+            let path = self.cached_class_rust_path(ty_name);
+            write_code_link(out, ty_name, path);
         }
     }
 
     /// Emit Markdown for `[method Class.fn]` or `[method fn]` (latter resolved against surrounding class).
     /// Falls back to escaping the original `[method ...]` literal if the target cannot be resolved.
-    fn write_method_link(&self, out: &mut String, whole_match: &str, method_path: &str) {
+    fn write_method_link(&mut self, out: &mut String, whole_match: &str, method_path: &str) {
         if let Some(method_path) =
-            convert_to_method_path(method_path, self.surrounding_class, self.ctx, self.view)
+            convert_to_method_path(method_path, self.surrounding_class, self.ctx, self.view, &mut self.path_cache)
         {
             let (_, method_name) = method_path
                 .rsplit_once("::")
@@ -635,6 +652,15 @@ impl<'d> DocImporter<'d> {
         }
     }
 
+    /// Return the Rust crate path for a Godot class name, caching the result for the lifetime of this import.
+    fn cached_class_rust_path(&mut self, godot_class_name: &str) -> &str {
+        if !self.path_cache.contains_key(godot_class_name) {
+            let path = get_class_rust_path(godot_class_name, self.ctx).into_owned();
+            self.path_cache.insert(godot_class_name.to_owned(), path);
+        }
+        &self.path_cache[godot_class_name]
+    }
+
     fn remaining(&self) -> &'d str {
         &self.doc[self.pos..]
     }
@@ -721,6 +747,7 @@ fn convert_to_method_path(
     surrounding_class: Option<&Class>,
     ctx: &Context,
     view: &ApiView,
+    path_cache: &mut HashMap<String, String>,
 ) -> Option<CowStr> {
     // Get the class name from the link if it has one, otherwise use the surrounding class's name.
     // For example, in `CanvasItem` docs the link `[method Object.notification]` is owned by `Object`, while bare `[method queue_redraw]`
@@ -749,7 +776,13 @@ fn convert_to_method_path(
         return None;
     }
 
-    let rust_class_path = get_class_rust_path(link_godot_class, ctx);
+    let rust_class_path: &str = {
+        if !path_cache.contains_key(link_godot_class) {
+            let path = get_class_rust_path(link_godot_class, ctx).into_owned();
+            path_cache.insert(link_godot_class.to_owned(), path);
+        }
+        &path_cache[link_godot_class]
+    };
 
     let Some(class) = view.find_engine_class(&TyName::from_godot(link_godot_class)) else {
         // Builtins (Vector2, Transform2D, ...) are not engine classes in the API view; their methods aren't captured here, so we trust the link.
@@ -855,8 +888,6 @@ fn convert_builtin_types(type_name: &str) -> Option<&'static str> {
     }
 }
 
-// Optimization: results could be memoized via `HashMap<&str, CowStr>` on `Context` to avoid re-formatting the same `crate::classes::MyClass`
-// path per type link. Only worthwhile if doc import shows up in codegen profiles.
 fn get_class_rust_path(godot_class_name: &str, ctx: &Context) -> CowStr {
     if let Some(hardcoded_builtin_type) = convert_builtin_types(godot_class_name) {
         return hardcoded_builtin_type.into();

--- a/godot-codegen/src/generator/import_docs.rs
+++ b/godot-codegen/src/generator/import_docs.rs
@@ -145,7 +145,7 @@ struct DocImporter<'d> {
     doc: &'d str,
     pos: usize,
     surrounding_class: Option<&'d Class>,
-    ctx: &'d Context<'d>,
+    ctx: &'d Context,
     view: &'d ApiView<'d>,
     /// Cache of Godot class name -> Rust crate path (e.g. `"Node"` -> `"crate::classes::Node"`).
     /// Lives for the duration of one doc-string import; avoids repeated `to_pascal_case` + `format!` per link.
@@ -156,7 +156,7 @@ impl<'d> DocImporter<'d> {
     fn new(
         doc: &'d str,
         surrounding_class: Option<&'d Class>,
-        ctx: &'d Context<'d>,
+        ctx: &'d Context,
         view: &'d ApiView<'d>,
     ) -> Self {
         Self {
@@ -526,9 +526,13 @@ impl<'d> DocImporter<'d> {
     /// Emit Markdown for `[method Class.fn]` or `[method fn]` (latter resolved against surrounding class).
     /// Falls back to escaping the original `[method ...]` literal if the target cannot be resolved.
     fn write_method_link(&mut self, out: &mut String, whole_match: &str, method_path: &str) {
-        if let Some(method_path) =
-            convert_to_method_path(method_path, self.surrounding_class, self.ctx, self.view, &mut self.path_cache)
-        {
+        if let Some(method_path) = convert_to_method_path(
+            method_path,
+            self.surrounding_class,
+            self.ctx,
+            self.view,
+            &mut self.path_cache,
+        ) {
             let (_, method_name) = method_path
                 .rsplit_once("::")
                 .expect("rsplit_once should return a method name");
@@ -626,10 +630,11 @@ impl<'d> DocImporter<'d> {
         if class_godot_name.starts_with('@') {
             return None;
         }
-        let class = self
+        let class_ty = TyName::from_godot(class_godot_name);
+        let class = self.view.find_engine_class(&class_ty)?;
+        let (enum_, enumerator) = self
             .view
-            .find_engine_class(&TyName::from_godot(class_godot_name))?;
-        let (enum_, enumerator) = find_enumerator_in_class(class, const_godot_name)?;
+            .find_class_enum_constant(&class_ty, const_godot_name)?;
         Some((class, enum_, enumerator))
     }
 
@@ -644,7 +649,10 @@ impl<'d> DocImporter<'d> {
     ) -> Option<(&'d Class, &'d Enum, &'d Enumerator)> {
         let mut current = starting_class;
         loop {
-            if let Some((enum_, enumerator)) = find_enumerator_in_class(current, const_godot_name) {
+            if let Some((enum_, enumerator)) = self
+                .view
+                .find_class_enum_constant(current.name(), const_godot_name)
+            {
                 return Some((current, enum_, enumerator));
             }
             let base_name = current.base_class.as_ref()?;
@@ -669,19 +677,6 @@ impl<'d> DocImporter<'d> {
 /// Emit `` `text` ``.
 fn write_code_span(out: &mut String, text: &str) {
     write_str!(out, "`{text}`");
-}
-
-/// Search a single class's enums for an enumerator with the given Godot name.
-fn find_enumerator_in_class<'a>(
-    class: &'a Class,
-    const_godot_name: &str,
-) -> Option<(&'a Enum, &'a Enumerator)> {
-    class.enums.iter().find_map(|e| {
-        e.enumerators
-            .iter()
-            .find(|en| en.godot_name == const_godot_name)
-            .map(|en| (e, en))
-    })
 }
 
 /// Emit a Rustdoc reference link `` [`label`][path] ``.
@@ -911,15 +906,14 @@ mod tests {
     use std::cell::OnceCell;
 
     use super::*;
-    use crate::models::api_json::{JsonExtensionApi, load_extension_api};
+    use crate::models::api_json::load_extension_api;
     use crate::models::domain::ExtensionApi;
 
-    // `JsonExtensionApi` and `ExtensionApi` are cached per thread; `Context`/`ApiView` are
-    // cheap to rebuild and need lifetimes tied to those owners, so we rebuild them per test.
+    // `Context` and `ExtensionApi` are cached per thread; `ApiView` is cheap to rebuild per test.
     // Using `thread_local` (rather than a global `OnceLock`) avoids needing a `Mutex`, since
     // `ExtensionApi` contains `proc_macro2::TokenStream` and is therefore `!Sync`.
     struct DocTestCache {
-        json: JsonExtensionApi,
+        ctx: Context,
         api: ExtensionApi,
     }
 
@@ -933,16 +927,15 @@ mod tests {
                 let mut watch = godot_bindings::StopWatch::start();
                 let json = load_extension_api(&mut watch);
                 let mut ctx = Context::build_from_api(&json);
-                let api = ExtensionApi::from_json(&json, &mut ctx);
-                DocTestCache { json, api }
+                let api = ExtensionApi::from_json(json, &mut ctx);
+                DocTestCache { ctx, api }
             });
 
-            let ctx = Context::build_from_api(&cache.json);
             let view = ApiView::new(&cache.api);
             let surrounding_class = surrounding_class_name
                 .and_then(|name| view.find_engine_class(&TyName::from_godot(name)));
 
-            import_docs(description, surrounding_class, &ctx, &view)
+            import_docs(description, surrounding_class, &cache.ctx, &view)
         })
     }
 

--- a/godot-codegen/src/lib.rs
+++ b/godot-codegen/src/lib.rs
@@ -111,7 +111,7 @@ pub fn generate_sys_files(sys_gen_path: &Path, watch: &mut godot_bindings::StopW
     let mut ctx = Context::build_from_api(&json_api);
     watch.record("build_context");
 
-    let api = ExtensionApi::from_json(&json_api, &mut ctx);
+    let api = ExtensionApi::from_json(json_api, &mut ctx);
     watch.record("map_domain_models");
 
     generate_sys_central_file(&api, sys_gen_path, &mut submit_fn);
@@ -160,7 +160,7 @@ pub fn generate_core_files(core_gen_path: &Path) {
     let mut ctx = Context::build_from_api(&json_api);
     watch.record("build_context");
 
-    let api = ExtensionApi::from_json(&json_api, &mut ctx);
+    let api = ExtensionApi::from_json(json_api, &mut ctx);
     let view = ApiView::new(&api);
     watch.record("map_domain_models");
 

--- a/godot-codegen/src/models/api_json.rs
+++ b/godot-codegen/src/models/api_json.rs
@@ -113,11 +113,11 @@ pub struct JsonBuiltinEnum {
 }
 
 impl JsonBuiltinEnum {
-    pub fn to_enum(&self) -> JsonEnum {
+    pub fn into_enum(self) -> JsonEnum {
         JsonEnum {
-            name: self.name.clone(),
+            name: self.name,
             is_bitfield: false,
-            values: self.values.clone(),
+            values: self.values,
         }
     }
 }
@@ -220,7 +220,7 @@ pub struct JsonBuiltinMethod {
     pub description: Option<String>,
 }
 
-#[derive(DeJson, Clone)]
+#[derive(DeJson)]
 pub struct JsonClassMethod {
     pub name: String,
     pub is_const: bool,

--- a/godot-codegen/src/models/domain.rs
+++ b/godot-codegen/src/models/domain.rs
@@ -18,7 +18,7 @@ use quote::{ToTokens, format_ident, quote};
 
 use crate::context::Context;
 use crate::models::api_json::{JsonBuiltinClass, JsonMethodArg, JsonMethodReturn};
-use crate::util::{ident, option_as_slice, safe_ident};
+use crate::util::{ident, safe_ident};
 use crate::{conv, special_cases};
 
 mod enums;
@@ -59,6 +59,9 @@ pub struct ApiView<'a> {
     /// Global enumerator names are unique; they carry the enum name as prefix (e.g. `MIDI_MESSAGE_NOTE_ON` for `MidiMessage`).
     /// Key is `godot_name` from [`Enumerator`], so lookup is O(1) without iterating all enums.
     global_enum_constants: HashMap<&'a str, (&'a Enum, &'a Enumerator)>,
+
+    /// Maps a class type to its enum constants by Godot name.
+    class_enum_constants: HashMap<TyName, HashMap<&'a str, (&'a Enum, &'a Enumerator)>>,
 }
 
 impl<'a> ApiView<'a> {
@@ -75,9 +78,28 @@ impl<'a> ApiView<'a> {
             })
             .collect();
 
+        let class_enum_constants = api
+            .classes
+            .iter()
+            .map(|class| {
+                let enum_constants = class
+                    .enums
+                    .iter()
+                    .flat_map(|e| {
+                        e.enumerators.iter().map(move |enumerator| {
+                            (enumerator.godot_name.as_str(), (e, enumerator))
+                        })
+                    })
+                    .collect();
+
+                (class.name().clone(), enum_constants)
+            })
+            .collect();
+
         Self {
             class_by_ty,
             global_enum_constants,
+            class_enum_constants,
         }
     }
 
@@ -100,6 +122,17 @@ impl<'a> ApiView<'a> {
         godot_name: &str,
     ) -> Option<(&'a Enum, &'a Enumerator)> {
         self.global_enum_constants.get(godot_name).copied()
+    }
+
+    pub fn find_class_enum_constant(
+        &self,
+        class: &TyName,
+        godot_name: &str,
+    ) -> Option<(&'a Enum, &'a Enumerator)> {
+        self.class_enum_constants
+            .get(class)
+            .and_then(|constants| constants.get(godot_name))
+            .copied()
     }
 }
 
@@ -642,13 +675,14 @@ impl FnParamBuilder {
     /// Builds a vector of function parameters from the provided JSON method arguments.
     pub fn build_many(
         self,
-        method_args: &Option<Vec<JsonMethodArg>>,
+        method_args: Option<Vec<JsonMethodArg>>,
         flow: FlowDirection,
         ctx: &mut Context,
     ) -> Vec<FnParam> {
-        option_as_slice(method_args)
-            .iter()
-            .map(|arg| self.build_single_impl(arg, flow, ctx))
+        method_args
+            .unwrap_or_default()
+            .into_iter()
+            .map(|arg| self.build_single_impl(&arg, flow, ctx))
             .collect()
     }
 

--- a/godot-codegen/src/models/domain_mapping.rs
+++ b/godot-codegen/src/models/domain_mapping.rs
@@ -23,43 +23,50 @@ use crate::models::domain::{
     FnParam, FnQualifier, FnReturn, FunctionCommon, GodotApiVersion, ModName, NativeStructure,
     Operator, RustTy, Singleton, TyName, UtilityFunction,
 };
-use crate::util::{get_api_level, ident, option_as_slice};
+use crate::util::{get_api_level, ident};
 use crate::{conv, special_cases};
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Top-level
 
 impl ExtensionApi {
-    pub fn from_json(json: &JsonExtensionApi, ctx: &mut Context) -> Self {
+    pub fn from_json(json: JsonExtensionApi, ctx: &mut Context) -> Self {
+        let JsonExtensionApi {
+            header,
+            builtin_class_sizes,
+            builtin_classes,
+            classes,
+            global_enums,
+            utility_functions,
+            native_structures,
+            singletons,
+        } = json;
+
         Self {
-            builtins: BuiltinVariant::all_from_json(&json.global_enums, &json.builtin_classes, ctx),
-            classes: json
-                .classes
-                .iter()
+            builtins: BuiltinVariant::all_from_json(&global_enums, builtin_classes, ctx),
+            classes: classes
+                .into_iter()
                 .filter_map(|json| Class::from_json(json, ctx))
                 .collect(),
-            singletons: json.singletons.iter().map(Singleton::from_json).collect(),
-            native_structures: json
-                .native_structures
-                .iter()
+            singletons: singletons.into_iter().map(Singleton::from_json).collect(),
+            native_structures: native_structures
+                .into_iter()
                 .map(NativeStructure::from_json)
                 .collect(),
-            utility_functions: json
-                .utility_functions
-                .iter()
+            utility_functions: utility_functions
+                .into_iter()
                 .filter_map(|json| UtilityFunction::from_json(json, ctx))
                 .collect(),
-            global_enums: json
-                .global_enums
-                .iter()
+            global_enums: global_enums
+                .into_iter()
                 .map(|json| Enum::from_json(json, None))
                 .collect(),
-            godot_version: GodotApiVersion::from_json(&json.header),
-            builtin_sizes: Self::builtin_size_from_json(&json.builtin_class_sizes),
+            godot_version: GodotApiVersion::from_json(header),
+            builtin_sizes: Self::builtin_size_from_json(builtin_class_sizes),
         }
     }
 
-    fn builtin_size_from_json(json_builtin_sizes: &[JsonBuiltinSizes]) -> Vec<BuiltinSize> {
+    fn builtin_size_from_json(json_builtin_sizes: Vec<JsonBuiltinSizes>) -> Vec<BuiltinSize> {
         let mut result = Vec::new();
 
         for json_builtin_size in json_builtin_sizes {
@@ -67,9 +74,9 @@ impl ExtensionApi {
             let config = BuildConfiguration::from_json(build_config_str);
 
             if config.is_applicable() {
-                for size_for_config in &json_builtin_size.sizes {
+                for size_for_config in json_builtin_size.sizes {
                     result.push(BuiltinSize {
-                        builtin_original_name: size_for_config.name.clone(),
+                        builtin_original_name: size_for_config.name,
                         config,
                         size: size_for_config.size,
                     });
@@ -85,7 +92,7 @@ impl ExtensionApi {
 // Builtins + classes + singletons
 
 impl Class {
-    pub fn from_json(json: &JsonClass, ctx: &mut Context) -> Option<Self> {
+    pub fn from_json(json: JsonClass, ctx: &mut Context) -> Option<Self> {
         let ty_name = TyName::from_godot(&json.name);
         if special_cases::is_class_deleted(&ty_name) {
             return None;
@@ -100,55 +107,56 @@ impl Class {
         let is_final = ctx.is_final(&ty_name);
 
         let mod_name = ModName::from_godot(&ty_name.godot_ty);
+        let api_level = get_api_level(&json);
 
-        let constants = option_as_slice(&json.constants)
-            .iter()
+        let JsonClass {
+            is_refcounted,
+            inherits,
+            constants,
+            enums,
+            methods,
+            signals,
+            description,
+            ..
+        } = json;
+
+        let constants = constants
+            .unwrap_or_default()
+            .into_iter()
             .map(ClassConstant::from_json)
             .collect();
 
-        let enums = option_as_slice(&json.enums)
-            .iter()
-            .map(|e| {
-                let surrounding_class = Some(&ty_name);
-                Enum::from_json(e, surrounding_class)
-            })
+        let enums = enums
+            .unwrap_or_default()
+            .into_iter()
+            .map(|e| Enum::from_json(e, Some(&ty_name)))
             .collect();
 
-        let methods = option_as_slice(&json.methods)
-            .iter()
-            .filter_map(|m| {
-                let surrounding_class = &ty_name;
-                ClassMethod::from_json(m, surrounding_class, ctx)
-            })
+        let methods = methods
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|m| ClassMethod::from_json(m, &ty_name, ctx))
             .collect();
 
-        let signals = option_as_slice(&json.signals)
-            .iter()
-            .filter_map(|s| {
-                let surrounding_class = &ty_name;
-                ClassSignal::from_json(s, surrounding_class, ctx)
-            })
+        let signals = signals
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|s| ClassSignal::from_json(s, &ty_name, ctx))
             .collect();
 
-        let base_class = json
-            .inherits
-            .as_ref()
-            .map(|godot_name| TyName::from_godot(godot_name));
-
-        // TODO(v0.6): find a better way than cloning (borrow, swap, ...).
-        let description = json.description.clone();
+        let base_class = inherits.map(|godot_name| TyName::from_godot(&godot_name));
 
         Some(Self {
             common: ClassCommons {
                 name: ty_name,
                 mod_name,
             },
-            is_refcounted: json.is_refcounted,
+            is_refcounted,
             is_instantiable,
             is_experimental,
             is_final,
             base_class,
-            api_level: get_api_level(json),
+            api_level,
             constants,
             enums,
             methods,
@@ -159,20 +167,29 @@ impl Class {
 }
 
 impl BuiltinClass {
-    pub fn from_json(json: &JsonBuiltinClass, ctx: &mut Context) -> Option<Self> {
-        let ty_name = TyName::from_godot_builtin(json);
+    pub fn from_json(json: JsonBuiltinClass, ctx: &mut Context) -> Option<Self> {
+        let ty_name = TyName::from_godot_builtin(&json);
 
         if special_cases::is_builtin_type_deleted(&ty_name) {
             return None;
         }
 
-        let mod_name = ModName::from_godot_builtin(json);
+        let mod_name = ModName::from_godot_builtin(&json);
         let inner_name = TyName::from_godot(&format!("Inner{}", ty_name.godot_ty));
+        let JsonBuiltinClass {
+            operators,
+            methods,
+            constructors,
+            has_destructor,
+            enums,
+            ..
+        } = json;
 
-        let operators = json.operators.iter().map(Operator::from_json).collect();
+        let operators = operators.into_iter().map(Operator::from_json).collect();
 
-        let methods = option_as_slice(&json.methods)
-            .iter()
+        let methods = methods
+            .unwrap_or_default()
+            .into_iter()
             .filter_map(|m| {
                 // Pass inner_name "Inner*" as surrounding class. This is later overridden to the outer type (e.g. "GString")
                 // for methods exposed in the public API via is_builtin_method_exposed().
@@ -180,20 +197,15 @@ impl BuiltinClass {
             })
             .collect();
 
-        let constructors = json
-            .constructors
-            .iter()
+        let constructors = constructors
+            .into_iter()
             .map(Constructor::from_json)
             .collect();
 
-        let has_destructor = json.has_destructor;
-
-        let enums = option_as_slice(&json.enums)
-            .iter()
-            .map(|e| {
-                let surrounding_class = Some(&ty_name);
-                Enum::from_json(&e.to_enum(), surrounding_class)
-            })
+        let enums = enums
+            .unwrap_or_default()
+            .into_iter()
+            .map(|e| Enum::from_json(e.into_enum(), Some(&ty_name)))
             .collect();
 
         Some(Self {
@@ -212,7 +224,7 @@ impl BuiltinClass {
 }
 
 impl Singleton {
-    pub fn from_json(json: &JsonSingleton) -> Self {
+    pub fn from_json(json: JsonSingleton) -> Self {
         Self {
             name: TyName::from_godot(&json.name),
         }
@@ -226,7 +238,7 @@ impl BuiltinVariant {
     /// Returns all builtins, ordered by enum ordinal value.
     pub fn all_from_json(
         global_enums: &[JsonEnum],
-        builtin_classes: &[JsonBuiltinClass],
+        builtin_classes: Vec<JsonBuiltinClass>,
         ctx: &mut Context,
     ) -> Vec<Self> {
         fn normalize(name: &str) -> String {
@@ -239,8 +251,8 @@ impl BuiltinVariant {
             .expect("missing enum for VariantType in JSON");
 
         // Make HashMap from builtin_classes, keyed by a normalized version of their names (all-lower, no underscores)
-        let builtin_classes: HashMap<String, &JsonBuiltinClass> = builtin_classes
-            .iter()
+        let mut builtin_classes: HashMap<String, JsonBuiltinClass> = builtin_classes
+            .into_iter()
             .map(|c| (normalize(&c.name), c))
             .collect();
 
@@ -258,7 +270,7 @@ impl BuiltinVariant {
                 }
 
                 let name = normalize(json_shout_case);
-                let json_builtin_class = builtin_classes.get(&name).copied();
+                let json_builtin_class = builtin_classes.remove(&name);
                 let json_ord = e.to_enum_ord();
 
                 Some(Self::from_json(
@@ -277,7 +289,7 @@ impl BuiltinVariant {
     pub fn from_json(
         json_variant_enumerator_name: &str,
         json_variant_enumerator_ord: i32,
-        json_builtin_class: Option<&JsonBuiltinClass>,
+        json_builtin_class: Option<JsonBuiltinClass>,
         ctx: &mut Context,
     ) -> Self {
         let builtin_class;
@@ -286,8 +298,8 @@ impl BuiltinVariant {
         // Nil, int, float etc. are not represented by a BuiltinVariant.
         // Object has no BuiltinClass, but still gets its BuiltinVariant instance.
         if let Some(json_builtin) = json_builtin_class {
-            builtin_class = BuiltinClass::from_json(json_builtin, ctx);
             godot_original_name = json_builtin.name.clone();
+            builtin_class = BuiltinClass::from_json(json_builtin, ctx);
         } else {
             assert_eq!(json_variant_enumerator_name, "OBJECT");
 
@@ -309,19 +321,17 @@ impl BuiltinVariant {
 // Constructors, operators
 
 impl Constructor {
-    pub fn from_json(json: &JsonConstructor) -> Self {
+    pub fn from_json(json: JsonConstructor) -> Self {
         Self {
             index: json.index, // TODO use enum for Default/Copy/Other(index)
-            raw_parameters: json.arguments.as_ref().map_or(vec![], |vec| vec.clone()),
+            raw_parameters: json.arguments.unwrap_or_default(),
         }
     }
 }
 
 impl Operator {
-    pub fn from_json(json: &JsonOperator) -> Self {
-        Self {
-            symbol: json.name.clone(),
-        }
+    pub fn from_json(json: JsonOperator) -> Self {
+        Self { symbol: json.name }
     }
 }
 
@@ -341,17 +351,24 @@ impl BuildConfiguration {
 }
 
 impl GodotApiVersion {
-    pub fn from_json(json: &JsonHeader) -> Self {
-        let version_string = json
-            .version_full_name
+    pub fn from_json(json: JsonHeader) -> Self {
+        let JsonHeader {
+            version_major,
+            version_minor,
+            version_patch,
+            version_full_name,
+            ..
+        } = json;
+
+        let version_string = version_full_name
             .strip_prefix("Godot Engine ")
-            .unwrap_or(&json.version_full_name)
+            .unwrap_or(&version_full_name)
             .to_string();
 
         Self {
-            major: json.version_major,
-            minor: json.version_minor,
-            patch: json.version_patch,
+            major: version_major,
+            minor: version_minor,
+            patch: version_patch,
             version_string,
         }
     }
@@ -362,21 +379,31 @@ impl GodotApiVersion {
 
 impl BuiltinMethod {
     pub fn from_json(
-        method: &JsonBuiltinMethod,
+        method: JsonBuiltinMethod,
         builtin_name: &TyName,
         inner_class_name: &TyName,
         ctx: &mut Context,
     ) -> Option<Self> {
-        if special_cases::is_builtin_method_deleted(builtin_name, method) {
+        if special_cases::is_builtin_method_deleted(builtin_name, &method) {
             return None;
         }
 
         let is_exposed_in_outer =
             special_cases::is_builtin_method_exposed(builtin_name, &method.name);
 
+        let JsonBuiltinMethod {
+            name,
+            return_type,
+            is_vararg,
+            is_const,
+            is_static,
+            hash,
+            arguments,
+            description,
+        } = method;
+
         let return_value = {
-            let return_value = &method
-                .return_type
+            let return_value = &return_type
                 .as_deref()
                 .map(JsonMethodReturn::from_type_no_meta);
 
@@ -385,7 +412,7 @@ impl BuiltinMethod {
             // arrays/dicts can be generic and store type info, thus typing returned collections differently. Thus use RustToGodot flow.
             let flow = if !is_exposed_in_outer
                 && matches!(builtin_name.godot_ty.as_str(), "Array" | "Dictionary")
-                && matches!(method.return_type.as_deref(), Some("Array" | "Dictionary"))
+                && matches!(return_type.as_deref(), Some("Array" | "Dictionary"))
             {
                 FlowDirection::RustToGodot // AnyArray + AnyDictionary.
             } else {
@@ -397,8 +424,7 @@ impl BuiltinMethod {
 
         // For parameters in builtin methods, flow is always Rust -> Godot.
         // Enable default parameters for builtin classes, generating _ex builders.
-        let parameters =
-            FnParam::builder().build_many(&method.arguments, FlowDirection::RustToGodot, ctx);
+        let parameters = FnParam::builder().build_many(arguments, FlowDirection::RustToGodot, ctx);
 
         // Construct surrounding_class with correct type names:
         // * godot_ty: Always the real Godot type (e.g. "String").
@@ -419,27 +445,24 @@ impl BuiltinMethod {
             }
         };
 
-        // TODO(v0.6): find a better way than cloning (borrow, swap, ...).
-        let description = method.description.clone();
-
         Some(Self {
             common: FunctionCommon {
                 // Fill in these fields
-                name: method.name.clone(),
-                godot_name: method.name.clone(),
+                name: name.clone(),
+                godot_name: name,
                 parameters,
                 return_value,
-                is_vararg: method.is_vararg,
+                is_vararg,
                 is_private: false, // See 'exposed' below. Could be special_cases::is_method_private(builtin_name, &method.name),
                 is_virtual_required: false,
                 is_unsafe: false, // Builtin methods don't use raw pointers.
                 direction: FnDirection::Outbound {
-                    hash: method.hash.expect("hash absent for builtin method"),
+                    hash: hash.expect("hash absent for builtin method"),
                 },
                 deprecation_msg: None, // Builtin methods are not deprecated yet.
                 description,
             },
-            qualifier: FnQualifier::from_const_static(method.is_const, method.is_static),
+            qualifier: FnQualifier::from_const_static(is_const, is_static),
             surrounding_class,
             is_exposed_in_outer,
         })
@@ -448,13 +471,13 @@ impl BuiltinMethod {
 
 impl ClassMethod {
     pub fn from_json(
-        method: &JsonClassMethod,
+        method: JsonClassMethod,
         class_name: &TyName,
         ctx: &mut Context,
     ) -> Option<ClassMethod> {
         assert!(!special_cases::is_class_deleted(class_name));
 
-        if special_cases::is_class_method_deleted(class_name, method, ctx) {
+        if special_cases::is_class_method_deleted(class_name, &method, ctx) {
             return None;
         }
 
@@ -466,7 +489,7 @@ impl ClassMethod {
     }
 
     fn from_json_outbound(
-        method: &JsonClassMethod,
+        method: JsonClassMethod,
         class_name: &TyName,
         ctx: &mut Context,
     ) -> Option<Self> {
@@ -475,11 +498,12 @@ impl ClassMethod {
             .hash
             .expect("hash absent for non-virtual class method");
 
-        let rust_method_name = special_cases::maybe_rename_class_method(class_name, &method.name);
+        let rust_method_name =
+            special_cases::maybe_rename_class_method(class_name, &method.name).into_owned();
 
         Self::from_json_inner(
             method,
-            rust_method_name.as_ref(),
+            rust_method_name,
             class_name,
             FnDirection::Outbound { hash },
             ctx,
@@ -487,7 +511,7 @@ impl ClassMethod {
     }
 
     fn from_json_virtual(
-        method: &JsonClassMethod,
+        method: JsonClassMethod,
         class_name: &TyName,
         ctx: &mut Context,
     ) -> Option<Self> {
@@ -515,29 +539,25 @@ impl ClassMethod {
         };
 
         // May still be renamed further, for unsafe methods. Not done here because data to determine safety is not available yet.
-        let rust_method_name = Self::make_virtual_method_name(class_name, &method.name);
+        let rust_method_name = Self::make_virtual_method_name(class_name, &method.name).to_string();
 
         Self::from_json_inner(method, rust_method_name, class_name, direction, ctx)
     }
 
     fn from_json_inner(
-        method: &JsonClassMethod,
-        rust_method_name: &str,
+        method: JsonClassMethod,
+        rust_method_name: String,
         class_name: &TyName,
         direction: FnDirection,
         ctx: &mut Context,
     ) -> Option<ClassMethod> {
-        if special_cases::is_class_method_deleted(class_name, method, ctx) {
-            return None;
-        }
-
         let is_private = special_cases::is_method_private(class_name, &method.name);
-        let godot_method_name = method.name.clone();
 
         let qualifier = {
             // Override const-qualification for known special cases (FileAccess::get_16, StreamPeer::get_u16, etc.).
             let mut is_actually_const = method.is_const;
-            if let Some(override_const) = special_cases::is_class_method_const(class_name, method) {
+            if let Some(override_const) = special_cases::is_class_method_const(class_name, &method)
+            {
                 is_actually_const = override_const;
             }
 
@@ -571,7 +591,7 @@ impl ClassMethod {
         let enum_replacements = validate_enum_replacements(
             class_name,
             &method.name,
-            option_as_slice(&method.arguments),
+            method.arguments.as_deref().unwrap_or(&[]),
             method.return_value.is_some(),
         );
 
@@ -582,40 +602,43 @@ impl ClassMethod {
             FnDirection::Virtual { .. } => (FlowDirection::GodotToRust, FlowDirection::RustToGodot),
         };
 
+        let deprecation_msg = special_cases::get_class_method_deprecation(class_name, &method);
+
+        let JsonClassMethod {
+            name,
+            is_vararg,
+            is_virtual,
+            return_value,
+            arguments,
+            description,
+            ..
+        } = method;
+
         let parameters = FnParam::builder()
             .enum_replacements(enum_replacements)
-            .build_many(&method.arguments, param_flow, ctx);
+            .build_many(arguments, param_flow, ctx);
 
-        let return_value = FnReturn::with_enum_replacements(
-            &method.return_value,
-            enum_replacements,
-            return_flow,
-            ctx,
-        );
+        let return_value =
+            FnReturn::with_enum_replacements(&return_value, enum_replacements, return_flow, ctx);
 
         let is_unsafe = Self::function_uses_pointers(&parameters, &return_value);
 
         // Future note: if further changes are made to the virtual method name, make sure to make it reversible so that #[godot_api]
         // can match on the Godot name of the virtual method.
-        let rust_method_name = if is_unsafe && method.is_virtual {
+        let rust_method_name = if is_unsafe && is_virtual {
             // If the method is unsafe, we need to rename it to avoid conflicts with the safe version.
-            conv::make_unsafe_virtual_fn_name(rust_method_name)
+            conv::make_unsafe_virtual_fn_name(&rust_method_name)
         } else {
-            rust_method_name.to_string()
+            rust_method_name
         };
-
-        let deprecation_msg = special_cases::get_class_method_deprecation(class_name, method);
-
-        // TODO(v0.6): find a better way than cloning (borrow, swap, ...).
-        let description = method.description.clone();
 
         Some(Self {
             common: FunctionCommon {
                 name: rust_method_name,
-                godot_name: godot_method_name,
+                godot_name: name,
                 parameters,
                 return_value,
-                is_vararg: method.is_vararg,
+                is_vararg,
                 is_private,
                 is_virtual_required,
                 is_unsafe,
@@ -656,11 +679,11 @@ impl ClassMethod {
 
 impl ClassSignal {
     pub fn from_json(
-        json_signal: &JsonSignal,
+        json_signal: JsonSignal,
         surrounding_class: &TyName,
         ctx: &mut Context,
     ) -> Option<Self> {
-        if special_cases::is_signal_deleted(surrounding_class, json_signal) {
+        if special_cases::is_signal_deleted(surrounding_class, &json_signal) {
             return None;
         }
 
@@ -668,41 +691,47 @@ impl ClassSignal {
         let flow = FlowDirection::RustToGodot;
 
         Some(Self {
-            name: json_signal.name.clone(),
-            parameters: FnParam::builder().build_many(&json_signal.arguments, flow, ctx),
+            name: json_signal.name,
+            parameters: FnParam::builder().build_many(json_signal.arguments, flow, ctx),
             surrounding_class: surrounding_class.clone(),
         })
     }
 }
 
 impl UtilityFunction {
-    pub fn from_json(function: &JsonUtilityFunction, ctx: &mut Context) -> Option<Self> {
-        if special_cases::is_utility_function_deleted(function, ctx) {
+    pub fn from_json(function: JsonUtilityFunction, ctx: &mut Context) -> Option<Self> {
+        if special_cases::is_utility_function_deleted(&function, ctx) {
             return None;
         }
-        let is_private = special_cases::is_utility_function_private(function);
+        let is_private = special_cases::is_utility_function_private(&function);
+
+        let JsonUtilityFunction {
+            name,
+            return_type,
+            is_vararg,
+            hash,
+            arguments,
+            description,
+            ..
+        } = function;
 
         // Some vararg functions like print() or str() are declared with a single argument "arg1: Variant", but that seems
         // to be a mistake. We change their parameter list by removing that.
-        let args = option_as_slice(&function.arguments);
-        let parameters = if function.is_vararg && args.len() == 1 && args[0].name == "arg1" {
-            vec![]
-        } else {
-            // Parameters in utility functions always flow Rust -> Godot.
-            FnParam::builder().build_many(&function.arguments, FlowDirection::RustToGodot, ctx)
-        };
+        let parameters =
+            if is_vararg && matches!(arguments.as_deref(), Some([arg]) if arg.name == "arg1") {
+                vec![]
+            } else {
+                // Parameters in utility functions always flow Rust -> Godot.
+                FnParam::builder().build_many(arguments, FlowDirection::RustToGodot, ctx)
+            };
 
-        let json_return = function
-            .return_type
+        let json_return = return_type
             .as_deref()
             .map(JsonMethodReturn::from_type_no_meta);
         let return_value = FnReturn::new(&json_return, FlowDirection::GodotToRust, ctx);
 
-        let godot_method_name = function.name.clone();
+        let godot_method_name = name;
         let rust_method_name = godot_method_name.clone(); // No change for now.
-
-        // TODO(v0.6): find a better way than cloning (borrow, swap, ...).
-        let description = function.description.clone();
 
         Some(Self {
             common: FunctionCommon {
@@ -710,13 +739,11 @@ impl UtilityFunction {
                 godot_name: godot_method_name,
                 parameters,
                 return_value,
-                is_vararg: function.is_vararg,
+                is_vararg,
                 is_private,
                 is_virtual_required: false,
                 is_unsafe: false, // Utility functions don't use raw pointers.
-                direction: FnDirection::Outbound {
-                    hash: function.hash,
-                },
+                direction: FnDirection::Outbound { hash },
                 deprecation_msg: None, // Utility functions are not deprecated.
                 description,
             },
@@ -728,17 +755,21 @@ impl UtilityFunction {
 // Enums + enumerator constants
 
 impl Enum {
-    pub fn from_json(json_enum: &JsonEnum, surrounding_class: Option<&TyName>) -> Self {
-        let godot_name = &json_enum.name;
-        let is_bitfield = special_cases::is_enum_bitfield(surrounding_class, godot_name)
-            .unwrap_or(json_enum.is_bitfield);
-        let is_private = special_cases::is_enum_private(surrounding_class, godot_name);
-        let is_exhaustive = special_cases::is_enum_exhaustive(surrounding_class, godot_name);
+    pub fn from_json(json_enum: JsonEnum, surrounding_class: Option<&TyName>) -> Self {
+        let JsonEnum {
+            name: godot_name,
+            is_bitfield: json_is_bitfield,
+            values,
+        } = json_enum;
 
-        let rust_enum_name = conv::make_enum_name_str(godot_name);
+        let is_bitfield = special_cases::is_enum_bitfield(surrounding_class, &godot_name)
+            .unwrap_or(json_is_bitfield);
+        let is_private = special_cases::is_enum_private(surrounding_class, &godot_name);
+        let is_exhaustive = special_cases::is_enum_exhaustive(surrounding_class, &godot_name);
+
+        let rust_enum_name = conv::make_enum_name_str(&godot_name);
         let rust_enumerator_names = {
-            let godot_enumerator_names = json_enum
-                .values
+            let godot_enumerator_names = values
                 .iter()
                 .map(|e| {
                     // Special cases. Extract to special_cases mode if more are added.
@@ -754,9 +785,8 @@ impl Enum {
             conv::make_enumerator_names(godot_class_name, &rust_enum_name, godot_enumerator_names)
         };
 
-        let enumerators: Vec<Enumerator> = json_enum
-            .values
-            .iter()
+        let enumerators: Vec<Enumerator> = values
+            .into_iter()
             .zip(rust_enumerator_names)
             .map(|(json_constant, rust_name)| {
                 Enumerator::from_json(json_constant, rust_name, is_bitfield)
@@ -767,7 +797,7 @@ impl Enum {
 
         Self {
             name: ident(&rust_enum_name),
-            godot_name: godot_name.clone(),
+            godot_name,
             surrounding_class: surrounding_class.cloned(),
             is_bitfield,
             is_private,
@@ -779,7 +809,7 @@ impl Enum {
 }
 
 impl Enumerator {
-    pub fn from_json(json: &JsonEnumConstant, rust_name: Ident, is_bitfield: bool) -> Self {
+    pub fn from_json(json: JsonEnumConstant, rust_name: Ident, is_bitfield: bool) -> Self {
         let value = if is_bitfield {
             let ord = json.value.try_into().unwrap_or_else(|_| {
                 panic!(
@@ -802,7 +832,7 @@ impl Enumerator {
 
         Self {
             name: rust_name,
-            godot_name: json.name.clone(),
+            godot_name: json.name,
             value,
         }
     }
@@ -812,7 +842,7 @@ impl Enumerator {
 // Constants
 
 impl ClassConstant {
-    pub fn from_json(json: &JsonClassConstant) -> Self {
+    pub fn from_json(json: JsonClassConstant) -> Self {
         // Godot types only use i32, but other extensions may have i64. Use smallest possible type.
         let value = if let Ok(i32_value) = i32::try_from(json.value) {
             ClassConstantValue::I32(i32_value)
@@ -821,7 +851,7 @@ impl ClassConstant {
         };
 
         Self {
-            name: json.name.clone(),
+            name: json.name,
             value,
         }
     }
@@ -871,15 +901,14 @@ fn validate_enum_replacements(
 // Native structures
 
 impl NativeStructure {
-    pub fn from_json(json: &JsonNativeStructure) -> Self {
-        // Some native-struct definitions are incorrect in earlier Godot versions; this backports corrections.
-        let format = special_cases::get_native_struct_definition(&json.name)
-            .map(|s| s.to_string())
-            .unwrap_or_else(|| json.format.clone());
+    pub fn from_json(json: JsonNativeStructure) -> Self {
+        let JsonNativeStructure { name, format } = json;
 
-        Self {
-            name: json.name.clone(),
-            format,
-        }
+        // Some native-struct definitions are incorrect in earlier Godot versions; this backports corrections.
+        let format = special_cases::get_native_struct_definition(&name)
+            .map(|s| s.to_string())
+            .unwrap_or(format);
+
+        Self { name, format }
     }
 }


### PR DESCRIPTION
When mapping from the JSON to the domain model, we kept the JSON allocated throughout the whole time and also cloned tens of thousands of strings. This PR now moves the data instead of borrowing/cloning it. `Context` as a result no longer has a lifetime (even if it means now cloning a couple of map keys).

Also improves some more localized doc-import logic.

This did not significantly impact compile-times on my machine, but it might also benefit memory on lower-end/CI hardware. A more linear flow instead of borrowing also makes reasoning about different models a bit easier.