### PR TITLE
`#[itest(editor)]` for itests running only with `-e --headless`

### DIFF
--- a/.github/composite/godot-itest/action.yml
+++ b/.github/composite/godot-itest/action.yml
@@ -7,6 +7,11 @@ name: godot
 description: "Run Godot integration tests"
 
 inputs:
+  run-editor-itest:
+    required: false
+    default: 'true'
+    description: "Run editor-mode integration tests (godot -e --headless). Set to 'false' for non-editor Godot builds (template_release)."
+
   godot-indirect-json:
     required: false
     default: ''
@@ -197,82 +202,27 @@ runs:
       shell: bash
 
     - name: "Run Godot integration tests"
-      # Aborts immediately if Godot outputs certain keywords (would otherwise stall until CI runner times out).
-      # Explanation:
-      # * tee:      still output logs while scanning for errors
-      # * grep -q:  no output, use exit code 0 if found -> thus also &&
-      # * pkill:    stop Godot execution (since it hangs in headless mode); simple 'head -1' did not work as expected
-      #             since it's not available on Windows, use taskkill in that case.
-      # * exit:     the terminated process would return 143, but this is more explicit and future-proof
-      #
-      # --disallow-focus: fail if #[itest (focus)] is encountered, to prevent running only a few tests for full CI
-      run: |
-        cd itest/godot
-        echo "OUTCOME=itest" >> $GITHUB_ENV
-        $GDRUST_GODOT_BIN --headless -- --disallow-focus ${{ inputs.godot-args }} 2>&1 \
-        | tee "${{ runner.temp }}/log.txt" \
-        | tee >(grep -E "SCRIPT ERROR:|Can't open dynamic library|Error loading extension" -q && {
-          printf "\n::error::godot-itest: unrecoverable Godot error, abort...\n";
-          if [[ "$RUNNER_OS" == "Windows" ]]; then
-            taskkill -f -im godot*
-          else
-            pkill godot
-          fi
-          echo "OUTCOME=godot-runtime" >> $GITHUB_ENV
-          exit 2
-        })
-        
-        echo "OUTCOME=success" >> $GITHUB_ENV
+      run: .github/other/run-godot-itest.sh "" "${{ runner.temp }}/log-runtime.txt" OUTCOME_RUNTIME itest godot-runtime ${{ inputs.godot-args }}
       shell: bash
 
     - name: "Check for memory leaks"
-      run: |
-        if grep -q "ObjectDB instances leaked at exit" "${{ runner.temp }}/log.txt"; then
-          echo "OUTCOME=godot-leak" >> $GITHUB_ENV
-          exit 3
-        fi
+      run: .github/other/check-godot-leaks.sh "${{ runner.temp }}/log-runtime.txt" OUTCOME_RUNTIME godot-leak
+      shell: bash
+
+    - name: "Run Godot editor integration tests"
+      if: always() && inputs.run-editor-itest == 'true'
+      run: .github/other/run-godot-itest.sh "-e" "${{ runner.temp }}/log-editor.txt" OUTCOME_EDITOR editor-itest godot-editor-runtime ${{ inputs.godot-args }}
+      shell: bash
+
+    - name: "Check for memory leaks (editor)"
+      if: always() && inputs.run-editor-itest == 'true'
+      run: .github/other/check-godot-leaks.sh "${{ runner.temp }}/log-editor.txt" OUTCOME_EDITOR godot-editor-leak
       shell: bash
 
     - name: "Conclusion"
       if: always()
       run: |
-        echo "Evaluate conclusion: $OUTCOME"
-        
-        case $OUTCOME in
-          "success")
-             # Do not output success for now, to keep summary focused on warnings/errors
-             #echo "### :heavy_check_mark: Godot integration tests passed" > $GITHUB_STEP_SUMMARY
-             #echo "$GODOT_BUILT_FROM" >> $GITHUB_STEP_SUMMARY
-            ;;
-        
-          "godot-runtime")
-            echo "### :x: Godot runtime error" > $GITHUB_STEP_SUMMARY
-            echo "$GODOT_BUILT_FROM" >> $GITHUB_STEP_SUMMARY
-            echo "Aborted due to an error during Godot execution." >> $GITHUB_STEP_SUMMARY
-            exit 2
-            ;;
-        
-          "godot-leak")
-            echo "### :x: Memory leak" > $GITHUB_STEP_SUMMARY
-            echo "$GODOT_BUILT_FROM" >> $GITHUB_STEP_SUMMARY
-            echo "Integration tests cause memory leaks." >> $GITHUB_STEP_SUMMARY
-            exit 3
-            ;;
-        
-          "itest")
-            echo "### :x: Godot integration tests failed" > $GITHUB_STEP_SUMMARY
-            echo "$GODOT_BUILT_FROM" >> $GITHUB_STEP_SUMMARY
-            exit 4
-            ;;
-        
-          "header-diff")
-            # already written
-            ;;
-
-          *)
-            echo "### :x: Unknown error occurred" > $GITHUB_STEP_SUMMARY
-            echo "$GODOT_BUILT_FROM" >> $GITHUB_STEP_SUMMARY
-            exit 5
-            ;;
-        esac
+        echo "Evaluate conclusion: $OUTCOME_RUNTIME, editor: ${OUTCOME_EDITOR:-(skipped)}"
+        .github/other/conclude-godot-itest.sh "$OUTCOME_RUNTIME"
+        .github/other/conclude-godot-itest.sh "${OUTCOME_EDITOR:-}" "editor"
       shell: bash

--- a/.github/other/check-godot-leaks.sh
+++ b/.github/other/check-godot-leaks.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Copyright (c) godot-rust; Bromeon and contributors.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+# Checks a Godot integration test log file for memory leaks and sets an outcome variable.
+# Usage: check-godot-leaks.sh <log-file> <outcome-var> <leak-val>
+#
+#   log-file:    absolute path to the Godot output log file
+#   outcome-var: name of the GitHub Actions env var to update, e.g. OUTCOME or EDITOR_OUTCOME
+#   leak-val:    value written to outcome-var if a leak is detected, e.g. 'godot-leak'
+
+set -euo pipefail
+
+logFile="$1"
+outcomeVar="$2"
+leakVal="$3"
+
+if grep -q "ObjectDB instances leaked at exit" "$logFile"; then
+  echo "${outcomeVar}=${leakVal}" >> "$GITHUB_ENV"
+  exit 3
+fi

--- a/.github/other/conclude-godot-itest.sh
+++ b/.github/other/conclude-godot-itest.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Copyright (c) godot-rust; Bromeon and contributors.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+# Evaluates an integration-test outcome and writes a GITHUB_STEP_SUMMARY entry on failure.
+# Usage: conclude-godot-itest.sh <outcome> [<mode>]
+#
+#   outcome: the outcome value to evaluate, e.g. 'success', 'itest', 'godot-editor-runtime', ''
+#   mode:    optional mode label, e.g. '' (normal run) or 'editor' (editor mode)
+#
+# Outcome values use consistent suffixes so one case block covers both modes:
+#   *-runtime  godot-runtime | godot-editor-runtime  -- unrecoverable Godot error
+#   *-leak     godot-leak    | godot-editor-leak     -- memory leak detected
+#   *itest     itest         | editor-itest          -- test suite failure
+
+set -euo pipefail
+
+outcome="$1"
+mode="${2:-}"
+
+# "Godot" for normal mode, "Godot editor" for editor mode.
+label="Godot${mode:+ $mode}"
+
+case "$outcome" in
+  "success" | "")
+    ;;
+
+  *-runtime)
+    echo "### :x: $label runtime error" >> "$GITHUB_STEP_SUMMARY"
+    echo "$GODOT_BUILT_FROM" >> "$GITHUB_STEP_SUMMARY"
+    echo "Aborted due to an error during $label execution." >> "$GITHUB_STEP_SUMMARY"
+    exit 2
+    ;;
+
+  *-leak)
+    echo "### :x: Memory leak${mode:+ ($mode)}" >> "$GITHUB_STEP_SUMMARY"
+    echo "$GODOT_BUILT_FROM" >> "$GITHUB_STEP_SUMMARY"
+    echo "$label integration tests cause memory leaks." >> "$GITHUB_STEP_SUMMARY"
+    exit 3
+    ;;
+
+  *itest)
+    echo "### :x: $label integration tests failed" >> "$GITHUB_STEP_SUMMARY"
+    echo "$GODOT_BUILT_FROM" >> "$GITHUB_STEP_SUMMARY"
+    exit 4
+    ;;
+
+  "header-diff")
+    # already written.
+    ;;
+
+  *)
+    echo "### :x: Unknown${mode:+ $mode} error occurred" >> "$GITHUB_STEP_SUMMARY"
+    echo "$GODOT_BUILT_FROM" >> "$GITHUB_STEP_SUMMARY"
+    exit 5
+    ;;
+esac

--- a/.github/other/run-godot-itest.sh
+++ b/.github/other/run-godot-itest.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Copyright (c) godot-rust; Bromeon and contributors.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+# Runs Godot integration tests and sets an outcome environment variable.
+# Called from the workspace root; changes to itest/godot before running Godot.
+#
+# Usage: run-godot-itest.sh <godot-extra-args> <log-file> <outcome-var> <failure-val> <abort-val> [user-args...]
+#
+#   godot-extra-args: extra args before '--headless', e.g. '' (normal run) or '-e' (editor mode)
+#   log-file:         absolute path for the Godot output log file
+#   outcome-var:      name of the GitHub Actions env var to update, e.g. OUTCOME or EDITOR_OUTCOME
+#   failure-val:      value written to outcome-var on test failure, e.g. 'itest' or 'editor-itest'
+#   abort-val:        value written to outcome-var on unrecoverable error, e.g. 'godot-runtime'
+#   user-args:        optional remaining arguments passed after '--' to Godot
+
+set -euo pipefail
+
+godotExtraArgs="$1"
+logFile="$2"
+outcomeVar="$3"
+failureVal="$4"
+abortVal="$5"
+shift 5
+
+cd itest/godot
+
+echo "${outcomeVar}=${failureVal}" >> "$GITHUB_ENV"
+
+# Aborts immediately if Godot outputs certain keywords (would otherwise stall until CI runner times out).
+# Explanation:
+# * tee:      still output logs while scanning for errors
+# * grep -q:  no output, use exit code 0 if found -> thus also &&
+# * pkill:    stop Godot execution (since it hangs in headless mode); simple 'head -1' did not work as expected
+#             since it's not available on Windows, use taskkill in that case.
+# * exit:     the terminated process would return 143, but this is more explicit and future-proof
+#
+# --disallow-focus: fail if #[itest(focus)] is encountered, to prevent running only a few tests for full CI.
+#
+# shellcheck disable=SC2086 -- intentional word splitting for godotExtraArgs
+$GDRUST_GODOT_BIN $godotExtraArgs --headless -- --disallow-focus "$@" 2>&1 \
+| tee "$logFile" \
+| tee >(grep -E "SCRIPT ERROR:|Can't open dynamic library|Error loading extension" -q && {
+  printf "\n::error::godot-itest: unrecoverable Godot error, abort...\n";
+  if [[ "$RUNNER_OS" == "Windows" ]]; then
+    taskkill -f -im godot*
+  else
+    pkill godot
+  fi
+  echo "${outcomeVar}=${abortVal}" >> "$GITHUB_ENV"
+  exit 2
+})
+
+echo "${outcomeVar}=success" >> "$GITHUB_ENV"

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -366,6 +366,7 @@ jobs:
             # If the experimental part causes problems, downgrade to `codegen-full`.
             rust-extra-args: --release --features itest/codegen-full-experimental
             rust-cache-key: release
+            run-editor-itest: 'false' # template_release binary has no editor.
 
           # Linux compat:
           # No hot-reload before 4.4, as the Godot project is 4.4+.
@@ -474,6 +475,7 @@ jobs:
           with-llvm: ${{ contains(matrix.name, 'macos') && contains(matrix.rust-extra-args, 'api-custom') }}
           godot-check-header: ${{ matrix.godot-check-header }}
           godot-indirect-json: ${{ matrix.godot-indirect-json }}
+          run-editor-itest: ${{ matrix.run-editor-itest || 'true' }} # opt-out.
 
       - name: "Build and test hot-reload"
         if: ${{ matrix.hot-reload }}

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -423,6 +423,7 @@ jobs:
             rust-extra-args: --features godot/api-custom
             # Sanitizers can't build proc-macros and build scripts; with --target, cargo ignores RUSTFLAGS for those two.
             rust-target: x86_64-unknown-linux-gnu
+            run-editor-itest: 'false' # editor has memory leaks; https://github.com/godot-rust/gdext/pull/1591.
 
           - name: memcheck-release-disengaged
             os: ubuntu-22.04
@@ -434,6 +435,7 @@ jobs:
             rust-extra-args: --release --features godot/safeguards-release-disengaged
             rust-target: x86_64-unknown-linux-gnu
             rust-target-dir: release # We're running Godot debug build with Rust release dylib.
+            run-editor-itest: 'false' # editor has memory leaks; https://github.com/godot-rust/gdext/pull/1591.
 
           - name: memcheck-dev-balanced
             os: ubuntu-22.04
@@ -444,6 +446,7 @@ jobs:
             # Currently without itest/codegen-full-experimental.
             rust-extra-args: --features godot/safeguards-dev-balanced
             rust-target: x86_64-unknown-linux-gnu
+            run-editor-itest: 'false' # editor has memory leaks; https://github.com/godot-rust/gdext/pull/1591.
 
           - name: memcheck-4.2
             os: ubuntu-22.04
@@ -454,6 +457,7 @@ jobs:
             rust-env-rustflags: -Zrandomize-layout -Zsanitizer=address
             # Sanitizers can't build proc-macros and build scripts; with --target, cargo ignores RUSTFLAGS for those two.
             rust-target: x86_64-unknown-linux-gnu
+            run-editor-itest: 'false' # editor has memory leaks; https://github.com/godot-rust/gdext/pull/1591.
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/minimal-ci.yml
+++ b/.github/workflows/minimal-ci.yml
@@ -272,6 +272,7 @@ jobs:
             rust-extra-args: --features godot/api-custom
             # Sanitizers can't build proc-macros and build scripts; with --target, cargo ignores RUSTFLAGS for those two.
             rust-target: x86_64-unknown-linux-gnu
+            run-editor-itest: 'false' # editor has memory leaks; https://github.com/godot-rust/gdext/pull/1591.
 
           - name: memcheck-release-disengaged
             os: ubuntu-22.04
@@ -283,6 +284,7 @@ jobs:
             rust-extra-args: --release --features godot/safeguards-release-disengaged
             rust-target: x86_64-unknown-linux-gnu
             rust-target-dir: release # We're running Godot debug build with Rust release dylib.
+            run-editor-itest: 'false' # editor has memory leaks; https://github.com/godot-rust/gdext/pull/1591.
 
           - name: memcheck-dev-balanced
             os: ubuntu-22.04
@@ -293,6 +295,7 @@ jobs:
             # Currently without itest/codegen-full-experimental.
             rust-extra-args: --features godot/safeguards-dev-balanced
             rust-target: x86_64-unknown-linux-gnu
+            run-editor-itest: 'false' # editor has memory leaks; https://github.com/godot-rust/gdext/pull/1591.
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/minimal-ci.yml
+++ b/.github/workflows/minimal-ci.yml
@@ -227,6 +227,7 @@ jobs:
             # If the experimental part causes problems, downgrade to `codegen-full`.
             rust-extra-args: --release --features itest/codegen-full-experimental
             rust-cache-key: release
+            run-editor-itest: 'false' # template_release binary has no editor.
 
           # Linux compat
 
@@ -312,6 +313,7 @@ jobs:
           with-llvm: ${{ contains(matrix.name, 'macos') && contains(matrix.rust-extra-args, 'api-custom') }}
           godot-check-header: ${{ matrix.godot-check-header }}
           godot-indirect-json: ${{ matrix.godot-indirect-json }}
+          run-editor-itest: ${{ matrix.run-editor-itest || 'true' }} # opt-out.
 
       - name: "Build and test hot-reload"
         if: ${{ matrix.hot-reload }}

--- a/check.sh
+++ b/check.sh
@@ -40,6 +40,7 @@ Options:
     --double                 run check with double-precision (implies 'api-custom' feature)
     -f, --filter <arg>       only run integration tests which contain any of the
                              args (comma-separated). requires itest.
+        --editor             run integration tests in editor mode (passes -e to Godot). requires itest.
     -a, --api-version <ver>  specify the Godot API version to use (e.g. 4.3, 4.3.1).
 
 Examples:
@@ -201,8 +202,13 @@ function cmd_itest() {
     local logFile
     logFile=$(mktemp)
 
+    local editorArgs=()
+    if [[ "$editorMode" -eq 1 ]]; then
+        editorArgs+=("-e")
+    fi
+
     cd itest/godot || return 1
-    "$godotBin" --headless -- "[${extraArgs[@]}]" 2>&1 \
+    "$godotBin" "${editorArgs[@]}" --headless -- "[${extraArgs[@]}]" 2>&1 \
     | tee "$logFile"
 
     # PIPESTATUS[0] is Godot's exit code; $? would only give tee's exit code (masking crashes).
@@ -272,6 +278,7 @@ extraCargoArgs=("--no-default-features")
 cmds=()
 extraArgs=()
 apiVersion=""
+editorMode=0
 
 while [[ $# -gt 0 ]]; do
     arg="$1"
@@ -300,6 +307,14 @@ while [[ $# -gt 0 ]]; do
                 shift
             else
                 log "-f/--filter requires 'itest' to be specified as a command."
+                exit 2
+            fi
+            ;;
+        --editor)
+            if [[ "${cmds[*]}" =~ itest ]]; then
+                editorMode=1
+            else
+                log "--editor requires 'itest' to be specified as a command."
                 exit 2
             fi
             ;;

--- a/godot-macros/src/itest.rs
+++ b/godot-macros/src/itest.rs
@@ -23,6 +23,7 @@ pub fn attribute_itest(input_item: venial::Item) -> ParseResult<TokenStream> {
     let skipped = attr.handle_alone("skip")?;
     let focused = attr.handle_alone("focus")?;
     let is_async = attr.handle_alone("async")?;
+    let editor_only = attr.handle_alone("editor")?;
     attr.finish()?;
 
     // Note: allow attributes for things like #[rustfmt] or #[clippy]
@@ -99,6 +100,7 @@ pub fn attribute_itest(input_item: venial::Item) -> ParseResult<TokenStream> {
             name: #test_name_str,
             skipped: #skipped,
             focused: #focused,
+            editor_only: #editor_only,
             file: std::file!(),
             line: std::line!(),
             function: #test_name,

--- a/itest/godot/TestRunner.gd
+++ b/itest/godot/TestRunner.gd
@@ -10,9 +10,14 @@ class_name GDScriptTestRunner
 
 func _ready():
 	# Don't run tests when opened in the editor, unless it's headless mode (-e --headless).
+	# When editor tests are run, we skip GDScript suites and benchmarks -- they aren't editor-specific, and Godot's
+	# editor lifecycle (e.g. "scene must be saved first") interferes with them.
+	# TODO(v0.6): wire this into CI / check.sh. For now, editor-mode itests are invoked manually.
+	var editor_only_run := false
 	if Engine.is_editor_hint():
 		if DisplayServer.get_name() == 'headless':
-			print("Opened itest in editor in headless mode -> run integration tests.")
+			print("Opened itest in editor in headless mode -> run editor integration tests.")
+			editor_only_run = true
 		else:
 			print("Opened itest in editor in UI mode -> skip integration tests.")
 			return
@@ -41,7 +46,7 @@ func _ready():
 
 	var rust_runner = IntegrationTests.new()
 
-	var gdscript_suites: Array = [
+	var gdscript_suites: Array = [] if editor_only_run else [
 		load("res://ManualFfiTests.gd").new(),
 		load("res://gen/GenFfiTests.gd").new(),
 		load("res://InheritTests.gd").new(),
@@ -62,8 +67,9 @@ func _ready():
 	var property_tests = load("res://gen/GenPropertyTests.gd").new()
 
 	# Run benchmarks after all synchronous and asynchronous tests have completed.
+	# Skipped in editor-only mode -- benchmarks are not editor-specific.
 	var run_benchmarks = func (success: bool):
-		if success:
+		if success and not editor_only_run:
 			rust_runner.run_all_benchmarks(self)
 
 		var exit_code: int = 0 if success else 1

--- a/itest/godot/TestRunner.gd
+++ b/itest/godot/TestRunner.gd
@@ -10,9 +10,7 @@ class_name GDScriptTestRunner
 
 func _ready():
 	# Don't run tests when opened in the editor, unless it's headless mode (-e --headless).
-	# When editor tests are run, we skip GDScript suites and benchmarks -- they aren't editor-specific, and Godot's
-	# editor lifecycle (e.g. "scene must be saved first") interferes with them.
-	# TODO(v0.6): wire this into CI / check.sh. For now, editor-mode itests are invoked manually.
+	# When editor tests are run, we skip GDScript suites and benchmarks -- they aren't editor-specific.
 	var editor_only_run := false
 	if Engine.is_editor_hint():
 		if DisplayServer.get_name() == 'headless':

--- a/itest/rust/src/engine_tests/classdb_test.rs
+++ b/itest/rust/src/engine_tests/classdb_test.rs
@@ -70,26 +70,36 @@ pub fn check_classdb_full_api() {
     assert!(!signals.is_empty());
     assert!(has_dict_named(signals, "script_changed"));
 
+    // In Godot 4.2 **editor** mode, `resource_scene_unique_id` is only registered after Editor init, not at Scene stage (when this function
+    // runs). Non-editor mode is fine; the property was promoted to a static ADD_PROPERTY binding in 4.3, making it available in all init stages.
+    let has_resource_scene_unique_id =
+        GdextBuild::since_api("4.3") || !godot::sys::is_editor_hint();
+
     // ClassDB.class_get_property_list()
-    let properties = db.class_get_property_list("Resource");
-    assert!(has_dict_named(properties, "resource_scene_unique_id"));
+    if has_resource_scene_unique_id {
+        let properties = db.class_get_property_list("Resource");
+        assert!(has_dict_named(properties, "resource_scene_unique_id"));
+    }
 
     // ClassDB.class_get_property() and class_set_property()
     let obj = Resource::new_gd();
     let result = db.class_set_property(&obj, "script", &Variant::nil());
     assert_eq!(result, Error::ERR_UNAVAILABLE);
 
-    let result = db.class_set_property(&obj, "resource_scene_unique_id", &123.to_variant());
-    // Release templates skip type validation, see https://github.com/godotengine/godot/issues/86264.
-    if !runs_release() {
-        assert_eq!(result, Error::ERR_INVALID_DATA);
+    if has_resource_scene_unique_id {
+        let result = db.class_set_property(&obj, "resource_scene_unique_id", &123.to_variant());
+        // Release templates skip type validation, see https://github.com/godotengine/godot/issues/86264.
+        if !runs_release() {
+            assert_eq!(result, Error::ERR_INVALID_DATA);
+        }
+
+        let result =
+            db.class_set_property(&obj, "resource_scene_unique_id", &"uid123".to_variant());
+        assert_eq!(result, Error::OK);
+
+        let rid = db.class_get_property(&obj, "resource_scene_unique_id");
+        assert_eq!(rid, "uid123".to_variant());
     }
-
-    let result = db.class_set_property(&obj, "resource_scene_unique_id", &"uid123".to_variant());
-    assert_eq!(result, Error::OK);
-
-    let rid = db.class_get_property(&obj, "resource_scene_unique_id");
-    assert_eq!(rid, "uid123".to_variant());
 
     // ClassDB.class_has_method()
     assert!(db.class_has_method("Object", "get_class"));

--- a/itest/rust/src/framework/mod.rs
+++ b/itest/rust/src/framework/mod.rs
@@ -151,7 +151,6 @@ pub struct RustTestCase {
     ///
     /// Used for testing behavior specific to the editor, e.g. placeholder substitution for runtime classes.
     /// Editor-only tests are skipped in non-editor runs, and non-editor tests are skipped in editor runs.
-    // TODO(v0.6): integrate editor-mode itest into CI / check.sh. For now, must be invoked manually with `godot -e --headless`.
     pub editor_only: bool,
     #[allow(dead_code)]
     pub line: u32,

--- a/itest/rust/src/framework/mod.rs
+++ b/itest/rust/src/framework/mod.rs
@@ -33,8 +33,14 @@ fn collect_rust_tests(filters: &[String]) -> (Vec<RustTestCase>, HashSet<&str>, 
     let mut all_files = HashSet::new();
     let mut tests: Vec<RustTestCase> = vec![];
     let mut is_focused_run = false;
+    let in_editor = Engine::singleton().is_editor_hint();
 
     sys::plugin_foreach!(__GODOT_ITEST; |test: &RustTestCase| {
+        // Editor itests run only in editor; non-editor itests run only outside editor.
+        if test.editor_only != in_editor {
+            return;
+        }
+
         // First time a focused test is encountered, switch to "focused" mode and throw everything away.
         if !is_focused_run && test.focused {
             tests.clear();
@@ -63,8 +69,14 @@ fn collect_async_rust_tests(
     let mut all_files = HashSet::new();
     let mut tests = vec![];
     let mut is_focused_run = sync_focused_run;
+    let in_editor = Engine::singleton().is_editor_hint();
 
     sys::plugin_foreach!(__GODOT_ASYNC_ITEST; |test: &AsyncRustTestCase| {
+        // Editor itests run only in editor; non-editor itests run only outside editor.
+        if test.editor_only != in_editor {
+            return;
+        }
+
         // First time a focused test is encountered, switch to "focused" mode and throw everything away.
         if !is_focused_run && test.focused {
             tests.clear();
@@ -135,6 +147,12 @@ pub struct RustTestCase {
     pub skipped: bool,
     /// If one or more tests are focused, only they will be executed. Helpful for debugging and working on specific features.
     pub focused: bool,
+    /// Test only runs when the engine is in editor mode (`Engine::is_editor_hint() == true`).
+    ///
+    /// Used for testing behavior specific to the editor, e.g. placeholder substitution for runtime classes.
+    /// Editor-only tests are skipped in non-editor runs, and non-editor tests are skipped in editor runs.
+    // TODO(v0.6): integrate editor-mode itest into CI / check.sh. For now, must be invoked manually with `godot -e --headless`.
+    pub editor_only: bool,
     #[allow(dead_code)]
     pub line: u32,
     pub function: fn(&TestContext),
@@ -147,6 +165,8 @@ pub struct AsyncRustTestCase {
     pub skipped: bool,
     /// If one or more tests are focused, only they will be executed. Helpful for debugging and working on specific features.
     pub focused: bool,
+    /// See [`RustTestCase::editor_only`].
+    pub editor_only: bool,
     #[allow(dead_code)]
     pub line: u32,
     pub function: fn(&TestContext) -> godot::task::TaskHandle,

--- a/itest/rust/src/object_tests/editor_placeholder_test.rs
+++ b/itest/rust/src/object_tests/editor_placeholder_test.rs
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use godot::classes::Engine;
+use godot::obj::Singleton;
+
+use crate::framework::itest;
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// Tests
+
+#[itest(editor)]
+fn editor_sanity_check() {
+    assert!(
+        Engine::singleton().is_editor_hint(),
+        "editor-only test must run with editor hint set; invoke via `godot -e --headless`",
+    );
+}

--- a/itest/rust/src/object_tests/mod.rs
+++ b/itest/rust/src/object_tests/mod.rs
@@ -14,6 +14,7 @@ mod dynamic_call_test;
 mod enum_test;
 mod gd_duplicate_test;
 // `get_property_list` is only supported in Godot 4.3+
+mod editor_placeholder_test;
 #[cfg(since_api = "4.3")]
 mod get_property_list_test;
 mod init_stage_test;


### PR DESCRIPTION
Allows us to test behavior that's only visible in the editor, such as intricacies of `#[class(tool)]` etc.

For now, I disabled editor itests on `memcheck` CI jobs:
- godot-rust integration tests start as part of a `@tool` script's `_ready()` function, which can overlap with the initialization of Godot itself. As soon as the tests conclude, `get_tree().quit(...)` is invoked, which can shut down the engine while it's still loading.
- This *may* be a cause for some memory leaks, but needs further investigation. It's also possible that the editor has inherent leaks.