### PR TITLE
Add PhantomData<T> support for the GodotConvert derive macro

### DIFF
--- a/godot-macros/src/derive/data_models/godot_convert.rs
+++ b/godot-macros/src/derive/data_models/godot_convert.rs
@@ -7,6 +7,7 @@
 
 use proc_macro2::{Ident, TokenStream};
 use quote::ToTokens;
+use venial::{GenericParamList, WhereClause};
 
 use super::c_style_enum::CStyleEnum;
 use super::godot_attribute::{GodotAttribute, ViaType};
@@ -18,23 +19,41 @@ use crate::util::bail;
 pub struct GodotConvert {
     /// The name of the type we're deriving for.
     pub ty_name: Ident,
+    pub where_clause: Option<WhereClause>,
+    pub generic_params: Option<GenericParamList>,
     /// The data from the type and `godot` attribute.
     pub convert_type: ConvertType,
 }
 
 impl GodotConvert {
     pub fn parse_declaration(item: venial::Item) -> ParseResult<Self> {
-        let (name, where_clause, generic_params) = match &item {
-            venial::Item::Struct(struct_) => (
-                struct_.name.clone(),
-                &struct_.where_clause,
-                &struct_.generic_params,
-            ),
-            venial::Item::Enum(enum_) => (
-                enum_.name.clone(),
-                &enum_.where_clause,
-                &enum_.generic_params,
-            ),
+        let data = ConvertType::parse_declaration(&item)?;
+
+        let (name, where_clause, generic_params) = match item {
+            venial::Item::Struct(struct_) => {
+                (struct_.name, struct_.where_clause, struct_.generic_params)
+            }
+            venial::Item::Enum(enum_) => {
+                // We only have C-style enums, so Rust would already complain that generics are unused.
+                // This provides clearer error messages though.
+                if let Some(generic_params) = &enum_.generic_params {
+                    return bail!(
+                        generic_params,
+                        "#[derive(GodotConvert)] does not support lifetimes or generic parameters on enums"
+                    );
+                }
+
+                // Is this check even necessary? What's the use case of where clauses without generics?
+                // For traits, one can imagine `Self: SomeBound`, but for structs/enums?
+                if let Some(where_clause) = &enum_.where_clause {
+                    return bail!(
+                        where_clause,
+                        "#[derive(GodotConvert)] does not support where clauses"
+                    );
+                }
+
+                (enum_.name, enum_.where_clause, enum_.generic_params)
+            }
             other => {
                 return bail!(
                     other,
@@ -43,26 +62,10 @@ impl GodotConvert {
             }
         };
 
-        if let Some(generic_params) = generic_params {
-            return bail!(
-                generic_params,
-                "#[derive(GodotConvert)] does not support lifetimes or generic parameters"
-            );
-        }
-
-        // Is this check even necessary? What's the use case of where clauses without generics?
-        // For traits, one can imagine `Self: SomeBound`, but for structs/enums?
-        if let Some(where_clause) = where_clause {
-            return bail!(
-                where_clause,
-                "#[derive(GodotConvert)] does not support where clauses"
-            );
-        }
-
-        let data = ConvertType::parse_declaration(item)?;
-
         Ok(Self {
             ty_name: name,
+            where_clause,
+            generic_params,
             convert_type: data,
         })
     }
@@ -77,10 +80,10 @@ pub enum ConvertType {
 }
 
 impl ConvertType {
-    pub fn parse_declaration(item: venial::Item) -> ParseResult<Self> {
-        let attribute = GodotAttribute::parse_attribute(&item)?;
+    pub fn parse_declaration(item: &venial::Item) -> ParseResult<Self> {
+        let attribute = GodotAttribute::parse_attribute(item)?;
 
-        match &item {
+        match item {
             venial::Item::Struct(struct_) => {
                 let GodotAttribute::Transparent { .. } = attribute else {
                     return bail!(
@@ -113,7 +116,7 @@ impl ConvertType {
     /// Returns the type for use in `type Via = <type>;` in `GodotConvert` implementations.
     pub fn via_type(&self) -> TokenStream {
         match self {
-            ConvertType::NewType { field } => field.ty.to_token_stream(),
+            ConvertType::NewType { field } => field.sized.ty.to_token_stream(),
             ConvertType::Enum { via, .. } => via.to_token_stream(),
         }
     }

--- a/godot-macros/src/derive/data_models/godot_convert.rs
+++ b/godot-macros/src/derive/data_models/godot_convert.rs
@@ -69,6 +69,32 @@ impl GodotConvert {
             convert_type: data,
         })
     }
+
+    /// Generic parameters as arguments: `impl Type<GenericArgs>`.
+    pub fn generic_args(&self) -> Option<venial::InlineGenericArgs<'_>> {
+        self.generic_params
+            .as_ref()
+            .map(|params| params.as_inline_args())
+    }
+
+    /// Errors if the type is generic, for derives that don't support it yet.
+    pub fn ensure_no_generics(&self, derive_name: &str) -> ParseResult<()> {
+        if let Some(generic_params) = &self.generic_params {
+            return bail!(
+                generic_params,
+                "#[derive({derive_name})] does not support lifetimes or generic parameters"
+            );
+        }
+
+        if let Some(where_clause) = &self.where_clause {
+            return bail!(
+                where_clause,
+                "#[derive({derive_name})] does not support where clauses"
+            );
+        }
+
+        Ok(())
+    }
 }
 
 /// Stores what kind of `GodotConvert` derive we're doing.

--- a/godot-macros/src/derive/data_models/newtype.rs
+++ b/godot-macros/src/derive/data_models/newtype.rs
@@ -5,21 +5,40 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use proc_macro2::{Ident, TokenStream};
-use quote::quote;
+use proc_macro2::{Ident, Literal, TokenStream};
+use quote::{ToTokens, quote};
 
-use crate::ParseResult;
 use crate::util::bail;
+use crate::{KvParser, ParseResult};
+
+pub struct FieldIdent(TokenStream);
+
+impl FieldIdent {
+    fn named(id: Ident) -> Self {
+        Self(quote! { #id })
+    }
+    fn tuple(i: usize) -> Self {
+        Self(Literal::usize_unsuffixed(i).into_token_stream())
+    }
+}
+
+impl ToTokens for FieldIdent {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        self.0.to_tokens(tokens);
+    }
+}
+
+pub struct NewtypeField {
+    pub ident: FieldIdent,
+    pub ty: venial::TypeExpr,
+}
 
 /// Stores info from the field of a newtype struct for use in deriving `GodotConvert` and other related traits.
+///
+/// `NewtypeStruct` must have exactly 1 sized field, and can have an arbitrary amount of ZST fields.
 pub struct NewtypeStruct {
-    /// The name of the field.
-    ///
-    /// If `None`, then this represents a tuple-struct with one field.
-    pub name: Option<Ident>,
-
-    /// The type of the field.
-    pub ty: venial::TypeExpr,
+    pub sized: NewtypeField,     // Single sized field
+    pub zsts: Vec<NewtypeField>, // skipped ZSTs
 }
 
 impl NewtypeStruct {
@@ -30,58 +49,84 @@ impl NewtypeStruct {
         match &struct_.fields {
             venial::Fields::Unit => bail!(
                 &struct_.fields,
-                "GodotConvert expects a struct with a single field, unit structs are currently not supported"
+                "GodotConvert expects a struct with a single sized field, unit structs are currently not supported"
             ),
             venial::Fields::Tuple(fields) => {
-                if fields.fields.len() != 1 {
-                    return bail!(
-                        &fields.fields,
-                        "GodotConvert expects a struct with a single field, not {} fields",
-                        fields.fields.len()
-                    );
-                }
+                let (sized, zsts) = Self::partition_fields(
+                    fields
+                        .fields
+                        .iter()
+                        .map(|(field, _)| field.attributes.as_slice()),
+                    fields,
+                )?;
 
-                let (field, _) = fields.fields[0].clone();
+                let mk = |i: usize| NewtypeField {
+                    ident: FieldIdent::tuple(i),
+                    ty: fields.fields[i].0.ty.clone(),
+                };
 
                 Ok(NewtypeStruct {
-                    name: None,
-                    ty: field.ty,
+                    sized: mk(sized),
+                    zsts: zsts.into_iter().map(mk).collect(),
                 })
             }
             venial::Fields::Named(fields) => {
-                if fields.fields.len() != 1 {
-                    return bail!(
-                        &fields.fields,
-                        "GodotConvert expects a struct with a single field, not {} fields",
-                        fields.fields.len()
-                    );
-                }
+                let (sized, zsts) = Self::partition_fields(
+                    fields
+                        .fields
+                        .iter()
+                        .map(|(field, _)| field.attributes.as_slice()),
+                    fields,
+                )?;
 
-                let (field, _) = fields.fields[0].clone();
+                let mk = |i: usize| NewtypeField {
+                    ident: FieldIdent::named(fields.fields[i].0.name.clone()),
+                    ty: fields.fields[i].0.ty.clone(),
+                };
 
                 Ok(NewtypeStruct {
-                    name: Some(field.name),
-                    ty: field.ty,
+                    sized: mk(sized),
+                    zsts: zsts.into_iter().map(mk).collect(),
                 })
             }
         }
     }
 
-    /// Gets the field name.
+    /// Partitions fields into 1 sized field and an arbitrary amount of ZST fields
     ///
-    /// If this represents a tuple-struct, then it will return `0`. This can be used just like it was a named field with the name `0`.
-    /// For instance:
-    /// ```
-    /// struct Foo(i64);
-    ///
-    /// let mut foo = Foo { 0: 10 };
-    /// foo.0 = 20;
-    /// println!("{}", foo.0);
-    /// ```
-    pub fn field_name(&self) -> TokenStream {
-        match &self.name {
-            Some(name) => quote! { #name },
-            None => quote! { 0 },
+    /// Returns the indices to these fields
+    fn partition_fields<'a>(
+        attrs: impl Iterator<Item = &'a [venial::Attribute]>,
+        context: impl ToTokens,
+    ) -> ParseResult<(usize, Vec<usize>)> {
+        let mut sized = None;
+        let mut zsts = vec![];
+
+        for (i, attr) in attrs.enumerate() {
+            match KvParser::parse(attr, "godot")? {
+                Some(mut parser) => {
+                    if parser.handle_alone("skip")? {
+                        zsts.push(i)
+                    }
+                    parser.finish()?;
+                }
+                None if sized.is_none() => sized = Some(i),
+                None => {
+                    return bail!(
+                        &context,
+                        "GodotConvert expects a struct with a single sized field, found multple"
+                    );
+                }
+            }
         }
+
+        let Some(sized) = sized else {
+            return bail!(
+                &context,
+                "GodotConvert expects a struct with a single sized field, found none"
+            );
+        };
+
+        Ok((sized, zsts))
     }
 }

--- a/godot-macros/src/derive/data_models/newtype.rs
+++ b/godot-macros/src/derive/data_models/newtype.rs
@@ -5,22 +5,14 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use proc_macro2::{Ident, Literal, TokenStream};
+use proc_macro2::{Literal, TokenStream};
 use quote::{ToTokens, quote};
 
 use crate::util::bail;
 use crate::{KvParser, ParseResult};
 
+/// Field name of a named struct, or numeric index of a tuple struct.
 pub struct FieldIdent(TokenStream);
-
-impl FieldIdent {
-    fn named(id: Ident) -> Self {
-        Self(quote! { #id })
-    }
-    fn tuple(i: usize) -> Self {
-        Self(Literal::usize_unsuffixed(i).into_token_stream())
-    }
-}
 
 impl ToTokens for FieldIdent {
     fn to_tokens(&self, tokens: &mut TokenStream) {
@@ -31,6 +23,23 @@ impl ToTokens for FieldIdent {
 pub struct NewtypeField {
     pub ident: FieldIdent,
     pub ty: venial::TypeExpr,
+}
+
+impl NewtypeField {
+    fn named(field: &venial::NamedField) -> Self {
+        let name = &field.name;
+        Self {
+            ident: FieldIdent(quote! { #name }),
+            ty: field.ty.clone(),
+        }
+    }
+
+    fn tuple(index: usize, field: &venial::TupleField) -> Self {
+        Self {
+            ident: FieldIdent(Literal::usize_unsuffixed(index).into_token_stream()),
+            ty: field.ty.clone(),
+        }
+    }
 }
 
 /// Stores info from the field of a newtype struct for use in deriving `GodotConvert` and other related traits.
@@ -44,77 +53,51 @@ pub struct NewtypeStruct {
 impl NewtypeStruct {
     /// Parses a struct into a newtype struct.
     ///
-    /// This will fail if the struct doesn't have exactly one field.
+    /// This will fail if the struct doesn't have exactly one non-skipped field.
     pub fn parse_struct(struct_: &venial::Struct) -> ParseResult<NewtypeStruct> {
-        match &struct_.fields {
-            venial::Fields::Unit => bail!(
-                &struct_.fields,
-                "GodotConvert expects a struct with a single sized field, unit structs are currently not supported"
-            ),
-            venial::Fields::Tuple(fields) => {
-                let (sized, zsts) = Self::partition_fields(
-                    fields
-                        .fields
-                        .iter()
-                        .map(|(field, _)| field.attributes.as_slice()),
-                    fields,
-                )?;
+        let all_fields = &struct_.fields;
 
-                let mk = |i: usize| NewtypeField {
-                    ident: FieldIdent::tuple(i),
-                    ty: fields.fields[i].0.ty.clone(),
-                };
-
-                Ok(NewtypeStruct {
-                    sized: mk(sized),
-                    zsts: zsts.into_iter().map(mk).collect(),
-                })
+        // Tuple and named fields have no common accessor, so unify them here.
+        let fields: Vec<(NewtypeField, &[venial::Attribute])> = match all_fields {
+            venial::Fields::Unit => {
+                return bail!(
+                    all_fields,
+                    "GodotConvert expects a struct with a single sized field, unit structs are currently not supported"
+                );
             }
-            venial::Fields::Named(fields) => {
-                let (sized, zsts) = Self::partition_fields(
-                    fields
-                        .fields
-                        .iter()
-                        .map(|(field, _)| field.attributes.as_slice()),
-                    fields,
-                )?;
 
-                let mk = |i: usize| NewtypeField {
-                    ident: FieldIdent::named(fields.fields[i].0.name.clone()),
-                    ty: fields.fields[i].0.ty.clone(),
-                };
+            venial::Fields::Tuple(fields) => fields
+                .fields
+                .iter()
+                .enumerate()
+                .map(|(index, (f, _))| (NewtypeField::tuple(index, f), f.attributes.as_slice()))
+                .collect(),
 
-                Ok(NewtypeStruct {
-                    sized: mk(sized),
-                    zsts: zsts.into_iter().map(mk).collect(),
-                })
-            }
-        }
-    }
+            venial::Fields::Named(fields) => fields
+                .fields
+                .iter()
+                .map(|(f, _)| (NewtypeField::named(f), f.attributes.as_slice()))
+                .collect(),
+        };
 
-    /// Partitions fields into 1 sized field and an arbitrary amount of ZST fields
-    ///
-    /// Returns the indices to these fields
-    fn partition_fields<'a>(
-        attrs: impl Iterator<Item = &'a [venial::Attribute]>,
-        context: impl ToTokens,
-    ) -> ParseResult<(usize, Vec<usize>)> {
         let mut sized = None;
         let mut zsts = vec![];
 
-        for (i, attr) in attrs.enumerate() {
-            match KvParser::parse(attr, "godot")? {
+        for (field, attributes) in fields {
+            match KvParser::parse(attributes, "godot")? {
                 Some(mut parser) => {
-                    if parser.handle_alone("skip")? {
-                        zsts.push(i)
+                    // `skip` is the only key allowed on fields; reject `#[godot]` without it.
+                    if !parser.handle_alone("skip")? {
+                        return bail!(all_fields, "expected `#[godot(skip)]` on skipped fields");
                     }
                     parser.finish()?;
+                    zsts.push(field);
                 }
-                None if sized.is_none() => sized = Some(i),
+                None if sized.is_none() => sized = Some(field),
                 None => {
                     return bail!(
-                        &context,
-                        "GodotConvert expects a struct with a single sized field, found multple"
+                        all_fields,
+                        "GodotConvert expects a struct with a single sized field, found multiple"
                     );
                 }
             }
@@ -122,11 +105,27 @@ impl NewtypeStruct {
 
         let Some(sized) = sized else {
             return bail!(
-                &context,
+                all_fields,
                 "GodotConvert expects a struct with a single sized field, found none"
             );
         };
 
-        Ok((sized, zsts))
+        Ok(NewtypeStruct { sized, zsts })
+    }
+
+    /// Struct initializers `field: Default::default()` for skipped fields, each with a compile-time size check.
+    pub fn make_zst_field_inits(&self) -> TokenStream {
+        let idents = self.zsts.iter().map(|field| &field.ident);
+        let tys = self.zsts.iter().map(|field| &field.ty);
+
+        // const{} block rather than static_assert!, whose const *item* cannot name the enclosing generic parameters #tys.
+        quote! {
+            #(
+                #idents: {
+                    const { ::std::assert!(::std::mem::size_of::<#tys>() == 0, "#[godot(skip)] field must be zero-sized") };
+                    ::std::default::Default::default()
+                },
+            )*
+        }
     }
 }

--- a/godot-macros/src/derive/derive_export.rs
+++ b/godot-macros/src/derive/derive_export.rs
@@ -15,7 +15,10 @@ use crate::derive::data_models::GodotConvert;
 ///
 /// This currently just reuses the property hint from the `Var` implementation.
 pub fn derive_export(item: venial::Item) -> ParseResult<TokenStream> {
-    let GodotConvert { ty_name: name, .. } = GodotConvert::parse_declaration(item)?;
+    let convert = GodotConvert::parse_declaration(item)?;
+    convert.ensure_no_generics("Export")?;
+
+    let name = convert.ty_name;
 
     Ok(quote! {
         impl ::godot::register::property::Export for #name {}

--- a/godot-macros/src/derive/derive_from_godot.rs
+++ b/godot-macros/src/derive/derive_from_godot.rs
@@ -48,26 +48,17 @@ fn make_fromgodot_for_newtype_struct(convert: &GodotConvert, field: &NewtypeStru
         ..
     } = convert;
 
-    let generic_args = generic_params
-        .as_ref()
-        .map(|params| params.as_inline_args());
-
+    let generic_args = convert.generic_args();
     let field_name = &field.sized.ident;
     let via_type = &field.sized.ty;
-
-    let field_zst_names = field.zsts.iter().map(|field| &field.ident);
-    let field_zst_tys = field.zsts.iter().map(|field| &field.ty);
+    let zst_field_inits = field.make_zst_field_inits();
 
     quote! {
         impl #generic_params ::godot::meta::FromGodot for #name #generic_args #where_clause {
             fn try_from_godot(via: #via_type) -> ::std::result::Result<Self, ::godot::meta::error::ConvertError> {
-
                 Ok(Self {
                     #field_name: via,
-                    #(#field_zst_names: {
-                        assert_eq!(::std::mem::size_of::<#field_zst_tys>(), 0);
-                        ::std::default::Default::default()
-                    }),*
+                    #zst_field_inits
                 })
             }
         }

--- a/godot-macros/src/derive/derive_from_godot.rs
+++ b/godot-macros/src/derive/derive_from_godot.rs
@@ -19,10 +19,11 @@ pub fn make_fromgodot(convert: &GodotConvert, cache: &mut EnumeratorExprCache) -
     let GodotConvert {
         ty_name: name,
         convert_type: data,
+        ..
     } = convert;
 
     match data {
-        ConvertType::NewType { field } => make_fromgodot_for_newtype_struct(name, field),
+        ConvertType::NewType { field } => make_fromgodot_for_newtype_struct(convert, field),
 
         ConvertType::Enum {
             variants,
@@ -37,16 +38,37 @@ pub fn make_fromgodot(convert: &GodotConvert, cache: &mut EnumeratorExprCache) -
 }
 
 /// Derives `FromGodot` for newtype structs.
-fn make_fromgodot_for_newtype_struct(name: &Ident, field: &NewtypeStruct) -> TokenStream {
+fn make_fromgodot_for_newtype_struct(convert: &GodotConvert, field: &NewtypeStruct) -> TokenStream {
     // For tuple structs this ends up using the alternate tuple-struct constructor syntax of
     // TupleStruct { 0: value }
-    let field_name = field.field_name();
-    let via_type = &field.ty;
+    let GodotConvert {
+        ty_name: name,
+        generic_params,
+        where_clause,
+        ..
+    } = convert;
+
+    let generic_args = generic_params
+        .as_ref()
+        .map(|params| params.as_inline_args());
+
+    let field_name = &field.sized.ident;
+    let via_type = &field.sized.ty;
+
+    let field_zst_names = field.zsts.iter().map(|field| &field.ident);
+    let field_zst_tys = field.zsts.iter().map(|field| &field.ty);
 
     quote! {
-        impl ::godot::meta::FromGodot for #name {
+        impl #generic_params ::godot::meta::FromGodot for #name #generic_args #where_clause {
             fn try_from_godot(via: #via_type) -> ::std::result::Result<Self, ::godot::meta::error::ConvertError> {
-                Ok(Self { #field_name: via })
+
+                Ok(Self {
+                    #field_name: via,
+                    #(#field_zst_names: {
+                        assert_eq!(::std::mem::size_of::<#field_zst_tys>(), 0);
+                        ::std::default::Default::default()
+                    }),*
+                })
             }
         }
     }

--- a/godot-macros/src/derive/derive_godot_convert.rs
+++ b/godot-macros/src/derive/derive_godot_convert.rs
@@ -8,7 +8,7 @@
 use std::collections::HashMap;
 
 use proc_macro2::{Ident, TokenStream, TokenTree};
-use quote::{ToTokens, quote};
+use quote::quote;
 
 use crate::ParseResult;
 use crate::derive::data_models::{ConvertType, GodotConvert, ViaType};
@@ -27,10 +27,7 @@ pub fn derive_godot_convert(item: venial::Item) -> ParseResult<TokenStream> {
         ..
     } = &convert;
 
-    let generic_args = generic_params
-        .as_ref()
-        .map(|params| params.as_inline_args());
-
+    let generic_args = convert.generic_args();
     let via_type = convert.convert_type.via_type();
     let mut cache = EnumeratorExprCache::default();
 
@@ -39,15 +36,9 @@ pub fn derive_godot_convert(item: venial::Item) -> ParseResult<TokenStream> {
 
     let shape_override = make_shape_override(&convert.convert_type, &mut cache);
 
-    let element_where = match where_clause {
-        Some(w) => w
-            .clone()
-            .with_predicate(venial::WhereClausePredicate::parse(
-                quote! { Self: 'static },
-            ))
-            .to_token_stream(),
-        None => quote! { where Self: 'static },
-    };
+    // Element requires 'static, so add that bound on top of the user's predicates.
+    let user_predicates = where_clause.as_ref().map(|w| &w.items);
+    let element_where = quote! { where Self: 'static, #user_predicates };
 
     Ok(quote! {
         impl #generic_params ::godot::meta::GodotConvert for #name #generic_args #where_clause {

--- a/godot-macros/src/derive/derive_godot_convert.rs
+++ b/godot-macros/src/derive/derive_godot_convert.rs
@@ -8,7 +8,7 @@
 use std::collections::HashMap;
 
 use proc_macro2::{Ident, TokenStream, TokenTree};
-use quote::quote;
+use quote::{ToTokens, quote};
 
 use crate::ParseResult;
 use crate::derive::data_models::{ConvertType, GodotConvert, ViaType};
@@ -20,7 +20,17 @@ use crate::derive::{make_fromgodot, make_togodot};
 pub fn derive_godot_convert(item: venial::Item) -> ParseResult<TokenStream> {
     let convert = GodotConvert::parse_declaration(item)?;
 
-    let name = &convert.ty_name;
+    let GodotConvert {
+        ty_name: name,
+        generic_params,
+        where_clause,
+        ..
+    } = &convert;
+
+    let generic_args = generic_params
+        .as_ref()
+        .map(|params| params.as_inline_args());
+
     let via_type = convert.convert_type.via_type();
     let mut cache = EnumeratorExprCache::default();
 
@@ -29,8 +39,18 @@ pub fn derive_godot_convert(item: venial::Item) -> ParseResult<TokenStream> {
 
     let shape_override = make_shape_override(&convert.convert_type, &mut cache);
 
+    let element_where = match where_clause {
+        Some(w) => w
+            .clone()
+            .with_predicate(venial::WhereClausePredicate::parse(
+                quote! { Self: 'static },
+            ))
+            .to_token_stream(),
+        None => quote! { where Self: 'static },
+    };
+
     Ok(quote! {
-        impl ::godot::meta::GodotConvert for #name  {
+        impl #generic_params ::godot::meta::GodotConvert for #name #generic_args #where_clause {
             type Via = #via_type;
             #shape_override
         }
@@ -39,7 +59,7 @@ pub fn derive_godot_convert(item: venial::Item) -> ParseResult<TokenStream> {
         #from_godot_impl
 
         // Marker impl: defaults derive element metadata from shape().
-        impl ::godot::meta::Element for #name {}
+        impl #generic_params ::godot::meta::Element for #name #generic_args #element_where {}
     })
 }
 

--- a/godot-macros/src/derive/derive_to_godot.rs
+++ b/godot-macros/src/derive/derive_to_godot.rs
@@ -18,10 +18,11 @@ pub fn make_togodot(convert: &GodotConvert, cache: &mut EnumeratorExprCache) -> 
     let GodotConvert {
         ty_name: name,
         convert_type: data,
+        ..
     } = convert;
 
     match data {
-        ConvertType::NewType { field } => make_togodot_for_newtype_struct(name, field),
+        ConvertType::NewType { field } => make_togodot_for_newtype_struct(convert, field),
 
         ConvertType::Enum {
             variants,
@@ -36,12 +37,23 @@ pub fn make_togodot(convert: &GodotConvert, cache: &mut EnumeratorExprCache) -> 
 }
 
 /// Derives `ToGodot` for newtype structs.
-fn make_togodot_for_newtype_struct(name: &Ident, field: &NewtypeStruct) -> TokenStream {
-    let field_name = field.field_name();
-    let via_type = &field.ty;
+fn make_togodot_for_newtype_struct(convert: &GodotConvert, field: &NewtypeStruct) -> TokenStream {
+    let GodotConvert {
+        ty_name: name,
+        generic_params,
+        where_clause,
+        ..
+    } = convert;
+
+    let generic_args = generic_params
+        .as_ref()
+        .map(|params| params.as_inline_args());
+
+    let field_name = &field.sized.ident;
+    let via_type = &field.sized.ty;
 
     quote! {
-        impl ::godot::meta::ToGodot for #name {
+        impl #generic_params ::godot::meta::ToGodot for #name #generic_args #where_clause {
             type Pass = <#via_type as ::godot::meta::ToGodot>::Pass;
 
             fn to_godot(&self) -> ::godot::meta::ToArg<'_, Self::Via, Self::Pass> {

--- a/godot-macros/src/derive/derive_to_godot.rs
+++ b/godot-macros/src/derive/derive_to_godot.rs
@@ -45,10 +45,7 @@ fn make_togodot_for_newtype_struct(convert: &GodotConvert, field: &NewtypeStruct
         ..
     } = convert;
 
-    let generic_args = generic_params
-        .as_ref()
-        .map(|params| params.as_inline_args());
-
+    let generic_args = convert.generic_args();
     let field_name = &field.sized.ident;
     let via_type = &field.sized.ty;
 

--- a/godot-macros/src/derive/derive_var.rs
+++ b/godot-macros/src/derive/derive_var.rs
@@ -17,6 +17,7 @@ use crate::derive::data_models::GodotConvert;
 /// Property hints are derived from `GodotConvert::shape()`.
 pub fn derive_var(item: venial::Item) -> ParseResult<TokenStream> {
     let convert = GodotConvert::parse_declaration(item)?;
+    convert.ensure_no_generics("Var")?;
 
     let name = convert.ty_name;
 

--- a/godot-macros/src/lib.rs
+++ b/godot-macros/src/lib.rs
@@ -1349,7 +1349,7 @@ pub fn godot_dyn(_meta: TokenStream, input: TokenStream) -> TokenStream {
     translate(input, class::attribute_godot_dyn)
 }
 
-/// Derive macro for [`GodotConvert`](../meta/trait.GodotConvert.html) on structs.
+/// Derive macro for [`GodotConvert`](../meta/trait.GodotConvert.html) on structs and enums.
 ///
 /// This derive macro also derives [`ToGodot`](../meta/trait.ToGodot.html) and [`FromGodot`](../meta/trait.FromGodot.html).
 ///
@@ -1393,22 +1393,8 @@ pub fn godot_dyn(_meta: TokenStream, input: TokenStream) -> TokenStream {
 /// assert_eq!(obj.to_godot(), &GString::from("hello!"));
 /// ```
 ///
-/// You may have other fields in your newtype struct if they are ZSTs by using the attribute `#[godot(skip)]`
-/// ```no_run
-/// use godot::prelude::*;
-/// use std::marker::PhantomData;
-///
-/// #[derive(GodotConvert)]
-/// #[godot(transparent)]
-/// struct SomeNewtype<T> {
-///     int: i64,
-///     #[godot(skip)]
-///     _marker: PhantomData<T>,
-/// }
-/// ```
-///
-/// This is useful for cases where you want to have generics in Rust, but you still want to use that struct from Godot. For example, you have a
-/// key `Key<T>` to a registry `Registry<T>` that contains `T`.
+/// Additional fields are allowed if they are zero-sized types (ZSTs) and annotated with `#[godot(skip)]`. Such fields must implement `Default`,
+/// which is used to rebuild them in `FromGodot`. This makes generic types usable from Godot, for example a type-safe `Key<T>`:
 /// ```no_run
 /// use godot::prelude::*;
 /// use std::marker::PhantomData;
@@ -1422,14 +1408,27 @@ pub fn godot_dyn(_meta: TokenStream, input: TokenStream) -> TokenStream {
 /// }
 /// ```
 ///
-/// You may not `#[godot(skip)]` on sized fields, or have more than one sized field
+/// [`Var`] and [`Export`] cannot be derived for generic types:
 /// ```compile_fail
 /// use godot::prelude::*;
 /// use std::marker::PhantomData;
 ///
+/// #[derive(GodotConvert, Var)]
+/// #[godot(transparent)]
+/// struct Key<T> {
+///     id: u32,
+///     #[godot(skip)]
+///     _marker: PhantomData<T>,
+/// }
+/// ```
+///
+/// You cannot use `#[godot(skip)]` on sized fields, or have more than one sized field.
+/// ```compile_fail
+/// use godot::prelude::*;
+///
 /// #[derive(GodotConvert)]
 /// #[godot(transparent)]
-/// struct SomeNewtype<T> {
+/// struct SomeNewtype {
 ///     int: i64,
 ///     #[godot(skip)]
 ///     other_int: i64,
@@ -1525,7 +1524,7 @@ pub fn derive_godot_convert(input: TokenStream) -> TokenStream {
     translate(input, derive::derive_godot_convert)
 }
 
-/// Derive macro for [`Var`](../register/property/trait.Var.html) on enums.
+/// Derive macro for [`Var`](../register/property/trait.Var.html) on enums and `#[godot(transparent)]` structs.
 ///
 /// This expects a derived [`GodotConvert`](../meta/trait.GodotConvert.html) implementation, using a manual
 /// implementation of `GodotConvert` may lead to incorrect values being displayed in Godot.
@@ -1534,7 +1533,7 @@ pub fn derive_var(input: TokenStream) -> TokenStream {
     translate(input, derive::derive_var)
 }
 
-/// Derive macro for [`Export`](../register/property/trait.Export.html) on enums.
+/// Derive macro for [`Export`](../register/property/trait.Export.html) on enums and `#[godot(transparent)]` structs.
 ///
 /// See also [`Var`].
 #[proc_macro_derive(Export, attributes(godot))]

--- a/godot-macros/src/lib.rs
+++ b/godot-macros/src/lib.rs
@@ -1393,15 +1393,59 @@ pub fn godot_dyn(_meta: TokenStream, input: TokenStream) -> TokenStream {
 /// assert_eq!(obj.to_godot(), &GString::from("hello!"));
 /// ```
 ///
-/// However, it will not work for structs with more than one field, even if that field is zero sized:
-/// ```compile_fail
+/// You may have other fields in your newtype struct if they are ZSTs by using the attribute `#[godot(skip)]`
+/// ```no_run
 /// use godot::prelude::*;
+/// use std::marker::PhantomData;
 ///
 /// #[derive(GodotConvert)]
 /// #[godot(transparent)]
-/// struct SomeNewtype {
+/// struct SomeNewtype<T> {
 ///     int: i64,
-///     zst: (),
+///     #[godot(skip)]
+///     _marker: PhantomData<T>,
+/// }
+/// ```
+///
+/// This is useful for cases where you want to have generics in Rust, but you still want to use that struct from Godot. For example, you have a
+/// key `Key<T>` to a registry `Registry<T>` that contains `T`.
+/// ```no_run
+/// use godot::prelude::*;
+/// use std::marker::PhantomData;
+///
+/// #[derive(GodotConvert)]
+/// #[godot(transparent)]
+/// struct Key<T> {
+///     id: u32,
+///     #[godot(skip)]
+///     _marker: PhantomData<T>,
+/// }
+/// ```
+///
+/// You may not `#[godot(skip)]` on sized fields, or have more than one sized field
+/// ```compile_fail
+/// use godot::prelude::*;
+/// use std::marker::PhantomData;
+///
+/// #[derive(GodotConvert)]
+/// #[godot(transparent)]
+/// struct SomeNewtype<T> {
+///     int: i64,
+///     #[godot(skip)]
+///     other_int: i64,
+/// }
+/// ```
+/// ```compile_fail
+/// use godot::prelude::*;
+/// use std::marker::PhantomData;
+///
+/// #[derive(GodotConvert)]
+/// #[godot(transparent)]
+/// struct SomeNewtype<T> {
+///     int: i64,
+///     other_int: i64,
+///     #[godot(skip)]
+///     _marker: PhantomData<T>,
 /// }
 /// ```
 ///

--- a/itest/rust/src/register_tests/derive_godotconvert_test.rs
+++ b/itest/rust/src/register_tests/derive_godotconvert_test.rs
@@ -8,8 +8,8 @@
 use std::fmt::Debug;
 use std::marker::PhantomData;
 
-use godot::builtin::{GString, Vector2, array, dict};
-use godot::meta::{GodotConvert, ToGodot};
+use godot::builtin::{Array, GString, Vector2, array, dict};
+use godot::meta::{Element, GodotConvert, ToGodot};
 
 use crate::common::roundtrip;
 use crate::framework::itest;
@@ -21,12 +21,10 @@ use crate::framework::itest;
 #[godot(transparent)]
 struct TupleNewtype(GString);
 
+// Generic types are supported; params that aren't part of the via type live in zero-sized `#[godot(skip)]` fields.
 #[derive(GodotConvert, PartialEq, Debug)]
 #[godot(transparent)]
-struct TuplePhantomNewtype<T: Debug + godot::meta::Element, U>(
-    godot::prelude::Array<T>,
-    #[godot(skip)] PhantomData<U>,
-);
+struct TuplePhantomNewtype<T: Debug + Element, U>(Array<T>, #[godot(skip)] PhantomData<U>);
 
 #[derive(GodotConvert, PartialEq, Debug)]
 #[godot(transparent)]
@@ -34,6 +32,7 @@ struct NamedNewtype {
     field1: Vector2,
 }
 
+// The skipped type is not required to syntactically be `PhantomData`; only its size matters.
 type ZstType<T> = PhantomData<T>;
 
 #[derive(GodotConvert, PartialEq, Debug)]
@@ -47,6 +46,14 @@ where
     _marker: ZstType<T>,
     #[godot(skip)]
     _zilch: (),
+}
+
+#[derive(GodotConvert, PartialEq, Debug)]
+#[godot(transparent)]
+struct GenericFormsNewtype<'a, const N: usize, T> {
+    field1: i64,
+    #[godot(skip)]
+    _marker: PhantomData<(&'a T, [(); N])>,
 }
 
 #[derive(GodotConvert, Clone, PartialEq, Debug)]
@@ -93,6 +100,10 @@ fn newtype_named_struct() {
         field1: Vector2::new(10.0, 25.0),
         _marker: PhantomData,
         _zilch: (),
+    });
+    roundtrip(GenericFormsNewtype::<3, u8> {
+        field1: 7,
+        _marker: PhantomData,
     });
 }
 

--- a/itest/rust/src/register_tests/derive_godotconvert_test.rs
+++ b/itest/rust/src/register_tests/derive_godotconvert_test.rs
@@ -6,6 +6,7 @@
  */
 
 use std::fmt::Debug;
+use std::marker::PhantomData;
 
 use godot::builtin::{GString, Vector2, array, dict};
 use godot::meta::{GodotConvert, ToGodot};
@@ -22,8 +23,30 @@ struct TupleNewtype(GString);
 
 #[derive(GodotConvert, PartialEq, Debug)]
 #[godot(transparent)]
+struct TuplePhantomNewtype<T: Debug + godot::meta::Element, U>(
+    godot::prelude::Array<T>,
+    #[godot(skip)] PhantomData<U>,
+);
+
+#[derive(GodotConvert, PartialEq, Debug)]
+#[godot(transparent)]
 struct NamedNewtype {
     field1: Vector2,
+}
+
+type ZstType<T> = PhantomData<T>;
+
+#[derive(GodotConvert, PartialEq, Debug)]
+#[godot(transparent)]
+struct NamedPhantomNewtype<T>
+where
+    T: Clone,
+{
+    field1: Vector2,
+    #[godot(skip)]
+    _marker: ZstType<T>,
+    #[godot(skip)]
+    _zilch: (),
 }
 
 #[derive(GodotConvert, Clone, PartialEq, Debug)]
@@ -58,12 +81,18 @@ enum EnumIntyWithExprs {
 #[itest]
 fn newtype_tuple_struct() {
     roundtrip(TupleNewtype(GString::from("hello!")));
+    roundtrip(TuplePhantomNewtype::<u32, String>(array![], PhantomData));
 }
 
 #[itest]
 fn newtype_named_struct() {
     roundtrip(NamedNewtype {
         field1: Vector2::new(10.0, 25.0),
+    });
+    roundtrip(NamedPhantomNewtype::<usize> {
+        field1: Vector2::new(10.0, 25.0),
+        _marker: PhantomData,
+        _zilch: (),
     });
 }
 


### PR DESCRIPTION
Fix for godot-rust/gdext#1563

You can now do stuff like:
```rs
#[derive(GodotConvert, PartialEq, Debug)]
#[godot(transparent)]
struct NamedPhantomNewtype<T> {
    field1: Vector2,
    _marker: PhantomData<T>,
}
```


Additionally, as a consequence of the changes, you can now have generics on non-PhantomData fields as well, like:
```rs
#[derive(GodotConvert, PartialEq, Debug)]
#[godot(transparent)]
struct NamedPhantomNewtype<T: Element> {
    field1: Array<T>,
    _marker: PhantomData<T>,
}
```

I'm not sure this is intended behavior, however. I can't see a reason why not, but I'd like clarification. If it isn't I'll go add a check to make sure you can't use generics on non-PhantomData fields.