### PR TITLE
Tweak monomorphizations -> 7-9% lower `godot-core` compile times

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,7 @@
+[profile.dev]
+# Skips type/variable debug metadata while keeping file:line info for backtraces. Saves 1-4% build time on clean dev builds.
+debug = "line-tables-only"
+
 [workspace]
 resolver = "2"
 members = [

--- a/godot-core/src/meta/param_tuple/impls.rs
+++ b/godot-core/src/meta/param_tuple/impls.rs
@@ -74,19 +74,8 @@ macro_rules! unsafe_impl_param_tuple {
                 }
 
                 // Slow path: merge provided args with defaults (requires allocation).
-                let mut all_args = Vec::with_capacity(Self::LEN);
-
-                // Copy all provided args.
-                for i in 0..arg_count {
-                    all_args.push(unsafe { *args_ptr.add(i) });
-                }
-
-                // Fill remaining parameters with default values.
-                let required_param_count = Self::LEN - default_values.len();
-                let first_missing_index = arg_count - required_param_count;
-                for i in first_missing_index..default_values.len() {
-                    all_args.push(default_values[i].var_sys());
-                }
+                let all_args =
+                    unsafe { merge_varcall_with_defaults(args_ptr, arg_count, Self::LEN, default_values) };
 
                 // Convert all args to the tuple.
                 let param_tuple = (
@@ -193,6 +182,29 @@ macro_rules! unsafe_impl_param_tuple {
             }
         }
     };
+}
+
+unsafe fn merge_varcall_with_defaults(
+    args_ptr: *const sys::GDExtensionConstVariantPtr,
+    arg_count: usize,
+    expected_len: usize,
+    default_values: &[Variant],
+) -> Vec<sys::GDExtensionConstVariantPtr> {
+    let mut all_args = Vec::with_capacity(expected_len);
+
+    for i in 0..arg_count {
+        all_args.push(unsafe { *args_ptr.add(i) });
+    }
+
+    let required_param_count = expected_len - default_values.len();
+    let first_missing_default = arg_count - required_param_count;
+    all_args.extend(
+        default_values[first_missing_default..]
+            .iter()
+            .map(Variant::var_sys),
+    );
+
+    all_args
 }
 
 #[allow(unused_variables, unused_mut, clippy::unused_unit)]

--- a/godot-core/src/meta/signature.rs
+++ b/godot-core/src/meta/signature.rs
@@ -245,7 +245,7 @@ impl<Params: OutParamTuple, Ret: EngineFromGodot> Signature<Params, Ret> {
         });
 
         let result = <Ret as FromGodot>::try_from_variant(&variant);
-        result.unwrap_or_else(|err| return_error::<Ret>(&call_ctx, err))
+        result.unwrap_or_else(|err| return_error_dyn(&call_ctx, std::any::type_name::<Ret>(), err))
     }
 
     /// Make a ptrcall to the Godot engine for a utility function that has varargs.
@@ -264,14 +264,17 @@ impl<Params: OutParamTuple, Ret: EngineFromGodot> Signature<Params, Ret> {
         //$crate::out!("out_utility_ptrcall_varargs: {call_ctx}");
 
         unsafe {
-            Self::raw_ptrcall(args, &call_ctx, |explicit_args, return_ptr| {
-                let mut type_ptrs = Vec::with_capacity(explicit_args.len() + varargs.len());
-                type_ptrs.extend(explicit_args.iter());
-                type_ptrs.extend(varargs.iter().map(sys::GodotFfi::sys));
+            pack_ptrcall_args(args, |explicit_args, arg_count| {
+                finish_ptrcall(&call_ctx, |return_ptr| {
+                    let explicit_args = std::slice::from_raw_parts(explicit_args, arg_count);
+                    let mut type_ptrs = Vec::with_capacity(explicit_args.len() + varargs.len());
+                    type_ptrs.extend(explicit_args.iter().copied());
+                    type_ptrs.extend(varargs.iter().map(sys::GodotFfi::sys));
 
-                // Important: this calls from_sys_init_default().
-                // SAFETY: TODO.
-                utility_fn(return_ptr, type_ptrs.as_ptr(), type_ptrs.len() as i32);
+                    // Important: this calls from_sys_init_default().
+                    // SAFETY: TODO.
+                    utility_fn(return_ptr, type_ptrs.as_ptr(), type_ptrs.len() as i32);
+                })
             })
         }
     }
@@ -293,18 +296,21 @@ impl<Params: OutParamTuple, Ret: EngineFromGodot> Signature<Params, Ret> {
         //$crate::out!("out_builtin_ptrcall_varargs: {call_ctx}");
 
         unsafe {
-            Self::raw_ptrcall(args, &call_ctx, |explicit_args, return_ptr| {
-                let mut type_ptrs = Vec::with_capacity(explicit_args.len() + varargs.len());
-                type_ptrs.extend(explicit_args.iter());
-                type_ptrs.extend(varargs.iter().map(sys::GodotFfi::sys));
+            pack_ptrcall_args(args, |explicit_args, arg_count| {
+                finish_ptrcall(&call_ctx, |return_ptr| {
+                    let explicit_args = std::slice::from_raw_parts(explicit_args, arg_count);
+                    let mut type_ptrs = Vec::with_capacity(explicit_args.len() + varargs.len());
+                    type_ptrs.extend(explicit_args.iter().copied());
+                    type_ptrs.extend(varargs.iter().map(sys::GodotFfi::sys));
 
-                // Important: this calls from_sys_init_default().
-                builtin_fn(
-                    type_ptr,
-                    type_ptrs.as_ptr(),
-                    return_ptr,
-                    type_ptrs.len() as i32,
-                );
+                    // Important: this calls from_sys_init_default().
+                    builtin_fn(
+                        type_ptr,
+                        type_ptrs.as_ptr(),
+                        return_ptr,
+                        type_ptrs.len() as i32,
+                    );
+                })
             })
         }
     }
@@ -313,7 +319,6 @@ impl<Params: OutParamTuple, Ret: EngineFromGodot> Signature<Params, Ret> {
     ///
     /// # Safety
     /// - `method_bind` must expect explicit args `args`, and return a value of type `Ret`
-    #[inline]
     pub unsafe fn out_class_ptrcall(
         method_bind: sys::ClassMethodBind,
         // Separate parameters to reduce tokens in generated class API.
@@ -324,17 +329,13 @@ impl<Params: OutParamTuple, Ret: EngineFromGodot> Signature<Params, Ret> {
     ) -> Ret {
         let call_ctx = CallContext::outbound(class_name, method_name);
         // $crate::out!("out_class_ptrcall: {call_ctx}");
-
-        let class_fn = sys::interface_fn!(object_method_bind_ptrcall);
+        let object_ptr = ValidatedObject::object_ptr(validated_obj.as_ref());
 
         unsafe {
-            Self::raw_ptrcall(args, &call_ctx, |explicit_args, return_ptr| {
-                class_fn(
-                    method_bind.0,
-                    ValidatedObject::object_ptr(validated_obj.as_ref()),
-                    explicit_args.as_ptr(),
-                    return_ptr,
-                );
+            pack_ptrcall_args(args, |explicit_args, _arg_count| {
+                finish_ptrcall(&call_ctx, |return_ptr| {
+                    dispatch_class_ptrcall(method_bind, object_ptr, explicit_args, return_ptr);
+                })
             })
         }
     }
@@ -343,7 +344,6 @@ impl<Params: OutParamTuple, Ret: EngineFromGodot> Signature<Params, Ret> {
     ///
     /// # Safety
     /// - `builtin_fn` must expect explicit args `args`, and return a value of type `Ret`
-    #[inline]
     pub unsafe fn out_builtin_ptrcall(
         builtin_fn: sys::BuiltinMethodBind,
         // Separate parameters to reduce tokens in generated class API.
@@ -356,13 +356,16 @@ impl<Params: OutParamTuple, Ret: EngineFromGodot> Signature<Params, Ret> {
         // $crate::out!("out_builtin_ptrcall: {call_ctx}");
 
         unsafe {
-            Self::raw_ptrcall(args, &call_ctx, |explicit_args, return_ptr| {
-                builtin_fn(
-                    type_ptr,
-                    explicit_args.as_ptr(),
-                    return_ptr,
-                    explicit_args.len() as i32,
-                );
+            pack_ptrcall_args(args, |explicit_args, arg_count| {
+                finish_ptrcall(&call_ctx, |return_ptr| {
+                    dispatch_builtin_ptrcall(
+                        builtin_fn,
+                        type_ptr,
+                        explicit_args,
+                        arg_count,
+                        return_ptr,
+                    );
+                })
             })
         }
     }
@@ -371,7 +374,6 @@ impl<Params: OutParamTuple, Ret: EngineFromGodot> Signature<Params, Ret> {
     ///
     /// # Safety
     /// - `utility_fn` must expect explicit args `args`, and return a value of type `Ret`
-    #[inline]
     pub unsafe fn out_utility_ptrcall(
         utility_fn: sys::UtilityFunctionBind,
         function_name: &'static str,
@@ -381,33 +383,78 @@ impl<Params: OutParamTuple, Ret: EngineFromGodot> Signature<Params, Ret> {
         // $crate::out!("out_utility_ptrcall: {call_ctx}");
 
         unsafe {
-            Self::raw_ptrcall(args, &call_ctx, |explicit_args, return_ptr| {
-                utility_fn(
-                    return_ptr,
-                    explicit_args.as_ptr(),
-                    explicit_args.len() as i32,
-                );
+            pack_ptrcall_args(args, |explicit_args, arg_count| {
+                finish_ptrcall(&call_ctx, |return_ptr| {
+                    dispatch_utility_ptrcall(utility_fn, explicit_args, arg_count, return_ptr);
+                })
             })
         }
     }
+}
 
-    /// Performs a ptrcall and processes the return value to give nice error output.
-    ///
-    /// # Safety
-    /// This calls [`GodotFfi::new_with_init`] and passes the ptr as the second argument to `f`, see that function for safety docs.
-    unsafe fn raw_ptrcall(
-        args: Params,
-        call_ctx: &CallContext,
-        f: impl FnOnce(&[sys::GDExtensionConstTypePtr], sys::GDExtensionTypePtr),
-    ) -> Ret {
-        let ffi = args.with_type_pointers(|explicit_args| unsafe {
-            <<Ret::Via as GodotType>::Ffi>::new_with_init(|return_ptr| f(explicit_args, return_ptr))
-        });
+/// Packs ptrcall arguments into a pointer/length pair.
+///
+/// # Safety
+/// This forwards the slice produced by [`OutParamTuple::with_type_pointers`]. The callback must not retain the raw pointer beyond the call.
+unsafe fn pack_ptrcall_args<Params: OutParamTuple, R>(
+    args: Params,
+    f: impl FnOnce(*const sys::GDExtensionConstTypePtr, usize) -> R,
+) -> R {
+    args.with_type_pointers(|explicit_args| f(explicit_args.as_ptr(), explicit_args.len()))
+}
 
-        Ret::Via::try_from_ffi(ffi)
-            .and_then(Ret::engine_try_from_godot)
-            .unwrap_or_else(|err| return_error::<Ret>(call_ctx, err))
+/// Performs the return-value initialization and decode for a ptrcall.
+///
+/// # Safety
+/// This calls [`GodotFfi::new_with_init`] and passes the return pointer to `init`, see that function for safety docs.
+unsafe fn finish_ptrcall<Ret: EngineFromGodot>(
+    call_ctx: &CallContext,
+    init: impl FnOnce(sys::GDExtensionTypePtr),
+) -> Ret {
+    let ffi = unsafe { <<Ret::Via as GodotType>::Ffi>::new_with_init(init) };
+
+    match Ret::Via::try_from_ffi(ffi).and_then(Ret::engine_try_from_godot) {
+        Ok(ret) => ret,
+        Err(err) => return_error_dyn(call_ctx, std::any::type_name::<Ret>(), err),
     }
+}
+
+#[inline(never)]
+unsafe fn dispatch_class_ptrcall(
+    method_bind: sys::ClassMethodBind,
+    object_ptr: sys::GDExtensionObjectPtr,
+    args_ptr: *const sys::GDExtensionConstTypePtr,
+    return_ptr: sys::GDExtensionTypePtr,
+) {
+    unsafe {
+        sys::interface_fn!(object_method_bind_ptrcall)(
+            method_bind.0,
+            object_ptr,
+            args_ptr,
+            return_ptr,
+        )
+    };
+}
+
+#[inline(never)]
+unsafe fn dispatch_builtin_ptrcall(
+    builtin_fn: sys::BuiltinMethodBind,
+    type_ptr: sys::GDExtensionTypePtr,
+    args_ptr: *const sys::GDExtensionConstTypePtr,
+    arg_count: usize,
+    return_ptr: sys::GDExtensionTypePtr,
+) {
+    unsafe { builtin_fn(type_ptr, args_ptr, return_ptr, arg_count as i32) };
+}
+
+#[inline(never)]
+unsafe fn dispatch_utility_ptrcall(
+    utility_fn: sys::UtilityFunctionBind,
+    args_ptr: *const sys::GDExtensionConstTypePtr,
+    arg_count: usize,
+    return_ptr: sys::GDExtensionTypePtr,
+) {
+    unsafe { utility_fn(return_ptr, args_ptr, arg_count as i32) };
 }
 
 /// Moves `ret_val` into `ret`.
@@ -484,8 +531,9 @@ unsafe fn ptrcall_return<R: EngineToGodot>(
     Ok(())
 }
 
-fn return_error<R>(call_ctx: &CallContext, err: ConvertError) -> ! {
-    let return_ty = std::any::type_name::<R>();
+#[cold]
+#[inline(never)]
+fn return_error_dyn(call_ctx: &CallContext, return_ty: &'static str, err: ConvertError) -> ! {
     panic!("in function `{call_ctx}` at return type {return_ty}: {err}");
 }
 

--- a/godot-core/src/meta/signature.rs
+++ b/godot-core/src/meta/signature.rs
@@ -265,12 +265,8 @@ impl<Params: OutParamTuple, Ret: EngineFromGodot> Signature<Params, Ret> {
 
         unsafe {
             pack_ptrcall_args(args, |explicit_args, arg_count| {
-                finish_ptrcall(&call_ctx, |return_ptr| {
-                    let explicit_args = std::slice::from_raw_parts(explicit_args, arg_count);
-                    let mut type_ptrs = Vec::with_capacity(explicit_args.len() + varargs.len());
-                    type_ptrs.extend(explicit_args.iter().copied());
-                    type_ptrs.extend(varargs.iter().map(sys::GodotFfi::sys));
-
+                finish_ptrcall(&call_ctx, &mut |return_ptr| {
+                    let type_ptrs = concat_varargs_ptrs(explicit_args, arg_count, varargs);
                     // Important: this calls from_sys_init_default().
                     // SAFETY: TODO.
                     utility_fn(return_ptr, type_ptrs.as_ptr(), type_ptrs.len() as i32);
@@ -297,12 +293,8 @@ impl<Params: OutParamTuple, Ret: EngineFromGodot> Signature<Params, Ret> {
 
         unsafe {
             pack_ptrcall_args(args, |explicit_args, arg_count| {
-                finish_ptrcall(&call_ctx, |return_ptr| {
-                    let explicit_args = std::slice::from_raw_parts(explicit_args, arg_count);
-                    let mut type_ptrs = Vec::with_capacity(explicit_args.len() + varargs.len());
-                    type_ptrs.extend(explicit_args.iter().copied());
-                    type_ptrs.extend(varargs.iter().map(sys::GodotFfi::sys));
-
+                finish_ptrcall(&call_ctx, &mut |return_ptr| {
+                    let type_ptrs = concat_varargs_ptrs(explicit_args, arg_count, varargs);
                     // Important: this calls from_sys_init_default().
                     builtin_fn(
                         type_ptr,
@@ -333,7 +325,7 @@ impl<Params: OutParamTuple, Ret: EngineFromGodot> Signature<Params, Ret> {
 
         unsafe {
             pack_ptrcall_args(args, |explicit_args, _arg_count| {
-                finish_ptrcall(&call_ctx, |return_ptr| {
+                finish_ptrcall(&call_ctx, &mut |return_ptr| {
                     dispatch_class_ptrcall(method_bind, object_ptr, explicit_args, return_ptr);
                 })
             })
@@ -357,7 +349,7 @@ impl<Params: OutParamTuple, Ret: EngineFromGodot> Signature<Params, Ret> {
 
         unsafe {
             pack_ptrcall_args(args, |explicit_args, arg_count| {
-                finish_ptrcall(&call_ctx, |return_ptr| {
+                finish_ptrcall(&call_ctx, &mut |return_ptr| {
                     dispatch_builtin_ptrcall(
                         builtin_fn,
                         type_ptr,
@@ -384,7 +376,7 @@ impl<Params: OutParamTuple, Ret: EngineFromGodot> Signature<Params, Ret> {
 
         unsafe {
             pack_ptrcall_args(args, |explicit_args, arg_count| {
-                finish_ptrcall(&call_ctx, |return_ptr| {
+                finish_ptrcall(&call_ctx, &mut |return_ptr| {
                     dispatch_utility_ptrcall(utility_fn, explicit_args, arg_count, return_ptr);
                 })
             })
@@ -403,13 +395,40 @@ unsafe fn pack_ptrcall_args<Params: OutParamTuple, R>(
     args.with_type_pointers(|explicit_args| f(explicit_args.as_ptr(), explicit_args.len()))
 }
 
+/// Concatenates explicit ptrcall args with `varargs` into a single pointer vector.
+///
+/// # Safety
+/// `explicit_args` must point to an array of at least `arg_count` valid `GDExtensionConstTypePtr` entries. Pointers in `varargs` must
+/// remain valid for the duration of the returned vector's use.
+unsafe fn concat_varargs_ptrs(
+    explicit_args: *const sys::GDExtensionConstTypePtr,
+    arg_count: usize,
+    varargs: &[Variant],
+) -> Vec<sys::GDExtensionConstTypePtr> {
+    let explicit_args = unsafe { std::slice::from_raw_parts(explicit_args, arg_count) };
+    let mut type_ptrs = Vec::with_capacity(explicit_args.len() + varargs.len());
+    type_ptrs.extend(explicit_args.iter().copied());
+    type_ptrs.extend(varargs.iter().map(sys::GodotFfi::sys));
+    type_ptrs
+}
+
 /// Performs the return-value initialization and decode for a ptrcall.
+///
+/// `init` uses dynamic (`&mut dyn FnMut`) instead of static (`impl FnOnce`) dispatch on purpose: each call site captures different
+/// parameters, which makes the closure type unique. With static dispatch, `finish_ptrcall<Ret, F>` would be monomorphized once per
+/// `(Ret, captured-closure-type)` pair -- at last measurement ~700 instances despite only ~80 distinct `Ret` types. Switching `init`
+/// to `dyn` collapses that to ~180 instances (one per `Ret` that escapes the trait object), cutting godot-core LLVM IR by ~8% and
+/// debug compile time by ~25%, with no measurable runtime regression: the dyn fat-pointer call adds 1 indirect on a path that already
+/// crosses the GDExtension FFI boundary, where Godot's own dispatch dominates.
+///
+/// Tried but rejected: extending the same trick to `pack_ptrcall_args` / `with_type_pointers`. Doing so requires call sites to
+/// capture `Ret` via `Option<Ret>`/`MaybeUninit`, and the per-site option dance generates more code than the helper-outlining saves.
 ///
 /// # Safety
 /// This calls [`GodotFfi::new_with_init`] and passes the return pointer to `init`, see that function for safety docs.
 unsafe fn finish_ptrcall<Ret: EngineFromGodot>(
     call_ctx: &CallContext,
-    init: impl FnOnce(sys::GDExtensionTypePtr),
+    init: &mut dyn FnMut(sys::GDExtensionTypePtr),
 ) -> Ret {
     let ffi = unsafe { <<Ret::Via as GodotType>::Ffi>::new_with_init(init) };
 

--- a/itest/rust/src/framework/bencher.rs
+++ b/itest/rust/src/framework/bencher.rs
@@ -11,6 +11,11 @@
 // - https://github.com/bheisler/criterion.rs
 // - https://github.com/Canop/glassbench
 // - https://github.com/sharkdp/hyperfine
+//
+// TODO(v0.6): improve precision. Sub-30ns benches (utilities_rust_call, color_hsv_hue_wrap, builtin_ffi_call) show >100% run-to-run noise,
+// which makes A/B comparisons of optimization changes unreliable. Options: (1) auto-tune `inner_repetitions` to hit a minimum total wall
+// time per measurement (criterion-style), (2) report variance/IQR alongside min+median to flag noisy results, (3) pin to a CPU core and
+// disable frequency scaling in the harness. Until fixed, treat any single-bench delta below ~10% as noise.
 
 // We currently avoid mean or max, as we're not that interested in outliers (e.g. CPU spike).
 // This may of course obscure bad performance in only small number of cases, but that's something we take into account.


### PR DESCRIPTION
## Background

`godot-core` is the crate that suffers from the longest compile times due to its sheer size (hundreds of classes, ~10k methods). This causes a lot of effort in both compiler frontend and backend.

One lever is the number of monomorphizations that different `Signature` impls generate. At the moment this is excessive, because every return/parameter-tuple combination results in a separate `trait` impl. Moving away from generics would mean that `godot-codegen` directly generates per-argument marshalling, either still through a trait (which then is only 1 at a time, no cartesian product) or using an explicit function. It would also need more glue code in each method that's currently hidden in the `Signature` trait impls.

However that comes at more parsing/frontend effort, and it's not what I tried here. Might be worth separate investigation.

In this PR, I tried to reduce the number of monomorphizations in the current system.

## Methodology

To measure compile times, I used `hyperfine` for benchmarking. `[--release]` is present/absent depending on release/dev.
```bash
hyperfine \
  --warmup 1 --runs 5 \
  --prepare 'cargo +nightly clean -p godot-core [--release]' \
  'cargo +nightly build -p godot-core --features codegen-full [--release]'
```
Monomorphization count (release profile):

```bash
cargo +nightly rustc -p godot-core --features codegen-full --release -- \
  -Zprint-mono-items=yes > mono_<label>.txt
```

I used separate target dirs (`CARGO_TARGET_DIR`) for dev, release and mono runs. All measurements were run on 6 commits total (`master` + 5 in this PR). Compile times were measured in both dev and release profile.


## Results

| Commit                                  | Total Monos |    Δ Monos | Dev Δ (per commit)  | Release Δ (per commit) |
|-----------------------------------------|------------:|-----------:|---------------------|------------------------|
| 0) master baseline                      |      92'746 |         -- | 29.61 ± 0.10 s      | 31.66 ± 0.25 s         |
| 1) Refactor ptrcall internals           |      92'003 |       -743 | -0.30 s (-1.0%)     | -0.49 s (-1.5%)        |
| 2) Use dyn dispatch in `finish_ptrcall` |      92'689 |       +686 | -0.22 s (-0.7%)     | +0.47 s (+1.5%)        |
| 3) Enable `line-tables-only`            |      92'689 |          0 | -1.68 s (-5.8%)     | -0.77 s (-2.4%)        |
| 4) Specialize common return types       |      91'233 |     -1'456 | -0.35 s (-1.3%)     | -0.13 s (-0.4%)        |
| 5) Specialize void bucket (deferred)    |      84'868 |     -6'365 | +0.17 s (+0.6%)     | +0.86 s (+2.8%)        |
| **Cumulative 1-3**                      |  **92'689** |    **-57** | **-2.20 s (-7.4%)** | **-0.79 s (-2.5%)**    |
| **Cumulative 1-4**                      |  **91'233** | **-1'513** | **-2.55 s (-8.6%)** | **-0.92 s (-2.9%)**    |

Test 5), commit 5f4e9372411a04844b03c5511c672d719e9cc78e, was removed from this PR as it didn't achieve its intended goal.

Test 4), commit 46628f623b6db16a483e38fad46836e3e2f914af, selected some arbitrary types. I'm inclined to exclude this from the PR as it comes with +476 / -11 = +465 net LoC change. It _does_ reduce compile times by 1.3% but at quite a cost. Might be worth to evaluate in a separate PR which types bring the most gains and then focus on those.
- Edit: I removed this one for now. The PR still improves dev build times by 7.4% for `godot-core`.

In total, this PR **improves compile times by 7.4%** (dev) and 2.5% (release), respectively. These measurements are likely not the same on every machine, but they're statistically significant and show that there _is_ room for improvement by just tweaking how we work with generics.

---

<details>
<summary>More statistics</summary>

<sub>(AI summary)</sub>

**Branch tip (4) saves -2.55 s dev (-8.6%) and -0.92 s release (-2.9%).** Welch z for release Δ = -0.92 / sqrt(0.25²/5 + 0.61²/5) = -3.1σ -> the release-wall improvement is statistically real at this n, contrary to the earlier "no measurable release win" framing. Dev win is dominated by commit 3 (line-tables, -1.68 s of the -2.55 s); commit 4 adds another -0.35 s on top.

**Bucket-void (5) still does not pay off.** Largest mono cut on the table (-7,878 = -8.5%, vs commit 4's -1,513) yields **+0.17 s dev** and **+0.86 s release** vs commit 4. Both within noise but consistently negative-or-flat across runs -- the LLVM-LTO-already-dedupes hypothesis from `report.md` continues to hold. Confirms the prior decision to defer.

**Commit 2 (dyn dispatch) regressed monos slightly under `=yes` counting** (-57 net vs -1,914 reported under `=lazy` in the original sweep). The two `-Zprint-mono-items` modes count different categories; absolute totals are not directly comparable across modes, but intra-mode deltas are. Dev wall delta for commit 2 (-0.52 s) is near 2× stddev -- a weak but plausible signal. Still required as prerequisite for commit 4.

**Methodology delta vs original report.** Original v1 dev master: 29.50 ± 0.07 (this sweep: 29.61 ± 0.10) -- within 1×σ. Original release master: 32.22 ± 0.47 (this sweep: 31.66 ± 0.25) -- 0.5 s lower, likely from removing parallel-sweep memory-bandwidth contention. Branch-tip dev delta is unchanged (-2.55 vs original -2.22 to -2.30); branch-tip release delta strengthened (-0.92 at z=-3.1σ vs original -0.95 at ~1×σ).

</details>

