### PR TITLE
Rust-side `Variant` marshalling

### DIFF
--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -334,7 +334,8 @@ jobs:
             artifact-name: linux-nightly
             godot-binary: godot.linuxbsd.editor.dev.x86_64
             # Important to keep both experimental-threads and codegen-full. Some itests (native_st_audio) require both.
-            rust-extra-args: --features itest/experimental-threads,itest/codegen-full-experimental,itest/upcoming-editor-placeholders,godot/api-custom,godot/serde,itest/register-docs
+            # Also the only entry exercising the variant FFI-marshal fallback at runtime; the Rust-marshal default is covered everywhere else.
+            rust-extra-args: --features itest/experimental-threads,itest/codegen-full-experimental,itest/upcoming-editor-placeholders,godot/api-custom,godot/serde,itest/register-docs,godot/__variant-ffi-marshal
 
           # Compiles godot-rust with `api-custom-json` feature against the JSON file generated via `--dump-extension-api`.
           # Uses latest 4.x headers, while `extension_api.json` comes from the latest Godot binary.

--- a/godot-codegen/src/generator/central_files.rs
+++ b/godot-codegen/src/generator/central_files.rs
@@ -282,6 +282,7 @@ fn make_is_inplace_variant_method(api: &ExtensionApi) -> TokenStream {
         /// - always need Godot-side destruction (refcounted like `GString`, `Array` etc.).
         /// - are too big to be stored in-place in `Variant`, thus needing heap storage (`Aabb`, `Basis`, `Transform2D`, `Transform3D`, `Projection`).
         #[doc(hidden)]
+        #[inline] // Small match; runs on every Variant clone and drop.
         pub const fn is_inplace_variant(&self) -> bool {
             matches!(self.ord, #( #inplace_ords )|*)
         }

--- a/godot-codegen/src/generator/central_files.rs
+++ b/godot-codegen/src/generator/central_files.rs
@@ -19,6 +19,7 @@ pub fn make_sys_central_code(api: &ExtensionApi) -> TokenStream {
     let variant_type_enum = make_variant_type_enum(api, true);
     let [opaque_32bit, opaque_64bit] = make_opaque_types(api);
     let godot_type_name_method = make_godot_type_name_method(api);
+    let inplace_variant_method = make_is_inplace_variant_method(api);
 
     quote! {
         #[cfg(target_pointer_width = "32")]
@@ -49,6 +50,7 @@ pub fn make_sys_central_code(api: &ExtensionApi) -> TokenStream {
             }
 
             #godot_type_name_method
+            #inplace_variant_method
         }
     }
 }
@@ -226,6 +228,64 @@ fn make_variant_type_enum(api: &ExtensionApi, is_definition: bool) -> TokenStrea
     let define_traits = !is_definition;
 
     enums::make_enum_definition_with(variant_type_enum, define_enum, define_traits)
+}
+
+/// Generates the `VariantType::is_inplace_variant()` method from the builtins list.
+///
+/// Returns `false` if a variant of this type requires `variant_destroy` on drop, for two reasons:
+/// 1. Non-trivial destructor in `extension_api.json` (refcounted: `String`, `Array`, `Dictionary`, `Object`, ...).
+/// 2. Stored heap-allocated inside `Variant` because it exceeds the inline data segment (`Transform2D`, `Transform3D`, `Basis`, `Aabb`,
+///    `Projection`). Godot reports `has_destructor=false` for these (trivially destructible in C++), but `Variant` still owns the allocation.
+fn make_is_inplace_variant_method(api: &ExtensionApi) -> TokenStream {
+    use crate::models::domain::BuildConfiguration;
+
+    // Detecting case 2 needs the type's byte size. Godot's inline buffer is `max(sizeof(ObjData), 4 * sizeof(real_t))` -> 16 bytes in single,
+    // 32 bytes in double precision. Pointer width doesn't affect it (`ObjData` is 2 pointers, thus <= 16), so the 32-bit configuration's sizes
+    // decide it for both pointer widths. Only configurations of the current precision are present in `builtin_sizes`, see `is_applicable()`.
+    let (size_config, inplace_bytes_threshold) = if cfg!(feature = "double-precision") {
+        (BuildConfiguration::Double32, 32)
+    } else {
+        (BuildConfiguration::Float32, 16)
+    };
+
+    let sizes: std::collections::HashMap<&str, usize> = api
+        .builtin_sizes
+        .iter()
+        .filter(|s| s.config == size_config)
+        .map(|s| (s.builtin_original_name.as_str(), s.size))
+        .collect();
+
+    // `Nil` is not part of `api.builtins`, but the empty variant is stored in-place and trivially destructible. Include it explicitly, so the
+    // lifecycle fast paths (Clone/Drop) and `set_value` treat a nil variant as overwritable/copyable without FFI.
+    let mut inplace_ords = vec![0_i32];
+
+    for builtin in api.builtins.iter() {
+        let size = sizes
+            .get(builtin.godot_original_name())
+            .copied()
+            .unwrap_or_else(|| {
+                panic!(
+                    "no size found for builtin `{}`",
+                    builtin.godot_original_name()
+                )
+            });
+
+        if size <= inplace_bytes_threshold && !builtin.has_destructor {
+            inplace_ords.push(builtin.variant_type_ord);
+        }
+    }
+
+    quote! {
+        /// Returns `true` if _variants_ of this type can store the value in-place (SBO) and thus don't require FFI copies and destruction.
+        ///
+        /// `false` for types that either:
+        /// - always need Godot-side destruction (refcounted like `GString`, `Array` etc.).
+        /// - are too big to be stored in-place in `Variant`, thus needing heap storage (`Aabb`, `Basis`, `Transform2D`, `Transform3D`, `Projection`).
+        #[doc(hidden)]
+        pub const fn is_inplace_variant(&self) -> bool {
+            matches!(self.ord, #( #inplace_ords )|*)
+        }
+    }
 }
 
 /// Generates the `VariantType::godot_type_name()` method from the builtins list.

--- a/godot-codegen/src/generator/central_files.rs
+++ b/godot-codegen/src/generator/central_files.rs
@@ -257,7 +257,8 @@ fn make_is_inplace_variant_method(api: &ExtensionApi) -> TokenStream {
 
     // `Nil` is not part of `api.builtins`, but the empty variant is stored in-place and trivially destructible. Include it explicitly, so the
     // lifecycle fast paths (Clone/Drop) and `set_value` treat a nil variant as overwritable/copyable without FFI.
-    let mut inplace_ords = vec![0_i32];
+    let mut inplace_mask = 1_u64; // Bit 0 = NIL.
+    let mut max_ord = 0_i32;
 
     for builtin in api.builtins.iter() {
         let size = sizes
@@ -270,10 +271,18 @@ fn make_is_inplace_variant_method(api: &ExtensionApi) -> TokenStream {
                 )
             });
 
+        let ord = builtin.variant_type_ord;
+        max_ord = max_ord.max(ord);
+
         if size <= inplace_bytes_threshold && !builtin.has_destructor {
-            inplace_ords.push(builtin.variant_type_ord);
+            inplace_mask |= 1_u64 << ord;
         }
     }
+
+    assert!(
+        max_ord < 64,
+        "VariantType ord {max_ord} >= 64 no longer fits the `& 63` optimization"
+    );
 
     quote! {
         /// Returns `true` if _variants_ of this type can store the value in-place (SBO) and thus don't require FFI copies and destruction.
@@ -282,9 +291,14 @@ fn make_is_inplace_variant_method(api: &ExtensionApi) -> TokenStream {
         /// - always need Godot-side destruction (refcounted like `GString`, `Array` etc.).
         /// - are too big to be stored in-place in `Variant`, thus needing heap storage (`Aabb`, `Basis`, `Transform2D`, `Transform3D`, `Projection`).
         #[doc(hidden)]
-        #[inline] // Small match; runs on every Variant clone and drop.
+        #[inline] // Few instructions (shift, and, test) -- runs on every Variant clone/drop.
         pub const fn is_inplace_variant(&self) -> bool {
-            matches!(self.ord, #( #inplace_ords )|*)
+            // Bitmask instead of matches!(...): LLVM emits a range compare + branch for the latter.
+            // `& 63` avoids overflow check on shift (all ords < 64) and is free on x86 (64-bit shift already uses only the low 6 count bits).
+            const INPLACE_MASK: u64 = #inplace_mask;
+
+            let ord_u6 = self.ord as u32 & 63;
+            (INPLACE_MASK >> ord_u6) & 1 != 0
         }
     }
 }

--- a/godot-codegen/src/models/domain.rs
+++ b/godot-codegen/src/models/domain.rs
@@ -186,6 +186,7 @@ pub struct BuiltinVariant {
     pub builtin_class: Option<BuiltinClass>,
 
     pub variant_type_ord: i32,
+    pub has_destructor: bool,
 }
 
 impl BuiltinVariant {

--- a/godot-codegen/src/models/domain_mapping.rs
+++ b/godot-codegen/src/models/domain_mapping.rs
@@ -294,10 +294,12 @@ impl BuiltinVariant {
     ) -> Self {
         let builtin_class;
         let godot_original_name;
+        let has_destructor;
 
         // Nil, int, float etc. are not represented by a BuiltinVariant.
         // Object has no BuiltinClass, but still gets its BuiltinVariant instance.
         if let Some(json_builtin) = json_builtin_class {
+            has_destructor = json_builtin.has_destructor;
             godot_original_name = json_builtin.name.clone();
             builtin_class = BuiltinClass::from_json(json_builtin, ctx);
         } else {
@@ -306,6 +308,7 @@ impl BuiltinVariant {
                 "variant type {json_variant_enumerator_name:?} has no builtin class entry in the JSON"
             );
 
+            has_destructor = true; // Object requires ref-count management.
             builtin_class = None;
             godot_original_name = "Object".to_string();
         };
@@ -316,6 +319,7 @@ impl BuiltinVariant {
             godot_snake_name: conv::to_snake_case(json_variant_enumerator_name),
             builtin_class,
             variant_type_ord: json_variant_enumerator_ord,
+            has_destructor,
         }
     }
 }

--- a/godot-core/Cargo.toml
+++ b/godot-core/Cargo.toml
@@ -27,6 +27,8 @@ experimental-threads = ["godot-ffi/experimental-threads", "godot-codegen/experim
 experimental-wasm-nothreads = ["godot-ffi/experimental-wasm-nothreads"]
 debug-log = ["godot-ffi/debug-log"]
 itest = []
+# Disables Variant's RustMarshal optimization, falling back to FFI. Intended for A/B tests + benchmarks.
+variant-ffi-marshal = []
 
 api-custom = ["godot-ffi/api-custom", "godot-codegen/api-custom"]
 api-custom-json = ["godot-codegen/api-custom-json"]

--- a/godot-core/src/builtin/variant/impls.rs
+++ b/godot-core/src/builtin/variant/impls.rs
@@ -8,6 +8,7 @@
 use godot_ffi as sys;
 use sys::GodotFfi;
 
+use super::rust_variant::{RustVariant, USE_RUST_MARSHAL};
 use crate::builtin::*;
 use crate::meta::error::{ConvertError, FromVariantError};
 use crate::meta::sealed::Sealed;
@@ -25,67 +26,134 @@ use crate::task::{DynamicSend, IntoDynamicSend, ThreadConfined, impl_dynamic_sen
 // However, those same types would cause memory leaks in Godot 4.1 if pre-initialized. A compat layer `new_with_uninit_or_init()` addressed this.
 // As these Godot versions are no longer supported, the current implementation uses `new_with_uninit()` uniformly for all versions.
 macro_rules! impl_ffi_variant {
-    // With explicit metadata (e.g. for i64, f64).
-    (ref $T:ty, $from_fn:ident, $to_fn:ident; $metadata:expr) => {
-        impl_ffi_variant!(@impls by_ref, $metadata, main_thread; $T, $from_fn, $to_fn);
+    // Entry points with RustVariant optimization. By-val only: all current RustMarshal types are POD and passed by value; no
+    // by-ref arm exists since nothing invokes it (RustMarshal types don't need a by-ref conversion path).
+    ($T:ty, $from_fn:ident, $to_fn:ident; $metadata:expr, @rust_variant) => {
+        impl_ffi_variant!(@rust_variant_impls by_val, $metadata; $T, $from_fn, $to_fn);
     };
-    ($T:ty, $from_fn:ident, $to_fn:ident; $metadata:expr) => {
-        impl_ffi_variant!(@impls by_val, $metadata, main_thread; $T, $from_fn, $to_fn);
-    };
-
-    // Without metadata (defaults to ParamMetadata::NONE).
-    (ref $T:ty, $from_fn:ident, $to_fn:ident) => {
-        impl_ffi_variant!(@impls by_ref, ParamMetadata::NONE, main_thread; $T, $from_fn, $to_fn);
-    };
-    ($T:ty, $from_fn:ident, $to_fn:ident) => {
-        impl_ffi_variant!(@impls by_val, ParamMetadata::NONE, main_thread; $T, $from_fn, $to_fn);
+    ($T:ty, $from_fn:ident, $to_fn:ident, @rust_variant) => {
+        impl_ffi_variant!(@rust_variant_impls by_val, ParamMetadata::NONE; $T, $from_fn, $to_fn);
     };
 
     // Thread-safe variant: the to/from-variant converters resolve through the reviewed `sys::thread_safe_lifecycle()` subset instead of the
-    // main-thread-only `builtin_fn!` (string value types only touch caller-owned memory).
+    // main-thread-only `builtin_fn!` (string value types only touch caller-owned memory). Must precede the generic arms below.
     (thread_safe ref $T:ty, $from_fn:ident, $to_fn:ident) => {
-        impl_ffi_variant!(@impls by_ref, ParamMetadata::NONE, thread_safe; $T, $from_fn, $to_fn);
+        impl_ffi_variant!(@ffi_only_impls by_ref, ParamMetadata::NONE, thread_safe; $T, $from_fn, $to_fn);
+    };
+
+    // Entry points without RustVariant: the standard FFI path, selected by omitting the `@rust_variant` marker.
+    (ref $T:ty, $from_fn:ident, $to_fn:ident; $metadata:expr) => {
+        impl_ffi_variant!(@ffi_only_impls by_ref, $metadata, main_thread; $T, $from_fn, $to_fn);
+    };
+    ($T:ty, $from_fn:ident, $to_fn:ident; $metadata:expr) => {
+        impl_ffi_variant!(@ffi_only_impls by_val, $metadata, main_thread; $T, $from_fn, $to_fn);
+    };
+    (ref $T:ty, $from_fn:ident, $to_fn:ident) => {
+        impl_ffi_variant!(@ffi_only_impls by_ref, ParamMetadata::NONE, main_thread; $T, $from_fn, $to_fn);
+    };
+    ($T:ty, $from_fn:ident, $to_fn:ident) => {
+        impl_ffi_variant!(@ffi_only_impls by_val, ParamMetadata::NONE, main_thread; $T, $from_fn, $to_fn);
     };
 
     // Converter resolution: `main_thread` uses the main-thread table, `thread_safe` the reviewed subset.
     (@converter main_thread, $fn:ident) => { sys::builtin_fn!($fn) };
     (@converter thread_safe, $fn:ident) => { sys::thread_safe_lifecycle().$fn };
 
-    // Implementations
-    (@impls $by_ref_or_val:ident, $metadata:expr, $mode:ident; $T:ty, $from_fn:ident, $to_fn:ident) => {
+    // Shared to/from-variant bodies for `@rust_variant_impls` fallback and `@ffi_only_impls`. Routing through `@converter $mode`
+    // keeps a `thread_safe` type off the main-thread table. `$self`/`$variant` passed explicitly (macro hygiene).
+    (@ffi_to_variant_body $self:expr, $mode:ident, $from_fn:ident) => {
+        unsafe {
+            Variant::new_with_var_uninit(|variant_ptr| {
+                let converter = impl_ffi_variant!(@converter $mode, $from_fn);
+                converter(variant_ptr, sys::SysPtr::force_mut(($self).sys()));
+            })
+        }
+    };
+    (@ffi_from_variant_body $variant:expr, $mode:ident, $to_fn:ident) => {
+        {
+            let variant = $variant;
+            if variant.get_type() != Self::VARIANT_TYPE.variant_as_nil() {
+                return Err(FromVariantError::BadType {
+                    expected: Self::VARIANT_TYPE.variant_as_nil(),
+                    actual: variant.get_type(),
+                }
+                .into_error(variant.clone()));
+            }
+
+            let result = unsafe {
+                Self::new_with_uninit(|self_ptr| {
+                    let converter = impl_ffi_variant!(@converter $mode, $to_fn);
+                    converter(self_ptr, sys::SysPtr::force_mut(variant.var_sys()));
+                })
+            };
+
+            Ok(result)
+        }
+    };
+
+    // Implementation with RustVariant optimization.
+    (@rust_variant_impls $by_ref_or_val:ident, $metadata:expr; $T:ty, $from_fn:ident, $to_fn:ident) => {
+        // Single source of truth for the RustMarshal type set: each `@rust_variant` invocation registers the type and checks the size
+        // precondition here (regardless of feature flags), so marker impl and conversion path cannot drift.
+        // SAFETY: `@rust_variant` is only used for `#[repr(C)]` POD types matching Godot's in-memory layout; the `assert!` below upholds the size contract.
+        const _: () = {
+            use crate::builtin::variant::rust_variant::{RustMarshal, VARIANT_DATA_SIZE};
+            assert!(
+                std::mem::size_of::<$T>() <= VARIANT_DATA_SIZE,
+                "Type is too large for RustVariant"
+            );
+            assert!(
+                <$T as RustMarshal>::VARIANT_TYPE.is_inplace_variant(),
+                "RustMarshal type must be stored in-place in Variant"
+            );
+        };
+        // Full path avoids importing `RustMarshal`, which would make `Self::VARIANT_TYPE` below ambiguous (also defined on `GodotFfi`).
+        unsafe impl crate::builtin::variant::rust_variant::RustMarshal for $T {}
+
         impl GodotFfiVariant for $T {
             fn ffi_to_variant(&self) -> Variant {
-                let variant = unsafe {
-                    Variant::new_with_var_uninit(|variant_ptr| {
-                        let converter = impl_ffi_variant!(@converter $mode, $from_fn);
-                        converter(variant_ptr, sys::SysPtr::force_mut(self.sys()));
-                    })
-                };
-
-                variant
+                if USE_RUST_MARSHAL {
+                    RustVariant::from_pod(*self)
+                } else {
+                    impl_ffi_variant!(@ffi_to_variant_body self, main_thread, $from_fn)
+                }
             }
 
             fn ffi_from_variant(variant: &Variant) -> Result<Self, ConvertError> {
-                // Type check -- at the moment, a strict match is required.
-                if variant.get_type() != Self::VARIANT_TYPE.variant_as_nil() {
-                    return Err(FromVariantError::BadType {
-                        expected: Self::VARIANT_TYPE.variant_as_nil(),
-                        actual: variant.get_type(),
-                    }
-                    .into_error(variant.clone()));
+                if USE_RUST_MARSHAL {
+                    return RustVariant::view(variant).get_value::<Self>().ok_or_else(|| {
+                        FromVariantError::BadType {
+                            expected: Self::VARIANT_TYPE.variant_as_nil(),
+                            actual: variant.get_type(),
+                        }
+                        .into_error(variant.clone())
+                    });
                 }
 
-                let result = unsafe {
-                    Self::new_with_uninit(|self_ptr| {
-                        let converter = impl_ffi_variant!(@converter $mode, $to_fn);
-                        converter(self_ptr, sys::SysPtr::force_mut(variant.var_sys()));
-                    })
-                };
-
-                Ok(result)
+                impl_ffi_variant!(@ffi_from_variant_body variant, main_thread, $to_fn)
             }
         }
 
+        impl_ffi_variant!(@shared_impls $by_ref_or_val, $metadata; $T);
+    };
+
+    // Implementation without RustVariant (standard FFI, with converter mode selection).
+    (@ffi_only_impls $by_ref_or_val:ident, $metadata:expr, $mode:ident; $T:ty, $from_fn:ident, $to_fn:ident) => {
+        impl GodotFfiVariant for $T {
+            fn ffi_to_variant(&self) -> Variant {
+                impl_ffi_variant!(@ffi_to_variant_body self, $mode, $from_fn)
+            }
+
+            fn ffi_from_variant(variant: &Variant) -> Result<Self, ConvertError> {
+                impl_ffi_variant!(@ffi_from_variant_body variant, $mode, $to_fn)
+            }
+        }
+
+        impl_ffi_variant!(@shared_impls $by_ref_or_val, $metadata; $T);
+    };
+
+    // Shared implementations (GodotType, Element).
+    (@shared_impls $by_ref_or_val:ident, $metadata:expr; $T:ty) => {
         impl GodotType for $T {
             type Ffi = Self;
             impl_ffi_variant!(@assoc_to_ffi $by_ref_or_val);
@@ -136,33 +204,40 @@ mod impls {
     // IMPORTANT: the presence/absence of `ref` here should be aligned with the ArgPassing variant
     // used in codegen get_builtin_arg_passing().
 
-    impl_ffi_variant!(bool, bool_to_variant, bool_from_variant);
-    impl_ffi_variant!(i64, int_to_variant, int_from_variant; ParamMetadata::INT_IS_INT64);
-    impl_ffi_variant!(f64, float_to_variant, float_from_variant; ParamMetadata::REAL_IS_DOUBLE);
-    impl_ffi_variant!(Vector2, vector2_to_variant, vector2_from_variant);
-    impl_ffi_variant!(Vector3, vector3_to_variant, vector3_from_variant);
-    impl_ffi_variant!(Vector4, vector4_to_variant, vector4_from_variant);
-    impl_ffi_variant!(Vector2i, vector2i_to_variant, vector2i_from_variant);
-    impl_ffi_variant!(Vector3i, vector3i_to_variant, vector3i_from_variant);
-    impl_ffi_variant!(Vector4i, vector4i_to_variant, vector4i_from_variant);
-    impl_ffi_variant!(Quaternion, quaternion_to_variant, quaternion_from_variant);
+    // Types with RustVariant optimization (fit in Variant data, no destructors).
+    impl_ffi_variant!(bool, bool_to_variant, bool_from_variant, @rust_variant);
+    impl_ffi_variant!(i64, int_to_variant, int_from_variant; ParamMetadata::INT_IS_INT64, @rust_variant);
+    impl_ffi_variant!(f64, float_to_variant, float_from_variant; ParamMetadata::REAL_IS_DOUBLE, @rust_variant);
+    impl_ffi_variant!(Vector2i, vector2i_to_variant, vector2i_from_variant, @rust_variant);
+    impl_ffi_variant!(Vector3i, vector3i_to_variant, vector3i_from_variant, @rust_variant);
+    impl_ffi_variant!(Vector4i, vector4i_to_variant, vector4i_from_variant, @rust_variant);
+    impl_ffi_variant!(Color, color_to_variant, color_from_variant, @rust_variant);
+    impl_ffi_variant!(Rect2i, rect2i_to_variant, rect2i_from_variant, @rust_variant);
+    impl_ffi_variant!(Rid, rid_to_variant, rid_from_variant, @rust_variant);
+
+    // Precision-dependent types with RustVariant optimization.
+    impl_ffi_variant!(Vector2, vector2_to_variant, vector2_from_variant, @rust_variant);
+    impl_ffi_variant!(Vector3, vector3_to_variant, vector3_from_variant, @rust_variant);
+    impl_ffi_variant!(Vector4, vector4_to_variant, vector4_from_variant, @rust_variant);
+    impl_ffi_variant!(Quaternion, quaternion_to_variant, quaternion_from_variant, @rust_variant);
+    impl_ffi_variant!(Plane, plane_to_variant, plane_from_variant, @rust_variant);
+    impl_ffi_variant!(Rect2, rect2_to_variant, rect2_from_variant, @rust_variant);
+
+    // Large value types: heap-allocated inside Variant, not eligible for RustMarshal (see is_inplace_variant() doc).
     impl_ffi_variant!(Transform2D, transform_2d_to_variant, transform_2d_from_variant);
     impl_ffi_variant!(Transform3D, transform_3d_to_variant, transform_3d_from_variant);
     impl_ffi_variant!(Basis, basis_to_variant, basis_from_variant);
     impl_ffi_variant!(Projection, projection_to_variant, projection_from_variant);
-    impl_ffi_variant!(Plane, plane_to_variant, plane_from_variant);
-    impl_ffi_variant!(Rect2, rect2_to_variant, rect2_from_variant);
-    impl_ffi_variant!(Rect2i, rect2i_to_variant, rect2i_from_variant);
     impl_ffi_variant!(Aabb, aabb_to_variant, aabb_from_variant);
-    impl_ffi_variant!(Color, color_to_variant, color_from_variant);
-    impl_ffi_variant!(Rid, rid_to_variant, rid_from_variant);
-    impl_ffi_variant!(ref NodePath, node_path_to_variant, node_path_from_variant);
-    impl_ffi_variant!(ref Signal, signal_to_variant, signal_from_variant);
-    impl_ffi_variant!(ref Callable, callable_to_variant, callable_from_variant);
 
     // GString and StringName are string value types that only touch caller-owned memory, so their variant conversions are thread-safe.
     impl_ffi_variant!(thread_safe ref GString, string_to_variant, string_from_variant);
     impl_ffi_variant!(thread_safe ref StringName, string_name_to_variant, string_name_from_variant);
+
+    // Ref-counted types: require FFI for construction/destruction; RustMarshal is not applicable.
+    impl_ffi_variant!(ref NodePath, node_path_to_variant, node_path_from_variant);
+    impl_ffi_variant!(ref Signal, signal_to_variant, signal_from_variant);
+    impl_ffi_variant!(ref Callable, callable_to_variant, callable_from_variant);
 }
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------

--- a/godot-core/src/builtin/variant/mod.rs
+++ b/godot-core/src/builtin/variant/mod.rs
@@ -21,6 +21,16 @@ use crate::meta::{
 };
 
 mod impls;
+mod rust_variant;
+
+pub(crate) use rust_variant::check_layout_matches_godot;
+use rust_variant::{RustVariant, USE_RUST_MARSHAL};
+
+#[cfg(feature = "itest")] // Test only.
+#[doc(hidden)]
+pub mod __test_only {
+    pub use super::rust_variant::{RustMarshal, RustVariant};
+}
 
 /// Godot variant type, able to store a variety of different types.
 ///
@@ -35,7 +45,7 @@ mod impls;
 /// # Godot docs
 ///
 /// [`Variant` (stable)](https://docs.godotengine.org/en/stable/classes/class_variant.html)
-// We rely on the layout of `Variant` being the same as Godot's layout in `borrow_slice` and `borrow_slice_mut`.
+// We rely on the layout of `Variant` being the same as Godot's layout in `borrow_slice` and `borrow_slice_mut`, and for Array access.
 #[repr(transparent)]
 pub struct Variant {
     _opaque: sys::types::OpaqueVariant,
@@ -289,9 +299,11 @@ impl Variant {
     }
 
     pub(crate) fn sys_type(&self) -> sys::GDExtensionVariantType {
-        unsafe {
-            let ty: sys::GDExtensionVariantType = interface_fn!(variant_get_type)(self.var_sys());
-            ty
+        if USE_RUST_MARSHAL {
+            // Reading the type tag is a plain memory access; `RustVariant::view()` never goes through FFI.
+            RustVariant::view(self).type_tag()
+        } else {
+            unsafe { interface_fn!(variant_get_type)(self.var_sys()) }
         }
     }
 
@@ -483,6 +495,10 @@ impl Variant {
     ///
     /// Either `variant_array` is null, or it must be safe to call [`std::slice::from_raw_parts_mut`] with
     /// `variant_array` cast to `*mut Variant` and `length`.
+    ///
+    /// If the pointer aliases into a ref-counted container's backing store (e.g. `Array`), the caller must guarantee that container is uniquely
+    /// owned (refcount == 1) for the slice's lifetime; otherwise a multi-element `&mut [Variant]` aliases storage another handle can read,
+    /// violating Rust's rules. When uniqueness is not guaranteed, write individual elements via a raw pointer (see `Array::extend`).
     pub(crate) unsafe fn borrow_slice_mut<'a>(
         variant_array: sys::GDExtensionVariantPtr,
         length: usize,
@@ -553,19 +569,33 @@ unsafe impl GodotFfi for Variant {
 crate::meta::impl_godot_as_self!(Variant: ByVariant);
 
 // TODO(v0.6): Variant lifecycle stays on the main-thread accessor because a Variant can hold a reference type (Object), whose refcount/free is
-// not safe off the main thread. Once we can classify the inner type, the value-type cases could opt into thread-safe access.
+// not safe off the main thread. `RustVariant::has_inplace_type()` classifies the inner type, so value-type cases could opt into thread-safe
+// access on top of it.
 impl Default for Variant {
     fn default() -> Self {
-        unsafe {
-            Self::new_with_var_uninit(|variant_ptr| {
-                interface_fn!(variant_new_nil)(variant_ptr);
-            })
+        if USE_RUST_MARSHAL {
+            // SAFETY: zeroed buffer is a valid NIL variant. The type tag (0 = NIL) is always read before accessing the data union.
+            // (Godot's `variant_new_nil` leaves data uninitialized, too).
+            unsafe { std::mem::zeroed() }
+        } else {
+            unsafe {
+                Self::new_with_var_uninit(|variant_ptr| {
+                    interface_fn!(variant_new_nil)(variant_ptr);
+                })
+            }
         }
     }
 }
 
 impl Clone for Variant {
     fn clone(&self) -> Self {
+        // POD types (`bool`, `i64`, `f64`, vectors, color, ...) have no shared ownership: a bytewise copy is sufficient.
+        // Both source and copy will skip `variant_destroy` in `Drop` (see below), so no double-free.
+        if USE_RUST_MARSHAL && RustVariant::view(self).has_inplace_type() {
+            // SAFETY: `self` is initialized; POD types carry no destructor and copy-by-value is safe.
+            return unsafe { std::ptr::read(self) };
+        }
+
         unsafe {
             Self::new_with_var_uninit(|variant_ptr| {
                 interface_fn!(variant_new_copy)(variant_ptr, self.var_sys());
@@ -576,6 +606,11 @@ impl Clone for Variant {
 
 impl Drop for Variant {
     fn drop(&mut self) {
+        // POD types have no Godot-side destructor; `variant_destroy` is a no-op for them. Skip the FFI call entirely.
+        if USE_RUST_MARSHAL && RustVariant::view(self).has_inplace_type() {
+            return;
+        }
+
         unsafe {
             interface_fn!(variant_destroy)(self.var_sys_mut());
         }

--- a/godot-core/src/builtin/variant/rust_variant.rs
+++ b/godot-core/src/builtin/variant/rust_variant.rs
@@ -1,0 +1,252 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+//! Pure-Rust view into Variant memory, enabling FFI-free access to scalar types.
+
+use godot_ffi as sys;
+
+use crate::builtin::{Variant, VariantType, Vector3};
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// Layout types (internal)
+
+// Variant data size depends on precision:
+// - Single precision (real_t=float): 16 bytes data, 24 bytes total
+// - Double precision (real_t=double): 32 bytes data, 40 bytes total
+#[cfg(not(feature = "double-precision"))]
+pub(crate) const VARIANT_DATA_SIZE: usize = 16;
+
+#[cfg(feature = "double-precision")]
+pub(crate) const VARIANT_DATA_SIZE: usize = 32;
+
+// Compile-time size/alignment checks for the layout itself. Per-type size checks (`size_of::<T>() <= VARIANT_DATA_SIZE`) live at the
+// `impl_ffi_variant!(.., @rust_variant)` expansion site, so they cannot drift from the RustMarshal type set.
+const _: () = {
+    use std::mem::size_of;
+
+    sys::static_assert_eq_size_align!(RustVariant, sys::types::OpaqueVariant);
+
+    assert!(std::mem::align_of::<RustVariant>() == 8);
+    assert!(std::mem::offset_of!(RustVariant, type_tag) == 0);
+    assert!(std::mem::offset_of!(RustVariant, data) == 8);
+
+    // Size depends on precision feature.
+    // Note: Use `assert!` instead of `assert_eq!` in const contexts (`assert_eq!` is not yet const-compatible).
+    #[cfg(not(feature = "double-precision"))]
+    assert!(size_of::<RustVariant>() == 24);
+
+    #[cfg(feature = "double-precision")]
+    assert!(size_of::<RustVariant>() == 40);
+};
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// Feature toggle
+
+/// `true` when Rust-side variant marshalling is enabled (default). `false` selects the FFI fallback (`variant-ffi-marshal` feature).
+///
+/// Use this constant in `if`-expressions instead of `#[cfg]` blocks: the dead branch is eliminated by LLVM, but both branches type-check
+/// under either feature setting, keeping the source uniform.
+pub(crate) const USE_RUST_MARSHAL: bool = !cfg!(feature = "variant-ffi-marshal");
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// Public API
+
+/// Marker trait for plain-old-data types that marshal to/from `Variant`'s data union directly in Rust, without going through FFI.
+///
+/// The supertrait `GodotType<Ffi = Self>` encodes the core contract: the type is its own FFI carrier (no widening needed), enabling sound
+/// in-memory marshalling.
+///
+/// # Safety
+/// Implementors must:
+/// - Fit in `VARIANT_DATA_SIZE` (16 or 32 bytes depending on precision; verified at macro expansion site).
+/// - Have `#[repr(C)]` layout matching Godot's in-memory representation for the corresponding variant type.
+///
+/// TODO(v0.6): `Rid` doesn't literally satisfy `#[repr(C)]` (uses niche-optimized enum layout instead, see `rid.rs`). Revisit.
+pub unsafe trait RustMarshal:
+    crate::meta::GodotType<Ffi = Self> + Copy + sys::GodotFfi
+{
+    /// The Godot [`VariantType`] for this type.
+    const VARIANT_TYPE: VariantType = <Self as sys::GodotFfi>::VARIANT_TYPE.variant_as_nil();
+}
+
+/// Mutable or immutable view into a [`Variant`], providing FFI-free read/write access for POD types that implement [`RustMarshal`].
+///
+/// [`GodotFfiVariant`][crate::meta::GodotFfiVariant] dispatches internally: `RustMarshal` types use direct memory access, all others go
+/// through Godot's FFI layer. Internal type.
+///
+/// # Memory management
+/// **POD types** (`bool`, `i64`, `f64`, `Vector2/3/4`, `Color`, etc.) copy by value: each variant holds independent data and has no destructor.
+///
+/// **Shared types** (`Object`, `Array`, `Dictionary`, `GString`, etc.) are reference-counted and require FFI destruction, so this view only
+/// reads them; [`has_inplace_type()`][Self::has_inplace_type] distinguishes the two.
+#[repr(C, align(8))]
+pub struct RustVariant {
+    // Godot stores the variant type as a C++ enum (32-bit signed). We use u32 here because the Rust binding may expose GDExtensionVariantType
+    // as either i32 or u32 depending on platform. All valid type ordinals are non-negative (0..=38), so the cast between the two is always safe.
+    type_tag: u32,                 // 4 bytes.
+    _padding: u32,                 // 4 bytes padding to align the data union to 8 bytes.
+    data: [u8; VARIANT_DATA_SIZE], // 16 bytes (32 in double-precision).
+}
+
+impl RustVariant {
+    /// Create an immutable view from a Variant reference.
+    pub fn view(variant: &Variant) -> &Self {
+        // SAFETY: OpaqueVariant and RustVariant have the same size/alignment (verified at compile time).
+        unsafe { std::mem::transmute::<&Variant, &RustVariant>(variant) }
+    }
+
+    /// Construct a [`Variant`] from a POD value without going through FFI.
+    ///
+    /// Writes the type tag and data bytes directly into a stack-allocated `RustVariant`, then transmutes it to `Variant`.
+    /// `Variant::drop()` calls `variant_destroy`, which is a no-op for POD types (`T: RustMarshal`).
+    pub(crate) fn from_pod<T: RustMarshal>(value: T) -> Variant {
+        let mut rv = RustVariant {
+            // VariantType::ord is i32, ordinals are non-negative -> cast to u32 is safe.
+            type_tag: <T as RustMarshal>::VARIANT_TYPE.ord as u32,
+            _padding: 0,
+            data: [0u8; VARIANT_DATA_SIZE],
+        };
+
+        // SAFETY: `RustMarshal` guarantees `T` has `#[repr(C)]` layout matching Godot's in-memory representation and fits in `VARIANT_DATA_SIZE`.
+        unsafe { rv.data_ptr_mut::<T>().write(value) };
+
+        // SAFETY: `Variant` is `#[repr(transparent)]` over `OpaqueVariant`; `RustVariant` has identical size and alignment (asserted above).
+        unsafe { std::mem::transmute::<RustVariant, Variant>(rv) }
+    }
+
+    /// Get the raw type tag without FFI.
+    ///
+    /// Unlike [`Variant::get_type()`], this does not handle the special case of null object pointers.
+    #[inline]
+    pub(crate) fn type_tag(&self) -> sys::GDExtensionVariantType {
+        self.type_tag as sys::GDExtensionVariantType
+    }
+
+    /// Get the variant type without FFI.
+    ///
+    /// "Unchecked" refers to the fact that, unlike [`Variant::get_type()`], this does not normalize the special case of null object
+    /// pointers to `NIL` -- it returns the raw stored type tag. This is not unsafe; the distinction only matters for `OBJECT` variants.
+    pub fn get_type_unchecked(&self) -> VariantType {
+        VariantType::from_sys(self.type_tag())
+    }
+
+    /// Returns `true` if the variant currently holds a value whose `Variant` can be bit-copied and bit-dropped without FFI.
+    ///
+    /// This is a property of the *variant*, not the payload: large math types like `Transform2D` are `Copy` in Rust but heap-allocated inside
+    /// `Variant`, so they return `false`. Delegates to [`VariantType::is_inplace_variant()`]; used by `Variant`'s lifecycle fast paths
+    /// (Clone/Drop).
+    #[inline]
+    pub(crate) fn has_inplace_type(&self) -> bool {
+        self.get_type_unchecked().is_inplace_variant()
+    }
+
+    /// Returns `true` if the variant currently holds a value of type `T`.
+    #[inline]
+    pub(crate) fn is_type<T: RustMarshal>(&self) -> bool {
+        self.get_type_unchecked() == <T as RustMarshal>::VARIANT_TYPE
+    }
+
+    /// Get a typed value from the variant without going through FFI.
+    ///
+    /// Returns `None` if the variant's type doesn't match `T`.
+    pub fn get_value<T: RustMarshal>(&self) -> Option<T> {
+        if !self.is_type::<T>() {
+            return None;
+        }
+
+        // SAFETY: type was verified to match T via `is_type`.
+        let value: T = unsafe { self.data_ptr::<T>().read() };
+        Some(value)
+    }
+
+    /// Returns a raw typed pointer to the variant's data for reading.
+    #[inline]
+    fn data_ptr<T: RustMarshal>(&self) -> *const T {
+        sys::strict_assert!(self.is_type::<T>());
+        self.data.as_ptr().cast::<T>()
+    }
+
+    /// Returns a raw typed mutable pointer to the variant's data for writing.
+    #[inline]
+    fn data_ptr_mut<T: RustMarshal>(&mut self) -> *mut T {
+        sys::strict_assert!(self.is_type::<T>());
+        self.data.as_mut_ptr().cast::<T>()
+    }
+}
+
+// `RustMarshal` is implemented centrally by the `impl_ffi_variant!(.., @rust_variant)` macro in `impls.rs`, keeping the marshalled type set
+// in a single place (the macro also enforces the size precondition at its expansion site).
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// Startup self-check
+
+/// Checks Godot's actual Variant layout (tag@0, data@8) against what RustMarshal assumes. Builds variants via raw FFI (bypassing
+/// `USE_RUST_MARSHAL`) and compares against `RustVariant` reads.
+///
+/// # Safety
+/// Must be called from the main thread, after the Godot interface/binding is initialized.
+pub(crate) unsafe fn check_layout_matches_godot() {
+    if !USE_RUST_MARSHAL {
+        return;
+    }
+
+    unsafe {
+        check_scalar_layout();
+        check_vector_layout();
+    }
+}
+
+fn panic_layout_mismatch(type_name: &str) -> ! {
+    panic!(
+        "godot-rust: Variant layout self-check failed for `{type_name}`; enable Cargo feature `godot/__variant-ffi-marshal` and report this bug."
+    );
+}
+
+unsafe fn check_scalar_layout() {
+    const SENTINEL: i64 = 0x1234_5678_9ABC_DEF0;
+
+    let variant = unsafe {
+        Variant::new_with_var_uninit(|variant_ptr| {
+            let converter = sys::builtin_fn!(int_to_variant);
+            converter(
+                variant_ptr,
+                sys::SysPtr::force_mut(sys::GodotFfi::sys(&SENTINEL)),
+            );
+        })
+    };
+
+    let view = RustVariant::view(&variant);
+    let matches =
+        view.get_type_unchecked() == VariantType::INT && view.get_value::<i64>() == Some(SENTINEL);
+
+    if !matches {
+        panic_layout_mismatch("i64");
+    }
+}
+
+// Distinct x/y/z sentinel values catch a field-order transposition, not just an offset shift.
+unsafe fn check_vector_layout() {
+    const SENTINEL: Vector3 = Vector3::new(1.5, 2.5, 3.5);
+
+    let variant = unsafe {
+        Variant::new_with_var_uninit(|variant_ptr| {
+            let converter = sys::builtin_fn!(vector3_to_variant);
+            converter(
+                variant_ptr,
+                sys::SysPtr::force_mut(sys::GodotFfi::sys(&SENTINEL)),
+            );
+        })
+    };
+
+    let view = RustVariant::view(&variant);
+    let matches = view.get_type_unchecked() == VariantType::VECTOR3
+        && view.get_value::<Vector3>() == Some(SENTINEL);
+
+    if !matches {
+        panic_layout_mismatch("Vector3");
+    }
+}

--- a/godot-core/src/builtin/variant/rust_variant.rs
+++ b/godot-core/src/builtin/variant/rust_variant.rs
@@ -141,7 +141,7 @@ impl RustVariant {
     /// This is a property of the *variant*, not the payload: large math types like `Transform2D` are `Copy` in Rust but heap-allocated inside
     /// `Variant`, so they return `false`. Delegates to [`VariantType::is_inplace_variant()`]; used by `Variant`'s lifecycle fast paths
     /// (Clone/Drop).
-    #[inline]
+    #[inline] // Few instructions (tag load, shift, and, test) -- runs on every Variant clone/drop.
     pub(crate) fn has_inplace_type(&self) -> bool {
         self.get_type_unchecked().is_inplace_variant()
     }

--- a/godot-core/src/builtin/variant/rust_variant.rs
+++ b/godot-core/src/builtin/variant/rust_variant.rs
@@ -94,6 +94,7 @@ pub struct RustVariant {
 
 impl RustVariant {
     /// Create an immutable view from a Variant reference.
+    #[inline] // Transmute only; runs on every Variant clone and drop.
     pub fn view(variant: &Variant) -> &Self {
         // SAFETY: OpaqueVariant and RustVariant have the same size/alignment (verified at compile time).
         unsafe { std::mem::transmute::<&Variant, &RustVariant>(variant) }
@@ -130,6 +131,7 @@ impl RustVariant {
     ///
     /// "Unchecked" refers to the fact that, unlike [`Variant::get_type()`], this does not normalize the special case of null object
     /// pointers to `NIL` -- it returns the raw stored type tag. This is not unsafe; the distinction only matters for `OBJECT` variants.
+    #[inline] // One field read; feeds the Variant clone/drop fast paths.
     pub fn get_type_unchecked(&self) -> VariantType {
         VariantType::from_sys(self.type_tag())
     }

--- a/godot-core/src/init/mod.rs
+++ b/godot-core/src/init/mod.rs
@@ -306,6 +306,9 @@ unsafe fn gdext_on_level_init(level: InitLevel, _userdata: &InitUserData) {
 
     match level {
         InitLevel::Core => {
+            // SAFETY: main thread, interface/binding initialized above.
+            unsafe { crate::builtin::check_layout_matches_godot() };
+
             #[cfg(since_api = "4.5")]
             unsafe {
                 sys::interface_fn!(register_main_loop_callbacks)(

--- a/godot-core/src/meta/traits.rs
+++ b/godot-core/src/meta/traits.rs
@@ -20,9 +20,16 @@ pub use sys::{ExtVariantType, GodotFfi};
 pub use crate::builtin::meta_reexport::PackedElement;
 
 /// Conversion of [`GodotFfi`] types to/from [`Variant`].
+///
+/// Implementations may use rust-side marshalling for types where `RustMarshal` is implemented, bypassing FFI.
+///
+/// This trait overlaps strongly with `GodotType`, but currently has an `impl ObjectArg<'gd>` on top. Vice versa, following types implement
+/// `GodotType` but not `GodotFfiVariant`: `u8, u16, u32, i8, i16, i32, f32, u64`.
 #[doc(hidden)]
 pub trait GodotFfiVariant: Sized + GodotFfi {
+    // TODO(v0.5.x): rename -> rust_{to,from}_variant
     fn ffi_to_variant(&self) -> Variant;
+
     fn ffi_from_variant(variant: &Variant) -> Result<Self, ConvertError>;
 }
 

--- a/godot-macros/src/class/derive_godot_class.rs
+++ b/godot-macros/src/class/derive_godot_class.rs
@@ -398,7 +398,8 @@ impl ClassAttributes {
 
 fn make_godot_init_impl(class_name: &Ident, fields: &Fields) -> TokenStream {
     let base_init = if let Some(Field { name, ty, .. }) = &fields.base_field {
-        quote_spanned! { ty.span()=> #name: base, }
+        // Do not name `base` to avoid tripping clippy::redundant_field_names when resulting user code is { base: base, ... }.
+        quote_spanned! { ty.span()=> #name: base_param, }
     } else {
         TokenStream::new()
     };
@@ -417,7 +418,7 @@ fn make_godot_init_impl(class_name: &Ident, fields: &Fields) -> TokenStream {
 
     quote! {
         impl ::godot::obj::cap::GodotDefault for #class_name {
-            fn __godot_user_init(base: ::godot::obj::Base<<#class_name as ::godot::obj::GodotClass>::Base>) -> Self {
+            fn __godot_user_init(base_param: ::godot::obj::Base<<#class_name as ::godot::obj::GodotClass>::Base>) -> Self {
                 Self {
                     #( #rest_init )*
                     #base_init

--- a/godot/Cargo.toml
+++ b/godot/Cargo.toml
@@ -50,6 +50,7 @@ default = ["__codegen-full"]
 __codegen-full = ["godot-core/codegen-full", "godot-macros/codegen-full"]
 __debug-log = ["godot-core/debug-log"]
 __itest = ["godot-core/itest"]
+__variant-ffi-marshal = ["godot-core/variant-ffi-marshal"]
 
 [dependencies]
 godot-core = { path = "../godot-core", version = "=0.5.5" }

--- a/itest/rust/src/builtin_tests/containers/callable_test.rs
+++ b/itest/rust/src/builtin_tests/containers/callable_test.rs
@@ -143,7 +143,7 @@ fn callable_variant_method() {
     assert_eq!(dict_get.call(vslice!["one"]), 1.to_variant());
 
     // GString
-    let string = GString::from("some string").to_variant();
+    let string = "some string".to_variant();
     let string_md5 = Callable::from_variant_method(&string, "md5_text");
     assert_eq!(
         string_md5.call(vslice![]), // use vslice![] as alternative &[] syntax.

--- a/itest/rust/src/builtin_tests/containers/rust_variant_test.rs
+++ b/itest/rust/src/builtin_tests/containers/rust_variant_test.rs
@@ -1,0 +1,410 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use godot::builtin::__test_only::{RustMarshal, RustVariant};
+use godot::builtin::{
+    Array, Callable, Color, Plane, Quaternion, Rect2, Rect2i, Rid, Variant, VariantType, Vector2,
+    Vector2i, Vector3, Vector3i, Vector4, Vector4i, varray,
+};
+use godot::meta::{FromGodot, ToGodot};
+
+use crate::framework::itest;
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// Generic Test Infrastructure
+
+/// Verify variant round-trip: public conversion API and direct `RustVariant` view agree.
+fn verify_variant_roundtrip<T>(value: T, index: usize)
+where
+    T: RustMarshal + FromGodot + ToGodot + PartialEq + std::fmt::Debug + Copy,
+{
+    let label = format!("{}[{}]", std::any::type_name::<T>(), index);
+    let variant = value.to_variant();
+
+    assert_eq!(
+        variant.get_type(),
+        <T as RustMarshal>::VARIANT_TYPE,
+        "{label}: unexpected variant type"
+    );
+
+    // Public path: full conversion API.
+    let via_public = T::from_variant(&variant);
+    assert_eq!(via_public, value, "{label}: public from_variant mismatch");
+
+    // Direct path: inline memory access via read-only `RustVariant` view.
+    let via_view = RustVariant::view(&variant).get_value::<T>();
+    assert_eq!(via_view, Some(value), "{label}: RustVariant view mismatch");
+}
+
+/// Rust encode + decode (roundtrip test) isn't sufficient to ensure that we match *Godot's* layout, so additionally check `stringify()` via FFI.
+fn verify_godot_side_read<T: ToGodot>(value: T, expected: &str) {
+    let variant = value.to_variant();
+    assert_eq!(variant.stringify().to_string(), expected);
+}
+
+/// Macro to generate comprehensive tests for a type.
+macro_rules! declare_variant_test {
+    ($T:ty, $test_name:ident, [$($test_val:expr),+ $(,)?]) => {
+        #[itest]
+        fn $test_name() {
+            for (i, value) in [$($test_val),+].iter().enumerate() {
+                verify_variant_roundtrip::<$T>(*value, i);
+            }
+        }
+    };
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// Implementations for RustMarshal Types
+
+declare_variant_test!(bool, rust_variant_roundtrip_bool, [true, false]);
+
+declare_variant_test!(
+    i64,
+    rust_variant_roundtrip_i64,
+    [
+        0,
+        1,
+        -1,
+        42,
+        -12345,
+        i64::MIN,
+        i64::MAX,
+        i64::MIN + 1,
+        i64::MAX - 1
+    ]
+);
+
+declare_variant_test!(
+    f64,
+    rust_variant_roundtrip_f64,
+    [
+        0.0,
+        1.0,
+        -1.0,
+        3.125,
+        -1.5e10,
+        99.5,
+        f64::MIN,
+        f64::MAX,
+        f64::EPSILON,
+        -f64::EPSILON
+    ]
+);
+
+declare_variant_test!(
+    Vector2i,
+    rust_variant_roundtrip_vector2i,
+    [
+        Vector2i::ZERO,
+        Vector2i::ONE,
+        Vector2i::new(i32::MIN, i32::MAX),
+        Vector2i::new(-1, -1),
+        Vector2i::new(100, -200)
+    ]
+);
+
+declare_variant_test!(
+    Vector3i,
+    rust_variant_roundtrip_vector3i,
+    [
+        Vector3i::ZERO,
+        Vector3i::ONE,
+        Vector3i::new(-1, i32::MIN, i32::MAX),
+        Vector3i::new(100, 200, 300),
+        Vector3i::new(-100, -200, -300)
+    ]
+);
+
+declare_variant_test!(
+    Vector4i,
+    rust_variant_roundtrip_vector4i,
+    [
+        Vector4i::ZERO,
+        Vector4i::ONE,
+        Vector4i::new(-1, i32::MIN, i32::MAX, 1000),
+        Vector4i::new(1, 2, 3, 4),
+        Vector4i::new(-1, -2, -3, -4)
+    ]
+);
+
+declare_variant_test!(
+    Color,
+    rust_variant_roundtrip_color,
+    [
+        Color::from_rgba(0.0, 0.0, 0.0, 1.0),
+        Color::from_rgba(1.0, 1.0, 1.0, 1.0),
+        Color::from_rgba(0.7, 0.5, 0.3, 0.2),
+        Color::from_rgba(0.0, 0.0, 0.0, 0.0)
+    ]
+);
+
+declare_variant_test!(
+    Rect2i,
+    rust_variant_roundtrip_rect2i,
+    [
+        Rect2i::default(),
+        Rect2i::new(Vector2i::ZERO, Vector2i::new(100, 200)),
+        Rect2i::new(Vector2i::new(-50, -50), Vector2i::new(100, 100))
+    ]
+);
+
+declare_variant_test!(
+    Rid,
+    rust_variant_roundtrip_rid,
+    [
+        Rid::Invalid,
+        Rid::new(1),
+        Rid::new(12345),
+        Rid::new(u64::MAX),
+    ]
+);
+
+// Precision-dependent types (fit in both single and double precision).
+declare_variant_test!(
+    Vector2,
+    rust_variant_roundtrip_vector2,
+    [
+        Vector2::ZERO,
+        Vector2::ONE,
+        Vector2::new(12.5, -3.5),
+        Vector2::new(-100.0, 200.0)
+    ]
+);
+
+declare_variant_test!(
+    Vector3,
+    rust_variant_roundtrip_vector3,
+    [
+        Vector3::ZERO,
+        Vector3::ONE,
+        Vector3::new(1.5, 2.5, 3.5),
+        Vector3::new(117.5, 100.0, -323.25),
+        Vector3::new(-1.0, -2.0, -3.0)
+    ]
+);
+
+declare_variant_test!(
+    Vector4,
+    rust_variant_roundtrip_vector4,
+    [
+        Vector4::ZERO,
+        Vector4::ONE,
+        Vector4::new(-18.5, 24.75, -1.25, 777.875),
+        Vector4::new(1.0, 2.0, 3.0, 4.0)
+    ]
+);
+
+declare_variant_test!(
+    Quaternion,
+    rust_variant_roundtrip_quaternion,
+    [
+        Quaternion::default(),
+        Quaternion::new(0.0, 0.0, 0.0, 1.0),
+        Quaternion::new(0.5, 0.5, 0.5, 0.5)
+    ]
+);
+
+declare_variant_test!(
+    Plane,
+    rust_variant_roundtrip_plane,
+    [
+        Plane::new(Vector3::new(1.0, 0.0, 0.0), 0.0),
+        Plane::new(Vector3::new(0.0, 1.0, 0.0), 10.0),
+        Plane::new(Vector3::new(0.0, 0.0, 1.0), -5.0)
+    ]
+);
+
+declare_variant_test!(
+    Rect2,
+    rust_variant_roundtrip_rect2,
+    [
+        Rect2::default(),
+        Rect2::new(Vector2::ZERO, Vector2::new(100.0, 200.0)),
+        Rect2::new(Vector2::new(-50.0, -50.0), Vector2::new(100.0, 100.0))
+    ]
+);
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// Edge Case Tests
+
+#[itest]
+fn rust_variant_type_mismatch() {
+    // Reading wrong type returns None, for nil and populated variants.
+    let nil_variant = Variant::nil();
+    let view = RustVariant::view(&nil_variant);
+    assert_eq!(view.get_type_unchecked(), VariantType::NIL);
+    assert_eq!(view.get_value::<i64>(), None);
+    assert_eq!(view.get_value::<bool>(), None);
+
+    let int_variant = Variant::from(42i64);
+    let view = RustVariant::view(&int_variant);
+    assert_eq!(view.get_value::<f64>(), None);
+    assert_eq!(view.get_value::<bool>(), None);
+
+    let bool_variant = Variant::from(true);
+    let view = RustVariant::view(&bool_variant);
+    assert_eq!(view.get_value::<i64>(), None);
+    assert_eq!(view.get_value::<f64>(), None);
+}
+
+#[itest]
+fn rust_variant_special_floats() {
+    // NaN/infinity round-trip through both public API and direct RustVariant view.
+    for value in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+        let variant = value.to_variant();
+        let via_view = RustVariant::view(&variant).get_value::<f64>().unwrap();
+        let via_public = f64::from_variant(&variant);
+
+        if value.is_nan() {
+            assert!(via_view.is_nan());
+            assert!(via_public.is_nan());
+        } else {
+            assert_eq!(via_view, value);
+            assert_eq!(via_public, value);
+        }
+    }
+}
+
+// Complex types keep FFI path: `RustVariant::view` still reports their type, but they are not `RustMarshal` and thus never bit-copied.
+#[itest]
+fn rust_variant_complex_types_not_inplace() {
+    let string_variant = Variant::from("hello");
+    assert_eq!(
+        RustVariant::view(&string_variant).get_type_unchecked(),
+        VariantType::STRING
+    );
+
+    let array_variant = Variant::from(varray![1, 2, 3]);
+    assert_eq!(
+        RustVariant::view(&array_variant).get_type_unchecked(),
+        VariantType::ARRAY
+    );
+}
+
+// `Variant::clone()` bit-copies in-place variants instead of calling `variant_new_copy`; the copy must be independent of the source.
+#[itest]
+fn rust_variant_clone_independence() {
+    let original = Vector2i::new(10, 20);
+    let modified = Vector2i::new(99, 88);
+
+    let mut variant1 = original.to_variant();
+    let variant2 = variant1.clone();
+    variant1 = modified.to_variant();
+
+    assert_eq!(
+        RustVariant::view(&variant2).get_value::<Vector2i>(),
+        Some(original)
+    );
+    assert_eq!(
+        RustVariant::view(&variant1).get_value::<Vector2i>(),
+        Some(modified)
+    );
+}
+
+// Godot-side decode of every RustMarshal type: catches a wrong data offset or field transposition that a Rust-only round-trip would miss.
+#[itest]
+fn rust_variant_godot_side_read_all_types() {
+    verify_godot_side_read(true, "true");
+    verify_godot_side_read(false, "false");
+    verify_godot_side_read(i64::MIN, "-9223372036854775808");
+    verify_godot_side_read(i64::MAX, "9223372036854775807");
+    verify_godot_side_read(2.5_f64, "2.5");
+    verify_godot_side_read(-0.125_f64, "-0.125");
+
+    verify_godot_side_read(Vector2i::new(1, -2), "(1, -2)");
+    verify_godot_side_read(Vector3i::new(1, -2, 3), "(1, -2, 3)");
+    verify_godot_side_read(Vector4i::new(1, -2, 3, -4), "(1, -2, 3, -4)");
+    verify_godot_side_read(Vector2::new(1.5, -2.5), "(1.5, -2.5)");
+    verify_godot_side_read(Vector3::new(1.5, -2.5, 3.5), "(1.5, -2.5, 3.5)");
+    verify_godot_side_read(Vector4::new(1.5, -2.5, 3.5, -4.5), "(1.5, -2.5, 3.5, -4.5)");
+
+    verify_godot_side_read(
+        Color::from_rgba(0.25, 0.5, 0.75, 0.125),
+        "(0.25, 0.5, 0.75, 0.125)",
+    );
+    verify_godot_side_read(Quaternion::new(0.0, 0.0, 0.0, 1.0), "(0, 0, 0, 1)");
+    verify_godot_side_read(
+        Rect2i::new(Vector2i::new(1, 2), Vector2i::new(30, 40)),
+        "[P: (1, 2), S: (30, 40)]",
+    );
+    verify_godot_side_read(
+        Rect2::new(Vector2::new(1.5, 2.5), Vector2::new(30.5, 40.5)),
+        "[P: (1.5, 2.5), S: (30.5, 40.5)]",
+    );
+    verify_godot_side_read(
+        Plane::new(Vector3::new(0.26726124, 0.5345225, 0.80178374), 2.5),
+        "[N: (0.267261, 0.534522, 0.801784), D: 2.5]",
+    );
+
+    // Rid's Rust representation is a niche-optimized enum, not a plain u64 -- worth an explicit Godot-side check.
+    verify_godot_side_read(Rid::new(12345), "RID(12345)");
+    verify_godot_side_read(Rid::Invalid, "RID(0)");
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// Cross-FFI Layout Tests
+
+/// Verify Rust-created (RustMarshal) and Godot-created (FFI) variants are byte-compatible.
+#[itest]
+fn rust_variant_layout_matches_godot_i64() {
+    // Godot writes the Variant; Rust reads via RustVariant.
+    let godot_created: Variant = varray![42_i64].at(0);
+    let rust_created = 42_i64.to_variant();
+
+    let godot_view = RustVariant::view(&godot_created);
+    let rust_view = RustVariant::view(&rust_created);
+
+    assert_eq!(
+        godot_view.get_type_unchecked(),
+        rust_view.get_type_unchecked()
+    );
+    assert_eq!(godot_view.get_value::<i64>(), Some(42_i64));
+    assert_eq!(rust_view.get_value::<i64>(), Some(42_i64));
+}
+
+#[itest]
+fn rust_variant_layout_matches_godot_vector3() {
+    let v = Vector3::new(1.5, 2.5, 3.5);
+
+    let godot_created: Variant = varray![v].at(0);
+    let rust_created = v.to_variant();
+
+    assert_eq!(
+        RustVariant::view(&godot_created).get_value::<Vector3>(),
+        Some(v),
+    );
+    assert_eq!(
+        RustVariant::view(&rust_created).get_value::<Vector3>(),
+        Some(v),
+    );
+}
+
+/// Verify Rust-written variants are readable by Godot (reverse direction).
+#[itest]
+fn rust_variant_readable_by_godot() {
+    let rust_variant = 12345_i64.to_variant();
+
+    let mut arr: Array<Variant> = Array::new();
+    arr.push(&rust_variant);
+
+    // Godot reads back from its own storage.
+    let retrieved = arr.at(0);
+    assert_eq!(i64::from_variant(&retrieved), 12345_i64);
+
+    // Godot-side stringify()/`==` read the payload independently, catching a bad offset that a round-trip alone would miss.
+    assert_eq!(rust_variant.stringify().to_string(), "12345");
+    assert_eq!(rust_variant, 12345_i64.to_variant());
+}
+
+// Engine-produced nil (via FFI) must match our zeroed-buffer `Variant::nil()`.
+#[itest]
+fn rust_variant_nil_matches_godot_nil() {
+    let godot_nil = Callable::invalid().call(&[]);
+
+    assert_eq!(godot_nil, Variant::nil());
+}

--- a/itest/rust/src/builtin_tests/mod.rs
+++ b/itest/rust/src/builtin_tests/mod.rs
@@ -32,6 +32,7 @@ mod containers {
     mod packed_array_test;
     mod rid_test;
     mod rpc_test;
+    mod rust_variant_test;
     mod signal_disconnect_test;
     mod signal_test;
     mod variant_test;

--- a/itest/rust/src/object_tests/virtual_methods_test.rs
+++ b/itest/rust/src/object_tests/virtual_methods_test.rs
@@ -277,7 +277,7 @@ impl IRefCounted for RevertTest {
 
         match String::from(property).as_str() {
             "property_not_revert" => None,
-            "property_do_revert" => Some(GString::from("hello!").to_variant()),
+            "property_do_revert" => Some("hello!".to_variant()),
             // No UB or anything else like a crash or panic should happen when `property_can_revert` and `property_get_revert` return
             // inconsistent values, but in case something like that happens we should be able to detect it through this function.
             "property_changes" => {


### PR DESCRIPTION
For `Variant` holding `Copy` builtin types (or rather those that don't need an FFI constructor/destructor), we can emulate Godot's `Variant` layout directly in Rust. This saves a large number of FFI calls for just `Variant` conversions and has the potential to speed up operations across the board.