### PR TITLE
Fix async panics at shutdown

### DIFF
--- a/godot-core/src/init/mod.rs
+++ b/godot-core/src/init/mod.rs
@@ -113,6 +113,10 @@ unsafe extern "C" fn frame_func<E: ExtensionLibrary>() {
 
 #[cfg(since_api = "4.5")]
 unsafe extern "C" fn shutdown_func<E: ExtensionLibrary>() {
+    // The main loop (SceneTree) is being torn down. Mark the async runtime as exiting, so a signal future whose object is freed during teardown
+    // is left suspended (and dropped in cleanup()) instead of being woken into a spurious panic. See `async_runtime::is_engine_exiting()`.
+    crate::task::mark_engine_exiting();
+
     let ctx = || "ExtensionLibrary::on_stage_deinit(MainLoop)".to_string();
 
     swallow_panics(ctx, || {

--- a/godot-core/src/task/async_runtime.rs
+++ b/godot-core/src/task/async_runtime.rs
@@ -11,6 +11,7 @@ use std::marker::PhantomData;
 use std::panic::AssertUnwindSafe;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::task::{Context, Poll, Wake, Waker};
 use std::thread::{self, LocalKey, ThreadId};
 
@@ -40,6 +41,12 @@ use crate::private::handle_panic;
 ///
 /// # Panics
 /// If called from any other thread than the main thread.
+///
+/// # Engine shutdown
+/// If the awaited signal's object is freed *before* the signal fires during engine teardown, the task does not resume: it stays suspended and is
+/// dropped when the runtime shuts down, without panicking. If the signal *does* fire (e.g. `tree_exiting`, emitted while the node is still alive),
+/// the task resumes as usual -- but by then the engine may have freed the node and any other captured `Gd<T>`, so accessing one follows the usual
+/// liveness rules (panic with safeguards, UB when disengaged).
 ///
 /// # Examples
 /// An example using timers:
@@ -249,12 +256,71 @@ thread_local! {
 /// try to access engine resources, which leads to SEGFAULTs.
 pub(crate) fn cleanup() {
     ASYNC_RUNTIME.set(None);
+
+    // Reset the flag, so a subsequent re-initialization (e.g. hot-reload on Linux) starts in a clean state.
+    ENGINE_EXITING.store(false, Ordering::Relaxed);
+}
+
+static ENGINE_EXITING: AtomicBool = AtomicBool::new(false);
+
+pub(crate) fn mark_engine_exiting() {
+    ENGINE_EXITING.store(true, Ordering::Relaxed);
+}
+
+pub(crate) fn is_engine_exiting() -> bool {
+    if ENGINE_EXITING.load(Ordering::Relaxed) {
+        return true;
+    }
+
+    // Godot < 4.5 has no `MainLoop` shutdown hook, so detect teardown heuristically: the `SceneTree`'s root window is freed during shutdown, but
+    // persists across scene changes otherwise.
+    #[cfg(before_api = "4.5")]
+    {
+        use crate::obj::Singleton as _;
+
+        match crate::classes::Engine::singleton().get_main_loop() {
+            // No main loop: the engine is shutting down (or has not started yet, in which case no signal future can be pending).
+            None => true,
+            Some(main_loop) => match main_loop.try_cast::<crate::classes::SceneTree>() {
+                Ok(tree) => tree.get_root().is_none(),
+                Err(_) => false,
+            },
+        }
+    }
+
+    #[cfg(since_api = "4.5")]
+    false
 }
 
 #[cfg(feature = "trace")]
-pub fn has_godot_task_panicked(task_handle: TaskHandle) -> bool {
-    ASYNC_RUNTIME.with_runtime(|rt| rt.panicked_tasks.contains(&task_handle.id))
+mod itest_only {
+    use super::*;
+
+    pub fn has_godot_task_panicked(task_handle: TaskHandle) -> bool {
+        ASYNC_RUNTIME.with_runtime(|rt| rt.panicked_tasks.contains(&task_handle.id))
+    }
+
+    /// Simulate engine teardown from integration tests, to test signal resolver's shutdown behavior.
+    ///
+    /// Sets the engine-exiting flag and restores it to `false` when the returned guard is dropped, so the flag never leaks into other tests
+    /// (even if the test panics).
+    #[must_use = "the engine-exiting flag is reset when the guard is dropped"]
+    pub fn simulate_engine_exiting() -> EngineExitingGuard {
+        ENGINE_EXITING.store(true, Ordering::Relaxed);
+        EngineExitingGuard { _private: () }
+    }
+
+    pub struct EngineExitingGuard {
+        _private: (), // needs field to be non-instantiable.
+    }
+    impl Drop for EngineExitingGuard {
+        fn drop(&mut self) {
+            ENGINE_EXITING.store(false, Ordering::Relaxed);
+        }
+    }
 }
+#[cfg(feature = "trace")]
+pub use itest_only::*;
 
 /// The current state of a future inside the async runtime.
 enum FutureSlotState<T> {

--- a/godot-core/src/task/futures.rs
+++ b/godot-core/src/task/futures.rs
@@ -36,6 +36,9 @@ pub(crate) use crate::impl_dynamic_send;
 /// - If the signal object is freed before the signal has been emitted.
 /// - If one of the signal arguments is `!Send`, but the signal was emitted on a different thread.
 ///
+/// During engine shutdown, this does **not** panic: when the signal object is freed before emission as part of the main loop being torn down,
+/// the awaiting task stays suspended and is dropped silently instead. This keeps "fire-and-forget" tasks from spamming errors on application exit.
+///
 /// # Keeping the signal object alive
 /// If the signal object is freed *concurrently* while the future is being dropped, connection cleanup is skipped and the stale connection is
 /// leaked (Godot removes it once the object dies), rather than aborting the process. This is only reachable by moving a `Gd` across threads,
@@ -152,6 +155,12 @@ impl<R: IntoDynamicSend> Drop for SignalFutureResolver<R> {
 
         if !matches!(data.state, SignalFutureState::Pending) {
             // The future is no longer pending, so no clean up is required.
+            return;
+        }
+
+        // During teardown, leave the future `Pending` (runtime drops it in `cleanup()`) instead of marking it `Dead` and waking it -> that would
+        // cause "signal object freed" error, i.e. a panic for `SignalFuture`, spamming on every exit. See `async_runtime::is_engine_exiting()`.
+        if crate::task::is_engine_exiting() {
             return;
         }
 

--- a/godot-core/src/task/mod.rs
+++ b/godot-core/src/task/mod.rs
@@ -23,7 +23,9 @@ pub use futures::{
 // For use in integration tests.
 #[cfg(feature = "trace")]
 mod reexport_test {
-    pub use super::async_runtime::has_godot_task_panicked;
+    pub use super::async_runtime::{
+        EngineExitingGuard, has_godot_task_panicked, simulate_engine_exiting,
+    };
     pub use super::futures::{SignalFutureResolver, create_test_signal_future_resolver};
 }
 
@@ -32,7 +34,9 @@ pub use reexport_test::*;
 
 // Crate-local re-exports.
 mod reexport_crate {
-    pub(crate) use super::async_runtime::{await_point_dec, await_point_inc, cleanup};
+    pub(crate) use super::async_runtime::{
+        await_point_dec, await_point_inc, cleanup, is_engine_exiting, mark_engine_exiting,
+    };
     pub(crate) use super::futures::{ThreadConfined, impl_dynamic_send};
 }
 

--- a/itest/rust/src/engine_tests/async_test.rs
+++ b/itest/rust/src/engine_tests/async_test.rs
@@ -5,7 +5,10 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+use std::future::Future;
 use std::ops::Deref;
+use std::pin::pin;
+use std::task::{Context, Poll, Waker};
 
 use godot::builtin::{Array, Callable, Signal, array, iarray, vslice};
 use godot::classes::{Object, RefCounted};
@@ -144,6 +147,34 @@ fn async_task_signal_future_panic() -> TaskHandle {
     obj.call_deferred("free", &[]);
 
     handle
+}
+
+// Regression test for https://github.com/godot-rust/gdext/issues/1624:
+// A `SignalFuture` whose object is freed during engine teardown must not panic, but be silently cancelled.
+#[itest]
+fn signal_future_cancelled_at_engine_exit() {
+    // We simulate teardown and free the object synchronously, so the whole flow is deterministic. The guard resets the flag on drop.
+    let _exiting_guard = task::simulate_engine_exiting();
+
+    let obj = Object::new_alloc();
+    let signal = Signal::from_object_signal(&obj, "script_changed");
+
+    let mut future = pin!(signal.to_future::<()>());
+    let mut cx = Context::from_waker(Waker::noop());
+
+    // First poll registers the one-shot connection and parks.
+    assert_eq!(future.as_mut().poll(&mut cx), Poll::Pending);
+
+    // Freeing the object drops the resolver:
+    // * In regular use, this marks the future dead and the next poll would panic.
+    // * While the engine is shutting down, the resolver leaves the future `Pending` instead, so it parks silently.
+    obj.free();
+
+    assert_eq!(
+        future.as_mut().poll(&mut cx),
+        Poll::Pending,
+        "SignalFuture must park silently (not panic) when its object is freed during engine teardown"
+    );
 }
 
 #[cfg(feature = "experimental-threads")]


### PR DESCRIPTION
During teardown, `SceneTree` frees objects while async tasks still await their signals. Freeing disconnects the resolver -> this marks the future `Dead` -> wakes -> deferred poll -> causes panic in `SignalFuture::poll()`. The panic is caught but spams errors on every exit.

The panicking poll fires after `MainLoop` de-init, but before the first level de-init hook. For Godot 4.5, we have no `MainLoop` hook, so we check `SceneTree::get_root()`.

Closes #1624.