### PR TITLE
Fix `Object` returns with dynamic type `RefCounted`

### DIFF
--- a/godot-core/src/meta/signature.rs
+++ b/godot-core/src/meta/signature.rs
@@ -265,7 +265,7 @@ impl<Params: OutParamTuple, Ret: EngineFromGodot> Signature<Params, Ret> {
 
         unsafe {
             pack_ptrcall_args(args, |explicit_args, arg_count| {
-                finish_ptrcall(&call_ctx, &mut |return_ptr| {
+                finish_ptrcall(&call_ctx, false, &mut |return_ptr| {
                     let type_ptrs = concat_varargs_ptrs(explicit_args, arg_count, varargs);
                     // Important: this calls from_sys_init_default().
                     // SAFETY: TODO.
@@ -293,7 +293,7 @@ impl<Params: OutParamTuple, Ret: EngineFromGodot> Signature<Params, Ret> {
 
         unsafe {
             pack_ptrcall_args(args, |explicit_args, arg_count| {
-                finish_ptrcall(&call_ctx, &mut |return_ptr| {
+                finish_ptrcall(&call_ctx, false, &mut |return_ptr| {
                     let type_ptrs = concat_varargs_ptrs(explicit_args, arg_count, varargs);
                     // Important: this calls from_sys_init_default().
                     builtin_fn(
@@ -325,7 +325,7 @@ impl<Params: OutParamTuple, Ret: EngineFromGodot> Signature<Params, Ret> {
 
         unsafe {
             pack_ptrcall_args(args, |explicit_args, _arg_count| {
-                finish_ptrcall(&call_ctx, &mut |return_ptr| {
+                finish_ptrcall(&call_ctx, true, &mut |return_ptr| {
                     dispatch_class_ptrcall(method_bind, object_ptr, explicit_args, return_ptr);
                 })
             })
@@ -349,7 +349,7 @@ impl<Params: OutParamTuple, Ret: EngineFromGodot> Signature<Params, Ret> {
 
         unsafe {
             pack_ptrcall_args(args, |explicit_args, arg_count| {
-                finish_ptrcall(&call_ctx, &mut |return_ptr| {
+                finish_ptrcall(&call_ctx, false, &mut |return_ptr| {
                     dispatch_builtin_ptrcall(
                         builtin_fn,
                         type_ptr,
@@ -376,7 +376,7 @@ impl<Params: OutParamTuple, Ret: EngineFromGodot> Signature<Params, Ret> {
 
         unsafe {
             pack_ptrcall_args(args, |explicit_args, arg_count| {
-                finish_ptrcall(&call_ctx, &mut |return_ptr| {
+                finish_ptrcall(&call_ctx, false, &mut |return_ptr| {
                     dispatch_utility_ptrcall(utility_fn, explicit_args, arg_count, return_ptr);
                 })
             })
@@ -428,9 +428,17 @@ unsafe fn concat_varargs_ptrs(
 /// This calls [`GodotFfi::new_with_init`] and passes the return pointer to `init`, see that function for safety docs.
 unsafe fn finish_ptrcall<Ret: EngineFromGodot>(
     call_ctx: &CallContext,
+    is_class_method: bool,
     init: &mut dyn FnMut(sys::GDExtensionTypePtr),
 ) -> Ret {
-    let ffi = unsafe { <<Ret::Via as GodotType>::Ffi>::new_with_init(init) };
+    let mut ffi = unsafe { <<Ret::Via as GodotType>::Ffi>::new_with_init(init) };
+
+    // Class methods returning static type Object (e.g. `EditorProperty::get_edited_object()`) hand back a raw `Object*` without incrementing the
+    // reference count. If the runtime type is `RefCounted`, we need to do that ourselves. Builtin/utility methods (e.g. `Callable::get_object()`)
+    // already return an owning `Ref<T>`, so they are not touched. See also https://github.com/godot-rust/gdext/issues/1626.
+    if is_class_method {
+        ffi.adjust_refcount_on_ptrcall_return();
+    }
 
     match Ret::Via::try_from_ffi(ffi).and_then(Ret::engine_try_from_godot) {
         Ok(ret) => ret,

--- a/godot-core/src/obj/raw_gd.rs
+++ b/godot-core/src/obj/raw_gd.rs
@@ -16,7 +16,7 @@ use crate::meta::CallContext;
 use crate::meta::error::{ConvertError, FromVariantError};
 use crate::meta::shape::GodotShape;
 use crate::meta::{FromGodot, GodotConvert, GodotFfiVariant, GodotType, RefArg, ToGodot};
-use crate::obj::bounds::{Declarer, DynMemory as _};
+use crate::obj::bounds::{Declarer, DynMemory as _, Memory};
 use crate::obj::rtti::ObjectRtti;
 use crate::obj::{Bounds, Gd, GdDerefTarget, GdMut, GdRef, GodotClass, InstanceId, bounds};
 use crate::storage::{InstanceCache, InstanceStorage, Storage};
@@ -625,6 +625,14 @@ where
             unsafe { ptr::write(ptr as *mut *mut T, self.obj) };
             // We've passed ownership to caller.
             std::mem::forget(self);
+        }
+    }
+
+    fn adjust_refcount_on_ptrcall_return(&mut self) {
+        // Static type not ref-counted -> is Object, Node etc -> possibly needs incrementing refcount.
+        // maybe_inc_ref() is a no-op for Node etc.
+        if !<T::Memory as Memory>::IS_REF_COUNTED {
+            T::DynMemory::maybe_inc_ref(self);
         }
     }
 }

--- a/godot-ffi/src/godot_ffi.rs
+++ b/godot-ffi/src/godot_ffi.rs
@@ -95,6 +95,15 @@ pub unsafe trait GodotFfi {
     ///   `call_type`'s encoding of return values.
     #[doc(hidden)]
     unsafe fn move_return_ptr(self, dst: sys::GDExtensionTypePtr, call_type: PtrcallType);
+
+    /// Make sure reference counts on values returned from an outbound ptrcall are correct.
+    ///
+    /// Most types don't need this (default no-op). It only matters for `Object`: class methods returning it return a raw `Object*` on C++ side,
+    /// for which Godot does *not* increment the reference count, even when the dynamic type is `RefCounted`. Since our `Drop` will decrement
+    /// such reference counts, we have to increment here to balance. For statically `RefCounted` return types, Godot already returns an owning
+    /// `Ref<T>` (incremented), so nothing is done.
+    #[doc(hidden)]
+    fn adjust_refcount_on_ptrcall_return(&mut self) {}
 }
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------

--- a/itest/rust/src/object_tests/object_test.rs
+++ b/itest/rust/src/object_tests/object_test.rs
@@ -489,6 +489,31 @@ fn check_convert_variant_refcount(obj: Gd<RefCounted>) {
     assert_eq!(obj.get_reference_count(), 1);
 }
 
+// Regression test for https://github.com/godot-rust/gdext/issues/1626. Class methods with static return type Object, but dynamic type
+// RefCounted need to be incremented by godot-rust.
+#[cfg(feature = "codegen-full")]
+#[itest]
+fn object_engine_get_object_but_dynamic_refcount() {
+    use godot::classes::Area2D;
+
+    let mut area = Area2D::new_alloc();
+
+    let owner = RefCounted::new_gd();
+    let owner_id = area.create_shape_owner(&owner);
+    let count_before = owner.get_reference_count();
+
+    // `shape_owner_get_owner()` returns `Gd<Object>`, but the instance is actually `RefCounted`.
+    let fetched: Gd<Object> = area
+        .shape_owner_get_owner(owner_id)
+        .expect("shape owner was just created");
+    assert_eq!(owner.get_reference_count(), count_before + 1);
+
+    drop(fetched);
+    area.free();
+
+    assert_eq!(owner.get_reference_count(), count_before);
+}
+
 #[itest]
 fn object_engine_convert_variant_nil() {
     let nil = Variant::nil();


### PR DESCRIPTION
When a ptrcall has static return type `Object`, but actually points to a `RefCounted` object, the reference count is not incremented, which then leads to use-after-free.

Fixes #1626.