### PR TITLE
Support async versions of `tools::load()` and `tools::try_load()`

### DIFF
--- a/godot-core/src/meta/error/io_error.rs
+++ b/godot-core/src/meta/error/io_error.rs
@@ -75,6 +75,21 @@ impl IoError {
         }
     }
 
+    #[cfg(feature = "experimental-threads")]
+    pub(crate) fn loading_precondition(
+        class: String,
+        path: String,
+        precondition: &'static str,
+    ) -> Self {
+        Self {
+            data: ErrorData::Load(LoaderError {
+                kind: LoaderErrorKind::Precondition(precondition),
+                class,
+                path,
+            }),
+        }
+    }
+
     pub(crate) fn check_unique_open_file_access(
         file_access: Gd<FileAccess>,
     ) -> Result<Gd<FileAccess>, Self> {
@@ -123,6 +138,8 @@ struct LoaderError {
 enum LoaderErrorKind {
     Load,
     Cast,
+    #[cfg(feature = "experimental-threads")]
+    Precondition(&'static str),
 }
 
 impl Error for LoaderError {}
@@ -140,6 +157,11 @@ impl fmt::Display for LoaderError {
             LoaderErrorKind::Cast => write!(
                 f,
                 "can't cast loaded resource to class: '{class}' from path: '{path}'"
+            ),
+            #[cfg(feature = "experimental-threads")]
+            LoaderErrorKind::Precondition(condition) => write!(
+                f,
+                "can't load resource due to missing precondition: {condition}, class: '{path}', path: '{path}"
             ),
         }
     }

--- a/godot-core/src/tools/save_load.rs
+++ b/godot-core/src/tools/save_load.rs
@@ -73,6 +73,68 @@ where
     load_impl(path)
 }
 
+/// ⚠️ Loads a resource from the filesystem located at `path` on a worker thread, panicking on error.
+///
+/// See [`try_load()`] and [`try_load_threaded()`] for more information.
+///
+/// # Example
+///
+/// ```no_run
+/// use godot::prelude::*;
+///
+/// godot::task::spawn(async {
+///     let scene = load_threaded::<PackedScene>("res://path/to/Main.tscn").await;
+/// });
+/// ```
+///
+/// # Panics
+/// If the resource cannot be loaded, is not of type `T` or inherited or the global `MainLoop` is not a `SceneTree`.
+#[inline]
+#[cfg(feature = "experimental-threads")]
+pub async fn load_threaded<T>(path: impl AsArg<GString>) -> Gd<T>
+where
+    T: Inherits<Resource>,
+{
+    arg_into_ref!(path);
+    load_threaded_impl(path)
+        .await
+        .unwrap_or_else(|err| panic!("failed to load resource at '{path}': {err}"))
+}
+
+/// Loads a resource from the filesystem located at `path` on a worker thread.
+///
+/// This function can fail if resource can't be loaded by [`ResourceLoader`] or if the subsequent cast into `T` fails.
+///
+/// This method is a simplified version of [`ResourceLoader::load_threaded_request`][crate::classes::ResourceLoader::load_threaded_request],
+/// which can be used for more advanced scenarios.
+///
+/// See synchronous version [`try_load()`] for more details.
+///
+/// # Example
+/// Loads a scene called `Main` located in the `path/to` subdirectory of the Godot project and caches it in a variable.
+/// The resource is directly stored with type `PackedScene`.
+///
+/// ```no_run
+/// use godot::prelude::*;
+///
+/// godot::task::spawn(async {
+///     if let Ok(scene) = try_load_threaded::<PackedScene>("res://path/to/Main.tscn").await {
+///         // all good
+///     } else {
+///         // handle error
+///     }
+/// });
+/// ```
+#[inline]
+#[cfg(feature = "experimental-threads")]
+pub async fn try_load_threaded<T>(path: impl AsArg<GString>) -> Result<Gd<T>, IoError>
+where
+    T: Inherits<Resource>,
+{
+    arg_into_ref!(path);
+    load_threaded_impl(path).await
+}
+
 /// ⚠️ Saves a [`Resource`]-inheriting object into the file located at `path`.
 ///
 /// See [`try_save()`] for more information.
@@ -160,6 +222,72 @@ where
             T::class_id().to_string(),
             path.to_string(),
         )),
+    }
+}
+
+// Separate function, to avoid constructing string twice
+// Note that more optimizations than that likely make no sense, as loading is quite expensive
+#[cfg(feature = "experimental-threads")]
+async fn load_threaded_impl<T>(path: &GString) -> Result<Gd<T>, IoError>
+where
+    T: Inherits<Resource>,
+{
+    use crate::classes::resource_loader::ThreadLoadStatus;
+    use crate::classes::{Engine, SceneTree};
+
+    let mut resource_loader = ResourceLoader::singleton();
+    let tree = Engine::singleton()
+        .get_main_loop()
+        .ok_or_else(|| {
+            IoError::loading_precondition(
+                T::class_id().to_string(),
+                path.to_string(),
+                "SceneTree is ready",
+            )
+        })?
+        .try_cast::<SceneTree>()
+        .map_err(|_| {
+            IoError::loading_precondition(
+                T::class_id().to_string(),
+                path.to_string(),
+                "MainLoop is SceneTree",
+            )
+        })?;
+
+    resource_loader
+        .load_threaded_request_ex(path)
+        .type_hint(&T::class_id().to_gstring())
+        .done();
+
+    loop {
+        match resource_loader.load_threaded_get_status(path) {
+            ThreadLoadStatus::IN_PROGRESS => {
+                tree.signals().process_frame().to_future().await;
+            }
+
+            ThreadLoadStatus::LOADED => {
+                break resource_loader
+                    .load_threaded_get(path)
+                    .unwrap()
+                    .try_cast::<T>()
+                    .map_err(|_| {
+                        IoError::loading_cast(T::class_id().to_string(), path.to_string())
+                    });
+            }
+
+            ThreadLoadStatus::INVALID_RESOURCE | ThreadLoadStatus::FAILED => {
+                // Prevents a memory leak. The engine creates a resource with ref-count 0 and it has to be collected from the loader.
+                resource_loader.load_threaded_get(path);
+
+                break Err(IoError::loading(
+                    T::class_id().to_string(),
+                    path.to_string(),
+                ));
+            }
+
+            // All load status variants have been covered.
+            _ => unreachable!(),
+        }
     }
 }
 

--- a/itest/rust/src/engine_tests/save_load_test.rs
+++ b/itest/rust/src/engine_tests/save_load_test.rs
@@ -101,3 +101,34 @@ fn load_with_onready() {
 
     remove_test_file(RESOURCE_NAME);
 }
+
+#[cfg(feature = "experimental-threads")]
+#[itest(async)]
+fn threaded_load_test() -> godot::task::TaskHandle {
+    use godot::tools::{load_threaded, try_load_threaded};
+
+    godot::task::spawn(async {
+        let level = 2317;
+        let res_path = format!("res://{RESOURCE_NAME}");
+
+        let mut resource = SavedGame::new_gd();
+        resource.bind_mut().set_level(level);
+
+        save(&resource, &res_path);
+
+        // TODO(v0.6): suppress "ERROR" print in API itself.
+        let res = try_load_threaded::<SavedGame>(FAULTY_PATH).await;
+        assert!(res.is_err());
+
+        let res = try_load_threaded::<SavedGame>(&res_path).await;
+        assert!(res.is_ok());
+
+        let loaded = res.unwrap();
+        assert_eq!(loaded.bind().get_level(), level);
+
+        let loaded = load_threaded::<SavedGame>(&res_path).await;
+        assert_eq!(loaded.bind().get_level(), level);
+
+        remove_test_file(RESOURCE_NAME);
+    })
+}


### PR DESCRIPTION
Async versions of `tools::load` and `tools::try_load` that abstract away the complexities and pitfalls of `ResourceLoaded::load_threaded_request`.

The implementation depends on a `SceneTree` main loop. It could be expanded to make the main loop replaceable, but this would increase the complexity for the average user, while someone who uses their own main loop should be able to replicate these functions themselves.