### PR TITLE
String conversions: ` to_gstring()`, `to_string_name()` etc.

### DIFF
--- a/godot-core/src/builtin/mod.rs
+++ b/godot-core/src/builtin/mod.rs
@@ -45,7 +45,7 @@ pub mod __prelude_reexport {
     pub use rect2i::*;
     pub use rid::*;
     pub use signal::*;
-    pub use strings::{Encoding, GString, NodePath, StringName};
+    pub use strings::{Encoding, GString, GodotStringExt, NodePath, StringName};
     pub use variant::*;
     pub use vectors::*;
 

--- a/godot-core/src/builtin/strings/godot_string_ext.rs
+++ b/godot-core/src/builtin/strings/godot_string_ext.rs
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use std::borrow::Cow;
+
+use godot_ffi as sys;
+use sys::GodotFfi;
+
+use crate::builtin::{GString, NodePath, StringName};
+
+/// Extension trait for converting to Godot string types.
+///
+/// Provides types like `&str` and `String` with "extension functions" to convert to one of the Godot string types.
+///
+/// An explicitly named `val.to_gstring()` method has several advantages over the `From` trait (which may be phased out over time):
+/// - Compared to `GString::from(&val)`, it is shorter and can be used in fluent expressions such as `val.replace(...).to_gstring()`.
+/// - Compared to `val.into()`, it makes the conversion more explicit by naming the type, and never runs into type-inference problems
+///   (the `into()` function requires an explicit type declaration somewhere).
+pub trait GodotStringExt {
+    /// Convert to a `GString`.
+    fn to_gstring(&self) -> GString;
+
+    /// Convert to a `StringName`.
+    fn to_string_name(&self) -> StringName;
+
+    /// Convert to a `NodePath`.
+    ///
+    /// Since `NodePath` doesn't allow many direct conversions, a default implementation converts via `GString`.
+    /// Override if you have a more performant implementation.
+    fn to_node_path(&self) -> NodePath {
+        self.to_gstring().to_node_path()
+    }
+}
+
+/// Macro to delegate a builtin conversion to the FFI layer.
+///
+/// Use: `let dest = unsafe_from_builtin!(dest_from_source -> Dest, source);`
+///
+/// # Safety
+/// The `Dest` type must match what the FFI function `dest_from_source` returns.
+macro_rules! unsafe_builtin_convert {
+    ($ctor:ident -> $Type:ty, $arg:expr) => {{
+        let __arg = $arg; // Must outlive the sys() call.
+
+        // SAFETY: Matching $Type and $ctor is caller responsibility. The rest adheres to Godot FFI for conversion constructors.
+        unsafe {
+            <$Type>::new_with_uninit(|self_ptr| {
+                let ctor = sys::builtin_fn!($ctor);
+                let args = [__arg.sys()];
+                ctor(self_ptr, args.as_ptr());
+            })
+        }
+    }};
+}
+
+impl GodotStringExt for GString {
+    fn to_gstring(&self) -> GString {
+        self.clone()
+    }
+
+    fn to_string_name(&self) -> StringName {
+        unsafe_builtin_convert!(string_name_from_string -> StringName, self)
+    }
+
+    fn to_node_path(&self) -> NodePath {
+        unsafe_builtin_convert!(node_path_from_string -> NodePath, self)
+    }
+}
+
+impl GodotStringExt for StringName {
+    fn to_gstring(&self) -> GString {
+        unsafe_builtin_convert!(string_from_string_name -> GString, self)
+    }
+
+    fn to_string_name(&self) -> StringName {
+        self.clone()
+    }
+}
+
+impl GodotStringExt for NodePath {
+    fn to_gstring(&self) -> GString {
+        unsafe_builtin_convert!(string_from_node_path -> GString, self)
+    }
+
+    fn to_string_name(&self) -> StringName {
+        // Godot FFI provides no direct NodePath -> StringName conversion.
+        self.to_gstring().to_string_name()
+    }
+
+    fn to_node_path(&self) -> NodePath {
+        self.clone()
+    }
+}
+
+impl GodotStringExt for &str {
+    fn to_gstring(&self) -> GString {
+        let utf8_bytes = self.as_bytes();
+
+        // SAFETY: string is UTF-8 encoded and len-bounded. Godot takes byte length, not character count.
+        unsafe {
+            GString::new_with_string_uninit(|string_ptr| {
+                #[cfg(before_api = "4.3")]
+                let ctor = sys::interface_fn!(string_new_with_utf8_chars_and_len);
+                #[cfg(since_api = "4.3")]
+                let ctor = sys::interface_fn!(string_new_with_utf8_chars_and_len2);
+
+                ctor(
+                    string_ptr,
+                    utf8_bytes.as_ptr().cast::<std::ffi::c_char>(),
+                    utf8_bytes.len() as i64,
+                );
+            })
+        }
+    }
+
+    fn to_string_name(&self) -> StringName {
+        let utf8_bytes = self.as_bytes();
+
+        // SAFETY: string is UTF-8 encoded and len-bounded. Godot takes byte length, not character count.
+        unsafe {
+            StringName::new_with_string_uninit(|string_ptr| {
+                sys::interface_fn!(string_name_new_with_utf8_chars_and_len)(
+                    string_ptr,
+                    utf8_bytes.as_ptr().cast::<std::ffi::c_char>(),
+                    utf8_bytes.len() as i64,
+                );
+            })
+        }
+    }
+}
+
+impl GodotStringExt for &[char] {
+    fn to_gstring(&self) -> GString {
+        let chars = *self;
+
+        // SAFETY: A `char` value is by definition a valid Unicode code point. Bounded by len().
+        unsafe {
+            GString::new_with_string_uninit(|string_ptr| {
+                sys::interface_fn!(string_new_with_utf32_chars_and_len)(
+                    string_ptr,
+                    chars.as_ptr().cast::<sys::char32_t>(),
+                    chars.len() as i64,
+                );
+            })
+        }
+    }
+
+    fn to_string_name(&self) -> StringName {
+        // There is no FFI function `string_name_new_with_utf32_chars_and_len` -> go via GString.
+        self.to_gstring().to_string_name()
+    }
+}
+
+impl GodotStringExt for String {
+    fn to_gstring(&self) -> GString {
+        self.as_str().to_gstring()
+    }
+
+    fn to_string_name(&self) -> StringName {
+        self.as_str().to_string_name()
+    }
+}
+
+impl GodotStringExt for Cow<'_, str> {
+    fn to_gstring(&self) -> GString {
+        self.as_ref().to_gstring()
+    }
+
+    fn to_string_name(&self) -> StringName {
+        self.as_ref().to_string_name()
+    }
+}

--- a/godot-core/src/builtin/strings/gstring.rs
+++ b/godot-core/src/builtin/strings/gstring.rs
@@ -30,7 +30,6 @@ use crate::{impl_shared_string_api, meta};
 /// In order to modify Godot strings, it's often easiest to convert them to Rust strings, perform the modifications and convert back.
 ///
 /// # `GString` vs. `String`
-///
 /// When interfacing with the Godot engine API, you often have the choice between `String` and `GString`. In user-declared methods
 /// exposed to Godot through the `#[func]` attribute, both types can be used as parameters and return types, and conversions
 /// are done transparently. For auto-generated binding APIs in `godot::classes`, both parameters and return types are `GString`.
@@ -48,21 +47,23 @@ use crate::{impl_shared_string_api, meta};
 /// * you have a large number of method calls per string instance (which are more expensive due to indirectly calling into Godot)
 /// * you need UTF-8 encoding (`GString` uses UTF-32)
 ///
-/// # Null bytes
+/// # All string types + conversions
+/// | String type                                | Intended use case       | Encoding  | Convert to                                 |
+/// |--------------------------------------------|-------------------------|-----------|--------------------------------------------|
+/// | **`GString`**                              | General purpose         | UTF-32    | `to_gstring()`                             |
+/// | [`StringName`][crate::builtin::StringName] | Interned names          | UTF-32    | [`to_string_name()`][Self::to_string_name] |
+/// | [`NodePath`][crate::builtin::NodePath]     | Scene-node paths        | segmented | [`to_node_path()`][Self::to_node_path]     |
+/// | `String`                                   | Owned, general purpose  | UTF-8     | [`to_string()`](#method.to_string)         |
+/// | `&str`                                     | Borrowed slice          | UTF-8     | _not supported_                            |
+/// | `&[char]`                                  | Borrowed slice (UTF-32) | UTF-32    | [`chars()`][Self::chars]                   |
 ///
+/// See also `GString` constructors for more low-level conversions from `&[u8]` and `CStr`.
+///
+/// # Null bytes
 /// Note that Godot ignores any bytes after a null-byte. This means that for instance `"hello, world!"` and `"hello, world!\0 ignored by Godot"`
 /// will be treated as the same string if converted to a `GString`.
 ///
-/// # All string types
-///
-/// | Intended use case | String type                                |
-/// |-------------------|--------------------------------------------|
-/// | General purpose   | **`GString`**                              |
-/// | Interned names    | [`StringName`][crate::builtin::StringName] |
-/// | Scene-node paths  | [`NodePath`][crate::builtin::NodePath]     |
-///
 /// # Godot docs
-///
 /// [`String` (stable)](https://docs.godotengine.org/en/stable/classes/class_string.html)
 #[doc(alias = "String")]
 // #[repr] is needed on GString itself rather than the opaque field, because PackedStringArray::as_slice() relies on a packed representation.

--- a/godot-core/src/builtin/strings/gstring.rs
+++ b/godot-core/src/builtin/strings/gstring.rs
@@ -13,7 +13,7 @@ use godot_ffi as sys;
 use sys::{ExtVariantType, GodotFfi, ffi_methods, interface_fn};
 
 use crate::builtin::strings::{Encoding, pad_if_needed};
-use crate::builtin::{NodePath, StringName, Variant, inner};
+use crate::builtin::{GodotStringExt, NodePath, StringName, Variant, inner};
 use crate::meta::AsArg;
 use crate::meta::error::StringError;
 use crate::{impl_shared_string_api, meta};
@@ -328,38 +328,13 @@ impl PartialEq<&str> for GString {
 
 impl From<&str> for GString {
     fn from(s: &str) -> Self {
-        let bytes = s.as_bytes();
-
-        unsafe {
-            Self::new_with_string_uninit(|string_ptr| {
-                #[cfg(before_api = "4.3")]
-                let ctor = interface_fn!(string_new_with_utf8_chars_and_len);
-                #[cfg(since_api = "4.3")]
-                let ctor = interface_fn!(string_new_with_utf8_chars_and_len2);
-
-                ctor(
-                    string_ptr,
-                    bytes.as_ptr() as *const std::ffi::c_char,
-                    bytes.len() as i64,
-                );
-            })
-        }
+        s.to_gstring()
     }
 }
 
 impl From<&[char]> for GString {
     fn from(chars: &[char]) -> Self {
-        // SAFETY: A `char` value is by definition a valid Unicode code point.
-        unsafe {
-            Self::new_with_string_uninit(|string_ptr| {
-                let ctor = interface_fn!(string_new_with_utf32_chars_and_len);
-                ctor(
-                    string_ptr,
-                    chars.as_ptr() as *const sys::char32_t,
-                    chars.len() as i64,
-                );
-            })
-        }
+        chars.to_gstring()
     }
 }
 
@@ -412,25 +387,13 @@ impl std::str::FromStr for GString {
 
 impl From<&StringName> for GString {
     fn from(string: &StringName) -> Self {
-        unsafe {
-            Self::new_with_uninit(|self_ptr| {
-                let ctor = sys::builtin_fn!(string_from_string_name);
-                let args = [string.sys()];
-                ctor(self_ptr, args.as_ptr());
-            })
-        }
+        string.to_gstring()
     }
 }
 
 impl From<&NodePath> for GString {
     fn from(path: &NodePath) -> Self {
-        unsafe {
-            Self::new_with_uninit(|self_ptr| {
-                let ctor = sys::builtin_fn!(string_from_node_path);
-                let args = [path.sys()];
-                ctor(self_ptr, args.as_ptr());
-            })
-        }
+        path.to_gstring()
     }
 }
 

--- a/godot-core/src/builtin/strings/mod.rs
+++ b/godot-core/src/builtin/strings/mod.rs
@@ -7,12 +7,14 @@
 
 //! Godot-types that are Strings.
 
+mod godot_string_ext;
 mod gstring;
 mod macros;
 mod node_path;
 mod string_macros;
 mod string_name;
 
+pub use godot_string_ext::GodotStringExt;
 pub use gstring::{ExFind as GStringExFind, ExSplit as GStringExSplit, *};
 pub use node_path::NodePath;
 pub use string_name::{ExFind as StringNameExFind, ExSplit as StringNameExSplit, *};

--- a/godot-core/src/builtin/strings/node_path.rs
+++ b/godot-core/src/builtin/strings/node_path.rs
@@ -12,6 +12,7 @@ use godot_ffi::{ExtVariantType, GdextBuild, GodotFfi, ffi_methods};
 
 use super::{GString, StringName};
 use crate::builtin::inner;
+use crate::builtin::strings::GodotStringExt;
 use crate::meta::signed_range::SignedRange;
 
 /// A pre-parsed scene tree path.
@@ -233,34 +234,26 @@ impl fmt::Debug for NodePath {
 impl_rust_string_conv!(NodePath);
 
 impl From<&str> for NodePath {
-    // NodePath doesn't offer direct construction from bytes; go via GString.
     fn from(s: &str) -> Self {
-        Self::from(&GString::from(s))
+        s.to_node_path()
     }
 }
 
 impl From<&String> for NodePath {
     fn from(s: &String) -> Self {
-        // NodePath doesn't offer direct construction from bytes; go via GString.
-        Self::from(&GString::from(s))
+        s.to_node_path()
     }
 }
 
 impl From<&GString> for NodePath {
     fn from(string: &GString) -> Self {
-        unsafe {
-            Self::new_with_uninit(|self_ptr| {
-                let ctor = sys::builtin_fn!(node_path_from_string);
-                let args = [string.sys()];
-                ctor(self_ptr, args.as_ptr());
-            })
-        }
+        string.to_node_path()
     }
 }
 
 impl From<&StringName> for NodePath {
     fn from(s: &StringName) -> Self {
-        Self::from(&GString::from(s))
+        s.to_node_path()
     }
 }
 

--- a/godot-core/src/builtin/strings/node_path.rs
+++ b/godot-core/src/builtin/strings/node_path.rs
@@ -17,21 +17,21 @@ use crate::meta::signed_range::SignedRange;
 
 /// A pre-parsed scene tree path.
 ///
-/// # Null bytes
+/// # All string types + conversions
+/// | String type                                | Intended use case       | Encoding  | Convert to                                 |
+/// |--------------------------------------------|-------------------------|-----------|--------------------------------------------|
+/// | [`GString`][crate::builtin::GString]       | General purpose         | UTF-32    | [`to_gstring()`][Self::to_gstring]         |
+/// | [`StringName`][crate::builtin::StringName] | Interned names          | UTF-32    | [`to_string_name()`][Self::to_string_name] |
+/// | **`NodePath`**                             | Scene-node paths        | segmented | `to_node_path()`                           |
+/// | `String`                                   | Owned, general purpose  | UTF-8     | [`to_string()`](#method.to_string)         |
+/// | `&str`                                     | Borrowed slice          | UTF-8     | _not supported_                            |
+/// | `&[char]`                                  | Borrowed slice (UTF-32) | UTF-32    | _not supported_                            |
 ///
+/// # Null bytes
 /// Note that Godot ignores any bytes after a null-byte. This means that for instance `"hello, world!"` and `"hello, world!\0 ignored by Godot"`
 /// will be treated as the same string if converted to a `NodePath`.
 ///
-/// # All string types
-///
-/// | Intended use case | String type                                |
-/// |-------------------|--------------------------------------------|
-/// | General purpose   | [`GString`][crate::builtin::GString]       |
-/// | Interned names    | [`StringName`][crate::builtin::StringName] |
-/// | Scene-node paths  | **`NodePath`**                             |
-///
 /// # Godot docs
-///
 /// [`NodePath` (stable)](https://docs.godotengine.org/en/stable/classes/class_nodepath.html)
 pub struct NodePath {
     opaque: sys::types::OpaqueNodePath,

--- a/godot-core/src/builtin/strings/string_name.rs
+++ b/godot-core/src/builtin/strings/string_name.rs
@@ -10,7 +10,7 @@ use std::fmt;
 use godot_ffi as sys;
 use sys::{ExtVariantType, GodotFfi, ffi_methods};
 
-use crate::builtin::{Encoding, GString, NodePath, Variant, inner};
+use crate::builtin::{Encoding, GString, GodotStringExt, NodePath, Variant, inner};
 use crate::meta::AsArg;
 use crate::meta::error::StringError;
 use crate::{impl_shared_string_api, meta};
@@ -373,18 +373,7 @@ impl_rust_string_conv!(StringName);
 
 impl From<&str> for StringName {
     fn from(string: &str) -> Self {
-        let utf8 = string.as_bytes();
-
-        // SAFETY: Rust guarantees validity and range of string.
-        unsafe {
-            Self::new_with_string_uninit(|ptr| {
-                sys::interface_fn!(string_name_new_with_utf8_chars_and_len)(
-                    ptr,
-                    utf8.as_ptr() as *const std::ffi::c_char,
-                    utf8.len() as i64,
-                );
-            })
-        }
+        string.to_string_name()
     }
 }
 
@@ -395,15 +384,9 @@ impl From<&String> for StringName {
 }
 
 impl From<&GString> for StringName {
-    /// See also [`GString::to_string_name()`].
+    /// See also [`GodotStringExt::to_string_name()`].
     fn from(string: &GString) -> Self {
-        unsafe {
-            Self::new_with_uninit(|self_ptr| {
-                let ctor = sys::builtin_fn!(string_name_from_string);
-                let args = [string.sys()];
-                ctor(self_ptr, args.as_ptr());
-            })
-        }
+        string.to_string_name()
     }
 }
 

--- a/godot-core/src/builtin/strings/string_name.rs
+++ b/godot-core/src/builtin/strings/string_name.rs
@@ -21,28 +21,29 @@ use crate::{impl_shared_string_api, meta};
 /// one instance of a given name exists.
 ///
 /// # Ordering
-///
 /// In Godot, `StringName`s are **not** ordered lexicographically, and the ordering relation is **not** stable across multiple runs of your
 /// application. Therefore, this type does not implement `PartialOrd` and `Ord`, as it would be very easy to introduce bugs by accidentally
 /// relying on lexicographical ordering.
 ///
 /// Instead, we provide [`transient_ord()`][Self::transient_ord] for ordering relations.
 ///
-/// # Null bytes
+/// # All string types + conversions
+/// | String type                                | Intended use case       | Encoding  | Convert to                                 |
+/// |--------------------------------------------|-------------------------|-----------|--------------------------------------------|
+/// | [`GString`][crate::builtin::GString]       | General purpose         | UTF-32    | [`to_gstring()`][Self::to_gstring]         |
+/// | **`StringName`**                           | Interned names          | UTF-32    | `to_string_name()`                         |
+/// | [`NodePath`][crate::builtin::NodePath]     | Scene-node paths        | segmented | [`to_node_path()`][Self::to_node_path]     |
+/// | `String`                                   | Owned, general purpose  | UTF-8     | [`to_string()`](#method.to_string)         |
+/// | `&str`                                     | Borrowed slice          | UTF-8     | _not supported_                            |
+/// | `&[char]`                                  | Borrowed slice (UTF-32) | UTF-32    | [`chars()`][Self::chars]                   |
 ///
+/// See also `StringName` constructors for more low-level conversions from `&[u8]` and `CStr`.
+///
+/// # Null bytes
 /// Note that Godot ignores any bytes after a null-byte. This means that for instance `"hello, world!"` and  \
 /// `"hello, world!\0 ignored by Godot"` will be treated as the same string if converted to a `StringName`.
 ///
-/// # All string types
-///
-/// | Intended use case | String type                                |
-/// |-------------------|--------------------------------------------|
-/// | General purpose   | [`GString`][crate::builtin::GString]       |
-/// | Interned names    | **`StringName`**                           |
-/// | Scene-node paths  | [`NodePath`][crate::builtin::NodePath]     |
-///
 /// # Godot docs
-///
 /// [`StringName` (stable)](https://docs.godotengine.org/en/stable/classes/class_stringname.html)
 // Currently we rely on `transparent` for `borrow_string_sys`.
 #[repr(transparent)]

--- a/itest/rust/src/builtin_tests/string/gstring_test.rs
+++ b/itest/rust/src/builtin_tests/string/gstring_test.rs
@@ -4,18 +4,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
-
+use std::borrow::Cow;
 use std::collections::HashSet;
+use std::fmt;
 
-use godot::builtin::{Encoding, GString, PackedStringArray};
+use godot::builtin::{Encoding, GString, GodotStringExt, PackedStringArray};
 
 use super::string_test_macros::{APPLE_CHARS, APPLE_STR};
 use crate::framework::{expect_panic_or_nothing, itest};
 
-// TODO use tests from godot-rust/gdnative
-
 #[itest]
-fn string_default() {
+fn gstring_default() {
     let string = GString::new();
     let back = String::from(&string);
 
@@ -23,7 +22,7 @@ fn string_default() {
 }
 
 #[itest]
-fn string_conversion() {
+fn gstring_conversion() {
     let string = String::from("some string");
     let second = GString::from(&string);
     let back = String::from(&second);
@@ -32,7 +31,7 @@ fn string_conversion() {
 }
 
 #[itest]
-fn string_equality() {
+fn gstring_equality() {
     let string = GString::from("some string");
     let second = GString::from("some string");
     let different = GString::from("some");
@@ -49,7 +48,7 @@ fn string_eq_str() {
 }
 
 #[itest]
-fn string_ordering() {
+fn gstring_ordering() {
     let low = GString::from("Alpha");
     let high = GString::from("Beta");
 
@@ -60,7 +59,7 @@ fn string_ordering() {
 }
 
 #[itest]
-fn string_clone() {
+fn gstring_clone() {
     let first = GString::from("some string");
     #[allow(clippy::redundant_clone)]
     let cloned = first.clone();
@@ -69,7 +68,7 @@ fn string_clone() {
 }
 
 #[itest]
-fn string_chars() {
+fn gstring_chars() {
     // Empty tests regression from #228: Null pointer passed to slice::from_raw_parts().
     let string = GString::new();
     let empty_char_slice: &[char] = &[];
@@ -87,7 +86,7 @@ fn string_chars() {
 }
 
 #[itest]
-fn string_unicode_at() {
+fn gstring_unicode_at() {
     let s = GString::from(APPLE_STR);
     assert_eq!(s.unicode_at(0), 'ö');
     assert_eq!(s.unicode_at(1), '🍎');
@@ -101,7 +100,7 @@ fn string_unicode_at() {
 }
 
 #[itest]
-fn string_hash() {
+fn gstring_hash() {
     let set: HashSet<GString> = [
         "string_1",
         "SECOND string! :D",
@@ -116,7 +115,7 @@ fn string_hash() {
 }
 
 #[itest]
-fn string_with_null() {
+fn gstring_with_null() {
     // Godot always ignores bytes after a null byte.
     let cases: &[(&str, &str)] = &[
         (
@@ -135,7 +134,7 @@ fn string_with_null() {
 }
 
 #[itest]
-fn string_substr() {
+fn gstring_substr() {
     let string = GString::from("stable");
     assert_eq!(string.substr(..), "stable");
     assert_eq!(string.substr(1..), "table");
@@ -288,4 +287,46 @@ crate::generate_string_standard_fmt_tests!(
 
 fn packed(strings: &[&str]) -> PackedStringArray {
     strings.iter().map(|&s| GString::from(s)).collect()
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// GodotStringExt roundtrips
+
+fn check_string_ext<T: fmt::Display + GodotStringExt>(value: T) {
+    let expected = value.to_string();
+    assert_eq!(value.to_gstring().to_string(), expected);
+    assert_eq!(value.to_string_name().to_string(), expected);
+    assert_eq!(value.to_node_path().to_string(), expected);
+}
+
+#[itest]
+fn string_ext_roundtrips() {
+    let utf8 = String::from("godöt-rust 🦀 ゴドー");
+    let utf8: &str = utf8.as_str(); // Ensure that non-'static lifetime is supported.
+
+    check_string_ext(utf8);
+    check_string_ext(utf8.to_string());
+    check_string_ext(utf8.to_gstring());
+    check_string_ext(utf8.to_string_name());
+    check_string_ext(utf8.to_node_path());
+    check_string_ext(Cow::Borrowed(utf8));
+}
+
+#[itest]
+fn string_ext_char_roundtrips() {
+    let utf32: &[char] = &['G', 'ゴ', ' ', '🦀'];
+    assert_eq!(utf32.to_gstring().chars(), utf32);
+
+    // StringName::chars() only in >= 4.5; fall back via to_string().
+    #[cfg(since_api = "4.5")]
+    assert_eq!(utf32.to_string_name().chars(), utf32);
+    #[cfg(before_api = "4.5")]
+    {
+        let np_string = utf32.to_string_name().to_string();
+        assert_eq!(np_string.chars().collect::<Vec<char>>(), utf32);
+    }
+
+    // NodePath has no chars() function, so use to_string().
+    let np_string = utf32.to_node_path().to_string();
+    assert_eq!(np_string.chars().collect::<Vec<char>>(), utf32);
 }

--- a/itest/rust/src/builtin_tests/string/string_test_macros.rs
+++ b/itest/rust/src/builtin_tests/string/string_test_macros.rs
@@ -18,6 +18,7 @@ pub(super) const APPLE_CHARS: &[char] = &[
     '\u{1F4A1}', // 💡
 ];
 
+/// Tests conversions from bytes and c-strings.
 #[macro_export]
 macro_rules! generate_string_bytes_and_cstr_tests {
     (
@@ -174,7 +175,7 @@ macro_rules! generate_string_bytes_and_cstr_tests {
     };
 }
 
-// Tests padding with the standard formatter.
+/// Tests `Display` + padding with the standard formatter.
 #[macro_export]
 macro_rules! generate_string_standard_fmt_tests {
     (


### PR DESCRIPTION
Adds an extension trait `GodotStringExt` which supports conversion to the three Godot string types:
- `GString`
- `StringName`
- `NodePath`

This is implemented for Rust `&str`, `String` and the 3 Godot strings.

An explicitly named `val.to_gstring()` method has several advantages over the `From` trait:
1. Compared to `GString::from(&val)`:
   1.  it is slightly shorter
   2. it can be used more naturally in fluent expressions such as `val.replace(...).to_gstring()` rather than `GString::from(&val.replace(...))`
1. Compared to `val.into()`:
   1. it makes the conversion more explicit by naming the type (which can be relevant for e.g. performance reasons, some conversions are cheap and some not).
   2. and never runs into type-inference problems -- the `into()` function requires an explicit type declaration for the "receiver" type.
1. The `GodotStringExt::to_node_path()` method has a default implementation, giving types a "free" conversion to `NodePath` (via `GString`, which is usually the fastest). The same isn't possible with `From` -- a blanket `impl From<T> for NodePath where T: Into<GString>` runs into coherence issues, e.g. for `T=NodePath` itself.

Main downside is that it doesn't allow `impl Into<GString>` parameter. However, godot-rust no longer uses those -- they're superseded by `impl AsArg<GString>`, the more idiomatic/performant choice for FFI passing.

So it's likely that we phase out the `From` conversions in the future. Given their use, I'd certainly approach this more carefully, for example I could imagine an inherent `GString::from(impl GodotStringExt)` or so during a migration period. 