### PR TITLE
Avoid potential use-after-free by unregistering `EditorPlugins` early.

### DIFF
--- a/godot-core/src/registry/class.rs
+++ b/godot-core/src/registry/class.rs
@@ -306,9 +306,17 @@ pub fn unregister_classes(init_level: InitLevel) {
     let mut loaded_classes_by_name = global_loaded_classes_by_name();
     // TODO clean up dyn traits
 
-    let loaded_classes_current_level = loaded_classes_by_level
+    let mut loaded_classes_current_level = loaded_classes_by_level
         .remove(&init_level)
         .unwrap_or_default();
+
+    // During unregistration, editor plugins are freed and run their lifecycle methods (for example the `exit_tree`).
+    // Since they might depend on other classes (for example `EditorDock` will always exist in tandem with the plugin), they MUST be
+    // unregistered first to avoid potential use-after-free (`EditorPlugin` tries to use some other, already unregistered class -> its
+    // user instance has been already freed -> UB).
+    if init_level == InitLevel::Editor {
+        loaded_classes_current_level.sort_by_key(|class| class.is_editor_plugin);
+    }
 
     out!("Unregister classes of level {init_level:?}...");
     for class in loaded_classes_current_level.into_iter().rev() {


### PR DESCRIPTION
Short story short: we unregister class -> user instance is freed -> editor plugin is being unregistered later -> it fires its lifecycle methods -> it tries to use some unregistered class -> use after free :partying_face:.

It was funny one, since we don't really guarantee any registration order, and UB could manifest itself long after the actual cause.

MRP:

<details>

<summary> Use after free (with print to show what class was unloaded at given time before changes)</summary>

```rs
struct MyExtension;

#[gdextension]
unsafe impl ExtensionLibrary for MyExtension {}

// Must be a class loaded on the same level. 
// Prolly a cause why this bug remained hidden for so long.
#[derive(GodotClass)]
#[class(init, tool, base = EditorDock)]
struct MyClass1 {
    value: i32,
}

#[derive(GodotClass)]
#[class(init, tool, base = EditorPlugin)]
pub struct MyPlugin {
    a: Option<Gd<MyClass1>>,
    b: Option<Gd<MyClass2>>,
    base: Base<EditorPlugin>,
}

#[godot_api]
impl IEditorPlugin for MyPlugin {
    fn enter_tree(&mut self) {
        self.a = Some(MyClass1::new_alloc());
        self.b = Some(MyClass2::new_alloc());
    }

    fn exit_tree(&mut self) {
        if let Some(obj) = self.b.take() {
            godot_print!("my obj: {obj} ");
            godot_print!("is instance valid? {}", obj.is_instance_valid());
            godot_print!(
                "this one haven't been unregistered yet (albeit oredering is not guaranteed) {}",
                obj.bind().value
            );
        }

        if let Some(obj) = self.a.take() {
            godot_print!("my obj: {obj}.");
            godot_print!("is instance valid?{}", obj.is_instance_valid());
            godot_print!("Use after free :) {}", obj.bind().value);
        }
    }
}

#[derive(GodotClass)]
#[class(init, tool, base = EditorDock)]
struct MyClass2 {
    value: i32,
}
```

And the output (after two hot reloads, since the first one failed to fail):

```
unregistering MyPlugin 
my obj: <MyClass2#1303589748371> 
is instance valid? true
this one haven't been unregistered yet (albeit oredering is not guaranteed) 0
my obj: <MyClass1#1303556193937>. 
is instance valid? true
Use after free :) 0
unregistering MyClass2
unregistering MyClass1
Initialize godot-rust (API v4.6.stable.official, runtime v4.6.1.stable.official, safeguards strict)

unregistering MyClass1
unregistering MyClass2
unregistering MyPlugin
my obj: <EditorDock#1813935892149> 
is instance valid? true
ERROR: [panic /home/irwin/apps/godot/opensource-contr/missing_docs/gdext/godot-core/src/classes/class_runtime.rs:318]
  Class docstest::MyClass2 -- null instance; does the class have a Godot creator function? Ensure that the given class is a tool class with #[class(tool)], if it is being accessed in the editor.
  in MyPlugin::exit_tree()
   at: godot_core::private::set_gdext_hook::{{closure}} (/home/irwin/apps/godot/opensource-contr/missing_docs/gdext/godot-core/src/private.rs:325)
(backtrace disabled, run application with `RUST_BACKTRACE=1` environment variable)
Initialize godot-rust (API v4.6.stable.official, runtime v4.6.1.stable.official, safeguards strict)
```
</details>