### PR TITLE
Fix panic-in-drop in future tests; harden against race conditions

### DIFF
--- a/godot-core/src/builtin/signal.rs
+++ b/godot-core/src/builtin/signal.rs
@@ -137,10 +137,17 @@ impl Signal {
     ///
     /// _Godot equivalent: `get_object`_
     pub fn object(&self) -> Option<Gd<Object>> {
-        self.as_inner().get_object().map(|mut object| {
-            <Object as Bounds>::DynMemory::maybe_inc_ref(&mut object.raw);
-            object
-        })
+        let mut object = self.as_inner().get_object()?;
+
+        // `get_object()` may hand out a pointer to an already-freed object (e.g. when the object was destroyed on another thread).
+        // Validate liveness before touching the instance, honoring this method's contract to return `None` for dead objects. Without this,
+        // `maybe_inc_ref()` below would access the freed instance and panic -- fatal if it happens during `Drop`, see `FallibleSignalFuture`.
+        if !object.is_instance_valid() {
+            return None;
+        }
+
+        <Object as Bounds>::DynMemory::maybe_inc_ref(&mut object.raw);
+        Some(object)
     }
 
     /// Returns the ID of this signal's object, see also [`Gd::instance_id`].

--- a/godot-core/src/task/futures.rs
+++ b/godot-core/src/task/futures.rs
@@ -283,9 +283,17 @@ impl<R: InParamTuple + IntoDynamicSend> Drop for FallibleSignalFuture<R> {
 
         let mut data_lock = self.data.lock().unwrap();
 
-        data_lock.state = SignalFutureState::Dropped;
+        let prev_state = std::mem::replace(&mut data_lock.state, SignalFutureState::Dropped);
 
         drop(data_lock);
+
+        // Only the still-`Pending` future has a live connection that needs cleanup. Once the signal has fired (`Ready`) or the resolver was
+        // already dropped (`Dead`), the `ONE_SHOT` connection is gone, so there is nothing to disconnect. Skipping the object access in that
+        // case is also crucial for correctness: the signal's object may be freed concurrently (e.g. emitted from another thread that then
+        // drops the last reference), and touching it here -- inside `Drop` -- would panic and escalate to a fatal non-unwinding abort.
+        if !matches!(prev_state, SignalFutureState::Pending) {
+            return;
+        }
 
         // We create a new Godot Callable from our RustCallable so we get independent reference counting.
         let gd_callable = Callable::from_custom(self.callable.clone());

--- a/godot-core/src/task/futures.rs
+++ b/godot-core/src/task/futures.rs
@@ -35,8 +35,13 @@ pub(crate) use crate::impl_dynamic_send;
 /// # Panics
 /// - If the signal object is freed before the signal has been emitted.
 /// - If one of the signal arguments is `!Send`, but the signal was emitted on a different thread.
-/// - The future's `Drop` implementation can cause a non-unwinding panic in rare cases, should the signal object be freed at the same time
-///   as the future is dropped. Make sure to keep signal objects alive until there are no pending futures anymore.
+///
+/// # Keeping the signal object alive
+/// If the signal object is freed *concurrently* while the future is being dropped, connection cleanup is skipped and the stale connection is
+/// leaked (Godot removes it once the object dies), rather than aborting the process. This is only reachable by moving a `Gd` across threads,
+/// which requires `unsafe` (`Gd` is `!Send`); in safe, single-threaded code it cannot happen. If you do bypass `!Send`, it is your
+/// responsibility to keep the object alive -- retain a strong `Gd` on the runtime thread, or `join()` the other thread -- until no pending
+/// future refers to it.
 pub struct SignalFuture<R: InParamTuple + IntoDynamicSend>(FallibleSignalFuture<R>);
 
 impl<R: InParamTuple + IntoDynamicSend> SignalFuture<R> {
@@ -188,8 +193,9 @@ impl<T> SignalFutureState<T> {
 ///
 /// # Panics
 /// - If one of the signal arguments is `!Send`, but the signal was emitted on a different thread.
-/// - The future's `Drop` implementation can cause a non-unwinding panic in rare cases, should the signal object be freed at the same time
-///   as the future is dropped. Make sure to keep signal objects alive until there are no pending futures anymore.
+///
+/// For behavior when the signal object is freed while a future is being dropped, see
+/// [_Keeping the signal object alive_](SignalFuture#keeping-the-signal-object-alive).
 pub struct FallibleSignalFuture<R: InParamTuple + IntoDynamicSend> {
     data: Arc<Mutex<SignalFutureData<R::Target>>>,
     callable: SignalFutureResolver<R>,
@@ -298,20 +304,29 @@ impl<R: InParamTuple + IntoDynamicSend> Drop for FallibleSignalFuture<R> {
         // We create a new Godot Callable from our RustCallable so we get independent reference counting.
         let gd_callable = Callable::from_custom(self.callable.clone());
 
-        // is_connected() will return true if the signal was never emitted before the future is dropped.
+        // The future was dropped before the signal fired, so the ONE_SHOT connection is still live and must be disconnected.
+        // Signal::object() resolves the object over separate FFI calls (validate liveness, then inc-ref), which creates a TOCTOU race:
+        // another thread holding the last Gd -- only reachable via `unsafe` (e.g. cross-thread accessor) -- can free it in between.
+        // The inc-ref would then access freed memory and panic/UB. A panic escaping `Drop` aborts the process, so we contain it:
+        // the stale connection is not disconnected, but Godot later does so when the object dies.
+        // The common case (object alive) disconnects normally.
         //
-        // TOCTOU resilience: Signal::is_null() answers "is signal valid right now"; the object may still be freed immediately afterwards,
-        // before Signal::is_connected() or Signal::disconnect().
-        // Using Signal::object() avoids this: if it returns Some(object), we have acquired a usable Gd<Object> handle and can perform
-        // follow-up checks through that handle instead of repeatedly re-resolving the Signal. Particularly important for RefCounted, where
-        // object() upgrades to a strong reference while we hold it.
-        if let Some(mut object) = self.signal.object() {
-            let signal_name = self.signal.name();
+        // Calling is_connected()/disconnect() on the Signal directly would re-resolve the object, reopening the TOCTOU window per call.
+        // Resolving once via Signal::object() avoids that: for RefCounted the handle is a strong reference, so it stays alive while used.
+        //
+        // is_connected() is true while the signal hasn't fired yet.
+        let cleanup = || {
+            if let Some(mut object) = self.signal.object() {
+                let signal_name = self.signal.name();
 
-            if object.is_connected(&signal_name, &gd_callable) {
-                object.disconnect(&signal_name, &gd_callable);
+                if object.is_connected(&signal_name, &gd_callable) {
+                    object.disconnect(&signal_name, &gd_callable);
+                }
             }
-        }
+        };
+
+        let context = || "FallibleSignalFuture::drop: object freed concurrently".to_string();
+        let _ = crate::private::handle_panic(context, cleanup);
     }
 }
 

--- a/itest/rust/src/engine_tests/async_test.rs
+++ b/itest/rust/src/engine_tests/async_test.rs
@@ -193,6 +193,11 @@ fn signal_future_send_arg_no_panic() -> TaskHandle {
         assert_eq!(value, 1);
     });
 
+    // Important: this test deliberately frees the signal's object on another thread -- do NOT "fix" by keeping `object` alive here.
+    // `object` is the only strong ref to the `RefCounted`. Moved into the worker thread (below), which emits the signal then drops the `Gd`
+    // at its closure's end -- freeing the `RefCounted` off the main thread. So when the `SignalFuture` is dropped on the main thread, the
+    // object is already gone, exercising the drop-after-free path guarded in `FallibleSignalFuture::drop` (formerly aborted the process).
+    // Retaining a strong ref here would mask the bug. See https://github.com/godot-rust/gdext/pull/1617.
     let object = ThreadCrosser::new(object);
 
     std::thread::spawn(move || {


### PR DESCRIPTION
In CI workflow runs [A](https://github.com/godot-rust/gdext/actions/runs/26330247118/job/77515028116), [B](https://github.com/godot-rust/gdext/actions/runs/26329826646/job/77513893462?pr=1614) and [C](https://github.com/godot-rust/gdext/actions/runs/26329826646/job/77544367289?pr=1614), job `godot-itest (linux-features-experimental)` failed with a process abort (core dump). The Godot process printed:
```
thread caused non-unwinding panic. aborting.
```
...but without any panic payload. It turned out to be a **latent race condition** in godot-rust; I could reproduce it on Godot version `fa6cad230`. Running tests filtered by `[async,signal_]` on two cores (`taskset -c 0,1`) let the abort appear in ~1/76 runs.

When a `SignalFuture` is dropped, `FallibleSignalFuture::drop` disconnects its `ONE_SHOT` resolver via `Signal::object()`. If the signal's object is freed concurrently on another thread, that access panics -- and a panic inside `Drop` becomes a non-unwinding abort. 

This was only reachable through `unsafe`, since `Gd` is `!Send` and must be bypassed to free it on another thread. In our case it's the `ThreadCrosser`.

---

This PR applies multiple fixes and hardenings:

1. Skip cleanup when nothing needs disconnecting. `drop` only touches the object while the future is still `Pending`; once the signal fired, the `ONE_SHOT` connection is already gone. This eliminates the reproduced abort.
2. Fix `Signal::object()` not properly catching dead objects. We now use `is_instance_valid()` on the object returned by Godot's own `Signal::get_object` API and return `None` for dead objects, instead of panicking (which could happen in `Drop`).
3. Contain remaining panics in `Drop`. For the rare `Pending`-and-freed-concurrently TOCTOU race, cleanup is wrapped in `handle_panic`. Instead of aborting, we skip the `disconnect()` and leave the connection registered. Godot will disconnect all object's signal connections when the object is destroyed, releasing the reference it holds to our resolver `Callable`.
