### PR TITLE
`#[export_tool_button]`: fix use-after-free in captured `Gd` pointer

### DIFF
--- a/godot-macros/src/class/data_models/field_var.rs
+++ b/godot-macros/src/class/data_models/field_var.rs
@@ -526,10 +526,26 @@ impl GetterSetterImpl {
             fn #rust_accessor(&self) -> <#field_type as ::godot::register::property::Var>::PubType
         };
 
+        // Capture `InstanceId` (quasi weak-ref) rather than `Gd<Self>` (strong-ref).
+        //
+        // Godot's `ClassDB::class_get_property_default_value` default-constructs a temporary instance, calls this getter and then frees
+        // the instance via `memdelete()` -- which bypasses `RefCounted::unreference()`. For Self inheriting RefCounted, a `Gd<Self>` pointer
+        // captured in the Callable closure would therefore point to a destroyed object. But Gd trusts the ref-count and assumes >0 means alive.
+        // So when the callable is invoked next time, use-after-free (disengaged) or a last-defense panic (balanced/strict) is triggered.
+        //
+        // So instead, we dereference through the InstanceId, which is safe. This falls back to a `godot_error!` if the instance is gone.
         let function_body = quote_spanned! { field_ty_span=>
-            let mut obj = self.to_gd();
+            let instance_id = ::godot::obj::WithBaseField::base(self).instance_id();
             #[allow(clippy::redundant_closure_call, clippy::explicit_auto_deref)]
-            Callable::from_fn(#callable_name, move |_args| (#tool_button_fn)(&mut *obj.bind_mut()))
+            Callable::from_fn(#callable_name, move |_args| {
+                match ::godot::obj::Gd::<Self>::try_from_instance_id(instance_id) {
+                    Ok(mut obj) => (#tool_button_fn)(&mut *obj.bind_mut()),
+                    Err(_) => ::godot::global::godot_error!(
+                        "tool button `{}` invoked on freed instance {:?}",
+                        #callable_name, instance_id,
+                    ),
+                }
+            })
         };
 
         (signature, function_body)

--- a/itest/rust/src/object_tests/phantom_var_test.rs
+++ b/itest/rust/src/object_tests/phantom_var_test.rs
@@ -79,7 +79,7 @@ impl HasPhantomVar {
 
 #[cfg(since_api = "4.4")]
 mod export_tool_button_test {
-    use godot::obj::{NewGd, WithBaseField};
+    use godot::obj::{NewGd, Singleton};
 
     use super::*;
 
@@ -107,5 +107,16 @@ mod export_tool_button_test {
             .to::<Callable>();
         tool_button_callable.call(&[]);
         assert_eq!(tool_button_exporter.bind().val, 33);
+    }
+
+    // Regression test for https://github.com/godot-rust/gdext/pull/1589.
+    // Before the fix, this test either triggers UB (disengaged) or a panic (balanced/strict safeguards).
+    #[itest]
+    fn test_tool_button_default_value() {
+        let default = godot::classes::ClassDb::singleton()
+            .class_get_property_default_value("ToolButtonExporter", "other_tool_button");
+        let callable = default.to::<Callable>();
+        // Calling on freed instance should not panic; emits godot_error and is a no-op.
+        callable.call(&[]);
     }
 }


### PR DESCRIPTION
Prevents dangling `Gd` pointer, when Godot's `ClassDB::class_get_default_property_value()` creates a temporary instance, calls the closure and then frees the instance again (without taking into account ref-counts; possible bug in Godot).

## Current problem

The current `#[export_tool_button]` generates code like:
```rust
fn get_my_button(&self) -> Callable {
    let mut obj = self.to_gd();          // Gd<Self>, +1 refc for RefCounted classes
    Callable::from_fn("my_button", move |_args| {
        my_fn(&mut *obj.bind_mut())      // deref captured Gd
    })
}
```

On Godot side, the API in question is [`ClassDB::class_get_property_default_value`](https://github.com/godotengine/godot/blob/aaaf76403e88a3316073f8506672d7e88f167df8/core/core_bind.cpp#L1693), which calls [`ClassDB::class_get_default_property_value`](https://github.com/godotengine/godot/blob/aaaf76403e88a3316073f8506672d7e88f167df8/core/object/class_db.cpp#L115) (great naming :grinning: ).

The engine then:
1. default-constructs a temporary instance of the class
2. calls its property getter -- here `get_my_button`
    - this getter returns a `Callable` that holds a captured `Gd<MyClass>` (refcount=1)
3. reads the returned property (as `Variant`) and stores it
4. frees the temporary instance via `memdelete` in 2nd function above.

Notably, the `memdelete` does not invoke `RefCounted::unreference`, which I believe is a bug on Godot side.
This means that the refcount stays at 1 but the underlying object is destroyed, which violates `RefCounted` invariants.

The `Gd` in our `Callable` now points to freed memory. Anyone later invoking that returned `Callable` will access `Gd::bind_mut()` and:
- run into a panic under balanced/strict safeguards
- run into **use-after-free** under disengaged safeguards[^rare]

Going through `InstanceId` does not retain a (strong) reference on our side, as such it's a workaround for the current Godot behavior.

[^rare]: admittedly rare, because `#[export_tool_button] is used in editor which is typically compiled in Debug (at least balanced level). But I'd rather not wait for the bug to manifest.

## Demonstration

I reproduced it in this CI run. It was based off master, with only the regression test + a modified `full-ci.yaml` that only runs memcheck tests.
- [Disengaged](https://github.com/godot-rust/gdext/actions/runs/25606222971/job/75168479650#step:3:500): use-after-free
- [Balanced](https://github.com/godot-rust/gdext/actions/runs/25606222971/job/75168479658#step:3:492): panic