### PR TITLE
Rename self-registration parts: `plugin` -> `shard`

### DIFF
--- a/godot-core/src/docs.rs
+++ b/godot-core/src/docs.rs
@@ -10,11 +10,11 @@ use std::collections::HashMap;
 use crate::meta::ClassId;
 use crate::obj::GodotClass;
 
-/// Piece of information that is gathered by the self-registration ("plugin") system.
+/// Piece of information that is gathered by the self-registration ("shard") system.
 ///
-/// You should not manually construct this struct, but rather use [`DocsPlugin::new()`].
+/// You should not manually construct this struct, but rather use [`DocsShard::new()`].
 #[derive(Debug)]
-pub struct DocsPlugin {
+pub struct DocsShard {
     /// The name of the class to register docs for.
     class_name: ClassId,
 
@@ -22,8 +22,8 @@ pub struct DocsPlugin {
     item: DocsItem,
 }
 
-impl DocsPlugin {
-    /// Creates a new `DocsPlugin`, automatically setting the `class_name` to the values defined in [`GodotClass`].
+impl DocsShard {
+    /// Creates a new `DocsShard`, automatically setting the `class_name` to the values defined in [`GodotClass`].
     pub fn new<T: GodotClass>(item: DocsItem) -> Self {
         Self {
             class_name: T::class_id(),
@@ -98,7 +98,7 @@ struct AggregatedDocs {
     constants_xmls: Vec<&'static str>,
 }
 
-/// This function scours the registered plugins to find their documentation pieces,
+/// This function scours the registered shards to find their documentation pieces,
 /// and strings them together.
 ///
 /// Returns an iterator over XML documents.
@@ -115,7 +115,7 @@ struct AggregatedDocs {
 pub fn gather_xml_docs() -> impl Iterator<Item = String> {
     let mut map = HashMap::<ClassId, AggregatedDocs>::new();
 
-    crate::private::iterate_docs_plugins(|shard| {
+    crate::private::iterate_docs_shards(|shard| {
         let class_name = shard.class_name;
         match &shard.item {
             DocsItem::Struct(struct_docs) => {

--- a/godot-core/src/private.rs
+++ b/godot-core/src/private.rs
@@ -23,7 +23,7 @@ use crate::{classes, sys};
 mod reexport_pub {
     pub use crate::arg_into_owned;
     #[cfg(all(since_api = "4.3", feature = "register-docs"))]
-    pub use crate::docs::{DocsItem, DocsPlugin, InherentImplDocs, StructDocs};
+    pub use crate::docs::{DocsItem, DocsShard, InherentImplDocs, StructDocs};
     pub use crate::r#gen::classes::class_macros;
     pub use crate::r#gen::virtuals; // virtual fn names, hashes, signatures
     pub use crate::meta::private_reexport::*;
@@ -31,9 +31,9 @@ mod reexport_pub {
     pub use crate::meta::{CowArg, FfiArg, trace};
     pub use crate::obj::rtti::ObjectRtti;
     pub use crate::registry::callbacks;
-    pub use crate::registry::plugin::{
-        ClassPlugin, DynTraitImpl, ErasedDynGd, ErasedRegisterFn, ITraitImpl, InherentImpl,
-        PluginItem, Struct,
+    pub use crate::registry::shard::{
+        ClassShard, DynTraitImpl, ErasedDynGd, ErasedRegisterFn, ITraitImpl, InherentImpl,
+        ShardItem, Struct,
     };
     pub use crate::signal::priv_re_export::*;
     pub use crate::storage::{
@@ -61,9 +61,9 @@ sys::atomic_enum! {
 
 static ERROR_PRINT_LEVEL: sys::AtomicEnum<ErrorPrintLevel> = sys::AtomicEnum::default();
 
-sys::plugin_registry!(pub __GODOT_PLUGIN_REGISTRY: ClassPlugin);
+sys::shard_registry!(pub __GODOT_SHARD_REGISTRY: ClassShard);
 #[cfg(all(since_api = "4.3", feature = "register-docs"))]
-sys::plugin_registry!(pub __GODOT_DOCS_REGISTRY: DocsPlugin);
+sys::shard_registry!(pub __GODOT_DOCS_REGISTRY: DocsShard);
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Call error handling
@@ -119,30 +119,30 @@ impl Drop for OutCallGuard {
 }
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
-// Plugin and global state handling
+// Shard and global state handling
 
 pub fn next_class_id() -> u16 {
     static NEXT_CLASS_ID: atomic::AtomicU16 = atomic::AtomicU16::new(0);
     NEXT_CLASS_ID.fetch_add(1, atomic::Ordering::Relaxed)
 }
 
-pub(crate) fn iterate_plugins(mut visitor: impl FnMut(&ClassPlugin)) {
-    sys::plugin_foreach!(__GODOT_PLUGIN_REGISTRY; visitor);
+pub(crate) fn iterate_shards(mut visitor: impl FnMut(&ClassShard)) {
+    sys::shard_foreach!(__GODOT_SHARD_REGISTRY; visitor);
 }
 
 #[cfg(all(since_api = "4.3", feature = "register-docs"))]
-pub(crate) fn iterate_docs_plugins(mut visitor: impl FnMut(&DocsPlugin)) {
-    sys::plugin_foreach!(__GODOT_DOCS_REGISTRY; visitor);
+pub(crate) fn iterate_docs_shards(mut visitor: impl FnMut(&DocsShard)) {
+    sys::shard_foreach!(__GODOT_DOCS_REGISTRY; visitor);
 }
 
 #[cfg(feature = "codegen-full")] // Remove if used in other scenarios.
 pub(crate) fn find_inherent_impl(class_name: crate::meta::ClassId) -> Option<InherentImpl> {
-    // We do this manually instead of using `iterate_plugins()` because we want to break as soon as we find a match.
-    let plugins = __GODOT_PLUGIN_REGISTRY.lock().unwrap();
+    // We do this manually instead of using `iterate_shards()` because we want to break as soon as we find a match.
+    let shards = __GODOT_SHARD_REGISTRY.lock().unwrap();
 
-    plugins.iter().find_map(|elem| {
+    shards.iter().find_map(|elem| {
         if elem.class_name == class_name
-            && let PluginItem::InherentImpl(inherent_impl) = &elem.item
+            && let ShardItem::InherentImpl(inherent_impl) = &elem.item
         {
             return Some(inherent_impl.clone());
         }

--- a/godot-core/src/registry/callbacks.rs
+++ b/godot-core/src/registry/callbacks.rs
@@ -22,7 +22,7 @@ use crate::classes::Object;
 use crate::obj::{AsDyn, Base, Bounds, Gd, GodotClass, Inherits, UserClass, bounds, cap};
 use crate::private::{IntoVirtualMethodReceiver, PanicPayload, handle_panic};
 use crate::registry::info::PropertyInfo;
-use crate::registry::plugin::ErasedDynGd;
+use crate::registry::shard::ErasedDynGd;
 use crate::storage::{InstanceStorage, Storage, StorageRefCounted, as_storage};
 
 /// Godot FFI default constructor.

--- a/godot-core/src/registry/class.rs
+++ b/godot-core/src/registry/class.rs
@@ -15,9 +15,9 @@ use crate::init::InitLevel;
 use crate::meta::ClassId;
 use crate::meta::error::FromGodotError;
 use crate::obj::{DynGd, Gd, GodotClass, Singleton, cap};
-use crate::private::{ClassPlugin, PluginItem};
+use crate::private::{ClassShard, ShardItem};
 use crate::registry::callbacks;
-use crate::registry::plugin::{DynTraitImpl, ErasedRegisterFn, ITraitImpl, InherentImpl, Struct};
+use crate::registry::shard::{DynTraitImpl, ErasedRegisterFn, ITraitImpl, InherentImpl, Struct};
 use crate::{godot_error, godot_warn, sys};
 
 /// Returns a lock to a global map of loaded classes, by initialization level.
@@ -124,18 +124,18 @@ struct ClassRegistrationInfo {
 }
 
 impl ClassRegistrationInfo {
-    fn validate_unique(&mut self, item: &PluginItem) {
+    fn validate_unique(&mut self, item: &ShardItem) {
         // We could use mem::Discriminant, but match will fail to compile when a new component is added.
 
         // Note: when changing this match, make sure the array has sufficient size.
         let index = match item {
-            PluginItem::Struct { .. } => 0,
-            PluginItem::InherentImpl(_) => 1,
-            PluginItem::ITraitImpl { .. } => 2,
+            ShardItem::Struct { .. } => 0,
+            ShardItem::InherentImpl(_) => 1,
+            ShardItem::ITraitImpl { .. } => 2,
 
             // Multiple dyn traits can be registered, thus don't validate for uniqueness.
             // (Still keep array size, so future additions don't have to regard this).
-            PluginItem::DynTraitImpl { .. } => return,
+            ShardItem::DynTraitImpl { .. } => return,
         };
 
         if self.component_already_filled[index] {
@@ -201,7 +201,7 @@ pub(crate) fn register_class<
     });
 }
 
-/// Lets Godot know about all classes that have self-registered through the plugin system.
+/// Lets Godot know about all classes that have self-registered through the shard system.
 pub fn auto_register_classes(init_level: InitLevel) {
     out!("Auto-register classes at level `{init_level:?}`...");
 
@@ -211,13 +211,13 @@ pub fn auto_register_classes(init_level: InitLevel) {
     //
     let mut map = HashMap::<ClassId, ClassRegistrationInfo>::new();
 
-    crate::private::iterate_plugins(|elem: &ClassPlugin| {
-        // Filter per ClassPlugin and not PluginItem, because all components of all classes are mixed together in one huge list.
+    crate::private::iterate_shards(|elem: &ClassShard| {
+        // Filter per ClassShard and not ShardItem, because all components of all classes are mixed together in one huge list.
         if elem.init_level != init_level {
             return;
         }
 
-        //out!("* Plugin: {elem:#?}");
+        //out!("* Shard: {elem:#?}");
 
         let name = elem.class_name;
         let class_info = map
@@ -297,7 +297,7 @@ fn register_classes_and_dyn_traits(
 
         // Transpose Class->Trait relations to Trait->Class relations.
         for (trait_type_id, mut dyn_trait_impl) in info.dynify_fns_by_trait.drain() {
-            // Note: Must be done after filling out the class info since plugins are being iterated in unspecified order.
+            // Note: Must be done after filling out the class info since shards are being iterated in unspecified order.
             dyn_trait_impl.parent_class_name = info.parent_class_name;
 
             dyn_traits_by_typeid
@@ -441,13 +441,13 @@ where
 }
 
 /// Populate `c` with all the relevant data from `component` (depending on component type).
-fn fill_class_info(item: PluginItem, c: &mut ClassRegistrationInfo) {
+fn fill_class_info(item: ShardItem, c: &mut ClassRegistrationInfo) {
     c.validate_unique(&item);
 
     // out!("|   reg (before):    {c:?}");
     // out!("|   comp:            {component:?}");
     match item {
-        PluginItem::Struct(Struct {
+        ShardItem::Struct(Struct {
             base_class_name,
             generated_create_fn,
             generated_recreate_fn,
@@ -507,14 +507,14 @@ fn fill_class_info(item: PluginItem, c: &mut ClassRegistrationInfo) {
             }
         }
 
-        PluginItem::InherentImpl(InherentImpl {
+        ShardItem::InherentImpl(InherentImpl {
             register_methods_constants_fn,
             register_rpcs_fn: _,
         }) => {
             c.register_methods_constants_fn = Some(register_methods_constants_fn);
         }
 
-        PluginItem::ITraitImpl(ITraitImpl {
+        ShardItem::ITraitImpl(ITraitImpl {
             user_register_fn,
             user_create_fn,
             user_recreate_fn,
@@ -553,7 +553,7 @@ fn fill_class_info(item: PluginItem, c: &mut ClassRegistrationInfo) {
                 c.godot_params.validate_property_func = validate_property_fn;
             }
         }
-        PluginItem::DynTraitImpl(dyn_trait_impl) => {
+        ShardItem::DynTraitImpl(dyn_trait_impl) => {
             let type_id = dyn_trait_impl.dyn_trait_typeid();
 
             let prev = c.dynify_fns_by_trait.insert(type_id, dyn_trait_impl);

--- a/godot-core/src/registry/mod.rs
+++ b/godot-core/src/registry/mod.rs
@@ -13,8 +13,8 @@ pub mod class;
 pub mod constant;
 pub mod info;
 pub mod method;
-pub mod plugin;
 pub mod property;
+pub mod shard;
 
 // RpcConfig uses MultiplayerPeer::TransferMode and MultiplayerApi::RpcMode, which are only enabled in `codegen-full` feature.
 #[cfg(feature = "codegen-full")]

--- a/godot-core/src/registry/shard.rs
+++ b/godot-core/src/registry/shard.rs
@@ -18,37 +18,37 @@ use crate::registry::callbacks;
 use crate::registry::class::GodotGetVirtual;
 use crate::{classes, sys};
 
-// TODO(bromeon): some information coming from the proc-macro API is deferred through PluginItem, while others is directly
-// translated to code. Consider moving more code to the PluginItem, which allows for more dynamic registration and will
+// TODO(bromeon): some information coming from the proc-macro API is deferred through ShardItem, while others is directly
+// translated to code. Consider moving more code to the ShardItem, which allows for more dynamic registration and will
 // be easier for a future builder API.
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 
-/// Piece of information that is gathered by the self-registration ("plugin") system.
+/// Piece of information that is gathered by the self-registration ("shard") system.
 ///
-/// You should not manually construct this struct, but rather use [`ClassPlugin::new()`].
+/// You should not manually construct this struct, but rather use [`ClassShard::new()`].
 #[derive(Debug)]
-pub struct ClassPlugin {
-    /// The name of the class to register plugins for.
+pub struct ClassShard {
+    /// The name of the class to register shards for.
     ///
-    /// This is used to group plugins so that all class properties for a single class can be registered at the same time.
+    /// This is used to group shards so that all class properties for a single class can be registered at the same time.
     /// Incorrectly setting this value should not cause any UB but will likely cause errors during registration time.
     pub(crate) class_name: ClassId,
 
-    /// Which [`InitLevel`] this plugin should be registered at.
+    /// Which [`InitLevel`] this shard should be registered at.
     ///
     /// Incorrectly setting this value should not cause any UB but will likely cause errors during registration time.
-    // Init-level is per ClassPlugin and not per PluginItem, because all components of all classes are mixed together in one
+    // Init-level is per ClassShard and not per ShardItem, because all components of all classes are mixed together in one
     // huge linker list. There is no per-class aggregation going on, so this allows to easily filter relevant classes.
     pub(crate) init_level: InitLevel,
 
     /// The actual item being registered.
-    pub(crate) item: PluginItem,
+    pub(crate) item: ShardItem,
 }
 
-impl ClassPlugin {
-    /// Creates a new `ClassPlugin`, automatically setting the `class_name` and `init_level` to the values defined in [`GodotClass`].
-    pub fn new<T: GodotClass>(item: PluginItem) -> Self {
+impl ClassShard {
+    /// Creates a new `ClassShard`, automatically setting the `class_name` and `init_level` to the values defined in [`GodotClass`].
+    pub fn new<T: GodotClass>(item: ShardItem) -> Self {
         Self {
             class_name: T::class_id(),
             init_level: T::INIT_LEVEL,
@@ -112,14 +112,14 @@ type GodotCreateFn = unsafe extern "C" fn(
 ) -> sys::GDExtensionObjectPtr;
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
-// Plugin items
+// Shard items
 
-/// Represents the data part of a [`ClassPlugin`] instance.
+/// Represents the data part of a [`ClassShard`] instance.
 ///
 /// Each enumerator represents a different item in Rust code, which is processed by an independent proc macro (for example,
 /// `#[derive(GodotClass)]` on structs, or `#[godot_api]` on impl blocks).
 #[derive(Clone, Debug)]
-pub enum PluginItem {
+pub enum ShardItem {
     /// Class definition itself, must always be available -- created by `#[derive(GodotClass)]`.
     Struct(Struct),
 
@@ -544,7 +544,7 @@ pub struct DynTraitImpl {
     ///
     /// Godot doesn't guarantee availability of all the GDExtension classes through the ClassDb while generating `PropertyHintInfo` for our exports.
     /// Therefore, we rely on the built-in inherited base class in such cases.
-    /// Only [`class_name`][DynTraitImpl::class_name] is available at the time of adding given `DynTraitImpl` to plugin registry with `#[godot_dyn]`;
+    /// Only [`class_name`][DynTraitImpl::class_name] is available at the time of adding given `DynTraitImpl` to shard registry with `#[godot_dyn]`;
     /// It is important to fill this information before registration.
     ///
     /// See also [`get_dyn_implementor_class_ids`][crate::registry::class::get_dyn_implementor_class_ids].

--- a/godot-ffi/src/lib.rs
+++ b/godot-ffi/src/lib.rs
@@ -81,7 +81,7 @@ mod interface_init;
 #[cfg(target_os = "linux")]
 pub mod linux_reload_workaround;
 mod opaque;
-mod plugins;
+mod shard_registry;
 mod string_cache;
 mod toolbox;
 

--- a/godot-ffi/src/shard_registry.rs
+++ b/godot-ffi/src/shard_registry.rs
@@ -5,17 +5,12 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-//! Distributed self-registration of "plugins" without central list
+//! Distributed self-registration of "shards" without central list.
 
-// Note: code in this file is safe, however it seems that some annotations fall into the "unsafe" category.
-// For example, adding #![forbid(unsafe_code)] causes this error:
-//   note: the program's behavior with overridden link sections on items is unpredictable
-//   and Rust cannot provide guarantees when you manually override them
-
-/// Declare a global registry for plugins with a given name
+/// Declare a global registry for shards with a given name
 #[doc(hidden)]
 #[macro_export]
-macro_rules! plugin_registry {
+macro_rules! shard_registry {
     ($vis:vis $registry:ident: $Type:ty) => {
         #[used]
         #[allow(non_upper_case_globals)]
@@ -28,7 +23,7 @@ macro_rules! plugin_registry {
 /// Executes a block of code before main, by utilising platform specific linker instructions.
 #[doc(hidden)]
 #[macro_export]
-macro_rules! plugin_execute_pre_main {
+macro_rules! shard_execute_pre_main {
     ($body:expr_2021) => {
         const _: () = {
             #[allow(non_upper_case_globals)]
@@ -62,20 +57,20 @@ macro_rules! plugin_execute_pre_main {
     };
 }
 
-/// Register a plugin to a registry.
+/// Register a shard to a registry.
 #[doc(hidden)]
 #[macro_export]
-macro_rules! plugin_add {
-    ( $registry:path; $plugin:expr_2021 ) => {
-        $crate::plugin_execute_pre_main!({
-            $registry.lock().unwrap().push($plugin);
+macro_rules! shard_add {
+    ( $registry:path; $shard:expr_2021 ) => {
+        $crate::shard_execute_pre_main!({
+            $registry.lock().unwrap().push($shard);
         });
     };
 }
 
 #[doc(hidden)]
 #[macro_export]
-macro_rules! plugin_foreach_inner {
+macro_rules! shard_foreach_inner {
     ( $registry:ident; $closure:expr_2021; $( $path_tt:tt )* ) => {
         let guard = $( $path_tt )* $registry
             .lock()
@@ -88,16 +83,16 @@ macro_rules! plugin_foreach_inner {
     };
 }
 
-/// Iterate over all plugins in unspecified order.
+/// Iterate over all shards in unspecified order.
 #[doc(hidden)]
 #[macro_export]
-macro_rules! plugin_foreach {
+macro_rules! shard_foreach {
     ( $registry:ident; $closure:expr_2021 ) => {
-		$crate::plugin_foreach_inner!($registry; $closure; );
+		$crate::shard_foreach_inner!($registry; $closure; );
 	};
 
     ( $registry:ident in $path:path; $closure:expr_2021 ) => {
-		$crate::plugin_foreach_inner!($registry; $closure; $path ::);
+		$crate::shard_foreach_inner!($registry; $closure; $path ::);
 	};
 }
 
@@ -106,24 +101,19 @@ macro_rules! plugin_foreach {
 #[cfg(test)]
 mod tests {
     use std::collections::HashSet;
-    plugin_registry!(V: &'static str);
+    shard_registry!(V: &'static str);
 
-    plugin_add!(V; "three");
-    plugin_add!(V; "four");
-    plugin_add!(V; "one");
-    plugin_add!(V; "two");
+    shard_add!(V; "three");
+    shard_add!(V; "four");
+    shard_add!(V; "one");
+    shard_add!(V; "two");
 
-    // TODO(v0.6): unignore this test once plugins are added for Wasm
     #[test]
-    #[cfg_attr(
-        target_family = "wasm",
-        ignore = "Requires a plugin implementation for Wasm"
-    )]
-    fn plugin_registry() {
+    fn shard_registry() {
         let expected = HashSet::from(["one", "two", "three", "four"]);
         let mut actual = HashSet::new();
 
-        plugin_foreach!(V; |e: &'static str| {
+        shard_foreach!(V; |e: &'static str| {
             actual.insert(e);
         });
 

--- a/godot-macros/src/bench.rs
+++ b/godot-macros/src/bench.rs
@@ -87,7 +87,7 @@ pub fn attribute_bench(input_decl: venial::Item) -> ParseResult<TokenStream> {
     Ok(quote! {
         #generated_fn
 
-        ::godot::sys::plugin_add!(crate::framework::__GODOT_BENCH; crate::framework::RustBenchmark {
+        ::godot::sys::shard_add!(crate::framework::__GODOT_BENCH; crate::framework::RustBenchmark {
             name: #bench_name_str,
             file: std::file!(),
             line: std::line!(),

--- a/godot-macros/src/class/data_models/inherent_impl.rs
+++ b/godot-macros/src/class/data_models/inherent_impl.rs
@@ -147,7 +147,7 @@ pub fn transform_inherent_impl(
 
     let fill_storage = {
         quote! {
-            ::godot::sys::plugin_execute_pre_main!({
+            ::godot::sys::shard_execute_pre_main!({
                 let mut guard = #class_name::__registration_storage().lock().unwrap();
 
                 guard.0.push(|| {
@@ -200,8 +200,8 @@ pub fn transform_inherent_impl(
         };
 
         let class_registration = quote! {
-            ::godot::sys::plugin_add!(#prv::__GODOT_PLUGIN_REGISTRY; #prv::ClassPlugin::new::<#class_name>(
-                #prv::PluginItem::InherentImpl(#prv::InherentImpl::new::<#class_name>())
+            ::godot::sys::shard_add!(#prv::__GODOT_SHARD_REGISTRY; #prv::ClassShard::new::<#class_name>(
+                #prv::ShardItem::InherentImpl(#prv::InherentImpl::new::<#class_name>())
             ));
         };
 

--- a/godot-macros/src/class/data_models/interface_trait_impl.rs
+++ b/godot-macros/src/class/data_models/interface_trait_impl.rs
@@ -173,8 +173,8 @@ pub fn transform_trait_impl(mut original_impl: venial::Impl) -> ParseResult<Toke
             }
         }
 
-        ::godot::sys::plugin_add!(#prv::__GODOT_PLUGIN_REGISTRY; #prv::ClassPlugin::new::<#class_name>(
-            #prv::PluginItem::ITraitImpl(#item_constructor)
+        ::godot::sys::shard_add!(#prv::__GODOT_SHARD_REGISTRY; #prv::ClassShard::new::<#class_name>(
+            #prv::ShardItem::ITraitImpl(#item_constructor)
         ));
 
         #register_docs

--- a/godot-macros/src/class/derive_godot_class.rs
+++ b/godot-macros/src/class/derive_godot_class.rs
@@ -211,8 +211,8 @@ pub fn derive_godot_class(item: venial::Item) -> ParseResult<TokenStream> {
         #user_singleton_impl
 
         #struct_docs_registration
-        ::godot::sys::plugin_add!(#prv::__GODOT_PLUGIN_REGISTRY; #prv::ClassPlugin::new::<#class_name>(
-            #prv::PluginItem::Struct(
+        ::godot::sys::shard_add!(#prv::__GODOT_SHARD_REGISTRY; #prv::ClassShard::new::<#class_name>(
+            #prv::ShardItem::Struct(
                 #prv::Struct::new::<#class_name>()#(.#modifiers())*
             )
         ));

--- a/godot-macros/src/class/godot_dyn.rs
+++ b/godot-macros/src/class/godot_dyn.rs
@@ -67,8 +67,8 @@ pub fn attribute_godot_dyn(input_decl: venial::Item) -> ParseResult<TokenStream>
             }
         }
 
-        ::godot::sys::plugin_add!(#prv::__GODOT_PLUGIN_REGISTRY; #prv::ClassPlugin::new::<#class_path>(
-            #prv::PluginItem::DynTraitImpl(#prv::DynTraitImpl::new::<#class_path, dyn #trait_path #assoc_type_constraints>()))
+        ::godot::sys::shard_add!(#prv::__GODOT_SHARD_REGISTRY; #prv::ClassShard::new::<#class_path>(
+            #prv::ShardItem::DynTraitImpl(#prv::DynTraitImpl::new::<#class_path, dyn #trait_path #assoc_type_constraints>()))
         );
 
     };

--- a/godot-macros/src/docs/mod.rs
+++ b/godot-macros/src/docs/mod.rs
@@ -28,7 +28,7 @@ mod docs_generators {
     ) -> TokenStream {
         let struct_docs = extract_docs::document_struct(base, description, fields);
         quote! {
-            ::godot::sys::plugin_add!(#prv::__GODOT_DOCS_REGISTRY; #prv::DocsPlugin::new::<#class_name>(
+            ::godot::sys::shard_add!(#prv::__GODOT_DOCS_REGISTRY; #prv::DocsShard::new::<#class_name>(
                 #prv::DocsItem::Struct(
                     #struct_docs
                 )
@@ -50,7 +50,7 @@ mod docs_generators {
         } = extract_docs::document_inherent_impl(functions, constants, signals);
 
         quote! {
-            ::godot::sys::plugin_add!(#prv::__GODOT_DOCS_REGISTRY; #prv::DocsPlugin::new::<#class_name>(
+            ::godot::sys::shard_add!(#prv::__GODOT_DOCS_REGISTRY; #prv::DocsShard::new::<#class_name>(
                 #prv::DocsItem::InherentImpl(#prv::InherentImplDocs {
                     methods_xml: #method_xml_elems,
                     signals_xml: #signal_xml_elems,
@@ -68,7 +68,7 @@ mod docs_generators {
         let virtual_methods = extract_docs::document_interface_trait_impl(impl_members);
 
         quote! {
-            ::godot::sys::plugin_add!(#prv::__GODOT_DOCS_REGISTRY; #prv::DocsPlugin::new::<#class_name>(
+            ::godot::sys::shard_add!(#prv::__GODOT_DOCS_REGISTRY; #prv::DocsShard::new::<#class_name>(
                 #prv::DocsItem::ITraitImpl(#virtual_methods)
             ));
         }

--- a/godot-macros/src/itest.rs
+++ b/godot-macros/src/itest.rs
@@ -76,16 +76,16 @@ pub fn attribute_itest(input_item: venial::Item) -> ParseResult<TokenStream> {
 
     let body = &func.body;
 
-    let (return_tokens, test_case_ty, plugin_name);
+    let (return_tokens, test_case_ty, shard_name);
     if is_async {
         let [arrow, arrow_head] = func.tk_return_arrow.unwrap();
         return_tokens = quote! { #arrow #arrow_head #return_ty }; // retain span.
         test_case_ty = quote! { crate::framework::AsyncRustTestCase };
-        plugin_name = ident("__GODOT_ASYNC_ITEST");
+        shard_name = ident("__GODOT_ASYNC_ITEST");
     } else {
         return_tokens = TokenStream::new();
         test_case_ty = quote! { crate::framework::RustTestCase };
-        plugin_name = ident("__GODOT_ITEST");
+        shard_name = ident("__GODOT_ITEST");
     };
 
     // Filter out #[itest] itself, but preserve other attributes like #[allow], #[expect], etc.
@@ -96,7 +96,7 @@ pub fn attribute_itest(input_item: venial::Item) -> ParseResult<TokenStream> {
         pub fn #test_name(#param) #return_tokens
             #body
 
-        ::godot::sys::plugin_add!(crate::framework::#plugin_name; #test_case_ty {
+        ::godot::sys::shard_add!(crate::framework::#shard_name; #test_case_ty {
             name: #test_name_str,
             skipped: #skipped,
             focused: #focused,

--- a/itest/rust/src/framework/mod.rs
+++ b/itest/rust/src/framework/mod.rs
@@ -21,12 +21,12 @@ pub use godot::test::{bench, itest};
 pub use runner::*;
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
-// Plugin registration
+// Shard registration
 
 // Registers all the `#[itest]` tests and `#[bench]` benchmarks.
-sys::plugin_registry!(pub(crate) __GODOT_ITEST: RustTestCase);
-sys::plugin_registry!(pub(crate) __GODOT_ASYNC_ITEST: AsyncRustTestCase);
-sys::plugin_registry!(pub(crate) __GODOT_BENCH: RustBenchmark);
+sys::shard_registry!(pub(crate) __GODOT_ITEST: RustTestCase);
+sys::shard_registry!(pub(crate) __GODOT_ASYNC_ITEST: AsyncRustTestCase);
+sys::shard_registry!(pub(crate) __GODOT_BENCH: RustBenchmark);
 
 /// Finds all `#[itest]` tests.
 fn collect_rust_tests(filters: &[String]) -> (Vec<RustTestCase>, HashSet<&str>, bool) {
@@ -35,7 +35,7 @@ fn collect_rust_tests(filters: &[String]) -> (Vec<RustTestCase>, HashSet<&str>, 
     let mut is_focused_run = false;
     let in_editor = Engine::singleton().is_editor_hint();
 
-    sys::plugin_foreach!(__GODOT_ITEST; |test: &RustTestCase| {
+    sys::shard_foreach!(__GODOT_ITEST; |test: &RustTestCase| {
         // Editor itests run only in editor; non-editor itests run only outside editor.
         if test.editor_only != in_editor {
             return;
@@ -71,7 +71,7 @@ fn collect_async_rust_tests(
     let mut is_focused_run = sync_focused_run;
     let in_editor = Engine::singleton().is_editor_hint();
 
-    sys::plugin_foreach!(__GODOT_ASYNC_ITEST; |test: &AsyncRustTestCase| {
+    sys::shard_foreach!(__GODOT_ASYNC_ITEST; |test: &AsyncRustTestCase| {
         // Editor itests run only in editor; non-editor itests run only outside editor.
         if test.editor_only != in_editor {
             return;
@@ -102,7 +102,7 @@ fn collect_rust_benchmarks() -> (Vec<RustBenchmark>, usize) {
     let mut all_files = HashSet::new();
     let mut benchmarks: Vec<RustBenchmark> = vec![];
 
-    sys::plugin_foreach!(__GODOT_BENCH; |bench: &RustBenchmark| {
+    sys::shard_foreach!(__GODOT_BENCH; |bench: &RustBenchmark| {
         benchmarks.push(*bench);
         all_files.insert(bench.file);
     });

--- a/itest/rust/src/register_tests/constant_test.rs
+++ b/itest/rust/src/register_tests/constant_test.rs
@@ -167,10 +167,10 @@ impl godot::obj::cap::ImplementsGodotApi for HasOtherConstants {
 }
 
 // TODO once this is done via proc-macro, see if `register-docs` is still used in register_docs_test.rs. Otherwise, remove feature from Cargo.toml.
-godot::sys::plugin_add!(
-    godot::private::__GODOT_PLUGIN_REGISTRY;
-    godot::private::ClassPlugin::new::<HasOtherConstants>(
-        godot::private::PluginItem::InherentImpl(
+godot::sys::shard_add!(
+    godot::private::__GODOT_SHARD_REGISTRY;
+    godot::private::ClassShard::new::<HasOtherConstants>(
+        godot::private::ShardItem::InherentImpl(
             godot::private::InherentImpl::new::<HasOtherConstants>(
             )
         )


### PR DESCRIPTION
For self-registering parts, I never liked the term "plugin", but didn't have a better one at the time. It also clashes with editor plugins and other plugin classes in Godot.

"Shard" on the other hand captures the "part of something bigger" concept pretty concisely, and is short and handy.
It also has no confusion potential in the Godot/Rust ecosystem (only association is DevOps/DB shards). Other terms I considered were "Fragment", "Strand", "Aspect", "Facet".
