### PR TITLE
Auto-remove custom callables also when connected in untyped APIs

### DIFF
--- a/.github/workflows/minimal-ci.yml
+++ b/.github/workflows/minimal-ci.yml
@@ -204,7 +204,7 @@ jobs:
             godot-binary: godot.linuxbsd.editor.dev.x86_64
             rust-extra-args: --features itest/codegen-full,itest/test-gdextension-dependency
             rust-extra-env: GDRUST_MAIN_EXTENSION=IntegrationTests
-            hot-reload: stable
+            hot-reload: stable signal-test
 
           - name: linux-custom-api-json
             os: ubuntu-24.04

--- a/godot-core/src/builtin/callable.rs
+++ b/godot-core/src/builtin/callable.rs
@@ -125,7 +125,9 @@ impl Callable {
     fn default_callable_custom_info() -> CallableCustomInfo {
         CallableCustomInfo {
             callable_userdata: ptr::null_mut(),
-            token: ptr::null_mut(),
+            // Token uniquely identifies this GDExtension. Set it so we can later recognize our own custom callables via `is_rust_callable()` --
+            // the engine returns userdata only when the token matches. Used e.g. during hot-reload cleanup.
+            token: rust_callable_token(),
             object_id: 0,
             call_func: None,
             is_valid_func: None, // overwritten later.
@@ -453,6 +455,23 @@ impl Callable {
         self.as_inner().is_custom()
     }
 
+    /// Returns true if this is a custom callable created by **this** godot-rust extension.
+    ///
+    /// Stricter than [`is_custom()`][Self::is_custom]: returns `false` for engine-side custom callables (e.g. GDScript lambdas, bound
+    /// methods) and for custom callables created by other GDExtensions. Detection relies on the GDExtension token set at creation, which
+    /// the engine only echoes back on a match.
+    ///
+    /// Note: callables produced by `bind()`/`bindv()`/`unbind()` on a Rust callable are re-wrapped **engine-side** and carry the engine's
+    /// token, not ours -- so this returns `false` for them, even though the underlying function is ours.
+    #[doc(hidden)] // Not yet exposed; name considerations: custom, local to *this* extension?
+    pub fn is_rust_callable(&self) -> bool {
+        // SAFETY: `self.sys()` is a valid Callable pointer; `get_userdata` only reads it and compares the token.
+        let userdata = unsafe {
+            sys::interface_fn!(callable_custom_get_userdata)(self.sys(), rust_callable_token())
+        };
+        !userdata.is_null()
+    }
+
     /// Returns true if this callable has no target to call the method on.
     ///
     /// This is not the negated form of [`is_valid`][Self::is_valid], as `is_valid` will return `false` if the callable has a
@@ -560,6 +579,15 @@ impl fmt::Display for Callable {
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Callbacks for custom implementations
+
+/// Token uniquely identifying this godot-rust extension, stamped on every custom callable we create.
+///
+/// The engine's `callable_custom_get_userdata` returns the userdata only when this exact token is passed back, which lets us recognize our
+/// own custom callables. We reuse the library pointer (same value passed to the entry symbol), as the GDExtension API recommends.
+fn rust_callable_token() -> *mut std::ffi::c_void {
+    // SAFETY: `get_library()` is valid after initialization, which has happened by the time any callable is created.
+    unsafe { sys::get_library().cast::<std::ffi::c_void>() }
+}
 
 pub use custom_callable::RustCallable;
 use custom_callable::*;

--- a/godot-core/src/builtin/signal.rs
+++ b/godot-core/src/builtin/signal.rs
@@ -18,6 +18,7 @@ use crate::meta;
 use crate::meta::{FromGodot, GodotType, ToGodot};
 use crate::obj::bounds::DynMemory;
 use crate::obj::{Bounds, EngineBitfield, Gd, GodotClass, InstanceId};
+use crate::signal::store_custom_callable_connection;
 
 /// Untyped Godot signal.
 ///
@@ -74,6 +75,7 @@ impl Signal {
     pub fn connect(&self, callable: &Callable) -> Error {
         let error = self.as_inner().connect(callable, 0i64);
 
+        track_custom_callable(self, callable);
         Error::from_godot(error as i32)
     }
 
@@ -88,6 +90,7 @@ impl Signal {
     pub fn connect_flags(&self, callable: &Callable, flags: ConnectFlags) -> Error {
         let error = self.as_inner().connect(callable, flags.ord() as i64);
 
+        track_custom_callable(self, callable);
         Error::from_godot(error as i32)
     }
 
@@ -183,6 +186,16 @@ impl Signal {
     #[doc(hidden)]
     pub fn as_inner(&self) -> inner::InnerSignal<'_> {
         inner::InnerSignal::from_outer(self)
+    }
+}
+
+/// See `Object::connect` companion in `type_safe_replacements.rs` for rationale.
+fn track_custom_callable(signal: &Signal, callable: &Callable) {
+    // Only the editor needs the registry; skip the `object()` FFI call entirely outside it.
+    if sys::is_editor()
+        && let Some(receiver) = signal.object()
+    {
+        store_custom_callable_connection(&receiver, &signal.name(), callable);
     }
 }
 

--- a/godot-core/src/classes/type_safe_replacements.rs
+++ b/godot-core/src/classes/type_safe_replacements.rs
@@ -17,8 +17,9 @@ use crate::classes::object::ConnectFlags;
 use crate::classes::scene_tree::GroupCallFlags;
 use crate::classes::{Node, Object, SceneTree, Script};
 use crate::global::Error;
-use crate::meta::{AsArg, ToGodot, arg_into_ref};
+use crate::meta::{AsArg, ToGodot, arg_into_owned, arg_into_ref};
 use crate::obj::{EngineBitfield, Gd};
+use crate::signal::store_custom_callable_connection;
 
 impl Object {
     pub fn get_script(&self) -> Option<Gd<Script>> {
@@ -37,7 +38,10 @@ impl Object {
     }
 
     pub fn connect(&mut self, signal: impl AsArg<StringName>, callable: &Callable) -> Error {
-        self.raw_connect(signal, callable)
+        arg_into_owned!(signal);
+        let result = self.raw_connect(&signal, callable);
+        track_callable_connection(self, &signal, callable);
+        result
     }
 
     pub fn connect_flags(
@@ -46,10 +50,30 @@ impl Object {
         callable: &Callable,
         flags: ConnectFlags,
     ) -> Error {
-        self.raw_connect_ex(signal, callable)
+        arg_into_owned!(signal);
+        let result = self
+            .raw_connect_ex(&signal, callable)
             .flags(flags.ord() as u32)
-            .done()
+            .done();
+        track_callable_connection(self, &signal, callable);
+        result
     }
+}
+
+/// Registers a custom-callable connection so it can be auto-disconnected before hot reload.
+///
+/// Called by `Object::connect` / `Object::connect_flags` APIs, used both directly and through typed signal APIs. Ignores non-custom callables.
+fn track_callable_connection(receiver: &Object, signal_name: &StringName, callable: &Callable) {
+    // Only the editor needs the registry; skip the weak-`Gd` construction entirely outside it.
+    if !crate::sys::is_editor() {
+        return;
+    }
+
+    // SAFETY: `receiver` is a live `Object` reference for the duration of this call. The weak `Gd` is passed to
+    // `store_custom_callable_connection` (which clones its own handle) and disposed of here via `drop_weak`.
+    let weak_gd: Gd<Object> = unsafe { Gd::from_obj_sys_weak(receiver.__object_ptr()) };
+    store_custom_callable_connection(&weak_gd, signal_name, callable);
+    weak_gd.drop_weak();
 }
 
 impl Node {

--- a/godot-core/src/signal/mod.rs
+++ b/godot-core/src/signal/mod.rs
@@ -31,7 +31,9 @@ pub mod priv_re_export {
 }
 
 // Crate-internal items used outside this module.
-pub(crate) use signal_connections_registry::prune_stored_signal_connections;
+pub(crate) use signal_connections_registry::{
+    prune_stored_signal_connections, store_custom_callable_connection,
+};
 pub(crate) use signal_object::SignalObject;
 
 use crate::builtin::{CowStr, Variant};

--- a/godot-core/src/signal/signal_connections_registry.rs
+++ b/godot-core/src/signal/signal_connections_registry.rs
@@ -51,22 +51,32 @@ fn prune_stale_connections(registry: &mut Vec<CachedSignalConnection>) {
     });
 }
 
-/// Stores a custom-callable connection so it can be disconnected during library deinitialization, and prunes existing connections to
-/// objects that are no longer valid.
-///
-/// Only custom callables are registered: standard (engine-side) callables are safe across hot reload, and disconnecting them could drop
-/// connections the user didn't establish through godot-rust.
-///
-/// `is_custom()` is intentionally broad: `bind()`/`bindv()`/`unbind()` wrap even an engine method into a Godot-side custom callable, and a
-/// bound godot-rust closure becomes indistinguishable from one -- yet is still stale after reload, so it must be caught. The cost is a false
-/// positive: a bound engine/named method (safe across reload) is also disconnected. Editor-only and not re-established, so such a connection
-/// is silently dropped -- no crash, just a lost connection.
+/// Stores a custom-callable connection so it can be disconnected before hot reload, and prunes connections to invalid objects.
 pub(crate) fn store_custom_callable_connection(
     receiver_object: &Gd<Object>,
     signal_name: &StringName,
     callable: &Callable,
 ) {
-    if !sys::is_editor() || !callable.is_custom() {
+    // We register only callables created by *this* extension, identified through `is_rust_callable()` relying on `rust_callable_token()`.
+    // Behavior per callable kind:
+    //
+    //   Callable kind                     | is_custom | is_rust_callable | stale on reload
+    //   ----------------------------------+-----------+------------------+------------------------------------------------------------
+    //   Rust callable                     |   yes     |     yes          |    yes  <- registered, disconnected before reload
+    //   Rust callable + bind/bindv        |   yes     |     no           |    yes  <- MISSED, see below
+    //   Rust callable, other extension    |   yes     |     no           |    no   <- other extension takes care of it
+    //   Object method                     |   no      |     no           |    no
+    //   Engine+bind, GDScript lambda, ... |   yes     |     no           |    no
+    //
+    // `is_rust_callable()` avoids touching connections we shouldn't (bound engine methods, other extensions' callables, GDScript lambdas
+    // routed through our `connect`) -- all of which the broad `is_custom()` would wrongly disconnect on every reload.
+    //
+    // Limitation: `bind/bindv/unbind` re-wrap their argument engine-side, so a bound Rust callable is no longer detected as Rust callable.
+    // However, it still becomes stale after reload (UAF). We accept this: binding a Rust callable is rare (closures are more powerful than
+    // `bind`), and a GDScript lambda calling a Rust callable would suffer from the same anyway. If we auto-disconnected these, we'd lose
+    // a lot Callables that would perfectly survive hot-reload. In other words, we trade many false positives for very few false negatives.
+
+    if !sys::is_editor() || !callable.is_rust_callable() {
         return;
     }
 

--- a/godot-core/src/signal/signal_connections_registry.rs
+++ b/godot-core/src/signal/signal_connections_registry.rs
@@ -16,7 +16,7 @@
 
 use std::cell::RefCell;
 
-use crate::builtin::{Callable, CowStr};
+use crate::builtin::{Callable, StringName};
 use crate::classes::Object;
 use crate::obj::Gd;
 use crate::{godot_warn, sys};
@@ -28,7 +28,7 @@ thread_local! {
 struct CachedSignalConnection {
     // `Option`, so we can mark objects for removal by setting receiver to None.
     receiver_object: Option<Gd<Object>>,
-    signal_name: CowStr,
+    signal_name: String,
     callable: Callable,
 }
 
@@ -51,14 +51,22 @@ fn prune_stale_connections(registry: &mut Vec<CachedSignalConnection>) {
     });
 }
 
-/// Stores the given connection in a registry so it can be disconnected during library deinitialization,
-/// and prunes any existing connections to objects that are no longer valid.
-pub(crate) fn store_signal_connection(
+/// Stores a custom-callable connection so it can be disconnected during library deinitialization, and prunes existing connections to
+/// objects that are no longer valid.
+///
+/// Only custom callables are registered: standard (engine-side) callables are safe across hot reload, and disconnecting them could drop
+/// connections the user didn't establish through godot-rust.
+///
+/// `is_custom()` is intentionally broad: `bind()`/`bindv()`/`unbind()` wrap even an engine method into a Godot-side custom callable, and a
+/// bound godot-rust closure becomes indistinguishable from one -- yet is still stale after reload, so it must be caught. The cost is a false
+/// positive: a bound engine/named method (safe across reload) is also disconnected. Editor-only and not re-established, so such a connection
+/// is silently dropped -- no crash, just a lost connection.
+pub(crate) fn store_custom_callable_connection(
     receiver_object: &Gd<Object>,
-    signal_name: &CowStr,
+    signal_name: &StringName,
     callable: &Callable,
 ) {
-    if !sys::is_editor() {
+    if !sys::is_editor() || !callable.is_custom() {
         return;
     }
 
@@ -70,7 +78,7 @@ pub(crate) fn store_signal_connection(
         let weak_object_ptr = unsafe { receiver_object.clone_weak() };
         connection_registry.push(CachedSignalConnection {
             receiver_object: Some(weak_object_ptr),
-            signal_name: signal_name.clone(),
+            signal_name: signal_name.to_string(),
             callable: callable.clone(),
         });
     });

--- a/godot-core/src/signal/typed_signal.rs
+++ b/godot-core/src/signal/typed_signal.rs
@@ -9,7 +9,6 @@ use std::borrow::Cow;
 use std::marker::PhantomData;
 use std::ops::DerefMut;
 
-use super::signal_connections_registry::store_signal_connection;
 use super::signal_receiver::{IndirectSignalReceiver, SignalReceiver};
 use super::{ConnectBuilder, ConnectHandle, SignalObject, make_callable_name, make_godot_fn};
 use crate::builtin::{Callable, CowStr, Variant};
@@ -225,14 +224,13 @@ impl<'c, C: WithSignals, Ps: meta::ParamTuple> TypedSignal<'c, C, Ps> {
 
         let mut owned_object = self.object.to_owned_object();
         owned_object.with_object_mut(|obj| {
+            // `Object::connect*` now tracks the (always custom) callable in the hot-reload registry, so it is auto-disconnected before reload.
             if let Some(flags) = flags {
                 obj.connect_flags(signal_name, &callable, flags);
             } else {
                 obj.connect(signal_name, &callable);
             }
         });
-
-        store_signal_connection(&owned_object, &self.name, &callable);
 
         ConnectHandle::new(owned_object, self.name.clone(), callable)
     }

--- a/itest/hot-reload/godot/ReloadTest.gd
+++ b/itest/hot-reload/godot/ReloadTest.gd
@@ -40,6 +40,8 @@ func _ready() -> void:
 
 	if ClassDB.class_exists("Signaller"):
 		self.signal_obj = ClassDB.instantiate("Signaller")
+		self.signal_obj.connect_custom_callables()
+		self.signal_obj.connect_bound_engine_method()
 		self.signal_obj.reloadable_signal.emit(42)
 		print("[GD Editor] Sanity check: Signaller emitted signal and holds ", self.signal_obj.value)
 	else:
@@ -86,6 +88,12 @@ func _process(delta: float) -> void:
 		self.signal_obj.reloadable_signal.emit(12)
 		# We did not crash thus all works well :).
 		print("[GD Editor] Signal has been properly hot reloaded!")
+
+		# The bound engine-method connection is safe across reload, and the registry only auto-disconnects callables created by this extension
+		# (see `Callable::is_rust_callable()`). A bound engine method is not one (even if it binds a Rust callable), so the connection survives.
+		if self.signal_obj.get_signal_connection_list("script_changed").is_empty():
+			fail("Connection to bind()-Callable dropped on reload")
+			return
 
 		self.signal_obj.free()
 

--- a/itest/hot-reload/rust/src/lib.rs
+++ b/itest/hot-reload/rust/src/lib.rs
@@ -112,10 +112,10 @@ mod signal_test {
         // closure (raw `RustCallable`), and a `bindv` wrapper hiding the closure (only caught by the broad `is_custom()` check). No crash = pass.
         #[func]
         fn connect_custom_callables(&mut self) {
-            let plain = Callable::from_fn("plain_reload_handler", |_| Variant::nil());
+            let plain = Callable::from_fn("rust_fn", |_| Variant::nil());
             self.base_mut().connect("property_list_changed", &plain);
 
-            let bound = Callable::from_fn("bound_reload_handler", |_| Variant::nil()).bind(vslice![10]);
+            let bound = Callable::from_fn("rust_bound_fn", |_| Variant::nil()).bind(vslice![10]);
             self.base_mut().connect("property_list_changed", &bound);
         }
 
@@ -125,7 +125,8 @@ mod signal_test {
         #[func]
         fn connect_bound_engine_method(&mut self) {
             let receiver = self.to_gd();
-            let bound = Callable::from_object_method(&receiver, "set_block_signals").bind(vslice![false]);
+            let bound =
+                Callable::from_object_method(&receiver, "set_block_signals").bind(vslice![false]);
             self.base_mut().connect("script_changed", &bound);
         }
 

--- a/itest/hot-reload/rust/src/lib.rs
+++ b/itest/hot-reload/rust/src/lib.rs
@@ -107,6 +107,28 @@ mod signal_test {
 
     #[godot_api]
     impl Signaller {
+        // Regression test for #984: custom callables connected via the untyped `Object::connect` API must be auto-disconnected before hot
+        // reload, else the stale Rust callable is touched when the object is freed afterwards and segfaults. Two forms: a plain `from_fn`
+        // closure (raw `RustCallable`), and a `bindv` wrapper hiding the closure (only caught by the broad `is_custom()` check). No crash = pass.
+        #[func]
+        fn connect_custom_callables(&mut self) {
+            let plain = Callable::from_fn("plain_reload_handler", |_| Variant::nil());
+            self.base_mut().connect("property_list_changed", &plain);
+
+            let bound = Callable::from_fn("bound_reload_handler", |_| Variant::nil()).bind(vslice![10]);
+            self.base_mut().connect("property_list_changed", &bound);
+        }
+
+        // Characterization test for the false positive in https://github.com/godot-rust/gdext/issues/984: a bound *engine* method is
+        // `is_custom()`, yet resolves by name and is safe across reload. The broad check disconnects it anyway, so `ReloadTest.gd` asserts
+        // it is gone after reload. If the registry is later narrowed to keep it, that assertion flips -- update the test then (not a regression).
+        #[func]
+        fn connect_bound_engine_method(&mut self) {
+            let receiver = self.to_gd();
+            let bound = Callable::from_object_method(&receiver, "set_block_signals").bind(vslice![false]);
+            self.base_mut().connect("script_changed", &bound);
+        }
+
         #[func]
         fn initialize_connections(&mut self) {
             self.signals()

--- a/itest/hot-reload/rust/src/lib.rs
+++ b/itest/hot-reload/rust/src/lib.rs
@@ -107,21 +107,18 @@ mod signal_test {
 
     #[godot_api]
     impl Signaller {
-        // Regression test for #984: custom callables connected via the untyped `Object::connect` API must be auto-disconnected before hot
-        // reload, else the stale Rust callable is touched when the object is freed afterwards and segfaults. Two forms: a plain `from_fn`
-        // closure (raw `RustCallable`), and a `bindv` wrapper hiding the closure (only caught by the broad `is_custom()` check). No crash = pass.
+        // Regression test for https://github.com/godot-rust/gdext/issues/984: a Rust callable connected via the untyped `Object::connect`
+        // API must be auto-disconnected before hot reload, else the stale callable is touched when the object is freed afterwards and
+        // segfaults. `is_rust_callable()` detects it via our extension token, so it is registered and disconnected. No crash = pass.
         #[func]
         fn connect_custom_callables(&mut self) {
             let plain = Callable::from_fn("rust_fn", |_| Variant::nil());
             self.base_mut().connect("property_list_changed", &plain);
-
-            let bound = Callable::from_fn("rust_bound_fn", |_| Variant::nil()).bind(vslice![10]);
-            self.base_mut().connect("property_list_changed", &bound);
         }
 
         // Characterization test for the false positive in https://github.com/godot-rust/gdext/issues/984: a bound *engine* method is
-        // `is_custom()`, yet resolves by name and is safe across reload. The broad check disconnects it anyway, so `ReloadTest.gd` asserts
-        // it is gone after reload. If the registry is later narrowed to keep it, that assertion flips -- update the test then (not a regression).
+        // `is_custom()` but not `is_rust_callable()`, so the narrowed registry does not register it -- correctly leaving it connected, as it
+        // resolves by name and is safe across reload. `ReloadTest.gd` asserts it survives. If the registry is later broadened, that flips.
         #[func]
         fn connect_bound_engine_method(&mut self) {
             let receiver = self.to_gd();

--- a/itest/rust/src/builtin_tests/containers/callable_test.rs
+++ b/itest/rust/src/builtin_tests/containers/callable_test.rs
@@ -45,6 +45,40 @@ impl CallableTestObj {
 }
 
 #[itest]
+fn callable_is_rust_callable() {
+    let obj = CallableTestObj::new_gd();
+    let rust_fn = || Callable::from_fn("rust_fn", |_args: &[&Variant]| Variant::nil());
+
+    // (description, callable, expected is_custom, expected is_rust_callable).
+    let cases: [(&str, Callable, bool, bool); 6] = [
+        ("invalid", Callable::invalid(), false, false),
+        ("engine method", obj.callable("assign_int"), false, false),
+        ("from_fn", rust_fn(), true, true),
+        ("from_fn + bind", rust_fn().bind(vslice![1]), true, false),
+        ("from_fn + unbind", rust_fn().unbind(1), true, false),
+        (
+            "engine method + bind",
+            obj.callable("stringify_int").bind(vslice![1]),
+            true,
+            false,
+        ),
+    ];
+
+    for (desc, callable, expected_custom, expected_rust) in cases {
+        assert_eq!(
+            callable.is_custom(),
+            expected_custom,
+            "is_custom() mismatch for: {desc}"
+        );
+        assert_eq!(
+            callable.is_rust_callable(),
+            expected_rust,
+            "is_rust_callable() mismatch for: {desc}"
+        );
+    }
+}
+
+#[itest]
 fn callable_validity() {
     let obj = CallableTestObj::new_gd();
 


### PR DESCRIPTION
Fixes #984.

@Yarwin already laid out the groundwork in #1223. This extends the auto-disconnection to untyped signal connections via `Object::connect*` and `Signal::connect*` APIs.

Custom callables can be Rust-based closures, but also just any callables that were wrapped with `bind()`/`bindv()`, and also GDScript lambdas. As such, it's inevitable that this approach has some false positives. Concretely, some callables may not survive hot-reload even though they would be safe -- on the other hand, we prevent UB for Rust callables.

Now I'm not 100% sure if this is the right trade-off, some considerations:
- Untyped APIs are rarely used -- but we still advertise them on the [signals page](https://godot-rust.github.io/book/register/signals.html)
- `Object::connect` then works slightly differently than `Object.connect` in GDScript/reflection calls (although it's just an extra best-effort check)
- We do emit a warning in such cases, so it's not just silent
- The original issue was reported before we had typed signals, so maybe it's not happening in practice anymore?

Maybe there's a better way to recognize Rust callables, heuristic based on their string representation, or trying to interpret the `user_data` (might also be UB though :thinking: )