### PR TITLE
Reduce number of "ERROR" prints in itest

### DIFF
--- a/godot-core/src/builtin/signal.rs
+++ b/godot-core/src/builtin/signal.rs
@@ -156,11 +156,19 @@ impl Signal {
     }
 
     /// Returns `true` if the specified [`Callable`] is connected to this signal.
+    ///
+    /// If you need to do something with the object, prefer calling [`object()`][Self::object]. For `RefCounted` objects, this gives you a
+    /// strong-ref that cannot be invalidated while you hold it, and thus avoids [TOCTOU](https://en.wikipedia.org/wiki/Time-of-check_to_time-of-use)
+    /// issues with `is_null()` followed by connectivity or other checks.
     pub fn is_connected(&self, callable: &Callable) -> bool {
         self.as_inner().is_connected(callable)
     }
 
     /// Returns `true` if the signal's name does not exist in its object, or the object is not valid.
+    ///
+    /// If you need to do something with the object, prefer calling [`object()`][Self::object]. For `RefCounted` objects, this gives you a
+    /// strong-ref that cannot be invalidated while you hold it, and thus avoids [TOCTOU](https://en.wikipedia.org/wiki/Time-of-check_to_time-of-use)
+    /// issues with `is_null()` followed by connectivity or other checks.
     pub fn is_null(&self) -> bool {
         self.as_inner().is_null()
     }

--- a/godot-core/src/init/mod.rs
+++ b/godot-core/src/init/mod.rs
@@ -12,7 +12,7 @@ use sys::GodotFfi;
 
 use crate::builtin::{GString, StringName};
 use crate::obj::{GodotClass, Singleton};
-use crate::out;
+use crate::{classes, out};
 
 mod reexport_pub {
     // `Engine::singleton()` is not available before `InitLevel::Scenes` for Godot before 4.4.
@@ -52,8 +52,24 @@ pub fn is_singleton_available<T: Singleton>() -> bool {
 
     let class_name = T::class_id().to_string_name();
 
-    // SAFETY: `class_name` is valid for `T`; if bindings are uninitialized, is_class_available() returns false above.
-    unsafe { !sys::interface_fn!(global_get_singleton)(class_name.string_sys()).is_null() }
+    // Use Engine::has_singleton() rather than global_get_singleton() directly.
+    // The latter prints a Godot error "Failed to retrieve non-existent singleton 'X'" whenever the singleton is absent.
+    // Engine is a Core-level class from Godot 4.4+, so it's available once bindings are initialized (guaranteed by is_class_available() above).
+    #[cfg(since_api = "4.4")]
+    {
+        classes::Engine::singleton().has_singleton(&class_name)
+    }
+
+    // Fallback for <4.4: call C API; Engine singleton is not available in all levels.
+    // Will emit an error if not found. We cannot disable through Engine::set_print_error_messages, if that class is not available itself.
+    // Could possibly be achieved through GDScript...
+    #[cfg(before_api = "4.4")]
+    {
+        let object_ptr =
+            unsafe { sys::interface_fn!(global_get_singleton)(class_name.string_sys()) };
+
+        !object_ptr.is_null()
+    }
 }
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
@@ -271,7 +287,7 @@ unsafe fn gdext_on_level_init(level: InitLevel, _userdata: &InitUserData) {
             };
 
             #[cfg(since_api = "4.4")]
-            sys::set_editor_hint(crate::classes::Engine::singleton().is_editor_hint());
+            sys::set_editor_hint(classes::Engine::singleton().is_editor_hint());
         }
         InitLevel::Servers => {}
         InitLevel::Scene => {

--- a/godot-core/src/obj/base_weak_initialization.rs
+++ b/godot-core/src/obj/base_weak_initialization.rs
@@ -44,6 +44,7 @@ impl<T: GodotClass> Base<T> {
         // First time handing out a Gd<T>, we need to take measures to temporarily upgrade the Base's weak pointer to a strong one.
         // During the initialization phase (derived object being constructed), increment refcount by 1.
         let instance_id = self.obj.instance_id();
+        let mut defer_unref = false;
         PENDING_STRONG_REFS.with(|refs| {
             let mut pending_refs = refs.borrow_mut();
             if let HashEntry::Vacant(e) = pending_refs.entry(instance_id) {
@@ -57,17 +58,22 @@ impl<T: GodotClass> Base<T> {
                     .expect("IS_REF_COUNTED guarantees T inherits RefCounted");
 
                 e.insert(Gd { raw });
+                defer_unref = true;
             }
         });
 
-        let name = format!("Base<{}> deferred unref", T::class_id());
-        let callable = Callable::from_once_fn(name, move |_args| {
-            Self::drop_strong_ref(instance_id);
-        });
+        // Only defer the drop-strong-ref function if we actually inserted the pending strong-ref.
+        // Avoids "ERROR: Error calling deferred method: '':"
+        if defer_unref {
+            let name = format!("Base<{}> deferred unref", T::class_id());
+            let callable = Callable::from_once_fn(name, move |_args| {
+                Self::drop_strong_ref(instance_id);
+            });
 
-        // Use Callable::call_deferred() instead of Gd::apply_deferred(). The latter implicitly borrows &mut self,
-        // causing a "destroyed while bind was active" panic.
-        callable.call_deferred(&[]);
+            // Use Callable::call_deferred() instead of Gd::apply_deferred(). The latter implicitly borrows &mut self,
+            // causing a "destroyed while bind was active" panic.
+            callable.call_deferred(&[]);
+        }
 
         (*self.obj).clone()
     }

--- a/godot-core/src/task/futures.rs
+++ b/godot-core/src/task/futures.rs
@@ -290,15 +290,19 @@ impl<R: InParamTuple + IntoDynamicSend> Drop for FallibleSignalFuture<R> {
         // We create a new Godot Callable from our RustCallable so we get independent reference counting.
         let gd_callable = Callable::from_custom(self.callable.clone());
 
-        // is_connected will return true if the signal was never emited before the future is dropped.
+        // is_connected() will return true if the signal was never emitted before the future is dropped.
         //
-        // There is a TOCTOU issue here that can occur when the FallibleSignalFuture is dropped at the same time as the signal object is
-        // freed on a different thread.
-        // We check in the beginning if the signal object is still alive, and we check here again, but the signal object still can be freed
-        // between our check and our usage of the object in `is_connected` and `disconnect`. The race condition will manifest in a
-        // non-unwinding panic that is hard to track down.
-        if !self.signal.is_null() && self.signal.is_connected(&gd_callable) {
-            self.signal.disconnect(&gd_callable);
+        // TOCTOU resilience: Signal::is_null() answers "is signal valid right now"; the object may still be freed immediately afterwards,
+        // before Signal::is_connected() or Signal::disconnect().
+        // Using Signal::object() avoids this: if it returns Some(object), we have acquired a usable Gd<Object> handle and can perform
+        // follow-up checks through that handle instead of repeatedly re-resolving the Signal. Particularly important for RefCounted, where
+        // object() upgrades to a strong reference while we hold it.
+        if let Some(mut object) = self.signal.object() {
+            let signal_name = self.signal.name();
+
+            if object.is_connected(&signal_name, &gd_callable) {
+                object.disconnect(&signal_name, &gd_callable);
+            }
         }
     }
 }

--- a/godot-macros/src/class/data_models/field_var.rs
+++ b/godot-macros/src/class/data_models/field_var.rs
@@ -530,9 +530,10 @@ impl GetterSetterImpl {
         //
         // Godot's `ClassDB::class_get_property_default_value` default-constructs a temporary instance, calls this getter and then frees
         // the instance via `memdelete()` -- which bypasses `RefCounted::unreference()`. For Self inheriting RefCounted, a `Gd<Self>` pointer
-        // captured in the Callable closure would therefore point to a destroyed object. But Gd trusts the ref-count and assumes >0 means alive.
-        // So when the callable is invoked next time, use-after-free (disengaged) or a last-defense panic (balanced/strict) is triggered.
+        // captured in the Callable closure would therefore point to a destroyed object. This violates invariants for a ref-counted Gd pointer,
+        // which embodies an always-valid strong-ref.
         //
+        // So when the callable is invoked next time, use-after-free (disengaged) or a last-defense panic (balanced/strict) is triggered.
         // So instead, we dereference through the InstanceId, which is safe. This falls back to a `godot_error!` if the instance is gone.
         let function_body = quote_spanned! { field_ty_span=>
             let instance_id = ::godot::obj::WithBaseField::base(self).instance_id();

--- a/itest/godot/ManualFfiTests.gd
+++ b/itest/godot/ManualFfiTests.gd
@@ -8,7 +8,9 @@ extends TestSuite
 func test_missing_init():
 	var class_found = ClassDB.class_exists("WithoutInit")
 	var can_instantiate = ClassDB.can_instantiate("WithoutInit")
+	Engine.print_error_messages = false # would print: "ERROR: Class 'WithoutInit' or its base class cannot be instantiated."
 	var instance = ClassDB.instantiate("WithoutInit")
+	Engine.print_error_messages = true
 
 	assert_eq(class_found, true, "ClassDB.class_exists() is true")
 	assert_eq(can_instantiate, false, "ClassDB.can_instantiate() is false")
@@ -454,7 +456,9 @@ func test_func_rename():
 	assert_eq(func_rename.spell_static(), "static")
 
 func test_init_panic():
+	Engine.print_error_messages = false # would print: "ERROR: Class type: 'InitPanic' is not instantiable."
 	var obj := InitPanic.new() # panics in Rust
+	Engine.print_error_messages = true
 	assert_eq(obj, null, "Rust panic in init() returns null in GDScript")
 
 	# Alternative behavior (probably not desired):

--- a/itest/rust/src/builtin_tests/containers/callable_test.rs
+++ b/itest/rust/src/builtin_tests/containers/callable_test.rs
@@ -18,7 +18,7 @@ use godot::meta::ToGodot;
 use godot::obj::{Gd, NewAlloc, NewGd};
 use godot::register::{GodotClass, godot_api};
 
-use crate::framework::itest;
+use crate::framework::{itest, suppress_godot_print};
 
 #[derive(GodotClass)]
 #[class(init, base=RefCounted)]
@@ -133,8 +133,10 @@ fn callable_variant_method() {
 
     // Color - invalid method.
     let color = Color::from_rgba8(255, 0, 127, 255).to_variant();
-    let color_to_html = Callable::from_variant_method(&color, "to_htmI");
-    assert!(!color_to_html.is_valid());
+    suppress_godot_print(|| {
+        let color_to_html = Callable::from_variant_method(&color, "to_htmI");
+        assert!(!color_to_html.is_valid());
+    });
 }
 
 #[itest]
@@ -420,7 +422,7 @@ pub mod custom_callable {
         // - We can't catch panics from Callable invocations yet (see above), only the FFI access panics.
         if cfg!(safeguards_balanced) && !cfg!(feature = "experimental-threads") {
             // Single-threaded with balanced safeguards: FFI access check will panic.
-            crate::framework::expect_panic(
+            crate::framework::expect_panic_quiet(
                 "Callable created with from_fn() must panic when invoked on other thread",
                 || {
                     quick_thread(|| {

--- a/itest/rust/src/builtin_tests/containers/packed_array_test.rs
+++ b/itest/rust/src/builtin_tests/containers/packed_array_test.rs
@@ -17,7 +17,7 @@ use godot::meta::inspect::ElementType;
 use godot::meta::{PackedElement, ToGodot, owned_into_arg, ref_to_arg, wrapped};
 
 use crate::assert_match;
-use crate::framework::{expect_panic, itest};
+use crate::framework::{expect_panic, itest, suppress_godot_print};
 
 /// Utility to run generic `PackedArray<T>` tests for multiple types `T`.
 macro_rules! test {
@@ -679,6 +679,7 @@ fn packed_byte_array_encode_decode_variant() {
     assert_eq!(decoded.0, variant);
     assert_eq!(decoded.1, 60);
 
+    // TODO(v0.6): suppress "ERROR" print in API itself.
     let decoded = a.decode_var(4, false);
     assert_eq!(decoded, Err(()));
 
@@ -698,7 +699,8 @@ fn packed_byte_array_encode_decode_variant() {
     assert_eq!(decoded.1, 4);
 
     // Only running out of size "fails".
-    let decoded = a.decode_var_allow_nil(77, false);
+    // TODO(v0.6): suppress "ERROR" print in API itself.
+    let decoded = suppress_godot_print(|| a.decode_var_allow_nil(77, false));
     assert_eq!(decoded.0, Variant::nil());
     assert_eq!(decoded.1, 0);
 }

--- a/itest/rust/src/builtin_tests/containers/signal_test.rs
+++ b/itest/rust/src/builtin_tests/containers/signal_test.rs
@@ -732,7 +732,7 @@ mod custom_callable {
     use godot::obj::{Gd, NewAlloc};
 
     use crate::builtin_tests::containers::callable_test::custom_callable::PanicCallable;
-    use crate::framework::{TestContext, itest};
+    use crate::framework::{TestContext, itest, suppress_godot_print};
 
     #[itest]
     fn signal_panic_user_from_fn() {
@@ -849,7 +849,7 @@ mod custom_callable {
         let callable = callable(received.clone());
         signal.connect(&callable);
 
-        emit(&mut node);
+        suppress_godot_print(|| emit(&mut node));
         assert_eq!(1, received.load(Ordering::SeqCst));
 
         node.free();

--- a/itest/rust/src/engine_tests/save_load_test.rs
+++ b/itest/rust/src/engine_tests/save_load_test.rs
@@ -69,6 +69,7 @@ fn load_test() {
 
     save(&resource, &res_path);
 
+    // TODO(v0.6): suppress "ERROR" print in API itself.
     let res = try_load::<SavedGame>(FAULTY_PATH);
     assert!(res.is_err());
 

--- a/itest/rust/src/framework/mod.rs
+++ b/itest/rust/src/framework/mod.rs
@@ -200,6 +200,16 @@ pub fn expect_panic(context: &str, code: impl FnOnce()) {
     );
 }
 
+/// Like [`expect_panic()`], but additionally silences Godot's error prints during the panicking call.
+///
+/// Use when the panicking code path also emits Godot errors (e.g. FFI access checks, errors emitted during unwind drops) that would otherwise
+/// spam the test output. Prefer plain [`expect_panic()`] when no Godot errors are expected, to avoid accidentally swallowing unrelated errors.
+pub fn expect_panic_quiet(context: &str, code: impl FnOnce()) {
+    // Future: could wire this up with Logger class, intercept output and check for containing an "expected" string.
+    // This would make expected errors visible in tests, and catch changes on Godot side. Possibly some maintenance if Godot error changes.
+    suppress_godot_print(|| expect_panic(context, code));
+}
+
 /// Run for code that should panic in *strict* and *balanced* safeguard levels, but cause UB in *disengaged* level.
 ///
 /// The code is not executed for the latter.
@@ -306,16 +316,23 @@ where
     }
 }
 
-/// Disable printing errors from Godot. Ideally we should catch and handle errors, ensuring they happen when
-/// expected. But that isn't possible, so for now we can just disable printing the error to avoid spamming
-/// the terminal when tests should error.
+/// Disable printing errors from Godot while running `f`.
 ///
-/// **Important:** Do not run this inside [`expect_panic()`], it will mute panic messages forever. Instead, make sure [`suppress_godot_print()`]
-/// is the outer function.
-pub fn suppress_godot_print(mut f: impl FnMut()) {
+/// Ideally we should catch and handle errors, ensuring they happen when expected. But that isn't always possible,
+/// so for now we can just disable printing the error to avoid spamming the terminal when tests should error.
+///
+/// This function is panic-safe via RAII; if the inner function `f` panics; error printing will be re-enabled.
+pub fn suppress_godot_print<R>(f: impl FnOnce() -> R) -> R {
+    struct RestoreGodotPrint;
+    impl Drop for RestoreGodotPrint {
+        fn drop(&mut self) {
+            Engine::singleton().set_print_error_messages(true); // Assume it was true before -> good enough.
+        }
+    }
+
     Engine::singleton().set_print_error_messages(false);
-    f();
-    Engine::singleton().set_print_error_messages(true);
+    let _guard = RestoreGodotPrint;
+    f()
 }
 
 /// Some tests are disabled, as they rely on Godot checks which are only available in Debug builds.

--- a/itest/rust/src/object_tests/dynamic_call_test.rs
+++ b/itest/rust/src/object_tests/dynamic_call_test.rs
@@ -15,7 +15,7 @@ use godot::meta::error::CallError;
 use godot::meta::{FromGodot, ToGodot};
 use godot::obj::{InstanceId, NewAlloc};
 
-use crate::framework::{expect_panic, itest, runs_release};
+use crate::framework::{expect_panic, expect_panic_quiet, itest, runs_release};
 use crate::object_tests::object_test::ObjPayload;
 
 #[itest]
@@ -275,11 +275,12 @@ fn dynamic_call_parameter_mismatch_engine() {
     let mut node = Node::new_alloc();
 
     // Use panicking version.
-    expect_panic("call with wrong argument type", || {
+    expect_panic_quiet("call with wrong argument type", || {
         node.call("set_name", vslice![123]);
     });
 
     // Use Result-based version.
+    // TODO(v0.6): suppress "ERROR" print in API itself.
     let call_error = node
         .try_call("set_name", vslice![123])
         .expect_err("expected failed call");

--- a/itest/rust/src/object_tests/enum_test.rs
+++ b/itest/rust/src/object_tests/enum_test.rs
@@ -15,7 +15,7 @@ use godot::classes::{ArrayMesh, time};
 use godot::global::{Key, Orientation};
 use godot::obj::{EngineEnum, NewGd};
 
-use crate::framework::itest;
+use crate::framework::{itest, suppress_godot_print};
 
 #[itest]
 fn enum_ords() {
@@ -73,7 +73,11 @@ fn enum_hash() {
 #[itest]
 fn enum_add_surface_from_arrays() {
     let mut mesh = ArrayMesh::new_gd();
-    mesh.add_surface_from_arrays(PrimitiveType::TRIANGLES, &varray![]);
+    // The empty array is invalid input on purpose -- the test only verifies the call doesn't crash. Godot prints an
+    // expected error; silence it here. No internal-suppression candidate, since the API has no Result/Option contract.
+    suppress_godot_print(|| {
+        mesh.add_surface_from_arrays(PrimitiveType::TRIANGLES, &varray![]);
+    });
 }
 
 #[itest]

--- a/itest/rust/src/object_tests/gd_duplicate_test.rs
+++ b/itest/rust/src/object_tests/gd_duplicate_test.rs
@@ -11,7 +11,7 @@ use godot::global;
 use godot::init::GdextBuild;
 use godot::prelude::*;
 
-use crate::framework::{expect_panic, itest};
+use crate::framework::{expect_panic_quiet, itest};
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Node duplication tests
@@ -287,7 +287,7 @@ fn duplicate_node_no_init_fails() {
 
     let node_ptr: Gd<Node> = Gd::from_object(NoInitNode {}).upcast();
 
-    expect_panic("no_init node duplication", || {
+    expect_panic_quiet("no_init node duplication", || {
         let _copy = node_ptr.duplicate_node();
     });
 
@@ -302,7 +302,7 @@ struct NoInitResource {}
 fn duplicate_resource_no_init_fails() {
     let resource_ptr: Gd<Resource> = Gd::from_object(NoInitResource {}).upcast();
 
-    expect_panic("no_init resource duplication", || {
+    expect_panic_quiet("no_init resource duplication", || {
         let _copy = resource_ptr.duplicate_resource();
     });
 }

--- a/itest/rust/src/object_tests/object_test.rs
+++ b/itest/rust/src/object_tests/object_test.rs
@@ -179,6 +179,7 @@ fn object_instance_id_when_freed() {
 fn object_from_invalid_instance_id() {
     let id = InstanceId::try_from_i64(0xDEADBEEF).unwrap();
 
+    // TODO(v0.6): suppress "ERROR" print in API itself.
     Gd::<RefcPayload>::try_from_instance_id(id)
         .expect_err("invalid instance id should not return a valid object");
 }

--- a/itest/rust/src/object_tests/phantom_var_test.rs
+++ b/itest/rust/src/object_tests/phantom_var_test.rs
@@ -11,7 +11,7 @@ use godot::obj::Base;
 use godot::register::property::PhantomVar;
 use godot::register::{GodotClass, godot_api};
 
-use crate::framework::itest;
+use crate::framework::{itest, suppress_godot_print};
 
 #[derive(GodotClass)]
 #[class(init)]
@@ -117,6 +117,6 @@ mod export_tool_button_test {
             .class_get_property_default_value("ToolButtonExporter", "other_tool_button");
         let callable = default.to::<Callable>();
         // Calling on freed instance should not panic; emits godot_error and is a no-op.
-        callable.call(&[]);
+        suppress_godot_print(|| callable.call(&[]));
     }
 }


### PR DESCRIPTION
My goal is to bring them down to zero.

In #1594 (last commit), two bugs appeared in GDScript tests. Both were invisible due to a mistake in the framework setup, but they both emitted `ERROR:` messages. If we can cut down all the current noise, CI can specifically start to look for `ERROR:` prints (not just `SCRIPT ERROR:` as of now). Furthermore, a red "ERROR:" appearing in IDE/console output is also a warning sign for humans looking at test output.

Not tolerating printed errors would have the additional benefit that APIs need to be designed in a way, such that they don't print Godot errors when errors are expected (e.g. `Result`/`Option` return types). The fact that this is a real problem is demonstrated by issues like #1239.

For now I added the following comment in call sites that should not simply suppress the error, but develop an API-specific strategy to not print errors:
```rs
// TODO(v0.6): suppress "ERROR" print in API itself.
```