### PR TITLE
Internal `AtomicEnum<T>` for global enum variables 

### DIFF
--- a/godot-core/src/init/mod.rs
+++ b/godot-core/src/init/mod.rs
@@ -5,7 +5,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use godot_ffi as sys;
 use sys::GodotFfi;
@@ -34,7 +34,9 @@ pub use reexport_pub::*;
 /// See also [`is_singleton_available()`] and [this section in `ExtensionLibrary`](../init/trait.ExtensionLibrary.html#availability-of-godot-apis-during-init-and-deinit).
 pub fn is_class_available<T: GodotClass>() -> bool {
     // If called when bindings are not yet/anymore initialized (e.g. in a global destructor), returns false.
-    current_init_level().is_some_and(|level| T::INIT_LEVEL <= level)
+    CURRENT_INIT_LEVEL
+        .load()
+        .is_some_and(|level| T::INIT_LEVEL <= level)
 }
 
 /// Return whether a certain singleton can currently be retrieved from Godot.
@@ -59,9 +61,7 @@ pub fn is_singleton_available<T: Singleton>() -> bool {
 
 use crate::obj::signal::prune_stored_signal_connections;
 
-const NO_INIT_LEVEL: u8 = u8::MAX;
-
-static CURRENT_INIT_LEVEL: AtomicU8 = AtomicU8::new(NO_INIT_LEVEL);
+static CURRENT_INIT_LEVEL: sys::AtomicEnum<Option<InitLevel>> = sys::AtomicEnum::default();
 
 #[repr(C)]
 struct InitUserData {
@@ -288,7 +288,7 @@ unsafe fn gdext_on_level_init(level: InitLevel, _userdata: &InitUserData) {
     }
 
     crate::registry::class::auto_register_classes(level);
-    set_available_init_level(Some(level));
+    CURRENT_INIT_LEVEL.store(Some(level));
 }
 
 /// Tasks needed to be done by gdext internally upon unloading an initialization level. Called after user code.
@@ -298,7 +298,7 @@ fn gdext_on_level_deinit(level: InitLevel) {
     }
 
     crate::registry::class::unregister_classes(level);
-    set_available_init_level(previous_init_level(level));
+    CURRENT_INIT_LEVEL.store(previous_init_level(level));
 
     if level == InitLevel::Core {
         // If lowest level is unloaded, call global deinitialization.
@@ -319,28 +319,6 @@ fn gdext_on_level_deinit(level: InitLevel) {
             sys::deinitialize();
         }
     }
-}
-
-fn current_init_level() -> Option<InitLevel> {
-    match CURRENT_INIT_LEVEL.load(Ordering::Relaxed) {
-        0 => Some(InitLevel::Core),
-        1 => Some(InitLevel::Servers),
-        2 => Some(InitLevel::Scene),
-        3 => Some(InitLevel::Editor),
-        _ => None,
-    }
-}
-
-fn set_available_init_level(level: Option<InitLevel>) {
-    let raw = match level {
-        Some(InitLevel::Core) => 0,
-        Some(InitLevel::Servers) => 1,
-        Some(InitLevel::Scene) => 2,
-        Some(InitLevel::Editor) => 3,
-        None => NO_INIT_LEVEL,
-    };
-
-    CURRENT_INIT_LEVEL.store(raw, Ordering::Relaxed);
 }
 
 const fn previous_init_level(level: InitLevel) -> Option<InitLevel> {

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -787,7 +787,8 @@ where
         let is_panic_unwind = std::thread::panicking();
         let error_or_panic = |msg: String| {
             if is_panic_unwind {
-                if crate::private::has_error_print_level(1) {
+                use crate::private::{ErrorPrintLevel, has_error_print_level};
+                if has_error_print_level(ErrorPrintLevel::Reduced) {
                     crate::godot_error!(
                         "Encountered 2nd panic in free() during panic unwind; will skip destruction:\n{msg}"
                     );

--- a/godot-core/src/private.rs
+++ b/godot-core/src/private.rs
@@ -47,11 +47,19 @@ pub use reexport_pub::*;
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Global variables
 
-/// Level:
-/// - 0: no error printing (during `expect_panic` in test)
-/// - 1: not yet implemented, but intended for `try_` function calls (which are expected to fail, so error is annoying)
-/// - 2: normal printing
-static ERROR_PRINT_LEVEL: atomic::AtomicU8 = atomic::AtomicU8::new(2);
+sys::atomic_enum! {
+    #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
+    pub enum ErrorPrintLevel {
+        /// All errors are printed (default).
+        Normal = 2,
+        /// Reserved for future use; intended for `try_` call sites where errors are expected and printing is noisy.
+        Reduced = 1,
+        /// No error printing; used during `expect_panic` in tests.
+        Silent = 0,
+    }
+}
+
+static ERROR_PRINT_LEVEL: sys::AtomicEnum<ErrorPrintLevel> = sys::AtomicEnum::default();
 
 sys::plugin_registry!(pub __GODOT_PLUGIN_REGISTRY: ClassPlugin);
 #[cfg(all(since_api = "4.3", feature = "register-docs"))]
@@ -333,14 +341,12 @@ where
     }));
 }
 
-pub fn set_error_print_level(level: u8) -> u8 {
-    assert!(level <= 2);
-    ERROR_PRINT_LEVEL.swap(level, atomic::Ordering::Relaxed)
+pub fn set_error_print_level(level: ErrorPrintLevel) -> ErrorPrintLevel {
+    ERROR_PRINT_LEVEL.replace(level)
 }
 
-pub(crate) fn has_error_print_level(level: u8) -> bool {
-    assert!(level <= 2);
-    ERROR_PRINT_LEVEL.load(atomic::Ordering::Relaxed) >= level
+pub(crate) fn has_error_print_level(level: ErrorPrintLevel) -> bool {
+    ERROR_PRINT_LEVEL.load() >= level
 }
 
 /// Internal type used to store context information for debug purposes. Debug context is stored on the thread-local
@@ -531,7 +537,7 @@ where
     // (2) ERROR: godot-rust function call failed: MyClass::my_method()
     //        Reason: function panicked: some panic message
     //     at: ...
-    if has_error_print_level(2)
+    if has_error_print_level(ErrorPrintLevel::Normal)
         && !call_error.caused_by_panic()
         && OUT_CALL_DEPTH.with(|d| d.get() == 0)
     {

--- a/godot-core/src/storage/instance_storage.rs
+++ b/godot-core/src/storage/instance_storage.rs
@@ -19,44 +19,17 @@ use crate::godot_error;
 use crate::obj::{Base, Gd, GodotClass, Inherits, Singleton};
 use crate::storage::log_pre_drop;
 
-#[derive(Copy, Clone, Debug)]
-pub enum Lifecycle {
-    // Warning: when reordering/changing enumerators, update match in AtomicLifecycle below
-    Alive,
-    Destroying,
+sys::atomic_enum! {
+    #[derive(Copy, Clone, Debug)]
+    pub enum Lifecycle {
+        Alive = 0,
+        Destroying = 1,
+    }
 }
 
+/// Type-safe atomic wrapper for [`Lifecycle`].
 #[cfg_attr(not(feature = "experimental-threads"), allow(dead_code))]
-pub struct AtomicLifecycle {
-    atomic: std::sync::atomic::AtomicU32,
-}
-
-#[cfg_attr(not(feature = "experimental-threads"), allow(dead_code))]
-impl AtomicLifecycle {
-    pub fn new(value: Lifecycle) -> Self {
-        Self {
-            atomic: std::sync::atomic::AtomicU32::new(value as u32),
-        }
-    }
-
-    pub fn get(&self) -> Lifecycle {
-        match self.atomic.load(std::sync::atomic::Ordering::Relaxed) {
-            0 => Lifecycle::Alive,
-            1 => Lifecycle::Destroying,
-            other => panic!("invalid lifecycle {other}"),
-        }
-    }
-
-    pub fn set(&self, lifecycle: Lifecycle) {
-        let value = match lifecycle {
-            Lifecycle::Alive => 0,
-            Lifecycle::Destroying => 1,
-        };
-
-        self.atomic
-            .store(value, std::sync::atomic::Ordering::Relaxed);
-    }
-}
+pub type AtomicLifecycle = sys::AtomicEnum<Lifecycle>;
 
 /// A storage for an instance binding.
 ///

--- a/godot-core/src/storage/multi_threaded.rs
+++ b/godot-core/src/storage/multi_threaded.rs
@@ -90,11 +90,11 @@ unsafe impl<T: GodotClass> Storage for InstanceStorage<T> {
     }
 
     fn get_lifecycle(&self) -> Lifecycle {
-        self.lifecycle.get()
+        self.lifecycle.load()
     }
 
     fn set_lifecycle(&self, lifecycle: Lifecycle) {
-        self.lifecycle.set(lifecycle)
+        self.lifecycle.store(lifecycle)
     }
 }
 

--- a/godot-ffi/src/atomic_enum.rs
+++ b/godot-ffi/src/atomic_enum.rs
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use std::marker::PhantomData;
+use std::sync::atomic::{AtomicU8, Ordering};
+
+/// A lock-free cell that stores a value of enum type `E` using a single byte.
+///
+/// All operations use [`Ordering::Relaxed`] -- sufficient for this crate (global flags not involved in acquire/release synchronisation chains).
+pub struct AtomicEnum<E> {
+    atomic: AtomicU8,
+    _phantom: PhantomData<E>,
+}
+
+impl<E: AtomicIntLike> AtomicEnum<E> {
+    /// Creates a new `AtomicEnum` with the given initial value.
+    pub fn new(value: E) -> Self {
+        Self {
+            atomic: AtomicU8::new(value.to_u8()),
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Creates a new `AtomicEnum` initialized to [`E::DEFAULT_ORD`][AtomicIntLike::DEFAULT_ORD].
+    ///
+    /// `const` constructor for use in `static` initializers, where [`new`][Self::new] cannot be used due to lack of `const` trait fns.
+    pub const fn default() -> Self {
+        Self {
+            atomic: AtomicU8::new(E::DEFAULT_ORD),
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Loads the current value.
+    pub fn load(&self) -> E {
+        let raw = self.atomic.load(Ordering::Relaxed);
+        E::from_u8(raw)
+    }
+
+    /// Stores a new value.
+    pub fn store(&self, value: E) {
+        self.atomic.store(value.to_u8(), Ordering::Relaxed);
+    }
+
+    /// Stores a new value and returns the previous one.
+    pub fn replace(&self, value: E) -> E {
+        let old = self.atomic.swap(value.to_u8(), Ordering::Relaxed);
+        E::from_u8(old)
+    }
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// Trait and macro
+
+/// Trait for types that can be used with [`AtomicEnum`].
+///
+/// Provides conversion to/from `u8` plus default constant for `const` construction. Typically implemented via the
+/// [`atomic_enum!`][crate::atomic_enum] macro.
+///
+/// Automatically implemented for `Option<T>` by mapping `None` to `u8::MAX`. Make sure no variant has this value.
+pub trait AtomicIntLike: Copy {
+    /// Raw byte used by [`AtomicEnum::default()`] for `const` (e.g. `static`) initialization.
+    const DEFAULT_ORD: u8;
+
+    /// Convert this value to a `u8`.
+    fn to_u8(self) -> u8;
+
+    /// Convert a `u8` back to this type.
+    ///
+    /// # Panics
+    /// Panics if the value is not a valid discriminant.
+    fn from_u8(value: u8) -> Self;
+}
+
+impl<T: AtomicIntLike> AtomicIntLike for Option<T> {
+    const DEFAULT_ORD: u8 = u8::MAX;
+
+    fn to_u8(self) -> u8 {
+        match self {
+            None => u8::MAX,
+            Some(inner) => T::to_u8(inner),
+        }
+    }
+
+    fn from_u8(value: u8) -> Self {
+        match value {
+            u8::MAX => None,
+            inner => Some(T::from_u8(inner)),
+        }
+    }
+}
+
+/// Macro to define atomic enums, automatically implementing the [`AtomicIntLike`] trait.
+#[macro_export]
+macro_rules! atomic_enum {
+    (
+        $(#[$attr:meta])*
+        $vis:vis enum $name:ident {
+            $(
+                $(#[$vattr:meta])*
+                $variant:ident = $ord:literal
+            ),+ $(,)?
+        }
+    ) => {
+        $(#[$attr])*
+        #[repr(u8)]
+        $vis enum $name {
+            $($(#[$vattr])* $variant = $ord,)+
+        }
+
+        impl $crate::AtomicIntLike for $name {
+            // Default is first variant's discriminant. Could use #[default], but needs complex macro machinery.
+            const DEFAULT_ORD: u8 = [$($ord),+][0];
+
+            fn to_u8(self) -> u8 { self as u8 }
+            fn from_u8(value: u8) -> Self {
+                match value {
+                    $($ord => Self::$variant,)+
+                    other => panic!(
+                        concat!("invalid ", stringify!($name), " discriminant: {}"),
+                        other
+                    ),
+                }
+            }
+        }
+    };
+}

--- a/godot-ffi/src/init_level.rs
+++ b/godot-ffi/src/init_level.rs
@@ -5,29 +5,31 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-/// Step in the Godot initialization process.
-///
-/// Godot's initialization and deinitialization processes are split into multiple stages, like a stack. At each level,
-/// a different amount of engine functionality is available. Deinitialization happens in reverse order.
-///
-/// See also:
-// Explicit HTML links because this is re-exported in godot::init, and we can't document a `use` statement.
-/// - [`InitStage`](enum.InitStage.html): all levels + main loop.
-/// - [`ExtensionLibrary::on_stage_init()`](trait.ExtensionLibrary.html#method.on_stage_init)
-/// - [`ExtensionLibrary::on_stage_deinit()`](trait.ExtensionLibrary.html#method.on_stage_deinit)
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-pub enum InitLevel {
-    /// First level loaded by Godot. Builtin types are available, classes are not.
-    Core,
+crate::atomic_enum! {
+    /// Step in the Godot initialization process.
+    ///
+    /// Godot's initialization and deinitialization processes are split into multiple stages, like a stack. At each level,
+    /// a different amount of engine functionality is available. Deinitialization happens in reverse order.
+    ///
+    /// See also:
+    // Explicit HTML links because this is re-exported in godot::init, and we can't document a `use` statement.
+    /// - [`InitStage`](enum.InitStage.html): all levels + main loop.
+    /// - [`ExtensionLibrary::on_stage_init()`](trait.ExtensionLibrary.html#method.on_stage_init)
+    /// - [`ExtensionLibrary::on_stage_deinit()`](trait.ExtensionLibrary.html#method.on_stage_deinit)
+    #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+    pub enum InitLevel {
+        /// First level loaded by Godot. Builtin types are available, classes are not.
+        Core = 0,
 
-    /// Second level loaded by Godot. Only server classes and builtins are available.
-    Servers,
+        /// Second level loaded by Godot. Only server classes and builtins are available.
+        Servers = 1,
 
-    /// Third level loaded by Godot. Most classes are available.
-    Scene,
+        /// Third level loaded by Godot. Most classes are available.
+        Scene = 2,
 
-    /// Fourth level loaded by Godot, only in the editor. All classes are available.
-    Editor,
+        /// Fourth level loaded by Godot, only in the editor. All classes are available.
+        Editor = 3,
+    }
 }
 
 impl InitLevel {

--- a/godot-ffi/src/lib.rs
+++ b/godot-ffi/src/lib.rs
@@ -73,6 +73,7 @@ pub(crate) mod r#gen {
 pub mod conv;
 
 mod assertions;
+mod atomic_enum;
 mod extras;
 mod global;
 mod godot_ffi;
@@ -86,6 +87,7 @@ mod toolbox;
 
 use std::sync::atomic::{AtomicBool, Ordering};
 
+pub use atomic_enum::*;
 // Other
 pub use extras::*;
 pub use r#gen::central::*;

--- a/itest/rust/src/framework/mod.rs
+++ b/itest/rust/src/framework/mod.rs
@@ -178,7 +178,8 @@ pub fn suppress_panic_log<R>(callback: impl FnOnce() -> R) -> R {
     ));
 
     // Keep following lines.
-    let prev_print_level = godot::private::set_error_print_level(0);
+    let prev_print_level =
+        godot::private::set_error_print_level(godot::private::ErrorPrintLevel::Silent);
     let res = callback();
     godot::private::set_error_print_level(prev_print_level);
 


### PR DESCRIPTION
Small utility for storing enums in atomics.

Could also be a derive-macro, but then other crates would need to depend on `godot-macros` and it would also be slower to compile.