### PR TITLE
`Gd` introspection APIs: `dynamic_class`, `is_dynamic_class[_of]`, `is_ref_counted`

### DIFF
--- a/godot-codegen/src/special_cases/special_cases.rs
+++ b/godot-codegen/src/special_cases/special_cases.rs
@@ -912,6 +912,7 @@ pub fn maybe_rename_virtual_method<'m>(
 }
 
 // TODO method-level extra docs, for:
+// - Object::get_class() + is_class() -> point to Gd::dynamic_class() + is_dynamic_class().
 // - Node::rpc_config() -> link to RpcConfig.
 // - Node::process/physics_process -> mention `f32`/`f64` duality.
 // - Node::duplicate -> to copy #[var] fields, needs STORAGE property usage, or #[export],

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -985,6 +985,17 @@ where
     }
 }
 
+impl Gd<classes::Object> {
+    /// Whether the object inherits `RefCounted`.
+    ///
+    /// This is a very fast check that involves no FFI roundtrip.
+    ///
+    /// Implemented only on `Object` because for all other classes, this property is statically known.
+    pub fn is_ref_counted(&self) -> bool {
+        self.instance_id_unchecked().is_ref_counted()
+    }
+}
+
 impl<T> Gd<T>
 where
     T: GodotClass + Bounds<Declarer = bounds::DeclEngine>,

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -215,8 +215,32 @@ where
     ///
     /// In the Godot editor, classes that are not marked `#[class(tool)]` are replaced with _placeholder instances_ (Godot 4.3+ "runtime classes").
     /// From Godot's perspective the instance still exists, so scenes and script code referring to it do not break, but the Rust side is absent.
+    ///
+    /// Specifically, the following logic is **disabled** for a placeholder:
+    /// * Rust-side objects. As a result, [`bind()`][Self::bind] and [`bind_mut()`][Self::bind_mut] panic on placeholders.
+    ///   Use this method to branch, or mark the class `#[class(tool)]` if editor-side Rust state is required.
+    /// * `init()` constructor -- *not* called on `new_alloc()` / `new_gd()` / `ClassDB.instantiate()` in the editor. However, Godot _does_
+    ///   invoke `init()` exactly once per class at editor startup, to populate its default-value cache.
+    /// * Custom property accessors (`#[var(get = ..., set = ...)]`, `IObject::get_property` / `set_property`). Placeholders keep their
+    ///   own property map: `set()` stores into it; `get()` returns the stored value or falls back to the class's default-value cache.
+    /// * Virtual callbacks (`ready`, `process`, `enter_tree`, `notification`, `on_property_get_revert`, ...) -- replaced with Godot-side stubs
+    ///   (e.g. `property_can_revert` always returns `false`, `property_get_revert` always returns nil). Rust overrides never run.
+    /// * `#[func]` methods -- callable through GDScript / `Callable`, but they `bind()` the receiver internally and will therefore panic.
+    /// * Signal connections wired up in `init()` or `ready()` -- since those methods don't run (except for one-time `init()` filling defaults).
+    ///
+    /// Note that only `#[export]` fields populate the default-value cache (their `PropertyUsageFlags` include the storage/editor bits).
+    /// `#[var]`-only fields do not, so placeholder `get()` returns `nil` for them rather than the value assigned in `init()`. `set()` on the
+    /// placeholder accepts both kinds and stores them, but cross-instance state is not shared.
+    ///
+    /// The following operations still work as usual on a placeholder:
+    /// * Holding the `Gd<T>` pointer, cloning it, comparing instance IDs, freeing it.
+    /// * Upcasts and downcasts -- the Godot class hierarchy is intact, and `Object::get_class()` reports the user-declared name (not internal
+    ///   `PlaceholderExtensionInstance`).
+    /// * `get`, `set`, `get_property_list()`, etc. However, they access the static map and don't route to Rust `IObject` virtual methods.
+    ///
+    /// On Godot versions before 4.3 placeholder substitution does not exist; non-tool classes are instead filtered out at registration when the
+    /// `tool_only_in_editor` config option is enabled (the default). This method then always returns `false`.
     #[cfg(all(feature = "trace", feature = "upcoming-editor-placeholders"))]
-    #[doc(hidden)]
     pub fn is_editor_placeholder(&self) -> bool {
         self.raw.storage().is_none()
     }

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -333,13 +333,39 @@ impl<T: GodotClass> Gd<T> {
         self.raw.is_instance_valid()
     }
 
-    /// Returns the dynamic class name of the object as `StringName`.
+    /// Returns the dynamic type of the object as [`ClassId`].
     ///
-    /// This method retrieves the class name of the object at runtime, which can be different from [`T::class_id()`][GodotClass::class_id]
-    /// if derived classes are involved.
+    /// Retrieves the class name of the object at runtime, which can differ from [`T::class_id()`][GodotClass::class_id] if derived
+    /// classes are involved (e.g. a `Gd<Node>` whose dynamic type is `Sprite2D`, or a GDScript class inheriting `T`).
     ///
-    /// Unlike [`Object::get_class()`][crate::classes::Object::get_class], this returns `StringName` instead of `GString` and needs no
-    /// `Inherits<Object>` bound.
+    /// Unlike [`Object::get_class()`][crate::classes::Object::get_class], this needs no `Inherits<Object>` bound and returns a
+    /// comparable [`ClassId`] instead of `GString`.
+    ///
+    /// To test whether the dynamic class _inherits_ a given class (not just equals it), use [`is_dynamic_class()`][Self::is_dynamic_class] or
+    ///  [`is_dynamic_class_of()`][Self::is_dynamic_class_of].
+    pub fn dynamic_class(&self) -> ClassId {
+        ClassId::new_dynamic(self.dynamic_class_string().to_string())
+    }
+
+    /// Returns whether the dynamic type of the object is `class_id` or a subclass thereof.
+    ///
+    /// Corresponds to GDScript's `is_class()` / [`Object::is_class()`][crate::classes::Object::is_class], but accepts a typed [`ClassId`]
+    /// argument and needs no `Inherits<Object>` bound. See also [`is_dynamic_class_of()`][Self::is_dynamic_class_of] for compile-time.
+    ///
+    /// Note that `class_id` is matched by name only; this is a runtime check based on Godot's class hierarchy. For a strict equality
+    /// check against the dynamic class without walking the hierarchy, compare against [`dynamic_class()`][Self::dynamic_class] directly.
+    pub fn is_dynamic_class(&self, class_id: ClassId) -> bool {
+        self.raw.is_dynamic_class(class_id)
+    }
+
+    /// Returns whether the dynamic type of the object is `U` or a subclass thereof.
+    ///
+    /// See also [`is_dynamic_class()`][Self::is_dynamic_class] for runtime arguments, and [`cast()`][Self::cast]/
+    /// [`try_cast()`][Self::try_cast] for obtaining the result of this check.
+    pub fn is_dynamic_class_of<U: GodotClass>(&self) -> bool {
+        self.is_dynamic_class(U::class_id())
+    }
+
     pub(crate) fn dynamic_class_string(&self) -> StringName {
         unsafe {
             StringName::new_with_string_uninit(|ptr| {

--- a/godot-core/src/obj/raw_gd.rs
+++ b/godot-core/src/obj/raw_gd.rs
@@ -15,7 +15,7 @@ use crate::builtin::{Variant, VariantType};
 use crate::meta::CallContext;
 use crate::meta::error::{ConvertError, FromVariantError};
 use crate::meta::shape::GodotShape;
-use crate::meta::{FromGodot, GodotConvert, GodotFfiVariant, GodotType, RefArg, ToGodot};
+use crate::meta::{ClassId, FromGodot, GodotConvert, GodotFfiVariant, GodotType, RefArg, ToGodot};
 use crate::obj::bounds::{Declarer, DynMemory as _, Memory};
 use crate::obj::rtti::ObjectRtti;
 use crate::obj::{Bounds, Gd, GdDerefTarget, GdMut, GdRef, GodotClass, InstanceId, bounds};
@@ -120,12 +120,17 @@ impl<T: GodotClass> RawGd<T> {
     }
 
     /// Checks whether `self` inherits from (or is) class `U`.
-    fn is_instance_of<U: GodotClass>(&self) -> bool {
+    fn is_dynamic_class_of<U: GodotClass>(&self) -> bool {
+        self.is_dynamic_class(U::class_id())
+    }
+
+    /// Checks whether `self` inherits from (or is) class `U`.
+    pub(super) fn is_dynamic_class(&self, class: ClassId) -> bool {
         // is_class() parameter changed from GString to StringName in Godot 4.7.
         #[cfg(since_api = "4.7")]
-        let class_name = U::class_id().to_string_name();
+        let class_name = class.to_string_name();
         #[cfg(before_api = "4.7")]
-        let class_name = U::class_id().to_gstring();
+        let class_name = class.to_gstring();
 
         self.as_object_ref().is_class(&class_name)
     }
@@ -146,7 +151,7 @@ impl<T: GodotClass> RawGd<T> {
         // a bug that must be solved by the user.
         self.check_rtti("cast");
 
-        if self.is_instance_of::<U>() {
+        if self.is_dynamic_class_of::<U>() {
             // SAFETY: is_class() confirmed U is a valid type.
             Ok(unsafe { self.into_reinterpreted() })
         } else {

--- a/itest/rust/src/object_tests/object_test.rs
+++ b/itest/rust/src/object_tests/object_test.rs
@@ -17,8 +17,10 @@ use godot::classes::{
     file_access,
 };
 use godot::global::godot_str;
-use godot::meta::{FromGodot, GodotType, ToGodot};
-use godot::obj::{Base, Gd, Inherits, InstanceId, NewAlloc, NewGd, RawGd, Singleton};
+use godot::meta::{ClassId, FromGodot, GodotType, ToGodot};
+use godot::obj::{
+    Base, Gd, GodotClass as _, Inherits, InstanceId, NewAlloc, NewGd, RawGd, Singleton,
+};
 use godot::register::{GodotClass, godot_api};
 use godot::sys::{self, GodotFfi, interface_fn};
 
@@ -165,6 +167,61 @@ fn object_is_ref_counted() {
 
     man_usr.free();
     man_eng.free();
+}
+
+#[itest]
+fn object_dynamic_class() {
+    // Engine class: dynamic class matches static class.
+    let node = Node3D::new_alloc();
+    assert_eq!(node.dynamic_class(), Node3D::class_id());
+
+    // After upcast, dynamic class still reflects the actual type (not the static one).
+    let upcast = node.clone().upcast::<Node>();
+    assert_eq!(upcast.dynamic_class(), Node3D::class_id());
+    assert_ne!(upcast.dynamic_class(), Node::class_id());
+
+    // User class: dynamic class is the user-declared name.
+    let user = ObjPayload::new_alloc().upcast::<Object>();
+    assert_eq!(user.dynamic_class(), ObjPayload::class_id());
+
+    node.free();
+    user.free();
+}
+
+#[itest]
+fn object_is_dynamic_class() {
+    let node = Node3D::new_alloc();
+
+    // Exact class + ancestors.
+    assert!(node.is_dynamic_class(Node3D::class_id()));
+    assert!(node.is_dynamic_class(Node::class_id()));
+    assert!(node.is_dynamic_class(Object::class_id()));
+
+    // Sibling / unrelated classes.
+    assert!(!node.is_dynamic_class(Node2D::class_id()));
+    assert!(!node.is_dynamic_class(Resource::class_id()));
+
+    // Dynamic class names (e.g. originating from GDScript / unknown-to-Rust classes).
+    assert!(node.is_dynamic_class(ClassId::new_dynamic("Node3D")));
+    assert!(!node.is_dynamic_class(ClassId::new_dynamic("NonExistentClass")));
+
+    node.free();
+}
+
+#[itest]
+fn object_is_dynamic_class_of() {
+    let node = Node3D::new_alloc();
+
+    // Exact class + ancestors.
+    assert!(node.is_dynamic_class_of::<Node3D>());
+    assert!(node.is_dynamic_class_of::<Node>());
+    assert!(node.is_dynamic_class_of::<Object>());
+
+    // Sibling / unrelated classes.
+    assert!(!node.is_dynamic_class_of::<Node2D>());
+    assert!(!node.is_dynamic_class_of::<Resource>());
+
+    node.free();
 }
 
 #[itest]

--- a/itest/rust/src/object_tests/object_test.rs
+++ b/itest/rust/src/object_tests/object_test.rs
@@ -13,7 +13,8 @@ use std::rc::Rc;
 
 use godot::builtin::{Array, GString, StringName, Variant, Vector3};
 use godot::classes::{
-    Engine, FileAccess, IRefCounted, Node, Node2D, Node3D, Object, RefCounted, file_access,
+    Engine, FileAccess, IRefCounted, Node, Node2D, Node3D, Object, RefCounted, Resource,
+    file_access,
 };
 use godot::global::godot_str;
 use godot::meta::{FromGodot, GodotType, ToGodot};
@@ -148,6 +149,22 @@ fn object_debug() {
 
     assert_eq!(actual, expected);
     obj.free();
+}
+
+#[itest]
+fn object_is_ref_counted() {
+    let refc_usr = Gd::from_object(RefcPayload { value: 8321 }).upcast::<Object>();
+    let refc_eng = Resource::new_gd().upcast::<Object>();
+    let man_usr = ObjPayload::new_alloc().upcast::<Object>();
+    let man_eng = Node3D::new_alloc().upcast::<Object>();
+
+    assert!(refc_usr.is_ref_counted());
+    assert!(refc_eng.is_ref_counted());
+    assert!(!man_usr.is_ref_counted());
+    assert!(!man_eng.is_ref_counted());
+
+    man_usr.free();
+    man_eng.free();
 }
 
 #[itest]


### PR DESCRIPTION
Two new methods `is_instance_of()` and `dynamic_class()` operate directly on `ClassId`, the canonical type for class type IDs in godot-rust. They're currently implemented via Godot APIs, but could potentially be optimized in the future, e.g. by caching a class' own ID, and rebuilding a fast-lookup inheritance table.

This PR also clarifies docs for the (currently still private) `is_editor_placeholder()`.