### PR TITLE
Work around broken `cargo` on macOS CI

### DIFF
--- a/.github/composite/rust/action.yml
+++ b/.github/composite/rust/action.yml
@@ -89,4 +89,14 @@ runs:
         echo RUST_BACKTRACE=1 >> $GITHUB_ENV
         
         rustc --version --verbose
+
+        # Sanity check: macOS arm64 runners have occasionally had a broken rustup proxy where `cargo` resolves to the
+        # rustup binary itself, making `cargo build` fail with "unexpected argument 'build' found". Dump info and reinstall.
+        cargo --version && exit 0
+        echo "::error::Rust toolchain broken; dumping diagnostics and reinstalling."
+        which cargo rustc; ls -la ~/.cargo/bin/; file ~/.cargo/bin/cargo; rustup show
+        rustup toolchain uninstall ${{ inputs.rust }} || true
+        $RETRY rustup toolchain install ${{ inputs.rust }} --profile minimal --no-self-update ${{ steps.configure.outputs.components }}
+        rustup default ${{ inputs.rust }}
+        cargo --version
       shell: bash


### PR DESCRIPTION
We sometimes had the problem that `cargo build` failed with:
```
error: error: unexpected argument 'build' found
```
Likely an issue with `rustup` install. If this happens, the CI now uninstalls + reinstalls the toolchain.

Example CI runs:
- https://github.com/godot-rust/gdext/actions/runs/25912577993
- https://github.com/godot-rust/gdext/actions/runs/25912912362