### PR TITLE
`Gd::is_editor_placeholder` + many more placeholder tests

### DIFF
--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -210,6 +210,16 @@ where
     pub fn bind_mut(&mut self) -> GdMut<'_, T> {
         self.raw.bind_mut()
     }
+
+    /// Returns `true` if this object has no Rust instance attached (placeholder).
+    ///
+    /// In the Godot editor, classes that are not marked `#[class(tool)]` are replaced with _placeholder instances_ (Godot 4.3+ "runtime classes").
+    /// From Godot's perspective the instance still exists, so scenes and script code referring to it do not break, but the Rust side is absent.
+    #[cfg(feature = "trace")] // itest only; not yet exposed publicly.
+    #[doc(hidden)]
+    pub fn is_editor_placeholder(&self) -> bool {
+        self.raw.storage().is_none()
+    }
 }
 
 /// _The methods in this impl block are available for any `T`._ <br><br>

--- a/godot-core/src/obj/script.rs
+++ b/godot-core/src/obj/script.rs
@@ -125,6 +125,10 @@ pub trait ScriptInstance: Sized {
     ///
     /// If this function and [IScriptExtension::is_placeholder_fallback_enabled] return true, Godot will call [`Self::property_set_fallback`]
     /// instead of [`Self::set_property`].
+    ///
+    /// Note: this is the _script-side_ placeholder (broken/unavailable script), distinct from the _class-side_ editor placeholder
+    /// substituted for "runtime classes" (non-tool classes, that don't run in the editor).
+    // TODO(v0.6): consider renaming to e.g. `is_script_placeholder`, also differentiate from Gd::is_editor_placeholder.
     fn is_placeholder(&self) -> bool;
 
     /// Validation function for the engine to verify if the script exposes a certain method.

--- a/godot/src/lib.rs
+++ b/godot/src/lib.rs
@@ -10,7 +10,7 @@
 //! The **gdext** library implements Rust bindings for the [Godot](https://godotengine.org) engine, more precisely its version 4.
 //! It does so using the GDExtension API, a C interface to integrate third-party language bindings with the engine.
 //!
-//! This API doc is accompanied by the [book](https://github.com/godot-rust/book), which provides tutorials
+//! This API doc is accompanied by the [book](https://godot-rust.github.io/book), which provides tutorials
 //! that guide you along the way.
 //!
 //! An overview of fundamental types and concepts can be found on [this page](__docs).

--- a/itest/rust/src/editor_test/editor_placeholder_test.rs
+++ b/itest/rust/src/editor_test/editor_placeholder_test.rs
@@ -16,20 +16,60 @@
 //! The cache is warmed at editor startup via doc generation, so the real `init()` has already run by the time these tests execute.
 
 use std::panic;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Mutex;
 
 use godot::builtin::{GString, StringName, Variant};
+use godot::classes::notify::NodeNotification;
 use godot::classes::{INode, Node};
 use godot::meta::ToGodot;
-use godot::obj::{Base, NewAlloc};
+use godot::obj::{Base, Gd, NewAlloc};
 use godot::register::{GodotClass, godot_api};
 
-use crate::framework::{itest, suppress_panic_log};
+use crate::framework::{itest, suppress_godot_print, suppress_panic_log};
 
-static RUNTIME_INIT_COUNT: AtomicUsize = AtomicUsize::new(0);
-static TOOL_INIT_COUNT: AtomicUsize = AtomicUsize::new(0);
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// Tally (global counter for individual operations)
 
-/// Runtime (non-tool) class. Has both `#[var]` and `#[export]` to cover both default-value cache outcomes.
+// Mutex good enough, no real contention.
+const N: usize = Tally::_Count as usize;
+static COUNTS: Mutex<[usize; N]> = Mutex::new([0; N]);
+
+#[derive(Copy, Clone)]
+#[repr(usize)]
+enum Tally {
+    RuntimeInit,
+    RuntimeReady,
+    RuntimeFunc,
+    ToolInit,
+    PropCustomGet,
+    PropCustomSet,
+    PropOnGet,
+    PropOnSet,
+    _Count,
+}
+
+impl Tally {
+    fn inc(self) {
+        COUNTS.lock().unwrap()[self as usize] += 1;
+    }
+
+    fn get(self) -> usize {
+        COUNTS.lock().unwrap()[self as usize]
+    }
+
+    /// Runs `op`, returns the increment observed on `self`.
+    fn delta(self, op: impl FnOnce()) -> usize {
+        let before = self.get();
+        op();
+        self.get() - before
+    }
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// Probe classes
+
+/// Runtime (non-tool) class. Combines `#[var]` + `#[export]` (default-value cache outcomes) with custom `#[var(get=..., set=...)]`
+/// accessors and `IObject::on_get` / `on_set` overrides -- placeholders bypass all of these, so they share one probe.
 #[derive(GodotClass)]
 #[class(base = Node)]
 struct RuntimeProbe {
@@ -38,20 +78,58 @@ struct RuntimeProbe {
 
     #[export]
     export_field: GString,
+
+    #[var(get = get_custom, set = set_custom)]
+    custom_field: i64,
 }
 
 #[godot_api]
 impl INode for RuntimeProbe {
     fn init(_base: Base<Node>) -> Self {
-        RUNTIME_INIT_COUNT.fetch_add(1, Ordering::SeqCst);
+        Tally::RuntimeInit.inc();
         Self {
             var_field: 43,
             export_field: GString::from("hello"),
+            custom_field: 0,
         }
+    }
+
+    fn ready(&mut self) {
+        Tally::RuntimeReady.inc();
     }
 
     fn on_property_get_revert(&self, property: StringName) -> Option<Variant> {
         (property == "var_field").then(|| 0.to_variant())
+    }
+
+    fn on_get(&self, _property: StringName) -> Option<Variant> {
+        Tally::PropOnGet.inc();
+        None
+    }
+
+    fn on_set(&mut self, _property: StringName, _value: Variant) -> bool {
+        Tally::PropOnSet.inc();
+        false
+    }
+}
+
+#[godot_api]
+impl RuntimeProbe {
+    #[func]
+    fn touch(&mut self) {
+        Tally::RuntimeFunc.inc();
+    }
+
+    #[func]
+    fn get_custom(&self) -> i64 {
+        Tally::PropCustomGet.inc();
+        self.custom_field
+    }
+
+    #[func]
+    fn set_custom(&mut self, value: i64) {
+        Tally::PropCustomSet.inc();
+        self.custom_field = value;
     }
 }
 
@@ -69,7 +147,7 @@ struct ToolProbe {
 #[godot_api]
 impl INode for ToolProbe {
     fn init(_base: Base<Node>) -> Self {
-        TOOL_INIT_COUNT.fetch_add(1, Ordering::SeqCst);
+        Tally::ToolInit.inc();
         Self {
             var_field: 43,
             export_field: GString::from("hello"),
@@ -81,18 +159,41 @@ impl INode for ToolProbe {
     }
 }
 
+#[godot_api]
+impl ToolProbe {
+    #[func]
+    fn touch(&mut self) {
+        // Shared counter with `RuntimeProbe::touch` is fine: each test only reads the delta around its own call.
+        Tally::RuntimeFunc.inc();
+    }
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// Test helpers
+
+/// Runs `op`, expects a panic, asserts the panic message contains every fragment.
+///
+/// Panic payload is assumed to be `String` -- godot-rust's runtime panics use `format!`, never plain string literals.
+fn expect_panic_with_fragments(label: &str, fragments: &[&str], op: impl FnOnce()) {
+    let result = suppress_panic_log(|| panic::catch_unwind(panic::AssertUnwindSafe(op)));
+    let payload = match result {
+        Ok(()) => panic!("{label}: must panic"),
+        Err(p) => p,
+    };
+    let msg = payload
+        .downcast_ref::<String>()
+        .expect("panic payload should be String");
+
+    for fragment in fragments {
+        assert!(
+            msg.contains(fragment),
+            "{label}: missing {fragment:?} in panic: {msg}"
+        );
+    }
+}
+
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Tests -- runtime class (placeholdered in editor)
-
-#[itest(editor)]
-fn editor_runtime_get_returns_cached_default() {
-    let node = RuntimeProbe::new_alloc();
-
-    assert_eq!(node.get("var_field"), Variant::nil());
-    assert_eq!(node.get("export_field"), "hello".to_variant());
-
-    node.free();
-}
 
 /// `PlaceholderExtensionInstance` stores property values in an internal map so the editor can preserve them while the extension is unavailable.
 #[itest(editor)]
@@ -136,6 +237,10 @@ fn editor_runtime_property_list_complete() {
         has_name("export_field"),
         "export_field missing from property list"
     );
+    assert!(
+        has_name("custom_field"),
+        "custom_field missing from property list"
+    );
 
     node.free();
 }
@@ -155,58 +260,15 @@ fn editor_runtime_class_identity() {
     node.free();
 }
 
-/// Regression test for <https://github.com/godot-rust/gdext/issues/1404>: `new_alloc()` on a runtime class in editor must not run `init()`.
-#[itest(editor)]
-fn editor_runtime_init_not_called() {
-    // Delta-based; doesn't care about #times that RuntimeProbe was constructed. Assumes serial itest execution.
-    let before = RUNTIME_INIT_COUNT.load(Ordering::SeqCst);
-    let node = RuntimeProbe::new_alloc();
-    let delta = RUNTIME_INIT_COUNT.load(Ordering::SeqCst) - before;
-    node.free();
-
-    assert_eq!(
-        delta, 0,
-        "runtime class instantiated in editor ran user init {delta} time(s); placeholder should have been substituted",
-    );
-}
-
-/// `bind()` on a placeholder panics with a message naming both the placeholder context and the class.
-#[itest(editor)]
-fn editor_runtime_bind_panics() {
-    let node = RuntimeProbe::new_alloc();
-
-    let result = suppress_panic_log(|| {
-        panic::catch_unwind(panic::AssertUnwindSafe(|| {
-            let _guard = node.bind();
-        }))
-    });
-
-    let payload = result.expect_err("bind() on placeholder must panic");
-    let msg = payload
-        .downcast_ref::<String>()
-        .map(String::as_str)
-        .or_else(|| payload.downcast_ref::<&'static str>().copied())
-        .unwrap_or("<non-string panic payload>");
-
-    assert!(
-        msg.contains("placeholder"),
-        "panic message missing 'placeholder': {msg}"
-    );
-    assert!(
-        msg.contains("RuntimeProbe"),
-        "panic message missing class name: {msg}"
-    );
-
-    node.free();
-}
-
 /// Lazy default-value probe: the per-class cache is populated by exactly one real instantiation. Once warm, no further `init()` calls
 /// happen for `new_alloc()` or `get()`. The editor warms the cache at startup (see module doc).
+///
+/// Doubles as regression test for <https://github.com/godot-rust/gdext/issues/1404>: `new_alloc()` on a runtime class in editor
+/// must not run `init()`.
 #[itest(editor)]
 fn editor_runtime_lazy_default_probe() {
-    // Use `>= 1` (not `== 1`): the cache is guaranteed warm by the time any test runs, but the exact probe count at startup is a Godot
-    // implementation detail that may change across versions. We only care that no further inits are triggered below.
-    let baseline = RUNTIME_INIT_COUNT.load(Ordering::SeqCst);
+    // `>= 1` (not `== 1`): the cache is warm by the time any test runs, but the exact startup probe count is a Godot impl detail.
+    let baseline = Tally::RuntimeInit.get();
     assert!(
         baseline >= 1,
         "editor startup must populate the ClassDB default-value cache by instantiating the class at least once; got {baseline}",
@@ -214,21 +276,27 @@ fn editor_runtime_lazy_default_probe() {
 
     let node = RuntimeProbe::new_alloc();
     assert_eq!(
-        RUNTIME_INIT_COUNT.load(Ordering::SeqCst) - baseline,
+        Tally::RuntimeInit.get() - baseline,
         0,
         "new_alloc() must not call init() for a runtime class in the editor",
     );
 
-    let value = node.get("export_field");
+    let export_value = node.get("export_field");
+    let var_value = node.get("var_field");
     assert_eq!(
-        RUNTIME_INIT_COUNT.load(Ordering::SeqCst) - baseline,
+        Tally::RuntimeInit.get() - baseline,
         0,
         "get() must not call init() -- the default-value cache is already populated",
     );
     assert_eq!(
-        value,
+        export_value,
         "hello".to_variant(),
         "placeholder get() must return cached class default for #[export] properties"
+    );
+    assert_eq!(
+        var_value,
+        Variant::nil(),
+        "placeholder get() must return nil for #[var]-only properties (not in default-value cache)"
     );
 
     node.free();
@@ -274,18 +342,172 @@ fn editor_runtime_virtual_callbacks_bypassed() {
 /// editor; `bind()` succeeds and returns the real Rust struct.
 #[itest(editor)]
 fn editor_tool_init_runs() {
-    let before = TOOL_INIT_COUNT.load(Ordering::SeqCst);
-    let node = ToolProbe::new_alloc();
-    let delta = TOOL_INIT_COUNT.load(Ordering::SeqCst) - before;
+    let mut node = None;
+    let init_delta = Tally::ToolInit.delta(|| node = Some(ToolProbe::new_alloc()));
+    let node = node.unwrap();
 
     assert_eq!(
-        delta, 1,
+        init_delta, 1,
         "tool class must run user init() exactly once on new_alloc()"
     );
     assert_eq!(
         node.bind().var_field,
         43,
         "bind() on tool class must return the real Rust struct"
+    );
+
+    node.free();
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// Additional placeholder API / behavior tests
+
+/// `Gd::is_editor_placeholder()`: true for runtime classes in editor, false for tool classes.
+#[itest(editor)]
+fn editor_placeholder_flag() {
+    let runtime = RuntimeProbe::new_alloc();
+    let tool = ToolProbe::new_alloc();
+
+    assert!(
+        runtime.is_editor_placeholder(),
+        "runtime class must report as placeholder in editor"
+    );
+    assert!(
+        !tool.is_editor_placeholder(),
+        "tool class must never report as placeholder"
+    );
+
+    runtime.free();
+    tool.free();
+}
+
+/// Both `bind()` and `bind_mut()` panic on a placeholder; panic message names the placeholder context and the class.
+#[itest(editor)]
+fn editor_runtime_bind_panics() {
+    let mut node = RuntimeProbe::new_alloc();
+    let fragments = &["placeholder", "RuntimeProbe"];
+
+    expect_panic_with_fragments("bind()", fragments, || drop(node.bind()));
+    expect_panic_with_fragments("bind_mut()", fragments, || drop(node.bind_mut()));
+
+    node.free();
+}
+
+/// `#[func]` is callable through `Object::call()` on a placeholder (method is in `ClassDB`), but the wrapper's internal `bind()` panics --
+/// so the user body never runs. Tool counterpart runs the body normally.
+#[itest(editor)]
+fn editor_runtime_func_body_skipped() {
+    let mut placeholder = RuntimeProbe::new_alloc();
+    let mut tool = ToolProbe::new_alloc();
+
+    let placeholder_delta = Tally::RuntimeFunc.delta(|| {
+        // FFI boundary catches the inner panic and turns the call into a nil-returning error log.
+        suppress_godot_print(|| {
+            let _ = placeholder.call("touch", &[]);
+        });
+    });
+    assert_eq!(
+        placeholder_delta, 0,
+        "#[func] body must not execute on placeholder"
+    );
+
+    let tool_delta = Tally::RuntimeFunc.delta(|| {
+        let _ = tool.call("touch", &[]);
+    });
+    assert_eq!(tool_delta, 1, "tool counterpart must execute #[func] body");
+
+    placeholder.free();
+    tool.free();
+}
+
+/// On a placeholder, `set`/`get` go through Godot's internal property map and bypass both `#[var(get=..., set=...)]` accessors and the
+/// `IObject::on_get` / `on_set` overrides.
+#[itest(editor)]
+fn editor_runtime_property_hooks_skipped() {
+    let mut node = RuntimeProbe::new_alloc();
+
+    let hooks = [
+        (Tally::PropCustomSet, "custom #[var(set=...)]"),
+        (Tally::PropOnSet, "IObject::on_set"),
+        (Tally::PropCustomGet, "custom #[var(get=...)]"),
+        (Tally::PropOnGet, "IObject::on_get"),
+    ];
+    let before = hooks.map(|(c, _)| c.get());
+
+    node.set("custom_field", &7.to_variant());
+    let roundtrip_value = node.get("custom_field");
+
+    for (i, (c, label)) in hooks.iter().enumerate() {
+        assert_eq!(c.get(), before[i], "{label} must not run on placeholder");
+    }
+
+    // Roundtrip resolves via the placeholder's internal map, not our accessors.
+    assert_eq!(
+        roundtrip_value,
+        7.to_variant(),
+        "placeholder set/get roundtrip must echo the raw Variant"
+    );
+
+    node.free();
+}
+
+/// Virtual `ready()` is bypassed on a placeholder: `NOTIFICATION_READY` does not invoke the Rust override.
+#[itest(editor)]
+fn editor_runtime_ready_skipped() {
+    let mut node = RuntimeProbe::new_alloc();
+
+    let ready_delta = Tally::RuntimeReady.delta(|| node.notify(NodeNotification::READY));
+    assert_eq!(
+        ready_delta, 0,
+        "ready() override must not run for placeholder (notification routed to Godot stub)"
+    );
+
+    node.free();
+}
+
+/// Placeholder property storage is per-instance: setting on one placeholder does not leak to another.
+#[itest(editor)]
+fn editor_runtime_storage_isolation() {
+    let mut a = RuntimeProbe::new_alloc();
+    let b = RuntimeProbe::new_alloc();
+
+    a.set("var_field", &111.to_variant());
+
+    assert_eq!(
+        a.get("var_field"),
+        111.to_variant(),
+        "A must read back its own value"
+    );
+    assert_eq!(
+        b.get("var_field"),
+        Variant::nil(),
+        "B must be independent (no shared storage; #[var] has no cached default)"
+    );
+
+    a.free();
+    b.free();
+}
+
+/// Upcasts and downcasts work on placeholders; the Godot-side class hierarchy is intact.
+#[itest(editor)]
+fn editor_runtime_upcast_downcast() {
+    let node = RuntimeProbe::new_alloc();
+    assert!(node.is_editor_placeholder());
+
+    // `is_editor_placeholder()` is only defined on user-declared `T`, so verify the upcasted object via its dynamic class.
+    let upcast: Gd<Node> = node.clone().upcast();
+    assert_eq!(
+        upcast.get_class(),
+        GString::from("RuntimeProbe"),
+        "upcast preserves dynamic class"
+    );
+
+    let downcast = upcast
+        .try_cast::<RuntimeProbe>()
+        .expect("downcast back to RuntimeProbe");
+    assert!(
+        downcast.is_editor_placeholder(),
+        "downcast back to user type preserves placeholder status"
     );
 
     node.free();

--- a/itest/rust/src/editor_test/mod.rs
+++ b/itest/rust/src/editor_test/mod.rs
@@ -10,3 +10,25 @@
 mod editor_placeholder_test;
 
 mod editor_general_test;
+
+/// On Godot < 4.3, placeholder substitution does not exist; `is_editor_placeholder()` always returns `false`.
+#[cfg(before_api = "4.3")]
+#[crate::framework::itest(editor)]
+fn editor_pre_4_3_no_placeholders() {
+    use godot::obj::NewGd;
+    use godot::register::GodotClass;
+
+    #[derive(GodotClass)]
+    #[class(init)]
+    struct RuntimeProbe {}
+
+    #[derive(GodotClass)]
+    #[class(tool, init)]
+    struct ToolProbe {}
+
+    let runtime = RuntimeProbe::new_gd();
+    let tool = ToolProbe::new_gd();
+
+    assert!(!runtime.is_editor_placeholder(), "no placeholders (<4.3)");
+    assert!(!tool.is_editor_placeholder(), "tool no placeholders (<4.3)");
+}


### PR DESCRIPTION
Codifies quite a few of the implicit assumptions that exist on placeholders as itests, concretely which operations are available on tool/runtime classes and how they differ.

Also adds `Gd::is_editor_placeholder`  to allow objects to be queried for being placeholders. This was useful for tests; I wonder if there's a use case beyond?