### PR TITLE
Support `@export_node_path` attribute

### DIFF
--- a/godot-core/src/registry/property/mod.rs
+++ b/godot-core/src/registry/property/mod.rs
@@ -316,7 +316,7 @@ impl<T: GodotNullableType> BuiltinExport for Option<T> {}
 ///
 /// You are not supposed to use these functions directly. They are used by the `#[export]` macro to generate the correct export hint.
 ///
-/// Each function is named the same as the equivalent Godot annotation.  
+/// Each function is named the same as the equivalent Godot annotation.
 /// For instance, `@export_range` in Godot is `fn export_range` here.
 pub mod export_fns {
     use godot_ffi::VariantType;
@@ -408,6 +408,40 @@ pub mod export_fns {
         PropertyHintInfo {
             hint: PropertyHint::RANGE,
             hint_string: GString::from(&hint_string),
+        }
+    }
+
+    /// Equivalent to `@export_node_path` in Godot.
+    ///
+    /// Accepts a list of node class names to restrict which node types can be selected.
+    /// An empty slice means any node type is allowed.
+    pub fn export_node_path<T: Export>(node_paths: &[&str]) -> PropertyHintInfo {
+        let hint_string = node_paths.join(",");
+        match T::Via::godot_shape() {
+            GodotShape::Builtin {
+                variant_type: VariantType::NODE_PATH,
+                ..
+            } => PropertyHintInfo {
+                hint: PropertyHint::NODE_PATH_VALID_TYPES,
+                hint_string: GString::from(&hint_string),
+            },
+            #[cfg(since_api = "4.3")]
+            GodotShape::TypedArray {
+                element:
+                    GodotElementShape::Builtin {
+                        variant_type: VariantType::NODE_PATH,
+                    },
+            } => PropertyHintInfo {
+                hint: PropertyHint::TYPE_STRING,
+                hint_string: GString::from(&crate::meta::shape::format_elements_typed(
+                    VariantType::NODE_PATH,
+                    PropertyHint::NODE_PATH_VALID_TYPES,
+                    &hint_string,
+                )),
+            },
+            other => panic!(
+                "#[export(node_path)] only supports NodePath or Array<NodePath> field types, found: {other:?}"
+            ),
         }
     }
 

--- a/godot-macros/src/class/data_models/field_export.rs
+++ b/godot-macros/src/class/data_models/field_export.rs
@@ -60,6 +60,13 @@ pub enum ExportType {
     Storage,
 
     /// ### GDScript annotations
+    /// - `@export_node_path`
+    ///
+    /// ### Property hints
+    /// - `NODE_PATH_VALID_TYPES`
+    NodePath { node_paths: Vec<TokenStream> },
+
+    /// ### GDScript annotations
     /// - `@export_range`
     ///
     /// ### Property hints
@@ -170,6 +177,10 @@ impl ExportType {
     pub(crate) fn new_from_kv(parser: &mut KvParser) -> ParseResult<Self> {
         if parser.handle_alone("storage")? {
             return Self::new_storage();
+        }
+
+        if let Some(list_parser) = parser.handle_list("node_path")? {
+            return Self::new_node_path_list(list_parser);
         }
 
         if let Some(list_parser) = parser.handle_list("range")? {
@@ -297,6 +308,14 @@ impl ExportType {
 
     fn new_storage() -> ParseResult<Self> {
         Ok(Self::Storage)
+    }
+
+    fn new_node_path_list(mut parser: ListParser) -> ParseResult<Self> {
+        let mut node_paths: Vec<TokenStream> = vec![];
+        while let Some(expr) = parser.try_next_expr()? {
+            node_paths.push(expr);
+        }
+        Ok(Self::NodePath { node_paths })
     }
 
     fn new_range_list(mut parser: ListParser) -> ParseResult<Self> {
@@ -438,6 +457,12 @@ impl ExportType {
             Self::Default => None,
 
             Self::Storage => quote_export_func! { export_storage() },
+
+            Self::NodePath { node_paths } => {
+                quote_export_func! {
+                    export_node_path<T>(&[#(#node_paths),*])
+                }
+            }
 
             Self::Range {
                 min,

--- a/godot-macros/src/lib.rs
+++ b/godot-macros/src/lib.rs
@@ -275,6 +275,10 @@ use crate::util::{KvParser, bail, ident};
 ///     #[export(storage)]
 ///     hidden_string: GString,
 ///
+///     // @export_node_path("Button", "TouchScreenButton")
+///     #[export(node_path = ("Button", "TouchScreenButton"))]
+///     node_path: NodePath,
+///
 ///     // @export_range(0.0, 10.0, or_greater)
 ///     #[export(range = (0.0, 10.0, or_greater))]
 ///     range_f64: f64,

--- a/godot-macros/src/util/list_parser.rs
+++ b/godot-macros/src/util/list_parser.rs
@@ -147,6 +147,19 @@ impl ListParser {
         Ok(Some(id))
     }
 
+    /// Take the next element of the list, if one exists, ensuring it is an expression.
+    ///
+    /// Returns `Ok(Some(expr))` if the next element exists and is a valid expression,
+    /// `Ok(None)` if there are no more elements left,
+    /// or `Err` if the next element is not a valid expression.
+    pub fn try_next_expr(&mut self) -> ParseResult<Option<TokenStream>> {
+        let Some(_kv) = self.peek() else {
+            return Ok(None);
+        };
+
+        Ok(Some(self.pop_next().unwrap().expr()?))
+    }
+
     /// Checks to see if there is a next element, and if so,
     /// whether it is one of the allowed identifiers,
     /// returning `Ok(Some(ident))` if successful.

--- a/itest/rust/build.rs
+++ b/itest/rust/build.rs
@@ -491,6 +491,15 @@ fn generate_property_template(inputs: &[Input]) -> PropertyTests {
         TokenStream::new()
     } else {
         quote! {
+            #[export(node_path)]
+            export_untyped_node_path_array: Array<NodePath>,
+
+            #[export(node_path = ("Button"))]
+            export_node_path_button_array: Array<NodePath>,
+
+            #[export(node_path = ("Button", "TouchScreenButton"))]
+            export_node_path_button_touch_screen_button_array: Array<NodePath>,
+
             #[export(storage)]
             export_storage: GString,
 
@@ -602,6 +611,13 @@ fn generate_property_template(inputs: &[Input]) -> PropertyTests {
             #rust_exports_4_3
             #rust_exports_4_4
 
+            #[export(node_path)]
+            export_node_path_untyped: NodePath,
+            #[export(node_path = ("Button"))]
+            export_node_path_button: NodePath,
+            #[export(node_path = ("Button", "TouchScreenButton"))]
+            export_node_path_button_touch_screen_button: NodePath,
+
             // All the @export_file/dir variants, with GString, Array<GString> and PackedStringArray.
             #[export(file)]
             export_file: GString,
@@ -672,6 +688,8 @@ fn generate_property_template(inputs: &[Input]) -> PropertyTests {
 @export_range(0, 100, 1, "or_greater", "or_less") var export_range_int_0_100_1_or_greater_or_less: int
 @export_exp_easing var export_exp_easing: float
 @export_color_no_alpha var export_color_no_alpha: Color
+@export_node_path var export_node_path_untyped: NodePath
+@export_node_path("Button") var export_node_path_button: NodePath
 @export_node_path("Button", "TouchScreenButton") var export_node_path_button_touch_screen_button: NodePath
 @export_flags("Fire", "Water", "Earth", "Wind") var export_flags_fire_water_earth_wind: int
 @export_flags("Self:4", "Allies:8", "Foes:16") var export_flags_self_4_allies_8_foes_16: int
@@ -701,6 +719,9 @@ fn generate_property_template(inputs: &[Input]) -> PropertyTests {
 @export_dir var export_dir_parray: PackedStringArray
 @export_global_dir var export_global_dir_array: Array[String]
 @export_global_dir var export_global_dir_parray: PackedStringArray
+@export_node_path var export_untyped_node_path_array: Array[NodePath]
+@export_node_path("Button") var export_node_path_button_array: Array[NodePath]
+@export_node_path("Button", "TouchScreenButton") var export_node_path_button_touch_screen_button_array: Array[NodePath]
     "#;
 
     // Only available in Godot 4.4+.


### PR DESCRIPTION
Added support for `export_node_path` annotation (Completes #1128)

Adds the ability to annotate fields with `@export_node_path`:
```rust
#[derive(GodotClass)]
#[class(base=Node2D)]
struct SomeClass {
    /// Equivalent to:
    /// ```gdscript
    /// @export_node_path("Button", "TouchScreenButton") var some_button: NodePath
    /// ```
    #[export(node_path = ("Button", "TouchScreenButton"))]
    some_button: NodePath,

    base: Base<Node2D>
}
```

Note: I didn't find the exact PR where `export_node_path` was introduced to GDScript upstream, so if it's needed let me know, and I will dig deeper. Otherwise let me know if I should adjust any of these changes.

Couldn't have done it without other PRs like those of @Swivelgames on #1183. It really made it a lot easier to have that as reference, so thanks to them a lot!