### PR TITLE
Slightly more flexible `GodotStringExt` through unsized impls

### DIFF
--- a/godot-codegen/src/generator/import_docs.rs
+++ b/godot-codegen/src/generator/import_docs.rs
@@ -750,10 +750,9 @@ fn convert_to_method_path(
     let (link_godot_class, link_godot_method) =
         if let Some((class_name, method_name)) = class_method.split_once('.') {
             (class_name, method_name)
-        } else if let Some(class) = surrounding_class {
-            (class.name().godot_ty.as_str(), class_method)
         } else {
-            return None;
+            let class = surrounding_class?;
+            (class.name().godot_ty.as_str(), class_method)
         };
 
     let link_godot_method = util::safe_ident(link_godot_method).to_string();

--- a/godot-core/src/builtin/strings/godot_string_ext.rs
+++ b/godot-core/src/builtin/strings/godot_string_ext.rs
@@ -5,8 +5,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::borrow::Cow;
-
 use godot_ffi as sys;
 use sys::GodotFfi;
 
@@ -96,7 +94,7 @@ impl GodotStringExt for NodePath {
     }
 }
 
-impl GodotStringExt for &str {
+impl GodotStringExt for str {
     fn to_gstring(&self) -> GString {
         let utf8_bytes = self.as_bytes();
 
@@ -133,9 +131,9 @@ impl GodotStringExt for &str {
     }
 }
 
-impl GodotStringExt for &[char] {
+impl GodotStringExt for [char] {
     fn to_gstring(&self) -> GString {
-        let chars = *self;
+        let chars = self;
 
         // SAFETY: A `char` value is by definition a valid Unicode code point. Bounded by len().
         unsafe {
@@ -155,17 +153,15 @@ impl GodotStringExt for &[char] {
     }
 }
 
-impl GodotStringExt for String {
-    fn to_gstring(&self) -> GString {
-        self.as_str().to_gstring()
-    }
+/*
+This blanket impl can be enabled if users need `T: GodotStringExt` as a generic bound. `expr.to_gstring()` is already supported for
+String, Cow<'_, str>, Rc<str>, Box<str>, Vec<char> etc. However, the str-based ones cannot be passed in generic contexts.
+Adding a blanket impl is always a coherence hazard in Rust; consider if truly needed or explicit impls (e.g. String/Cow) fit better.
 
-    fn to_string_name(&self) -> StringName {
-        self.as_str().to_string_name()
-    }
-}
-
-impl GodotStringExt for Cow<'_, str> {
+impl<T> GodotStringExt for T
+where
+    T: AsRef<str>,
+{
     fn to_gstring(&self) -> GString {
         self.as_ref().to_gstring()
     }
@@ -174,3 +170,4 @@ impl GodotStringExt for Cow<'_, str> {
         self.as_ref().to_string_name()
     }
 }
+*/

--- a/godot-core/src/tools/save_load.rs
+++ b/godot-core/src/tools/save_load.rs
@@ -157,7 +157,7 @@ where
     arg_into_ref!(path);
 
     save_impl(obj, path)
-        .unwrap_or_else(|err| panic!("failed to save resource at path '{}': {}", &path, err));
+        .unwrap_or_else(|err| panic!("failed to save resource at path '{path}': {err}"));
 }
 
 /// Saves a [`Resource`]-inheriting object into the file located at `path`.

--- a/itest/rust/src/builtin_tests/string/gstring_test.rs
+++ b/itest/rust/src/builtin_tests/string/gstring_test.rs
@@ -7,6 +7,7 @@
 use std::borrow::Cow;
 use std::collections::HashSet;
 use std::fmt;
+use std::rc::Rc;
 
 use godot::builtin::{Encoding, GString, GodotStringExt, PackedStringArray};
 
@@ -292,28 +293,30 @@ fn packed(strings: &[&str]) -> PackedStringArray {
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // GodotStringExt roundtrips
 
-fn check_string_ext<T: fmt::Display + GodotStringExt>(value: T) {
-    let expected = value.to_string();
-    assert_eq!(value.to_gstring().to_string(), expected);
-    assert_eq!(value.to_string_name().to_string(), expected);
-    assert_eq!(value.to_node_path().to_string(), expected);
-}
-
 #[itest]
-fn string_ext_roundtrips() {
+// Ignore warnings -- explicitly test Box<str>, &[char], Vec<char> auto-deref.
+#[expect(unused_allocation, clippy::needless_borrow, clippy::useless_vec)]
+fn string_ext_conversion() {
     let utf8 = String::from("godöt-rust 🦀 ゴドー");
     let utf8: &str = utf8.as_str(); // Ensure that non-'static lifetime is supported.
 
-    check_string_ext(utf8);
-    check_string_ext(utf8.to_string());
-    check_string_ext(utf8.to_gstring());
-    check_string_ext(utf8.to_string_name());
-    check_string_ext(utf8.to_node_path());
-    check_string_ext(Cow::Borrowed(utf8));
+    assert_eq!(utf8.to_gstring(), utf8);
+    assert_eq!(utf8.to_string_name(), utf8);
+    assert_eq!(utf8.to_node_path().to_string(), utf8); // NodePath == &str operator is not supported.
+
+    // Standard types converted to GString.
+    assert_eq!(utf8.to_gstring(), utf8); // &str
+    assert_eq!(Cow::Borrowed(utf8).to_gstring(), utf8); // String
+    assert_eq!(String::from(utf8).to_gstring(), utf8); // Cow<'_, str>
+    assert_eq!(Box::new(utf8).to_gstring(), utf8); // Box<str>
+    assert_eq!(Rc::new(utf8).to_gstring(), utf8); // Rc<str>
+    assert_eq!(['ĝ', 'ド'].to_gstring(), "ĝド"); // [char]
+    assert_eq!((&['ĝ', 'ド']).to_gstring(), "ĝド"); // &[char]
+    assert_eq!(vec!['ĝ', 'ド'].to_gstring(), "ĝド"); // Vec<char>
 }
 
 #[itest]
-fn string_ext_char_roundtrips() {
+fn string_ext_char_conversion() {
     let utf32: &[char] = &['G', 'ゴ', ' ', '🦀'];
     assert_eq!(utf32.to_gstring().chars(), utf32);
 
@@ -329,4 +332,24 @@ fn string_ext_char_roundtrips() {
     // NodePath has no chars() function, so use to_string().
     let np_string = utf32.to_node_path().to_string();
     assert_eq!(np_string.chars().collect::<Vec<char>>(), utf32);
+}
+
+#[itest]
+fn string_ext_bounds() {
+    let utf8 = String::from("godöt-rust 🦀 ゴドー");
+    let utf8: &str = utf8.as_str(); // Ensure that non-'static lifetime is supported.
+
+    check_string_ext(utf8.to_gstring());
+    check_string_ext(utf8.to_string_name());
+    check_string_ext(utf8.to_node_path());
+
+    // Standard string types currently not supported as Sized bound. Could be enabled if we add such impls in the future.
+}
+
+// Tests generic bounds (currently only Sized impls).
+fn check_string_ext<T: fmt::Display + GodotStringExt>(value: T) {
+    let expected = value.to_string();
+    assert_eq!(value.to_gstring().to_string(), expected);
+    assert_eq!(value.to_string_name().to_string(), expected);
+    assert_eq!(value.to_node_path().to_string(), expected);
 }


### PR DESCRIPTION
This was already a consideration in #1623, and with `[char]` support being a real use case, this has now concrete benefits.

If we need the `Sized` impls in the future for `T: GodotStringExt` bounds, we can either provide them individually or via `AsRef<str>` blanket (see sketch in code).