### PR TITLE
Thread-safe FFI scaffolding + cross-thread printing

### DIFF
--- a/godot-codegen/src/generator/utility_functions.rs
+++ b/godot-codegen/src/generator/utility_functions.rs
@@ -52,8 +52,16 @@ pub(crate) fn make_utility_function_definition(
     let function_ident = make_utility_function_ptr_name(function);
     let function_name_str = function.name();
 
+    // Most utility functions access shared engine state and go through the main-thread-asserting accessor. Those that are manually approved as
+    // thread-safe use the thread-safe accessor instead, which doesn't panic.
+    let table = if function.is_thread_safe {
+        quote! { sys::utility_function_table_thread_safe() }
+    } else {
+        quote! { sys::utility_function_table() }
+    };
+
     let ptrcall_invocation = quote! {
-        let utility_fn = sys::utility_function_table().#function_ident;
+        let utility_fn = #table.#function_ident;
 
         Signature::<CallParams, CallRet>::out_utility_ptrcall(
             utility_fn,
@@ -63,7 +71,7 @@ pub(crate) fn make_utility_function_definition(
     };
 
     let varcall_invocation = quote! {
-        let utility_fn = sys::utility_function_table().#function_ident;
+        let utility_fn = #table.#function_ident;
 
         Signature::<CallParams, CallRet>::out_utility_ptrcall_varargs(
             utility_fn,

--- a/godot-codegen/src/models/domain.rs
+++ b/godot-codegen/src/models/domain.rs
@@ -436,6 +436,9 @@ pub trait Function: fmt::Display {
 
 pub struct UtilityFunction {
     pub common: FunctionCommon,
+
+    /// True if manually approved as thread-safe. Routed through the thread-safe binding accessor in codegen.
+    pub is_thread_safe: bool,
 }
 
 impl UtilityFunction {

--- a/godot-codegen/src/models/domain_mapping.rs
+++ b/godot-codegen/src/models/domain_mapping.rs
@@ -704,6 +704,7 @@ impl UtilityFunction {
             return None;
         }
         let is_private = special_cases::is_utility_function_private(&function);
+        let is_thread_safe = special_cases::is_utility_function_thread_safe(&function);
 
         let JsonUtilityFunction {
             name,
@@ -747,6 +748,7 @@ impl UtilityFunction {
                 deprecation_msg: None, // Utility functions are not deprecated.
                 description,
             },
+            is_thread_safe,
         })
     }
 }

--- a/godot-codegen/src/special_cases/special_cases.rs
+++ b/godot-codegen/src/special_cases/special_cases.rs
@@ -860,6 +860,28 @@ pub fn is_utility_function_deleted(function: &JsonUtilityFunction, ctx: &mut Con
     hardcoded || codegen_special_cases::is_utility_function_excluded(function, ctx)
 }
 
+/// Utility functions manually reviewed as thread-safe (callable from any thread).
+#[rustfmt::skip]
+pub fn is_utility_function_thread_safe(function: &JsonUtilityFunction) -> bool {
+    match function.name.as_str() {
+        // Print group -> Godot's `OS::print()` -> active logger. See print.rs for the per-backend C++ analysis.
+        | "print"
+        | "print_rich"
+        | "printerr"
+        | "printraw"
+        | "printt"
+        | "prints"
+        | "print_verbose"
+        | "push_error"
+        | "push_warning"
+        
+        // Pure Variant -> GString conversion, touches only caller-owned memory.
+        | "str"
+
+        => true, _ => false
+    }
+}
+
 #[rustfmt::skip]
 pub fn is_utility_function_private(function: &JsonUtilityFunction) -> bool {
     match function.name.as_str() {

--- a/godot-core/src/builtin/macros.rs
+++ b/godot-core/src/builtin/macros.rs
@@ -7,77 +7,72 @@
 
 #![macro_use]
 
+// Trait bodies parametrized on the lifecycle accessor `$lifecycle`: the main-thread table or the reviewed thread-safe subset. See
+// `impl_builtin_traits!` for how the accessor is chosen.
 macro_rules! impl_builtin_traits_inner {
-    ( Default for $Type:ty => $gd_method:ident ) => {
+    ( Default for $Type:ty => $gd_method:ident, $lifecycle:path ) => {
         impl Default for $Type {
             #[inline]
             fn default() -> Self {
                 unsafe {
                     Self::new_with_uninit(|self_ptr| {
-                        let ctor = ::godot_ffi::builtin_fn!($gd_method);
-                        ctor(self_ptr, std::ptr::null_mut())
+                        ($lifecycle().$gd_method)(self_ptr, std::ptr::null());
                     })
                 }
             }
         }
     };
 
-    ( Clone for $Type:ty => $gd_method:ident ) => {
+    ( Clone for $Type:ty => $gd_method:ident, $lifecycle:path ) => {
         impl Clone for $Type {
             #[inline]
             fn clone(&self) -> Self {
                 unsafe {
                     Self::new_with_uninit(|self_ptr| {
-                        let ctor = ::godot_ffi::builtin_fn!($gd_method);
                         let args = [self.sys()];
-                        ctor(self_ptr, args.as_ptr());
+                        ($lifecycle().$gd_method)(self_ptr, args.as_ptr());
                     })
                 }
             }
         }
     };
 
-    ( Drop for $Type:ty => $gd_method:ident ) => {
+    ( Drop for $Type:ty => $gd_method:ident, $lifecycle:path ) => {
         impl Drop for $Type {
             #[inline]
             fn drop(&mut self) {
                 unsafe {
-                    let destructor = ::godot_ffi::builtin_fn!($gd_method @1);
-                    destructor(self.sys_mut());
+                    ($lifecycle().$gd_method)(self.sys_mut());
                 }
             }
         }
     };
 
-    ( PartialEq for $Type:ty => $gd_method:ident ) => {
+    ( PartialEq for $Type:ty => $gd_method:ident, $lifecycle:path ) => {
         impl PartialEq for $Type {
             #[inline]
             fn eq(&self, other: &Self) -> bool {
                 unsafe {
                     let mut result = false;
-                    ::godot_ffi::builtin_call! {
-                        $gd_method(self.sys(), other.sys(), result.sys_mut())
-                    };
+                    ($lifecycle().$gd_method)(self.sys(), other.sys(), result.sys_mut());
                     result
                 }
             }
         }
     };
 
-    ( Eq for $Type:ty => $gd_method:ident ) => {
-        impl_builtin_traits_inner!(PartialEq for $Type => $gd_method);
+    ( Eq for $Type:ty => $gd_method:ident, $lifecycle:path ) => {
+        impl_builtin_traits_inner!(PartialEq for $Type => $gd_method, $lifecycle);
         impl Eq for $Type {}
     };
 
-    ( Ord for $Type:ty => $gd_method:ident ) => {
+    ( Ord for $Type:ty => $gd_method:ident, $lifecycle:path ) => {
         impl Ord for $Type {
             #[inline]
             fn cmp(&self, other: &Self) -> std::cmp::Ordering {
                 let op_less = |lhs, rhs| unsafe {
                     let mut result = false;
-                    ::godot_ffi::builtin_call! {
-                        $gd_method(lhs, rhs, result.sys_mut())
-                    };
+                    ($lifecycle().$gd_method)(lhs, rhs, result.sys_mut());
                     result
                 };
 
@@ -98,9 +93,8 @@ macro_rules! impl_builtin_traits_inner {
         }
     };
 
-
-    // Requires a `hash` function.
-    ( Hash for $Type:ty ) => {
+    // Hash is pure Rust-side (no FFI), so it ignores the lifecycle accessor.
+    ( Hash for $Type:ty, $lifecycle:path ) => {
         impl std::hash::Hash for $Type {
             fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
                 // The GDExtension interface only deals in `int64_t`, but the engine's own `hash()` function
@@ -119,7 +113,22 @@ macro_rules! impl_builtin_traits {
     ) => (
         $(
             impl_builtin_traits_inner! {
-                $Trait for $Type $(=> $gd_method)?
+                $Trait for $Type $(=> $gd_method)?, ::godot_ffi::builtin_lifecycle_api
+            }
+        )*
+    );
+
+    // Thread-safe variant: routes through the reviewed `sys::thread_safe_lifecycle()` subset. Only traits whose lifecycle functions are in
+    // that subset may be listed; anything else is a compile error on the missing field. Additionally, $Type must implement Send.
+    (
+        thread_safe for $Type:ty {
+            $( $Trait:ident $(=> $gd_method:ident)?; )*
+        }
+    ) => (
+        const _: () = ::godot_ffi::require_send::<$Type>();
+        $(
+            impl_builtin_traits_inner! {
+                $Trait for $Type $(=> $gd_method)?, ::godot_ffi::thread_safe_lifecycle
             }
         )*
     )

--- a/godot-core/src/builtin/strings/godot_string_ext.rs
+++ b/godot-core/src/builtin/strings/godot_string_ext.rs
@@ -36,18 +36,27 @@ pub trait GodotStringExt {
 
 /// Macro to delegate a builtin conversion to the FFI layer.
 ///
-/// Use: `let dest = unsafe_from_builtin!(dest_from_source -> Dest, source);`
+/// Use: `let dest = unsafe_builtin_convert!(dest_from_source -> Dest, source);`
+///
+/// The `@thread_safe` variant routes through the reviewed `sys::thread_safe_lifecycle()` subset. This is currently needed because not all
+/// types are yet proven thread-safe (in particular `NodePath`). Can possibly be removed.
 ///
 /// # Safety
 /// The `Dest` type must match what the FFI function `dest_from_source` returns.
 macro_rules! unsafe_builtin_convert {
-    ($ctor:ident -> $Type:ty, $arg:expr) => {{
+    ($ctor:ident -> $Type:ty, $arg:expr) => {
+        unsafe_builtin_convert!(@impl sys::builtin_fn!($ctor), $Type, $arg)
+    };
+    (@thread_safe $ctor:ident -> $Type:ty, $arg:expr) => {
+        unsafe_builtin_convert!(@impl sys::thread_safe_lifecycle().$ctor, $Type, $arg)
+    };
+    (@impl $ctor:expr, $Type:ty, $arg:expr) => {{
         let __arg = $arg; // Must outlive the sys() call.
 
         // SAFETY: Matching $Type and $ctor is caller responsibility. The rest adheres to Godot FFI for conversion constructors.
         unsafe {
             <$Type>::new_with_uninit(|self_ptr| {
-                let ctor = sys::builtin_fn!($ctor);
+                let ctor = $ctor;
                 let args = [__arg.sys()];
                 ctor(self_ptr, args.as_ptr());
             })
@@ -61,17 +70,18 @@ impl GodotStringExt for GString {
     }
 
     fn to_string_name(&self) -> StringName {
-        unsafe_builtin_convert!(string_name_from_string -> StringName, self)
+        unsafe_builtin_convert!(@thread_safe string_name_from_string -> StringName, self)
     }
 
     fn to_node_path(&self) -> NodePath {
+        // `node_path_from_string` is not part of the reviewed thread-safe subset, so this stays main-thread-only.
         unsafe_builtin_convert!(node_path_from_string -> NodePath, self)
     }
 }
 
 impl GodotStringExt for StringName {
     fn to_gstring(&self) -> GString {
-        unsafe_builtin_convert!(string_from_string_name -> GString, self)
+        unsafe_builtin_convert!(@thread_safe string_from_string_name -> GString, self)
     }
 
     fn to_string_name(&self) -> StringName {
@@ -81,7 +91,7 @@ impl GodotStringExt for StringName {
 
 impl GodotStringExt for NodePath {
     fn to_gstring(&self) -> GString {
-        unsafe_builtin_convert!(string_from_node_path -> GString, self)
+        unsafe_builtin_convert!(@thread_safe string_from_node_path -> GString, self)
     }
 
     fn to_string_name(&self) -> StringName {
@@ -102,9 +112,9 @@ impl GodotStringExt for str {
         unsafe {
             GString::new_with_string_uninit(|string_ptr| {
                 #[cfg(before_api = "4.3")]
-                let ctor = sys::interface_fn!(string_new_with_utf8_chars_and_len);
+                let ctor = sys::thread_safe().string_new_with_utf8_chars_and_len;
                 #[cfg(since_api = "4.3")]
-                let ctor = sys::interface_fn!(string_new_with_utf8_chars_and_len2);
+                let ctor = sys::thread_safe().string_new_with_utf8_chars_and_len2;
 
                 ctor(
                     string_ptr,
@@ -121,7 +131,7 @@ impl GodotStringExt for str {
         // SAFETY: string is UTF-8 encoded and len-bounded. Godot takes byte length, not character count.
         unsafe {
             StringName::new_with_string_uninit(|string_ptr| {
-                sys::interface_fn!(string_name_new_with_utf8_chars_and_len)(
+                (sys::thread_safe().string_name_new_with_utf8_chars_and_len)(
                     string_ptr,
                     utf8_bytes.as_ptr().cast::<std::ffi::c_char>(),
                     utf8_bytes.len() as i64,
@@ -138,7 +148,7 @@ impl GodotStringExt for [char] {
         // SAFETY: A `char` value is by definition a valid Unicode code point. Bounded by len().
         unsafe {
             GString::new_with_string_uninit(|string_ptr| {
-                sys::interface_fn!(string_new_with_utf32_chars_and_len)(
+                (sys::thread_safe().string_new_with_utf32_chars_and_len)(
                     string_ptr,
                     chars.as_ptr().cast::<sys::char32_t>(),
                     chars.len() as i64,

--- a/godot-core/src/builtin/strings/gstring.rs
+++ b/godot-core/src/builtin/strings/gstring.rs
@@ -10,7 +10,7 @@ use std::fmt;
 use std::fmt::Write;
 
 use godot_ffi as sys;
-use sys::{ExtVariantType, GodotFfi, ffi_methods, interface_fn};
+use sys::{ExtVariantType, GodotFfi, ffi_methods};
 
 use crate::builtin::strings::{Encoding, pad_if_needed};
 use crate::builtin::{GodotStringExt, NodePath, StringName, Variant, inner};
@@ -128,7 +128,7 @@ impl GString {
 
                 let s = unsafe {
                     Self::new_with_string_uninit(|string_ptr| {
-                        let ctor = interface_fn!(string_new_with_latin1_chars_and_len);
+                        let ctor = sys::thread_safe().string_new_with_latin1_chars_and_len;
                         ctor(
                             string_ptr,
                             bytes.as_ptr() as *const std::ffi::c_char,
@@ -184,8 +184,8 @@ impl GString {
         let len: sys::GDExtensionInt;
         let ptr: *const sys::char32_t;
         unsafe {
-            len = interface_fn!(string_to_utf32_chars)(s, std::ptr::null_mut(), 0);
-            ptr = interface_fn!(string_operator_index_const)(s, 0);
+            len = (sys::thread_safe().string_to_utf32_chars)(s, std::ptr::null_mut(), 0);
+            ptr = (sys::thread_safe().string_operator_index_const)(s, 0);
         }
 
         (ptr.cast(), len as usize)
@@ -273,8 +273,9 @@ unsafe impl GodotFfi for GString {
 
 meta::impl_godot_as_self!(GString: ByRef);
 
+// These run through `sys::thread_safe_lifecycle()`, so they are thread-safe (string value types only touch caller-owned memory).
 impl_builtin_traits! {
-    for GString {
+    thread_safe for GString {
         Default => string_construct_default;
         Clone => string_construct_copy;
         Drop => string_destroy;
@@ -348,13 +349,16 @@ impl From<&String> for GString {
 impl From<&GString> for String {
     fn from(string: &GString) -> Self {
         unsafe {
-            let len =
-                interface_fn!(string_to_utf8_chars)(string.string_sys(), std::ptr::null_mut(), 0);
+            let len = (sys::thread_safe().string_to_utf8_chars)(
+                string.string_sys(),
+                std::ptr::null_mut(),
+                0,
+            );
 
             assert!(len >= 0);
             let mut buf = vec![0u8; len as usize];
 
-            interface_fn!(string_to_utf8_chars)(
+            (sys::thread_safe().string_to_utf8_chars)(
                 string.string_sys(),
                 buf.as_mut_ptr() as *mut std::ffi::c_char,
                 len,

--- a/godot-core/src/builtin/strings/string_name.rs
+++ b/godot-core/src/builtin/strings/string_name.rs
@@ -84,7 +84,7 @@ impl StringName {
             let is_static = sys::conv::SYS_FALSE;
             let s = unsafe {
                 Self::new_with_string_uninit(|string_ptr| {
-                    let ctor = sys::interface_fn!(string_name_new_with_latin1_chars);
+                    let ctor = sys::thread_safe().string_name_new_with_latin1_chars;
                     ctor(
                         string_ptr,
                         cstr.as_ptr() as *const std::ffi::c_char,
@@ -284,7 +284,7 @@ impl StringName {
         // SAFETY: c_str is nul-terminated and remains valid for entire program duration.
         unsafe {
             Self::new_with_string_uninit(|ptr| {
-                sys::interface_fn!(string_name_new_with_latin1_chars)(
+                (sys::thread_safe().string_name_new_with_latin1_chars)(
                     ptr,
                     c_str.as_ptr(),
                     sys::conv::bool_to_sys(is_static),
@@ -311,8 +311,9 @@ unsafe impl GodotFfi for StringName {
 
 meta::impl_godot_as_self!(StringName: ByRef);
 
+// Thread-safe in the sense of Send (not Sync): a single `StringName` is only accessed from one thread at a time, but cloning yields another instance pointing at the same shared read-only buffer, so distinct instances on distinct threads are fine.
 impl_builtin_traits! {
-    for StringName {
+    thread_safe for StringName {
         Default => string_name_construct_default;
         Clone => string_name_construct_copy;
         Drop => string_name_destroy;
@@ -424,9 +425,8 @@ impl Ord for TransientStringNameOrd<'_> {
         // SAFETY: builtin operator provided by Godot.
         let op_less = |lhs, rhs| unsafe {
             let mut result = false;
-            sys::builtin_call! {
-                string_name_operator_less(lhs, rhs, result.sys_mut())
-            }
+            let lifecycle = sys::thread_safe_lifecycle();
+            (lifecycle.string_name_operator_less)(lhs, rhs, result.sys_mut());
             result
         };
 

--- a/godot-core/src/builtin/variant/impls.rs
+++ b/godot-core/src/builtin/variant/impls.rs
@@ -27,27 +27,37 @@ use crate::task::{DynamicSend, IntoDynamicSend, ThreadConfined, impl_dynamic_sen
 macro_rules! impl_ffi_variant {
     // With explicit metadata (e.g. for i64, f64).
     (ref $T:ty, $from_fn:ident, $to_fn:ident; $metadata:expr) => {
-        impl_ffi_variant!(@impls by_ref, $metadata; $T, $from_fn, $to_fn);
+        impl_ffi_variant!(@impls by_ref, $metadata, main_thread; $T, $from_fn, $to_fn);
     };
     ($T:ty, $from_fn:ident, $to_fn:ident; $metadata:expr) => {
-        impl_ffi_variant!(@impls by_val, $metadata; $T, $from_fn, $to_fn);
+        impl_ffi_variant!(@impls by_val, $metadata, main_thread; $T, $from_fn, $to_fn);
     };
 
     // Without metadata (defaults to ParamMetadata::NONE).
     (ref $T:ty, $from_fn:ident, $to_fn:ident) => {
-        impl_ffi_variant!(@impls by_ref, ParamMetadata::NONE; $T, $from_fn, $to_fn);
+        impl_ffi_variant!(@impls by_ref, ParamMetadata::NONE, main_thread; $T, $from_fn, $to_fn);
     };
     ($T:ty, $from_fn:ident, $to_fn:ident) => {
-        impl_ffi_variant!(@impls by_val, ParamMetadata::NONE; $T, $from_fn, $to_fn);
+        impl_ffi_variant!(@impls by_val, ParamMetadata::NONE, main_thread; $T, $from_fn, $to_fn);
     };
 
+    // Thread-safe variant: the to/from-variant converters resolve through the reviewed `sys::thread_safe_lifecycle()` subset instead of the
+    // main-thread-only `builtin_fn!` (string value types only touch caller-owned memory).
+    (thread_safe ref $T:ty, $from_fn:ident, $to_fn:ident) => {
+        impl_ffi_variant!(@impls by_ref, ParamMetadata::NONE, thread_safe; $T, $from_fn, $to_fn);
+    };
+
+    // Converter resolution: `main_thread` uses the main-thread table, `thread_safe` the reviewed subset.
+    (@converter main_thread, $fn:ident) => { sys::builtin_fn!($fn) };
+    (@converter thread_safe, $fn:ident) => { sys::thread_safe_lifecycle().$fn };
+
     // Implementations
-    (@impls $by_ref_or_val:ident, $metadata:expr; $T:ty, $from_fn:ident, $to_fn:ident) => {
+    (@impls $by_ref_or_val:ident, $metadata:expr, $mode:ident; $T:ty, $from_fn:ident, $to_fn:ident) => {
         impl GodotFfiVariant for $T {
             fn ffi_to_variant(&self) -> Variant {
                 let variant = unsafe {
                     Variant::new_with_var_uninit(|variant_ptr| {
-                        let converter = sys::builtin_fn!($from_fn);
+                        let converter = impl_ffi_variant!(@converter $mode, $from_fn);
                         converter(variant_ptr, sys::SysPtr::force_mut(self.sys()));
                     })
                 };
@@ -67,7 +77,7 @@ macro_rules! impl_ffi_variant {
 
                 let result = unsafe {
                     Self::new_with_uninit(|self_ptr| {
-                        let converter = sys::builtin_fn!($to_fn);
+                        let converter = impl_ffi_variant!(@converter $mode, $to_fn);
                         converter(self_ptr, sys::SysPtr::force_mut(variant.var_sys()));
                     })
                 };
@@ -144,11 +154,13 @@ mod impls {
     impl_ffi_variant!(Aabb, aabb_to_variant, aabb_from_variant);
     impl_ffi_variant!(Color, color_to_variant, color_from_variant);
     impl_ffi_variant!(Rid, rid_to_variant, rid_from_variant);
-    impl_ffi_variant!(ref GString, string_to_variant, string_from_variant);
-    impl_ffi_variant!(ref StringName, string_name_to_variant, string_name_from_variant);
     impl_ffi_variant!(ref NodePath, node_path_to_variant, node_path_from_variant);
     impl_ffi_variant!(ref Signal, signal_to_variant, signal_from_variant);
     impl_ffi_variant!(ref Callable, callable_to_variant, callable_from_variant);
+
+    // GString and StringName are string value types that only touch caller-owned memory, so their variant conversions are thread-safe.
+    impl_ffi_variant!(thread_safe ref GString, string_to_variant, string_from_variant);
+    impl_ffi_variant!(thread_safe ref StringName, string_name_to_variant, string_name_from_variant);
 }
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------

--- a/godot-core/src/builtin/variant/mod.rs
+++ b/godot-core/src/builtin/variant/mod.rs
@@ -343,7 +343,26 @@ impl Variant {
         crate::global::is_instance_valid(self)
 
         // In case there are ever problems with this approach, alternative implementation:
-        // self.stringify() != "<Freed Object>".into()
+        // self.stringify() != "<Freed Object>"
+    }
+
+    /// Destroys this `Variant` without the main-thread assertion of [`Drop`], then forgets it.
+    ///
+    /// # Safety
+    /// Only sound for variant types that implement `Send`. Types such as `VariantType::OBJECT` can run Rust `Drop` code, which may not be
+    /// thread-safe.
+    // TODO(v0.6): pick this path automatically in `Drop`, based on a per-`VariantType` flag for which types are safe to destroy off the main thread.
+    pub(crate) unsafe fn destroy_unchecked_thread(self) {
+        let mut this = self;
+
+        // SAFETY: binding initialized; `variant_destroy` only reads `this` and frees its caller-owned payload (guaranteed a string here).
+        unsafe {
+            let variant_destroy = sys::thread_safe().variant_destroy;
+            variant_destroy(this.var_sys_mut());
+        }
+
+        // Skip `Drop`, since we already destroyed the payload above.
+        std::mem::forget(this);
     }
 
     // Conversions from/to Godot C++ `Variant*` pointers
@@ -531,6 +550,8 @@ unsafe impl GodotFfi for Variant {
 
 crate::meta::impl_godot_as_self!(Variant: ByVariant);
 
+// TODO(v0.6): Variant lifecycle stays on the main-thread accessor because a Variant can hold a reference type (Object), whose refcount/free is
+// not safe off the main thread. Once we can classify the inner type, the value-type cases could opt into thread-safe access.
 impl Default for Variant {
     fn default() -> Self {
         unsafe {

--- a/godot-core/src/global/mod.rs
+++ b/godot-core/src/global/mod.rs
@@ -45,7 +45,7 @@
 
 mod print;
 
-pub use print::{PrintLevel, PrintRecord, PrintSource, print_custom};
+pub use print::{__threadsafe_print, PrintLevel, PrintRecord, PrintSource, print_custom};
 
 // Some enums are directly re-exported from crate::builtin.
 pub use crate::r#gen::central::global_enums::*;

--- a/godot-core/src/global/print.rs
+++ b/godot-core/src/global/print.rs
@@ -7,6 +7,31 @@
 
 //! Printing and logging functionality.
 
+// Thread safety (applies to every print macro, to `print_custom`, and to the `print`/`printerr`/`str`/... utility functions):
+//
+// The whole print group can be called from any thread on standard Desktop builds. We therefore route it through the thread-safe binding
+// accessors (`utility_function_table_thread_safe()` for the utility functions, `sys::thread_safe()` for the error/warning interface functions)
+// rather than the main-thread-asserting default.
+//
+// Call chain from a worker thread: macro -> `global::print()` / `print_custom()` -> Godot `OS::print()` -> active `Logger` -> `CompositeLogger`
+// -> sub-loggers. `OS::print()` runs *outside* Godot's `_global_lock`, so line atomicity is not guaranteed; the C++ code below is nonetheless
+// safe against memory corruption because each backend ends up in a libc call that holds a per-`FILE` lock:
+// - `StdLogger` (always installed): `vprintf`/`vfprintf` -> glibc per-`FILE` lock. No data race on the C runtime; worst case is interleaved
+//   lines (cosmetic), never memory-unsafe.
+// - `RotatedFileLogger` (installed by `--log-file` or the `enable_file_logging` setting, default-on): per line it does `file->store_buffer(...)`
+//   -> `FileAccessUnix::store_buffer` = `fwrite` (+ `fflush`), again under glibc's per-`FILE` lock, so writes are serialized, not torn. The
+//   shared ANSI-strip `RegEx` hit on every line is used in PCRE2's documented thread-safe pattern (read-only compiled pattern, per-call match
+//   data and match context allocated as locals), and with `--log-file` there is no per-call rotation/size bookkeeping. Verified empirically:
+//   16 threads x 20000 iterations, 13 headless runs, produced a deterministic 560005-line log with no crash and no torn writes.
+//
+// Two *formal* C++ data races remain but are benign on real glibc targets: the non-atomic `CoreGlobals` print flags (an aligned `bool`
+// load/store is atomic on every real target) and the unlocked `file` access in `logv()` (serialized by the libc `FILE` lock underneath). A
+// thread sanitizer flags them; a running binary does not crash.
+//
+// Caveat: the file-logger safety relies on the `FileAccess` backend happening to lock internally. `FileAccessUnix` does (via libc); a custom or
+// exotic-platform `FileAccess` that buffers in its own non-thread-safe state could turn the formal `file` race into real torn writes. We accept
+// this -- it is not the default desktop/headless configuration -- rather than gate printing, which is a core cross-thread debugging tool.
+
 use crate::builtin::Variant;
 use crate::sys;
 
@@ -156,6 +181,11 @@ pub struct PrintRecord<'a> {
 /// See [`PrintRecord`] and [`PrintLevel`] for routing and source-location behavior. Due to the use of C-strings, if any of the string fields in
 /// `PrintRecord` or [`PrintSource`] have a nul byte (`\0`) in the middle, the printed text will be cut off at that nul byte. Consider this
 /// when working with user-provided texts (e.g. for logging).
+///
+/// # Thread safety
+/// Safe to call from any thread on standard desktop builds; output from concurrent threads may interleave between lines, which is cosmetic. See
+/// the thread-safety note at the print macros (this module) for the per-backend C++ rationale and the one caveat (custom non-locking
+/// `FileAccess` log backends).
 #[track_caller]
 pub fn print_custom(record: PrintRecord<'_>) {
     // Engine not yet loaded -- fall back to stderr.
@@ -197,13 +227,16 @@ pub fn print_custom(record: PrintRecord<'_>) {
     let file_ptr = sys::c_str_from_str(&file_nul);
     let line = line as i32;
 
-    // SAFETY: engine initialized; interface functions valid; pointers live for the call duration.
+    // SAFETY: engine initialized; interface functions valid; pointers live for the call duration. The print/error functions route to Godot's
+    // logger, which is thread-safe in practice (see the note at the print macros), so they go through the thread-safe accessor rather than the
+    // main-thread one -- allowing prints from worker threads.
     unsafe {
+        let interface = sys::thread_safe();
         if let Some(msg_z) = &msg_nul {
             let godot_fn = match record.level {
-                PrintLevel::Warn => sys::interface_fn!(print_warning_with_message),
-                PrintLevel::Error => sys::interface_fn!(print_error_with_message),
-                PrintLevel::ScriptError => sys::interface_fn!(print_script_error_with_message),
+                PrintLevel::Warn => interface.print_warning_with_message,
+                PrintLevel::Error => interface.print_error_with_message,
+                PrintLevel::ScriptError => interface.print_script_error_with_message,
                 PrintLevel::Info => unreachable!(),
             };
             godot_fn(
@@ -216,9 +249,9 @@ pub fn print_custom(record: PrintRecord<'_>) {
             );
         } else {
             let godot_fn = match record.level {
-                PrintLevel::Warn => sys::interface_fn!(print_warning),
-                PrintLevel::Error => sys::interface_fn!(print_error),
-                PrintLevel::ScriptError => sys::interface_fn!(print_script_error),
+                PrintLevel::Warn => interface.print_warning,
+                PrintLevel::Error => interface.print_error,
+                PrintLevel::ScriptError => interface.print_script_error,
                 PrintLevel::Info => unreachable!(),
             };
             godot_fn(desc_ptr, func_ptr, file_ptr, line, editor_notify);
@@ -243,8 +276,31 @@ fn print_info(description: &str, message: Option<&str>, source: Option<PrintSour
         (None, None) => description.to_string(),
     };
 
-    crate::global::print(&[Variant::from(full)]);
+    // Route through the thread-safe path: building+dropping a `Variant` here would hit the main-thread-gated `Drop`, but `print_custom` is callable
+    // from any thread.
+    __threadsafe_print(full, false);
 }
+
+/// Thread-safe printing backend.
+///
+/// The `print`/`print_rich` utility functions are themselves thread-safe, but they take a `Variant`, whose general destructor requires main
+/// thread (a `Variant` may hold an `Object`).
+#[doc(hidden)]
+pub fn __threadsafe_print(message: String, rich: bool) {
+    let variant = Variant::from(message);
+
+    if rich {
+        crate::global::print_rich(std::slice::from_ref(&variant));
+    } else {
+        crate::global::print(std::slice::from_ref(&variant));
+    }
+
+    // SAFETY: variant is GString payload, which is Send and thus safe to destroy across threads.
+    unsafe { variant.destroy_unchecked_thread() };
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// Print macros
 
 /// Pushes a warning message to Godot's built-in debugger and to the OS terminal.
 ///
@@ -314,11 +370,7 @@ macro_rules! godot_script_error {
 #[macro_export]
 macro_rules! godot_print {
     ($fmt:literal $(, $args:expr_2021)* $(,)?) => {
-        $crate::global::print(&[
-            $crate::builtin::Variant::from(
-                format!($fmt $(, $args)*)
-            )
-        ])
+        $crate::global::__threadsafe_print(format!($fmt $(, $args)*), false)
     };
 }
 
@@ -330,11 +382,7 @@ macro_rules! godot_print {
 #[macro_export]
 macro_rules! godot_print_rich {
     ($fmt:literal $(, $args:expr_2021)* $(,)?) => {
-        $crate::global::print_rich(&[
-            $crate::builtin::Variant::from(
-                format!($fmt $(, $args)*)
-            )
-        ])
+        $crate::global::__threadsafe_print(format!($fmt $(, $args)*), true)
     };
 }
 

--- a/godot-core/src/meta/error/convert_error.rs
+++ b/godot-core/src/meta/error/convert_error.rs
@@ -8,9 +8,7 @@
 use std::error::Error;
 use std::fmt;
 
-use godot_ffi::VariantType;
-
-use crate::builtin::Variant;
+use crate::builtin::{Variant, VariantType};
 use crate::meta::inspect::ElementType;
 use crate::meta::{ClassId, ToGodot};
 
@@ -399,7 +397,4 @@ impl fmt::Display for FromVariantError {
     }
 }
 
-fn __ensure_send_sync() {
-    fn check<T: Send + Sync>() {}
-    check::<ErasedConvertError>();
-}
+const _: () = godot_ffi::require_send_sync::<ErasedConvertError>();

--- a/godot-ffi/src/binding/mod.rs
+++ b/godot-ffi/src/binding/mod.rs
@@ -8,7 +8,9 @@
 use crate::{
     BuiltinLifecycleTable, BuiltinMethodTable, ClassCoreMethodTable, ClassEditorMethodTable,
     ClassSceneMethodTable, ClassServersMethodTable, GDExtensionClassLibraryPtr,
-    GDExtensionInterface, GdextRuntimeMetadata, ManualInitCell, UtilityFunctionTable,
+    GDExtensionConstTypePtr, GDExtensionInterface, GDExtensionTypePtr,
+    GDExtensionUninitializedTypePtr, GDExtensionUninitializedVariantPtr, GDExtensionVariantPtr,
+    GdextRuntimeMetadata, ManualInitCell, UtilityFunctionTable,
 };
 
 #[cfg(feature = "experimental-threads")]
@@ -43,6 +45,45 @@ pub(crate) struct GodotBinding {
     utility_function_table: UtilityFunctionTable,
     runtime_metadata: GdextRuntimeMetadata,
     config: GdextConfig,
+    thread_safe_lifecycle: ThreadSafeLifecycle,
+}
+
+// The reviewed thread-safe subset of `BuiltinLifecycleTable`. Field names must match the table 1:1; listed once here, so the struct
+// declaration and `from_table` copy cannot drift. Each entry being a separate field is the guardrail: macros can only reach reviewed functions.
+macro_rules! thread_safe_lifecycle {
+    ($( $field:ident: $sig:ty ),* $(,)?) => {
+        #[derive(Copy, Clone)]
+        pub struct ThreadSafeLifecycle {
+            $( pub $field: $sig, )*
+        }
+
+        impl ThreadSafeLifecycle {
+            /// Picks the reviewed thread-safe subset out of the full lifecycle table. Built once at binding init, handed out by reference.
+            fn from_table(table: &BuiltinLifecycleTable) -> Self {
+                Self { $( $field: table.$field, )* }
+            }
+        }
+    };
+}
+
+thread_safe_lifecycle! {
+    string_construct_default: unsafe extern "C" fn(GDExtensionUninitializedTypePtr, *const GDExtensionConstTypePtr),
+    string_construct_copy: unsafe extern "C" fn(GDExtensionUninitializedTypePtr, *const GDExtensionConstTypePtr),
+    string_destroy: unsafe extern "C" fn(GDExtensionTypePtr),
+    string_operator_equal: unsafe extern "C" fn(GDExtensionConstTypePtr, GDExtensionConstTypePtr, GDExtensionTypePtr),
+    string_operator_less: unsafe extern "C" fn(GDExtensionConstTypePtr, GDExtensionConstTypePtr, GDExtensionTypePtr),
+    string_from_string_name: unsafe extern "C" fn(GDExtensionUninitializedTypePtr, *const GDExtensionConstTypePtr),
+    string_from_node_path: unsafe extern "C" fn(GDExtensionUninitializedTypePtr, *const GDExtensionConstTypePtr),
+    string_to_variant: unsafe extern "C" fn(GDExtensionUninitializedVariantPtr, GDExtensionTypePtr),
+    string_from_variant: unsafe extern "C" fn(GDExtensionUninitializedTypePtr, GDExtensionVariantPtr),
+    string_name_construct_default: unsafe extern "C" fn(GDExtensionUninitializedTypePtr, *const GDExtensionConstTypePtr),
+    string_name_construct_copy: unsafe extern "C" fn(GDExtensionUninitializedTypePtr, *const GDExtensionConstTypePtr),
+    string_name_destroy: unsafe extern "C" fn(GDExtensionTypePtr),
+    string_name_operator_equal: unsafe extern "C" fn(GDExtensionConstTypePtr, GDExtensionConstTypePtr, GDExtensionTypePtr),
+    string_name_operator_less: unsafe extern "C" fn(GDExtensionConstTypePtr, GDExtensionConstTypePtr, GDExtensionTypePtr),
+    string_name_from_string: unsafe extern "C" fn(GDExtensionUninitializedTypePtr, *const GDExtensionConstTypePtr),
+    string_name_to_variant: unsafe extern "C" fn(GDExtensionUninitializedVariantPtr, GDExtensionTypePtr),
+    string_name_from_variant: unsafe extern "C" fn(GDExtensionUninitializedTypePtr, GDExtensionVariantPtr),
 }
 
 impl GodotBinding {
@@ -55,11 +96,14 @@ impl GodotBinding {
         runtime_metadata: GdextRuntimeMetadata,
         config: GdextConfig,
     ) -> Self {
+        let thread_safe_lifecycle = ThreadSafeLifecycle::from_table(&global_method_table);
+
         Self {
             interface,
             get_proc_address,
             library: ClassLibraryPtr(library),
             global_method_table,
+            thread_safe_lifecycle,
             class_core_method_table: ManualInitCell::new(),
             class_server_method_table: ManualInitCell::new(),
             class_scene_method_table: ManualInitCell::new(),
@@ -123,6 +167,33 @@ pub unsafe fn get_interface() -> &'static GDExtensionInterface {
     &get_binding().interface
 }
 
+/// Interface for FFI functions that touch shared engine/scene state and must run on the main thread.
+///
+/// Asserts main thread (non-disengaged profiles) plus binding-live check. For `classdb_*`, `object_method_bind_*`, etc.
+/// Not a thread-safe alternative; use [`thread_safe()`] for functions that only touch caller-owned memory.
+///
+/// # Safety
+/// The Godot binding must have been initialized before calling this function.
+#[inline(always)]
+#[allow(unsafe_op_in_unsafe_fn)] // Safety preconditions forwarded 1:1.
+pub unsafe fn on_main() -> &'static GDExtensionInterface {
+    &get_binding().interface
+}
+
+/// Access the interface for thread-safe FFI functions (they only touch caller-owned memory).
+///
+/// Skips the main-thread assertion, keeping only the binding-live check. Default to [`on_main`] until a function is reviewed thread-safe.
+/// Returns the full interface, so the restriction holds by convention only. TODO(v0.6): codegen a typed subset like [`thread_safe_lifecycle`],
+/// so misuse becomes a compile error.
+///
+/// # Safety
+/// The Godot binding must have been initialized before calling this function, and the accessed function must not touch shared engine state.
+#[inline(always)]
+#[allow(unsafe_op_in_unsafe_fn)] // Safety preconditions forwarded 1:1.
+pub unsafe fn thread_safe() -> &'static GDExtensionInterface {
+    &get_binding_thread_safe().interface
+}
+
 /// # Safety
 ///
 /// The Godot binding must have been initialized before calling this function.
@@ -153,6 +224,8 @@ pub unsafe fn get_ffi_ptr_by_cstr(name: &[u8]) -> crate::GDExtensionInterfaceFun
     get_proc_address(crate::c_str(name))
 }
 
+/// Access the builtin lifecycle table.
+///
 /// # Safety
 ///
 /// The Godot binding must have been initialized before calling this function.
@@ -162,6 +235,18 @@ pub unsafe fn get_ffi_ptr_by_cstr(name: &[u8]) -> crate::GDExtensionInterfaceFun
 #[allow(unsafe_op_in_unsafe_fn)] // Safety preconditions forwarded 1:1.
 pub unsafe fn builtin_lifecycle_api() -> &'static BuiltinLifecycleTable {
     &get_binding().global_method_table
+}
+
+/// Access the reviewed builtin lifecycle functions that are thread-safe.
+///
+/// Intentionally a narrow subset, not the full lifecycle table; additions must be reviewed individually.
+///
+/// # Safety
+/// The Godot binding must have been initialized before calling this function, and the accessed function must not touch shared engine state.
+#[inline(always)]
+#[allow(unsafe_op_in_unsafe_fn)] // Safety preconditions forwarded 1:1.
+pub unsafe fn thread_safe_lifecycle() -> &'static ThreadSafeLifecycle {
+    &get_binding_thread_safe().thread_safe_lifecycle
 }
 
 /// # Safety
@@ -250,6 +335,21 @@ pub unsafe fn utility_function_table() -> &'static UtilityFunctionTable {
     &get_binding().utility_function_table
 }
 
+/// Access the utility-function table for functions reviewed as thread-safe (currently the print group and `str`).
+///
+/// Skips the main-thread assertion, keeping only the binding-live check. Most utility functions touch shared engine state and must therefore
+/// keep going through [`utility_function_table`]; codegen routes only the individually reviewed ones here (see `is_utility_function_thread_safe`
+/// in `godot-codegen`).
+///
+/// # Safety
+///
+/// The Godot binding must have been initialized before calling this function, and the accessed function must not touch shared engine state.
+#[inline(always)]
+#[allow(unsafe_op_in_unsafe_fn)] // Safety preconditions forwarded 1:1.
+pub unsafe fn utility_function_table_thread_safe() -> &'static UtilityFunctionTable {
+    &get_binding_thread_safe().utility_function_table
+}
+
 /// # Safety
 ///
 /// The Godot binding must have been initialized before calling this function.
@@ -306,6 +406,19 @@ pub(crate) unsafe fn deinitialize_binding() {
 #[inline(always)]
 #[allow(unsafe_op_in_unsafe_fn)] // Safety preconditions forwarded 1:1.
 pub(crate) unsafe fn get_binding() -> &'static GodotBinding {
+    // Restricted access: assert main thread (no-op in multi-threaded builds), then perform the binding-live check.
+    BindingStorage::ensure_main_thread();
+    BindingStorage::get_binding_unchecked()
+}
+
+/// Like [`get_binding`], but without the main-thread assertion -- for thread-safe FFI functions.
+///
+/// # Safety
+/// The Godot binding must have been initialized before calling this function. The accessed FFI function must only touch caller-owned memory
+/// (e.g. builtin value-type ctors/dtors, mem alloc/free, type constructors), not shared engine or scene state.
+#[inline(always)]
+#[allow(unsafe_op_in_unsafe_fn)] // Safety preconditions forwarded 1:1.
+pub(crate) unsafe fn get_binding_thread_safe() -> &'static GodotBinding {
     BindingStorage::get_binding_unchecked()
 }
 

--- a/godot-ffi/src/binding/multi_threaded.rs
+++ b/godot-ffi/src/binding/multi_threaded.rs
@@ -83,6 +83,11 @@ impl BindingStorage {
         let storage = Self::storage();
         storage.binding.is_initialized()
     }
+
+    /// No-op in multi-threaded builds: with "experimental-threads", FFI access from any thread is permitted, so there is no main-thread
+    /// assertion to make. Exists for API parity with the single-threaded storage, which the shared `get_binding()` relies on.
+    #[inline(always)]
+    pub(super) fn ensure_main_thread() {}
 }
 
 pub struct GdextConfig {

--- a/godot-ffi/src/binding/single_threaded.rs
+++ b/godot-ffi/src/binding/single_threaded.rs
@@ -9,15 +9,16 @@
 //!
 //! If used from different threads then there will be runtime errors in debug mode and UB in release mode.
 
-use std::cell::Cell;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use super::GodotBinding;
 use crate::ManualInitCell;
 
 pub(super) struct BindingStorage {
-    // No threading when linking against Godot with a nothreads Wasm build.
-    // Therefore, we just need to check if the bindings were initialized, as all accesses are from the main thread.
-    initialized: Cell<bool>,
+    // Guards the binding-live window (set on init, cleared on deinit). `AtomicBool` instead of `Cell<bool>` so thread-safe FFI calls off the main
+    // thread still have well-defined ordering: `Release`-stores on init/deinit pair with `Acquire`-loads on read, establishing happens-before.
+    // Does *not* protect against concurrent teardown races -- the engine must join extension threads before unloading the library.
+    initialized: AtomicBool,
     binding: ManualInitCell<GodotBinding>,
 }
 
@@ -25,12 +26,12 @@ impl BindingStorage {
     /// Get the static binding storage.
     ///
     /// # Safety
-    ///
-    /// You must not access `binding` from a thread different from the thread [`initialize`](BindingStorage::initialize) was first called from.
+    /// You must not access `binding` from a thread different from the thread [`initialize`](BindingStorage::initialize) was first called from,
+    /// unless the accessed FFI function is itself thread-safe (see [`get_binding_unchecked`](BindingStorage::get_binding_unchecked)).
     #[inline(always)]
     unsafe fn storage() -> &'static Self {
         static BINDING: BindingStorage = BindingStorage {
-            initialized: Cell::new(false),
+            initialized: AtomicBool::new(false),
             binding: ManualInitCell::new(),
         };
 
@@ -41,28 +42,7 @@ impl BindingStorage {
     ///
     /// It is recommended to use this function for that purpose as the field to check varies depending on the compilation target.
     fn initialized(&self) -> bool {
-        self.initialized.get()
-    }
-
-    /// Marks the binding storage as initialized or deinitialized.
-    /// We store the thread ID to ensure future accesses to the binding only come from the main thread.
-    ///
-    /// # Safety
-    /// Must be called from the main thread. Additionally, the binding storage must be initialized immediately
-    /// after this function if `initialized` is `true`, or deinitialized if it is `false`.
-    ///
-    /// # Panics
-    /// If attempting to deinitialize before initializing, or vice-versa.
-    unsafe fn set_initialized(&self, initialized: bool) {
-        if initialized == self.initialized() {
-            if initialized {
-                panic!("already initialized");
-            } else {
-                panic!("deinitialize without prior initialize");
-            }
-        }
-
-        self.initialized.set(initialized);
+        self.initialized.load(Ordering::Acquire)
     }
 
     /// Initialize the binding storage, this must be called before any other public functions.
@@ -77,15 +57,16 @@ impl BindingStorage {
         // in which case we can tell that the storage has been initialized, and we don't access `binding`.
         let storage = unsafe { Self::storage() };
 
-        // SAFETY: We are about to initialize the binding below, so marking the binding as initialized is correct.
-        // If we can't initialize the binding at this point, we get a panic before changing the status, thus the
-        // binding won't be set.
-        unsafe { storage.set_initialized(true) };
+        assert!(!storage.initialized(), "already initialized");
 
-        // SAFETY: We are the first thread to set this binding (possibly after deinitialize), as otherwise the above set() would fail and
-        // return early. We also know initialize() is not called concurrently with anything else that can call another method on the binding,
-        // since this method is called from the main thread and so must any other methods.
+        // SAFETY: We are the first thread to set this binding (possibly after deinitialize), as otherwise the above assert would fail. We also
+        // know initialize() is not called concurrently with anything else that can call another method on the binding, since this method is
+        // called from the main thread and so must any other methods.
         unsafe { storage.binding.set(binding) };
+
+        // Publish the binding *before* marking it live: a reader observing `true` (with the corresponding `Acquire`-load) is then guaranteed to
+        // see the fully-written binding.
+        storage.initialized.store(true, Ordering::Release);
     }
 
     /// Deinitialize the binding storage.
@@ -99,10 +80,13 @@ impl BindingStorage {
         // SAFETY: We only call this once no other operations happen anymore, i.e. no other access to the binding.
         let storage = unsafe { Self::storage() };
 
-        // SAFETY: We are about to deinitialize the binding below, so marking the binding as deinitialized is correct.
-        // If we can't deinitialize the binding at this point, we get a panic before changing the status, thus the
-        // binding won't be deinitialized.
-        unsafe { storage.set_initialized(false) };
+        assert!(
+            storage.initialized(),
+            "deinitialize without prior initialize"
+        );
+
+        // Mark the binding not-live *before* clearing it: a reader observing `false` will not dereference the binding.
+        storage.initialized.store(false, Ordering::Release);
 
         // SAFETY: We are the only thread that can access the binding, and we know that it's initialized.
         unsafe { storage.binding.clear() };
@@ -110,18 +94,22 @@ impl BindingStorage {
 
     /// Get the binding from the binding storage.
     ///
+    /// This performs the "binding is live" check (turning before-init / after-deinit access into a clean panic), but does *not* assert that the
+    /// caller is on the main thread -- so it is the right entry point for thread-safe FFI functions. Callers that touch engine/scene state must
+    /// additionally go through [`ensure_main_thread`](BindingStorage::ensure_main_thread).
+    ///
     /// # Safety
-    /// - Must be called from the main thread.
     /// - The binding must be initialized.
     #[inline(always)]
     pub unsafe fn get_binding_unchecked() -> &'static GodotBinding {
-        // SAFETY: The bindings were initialized on the main thread because `initialize` must be called from the main thread,
-        // and this function is called from the main thread.
         let storage = unsafe { Self::storage() };
 
-        Self::ensure_main_thread();
+        // Live check: passes in ~100% of real calls. Compiled out under the disengaged safety profile, recovering unchecked speed for users who
+        // promise the invariant. The actual check lives in a standalone function so it can be unit-tested without a real binding.
+        #[cfg(safeguards_balanced)]
+        assert_binding_live(&storage.initialized);
 
-        // SAFETY: This function can only be called when the binding is initialized and from the main thread, so we know that it's initialized.
+        // SAFETY: Per the safety contract the binding is initialized, so the cell holds a value.
         unsafe { storage.binding.get_unchecked() }
     }
 
@@ -132,7 +120,9 @@ impl BindingStorage {
         storage.initialized()
     }
 
-    fn ensure_main_thread() {
+    /// Asserts that the caller is on the main thread. Used by the restricted accessor (`sys::on_main()`) for FFI functions that touch
+    /// engine/scene state; thread-safe functions skip this.
+    pub(super) fn ensure_main_thread() {
         // Check that we're on the main thread. Only enabled with balanced+ safeguards and, for Wasm, in threaded builds.
         // In wasm_nothreads, there's only one thread, so no check is needed.
         #[cfg(all(safeguards_balanced, not(wasm_nothreads)))]
@@ -160,6 +150,46 @@ impl BindingStorage {
 unsafe impl Sync for BindingStorage {}
 // SAFETY: We ensure that `binding` is only ever accessed from the same thread that initialized it.
 unsafe impl Send for BindingStorage {}
+
+/// Panics if the binding is not currently live, turning before-init / after-deinit access into a clean error instead of UB.
+///
+/// Standalone (not a method) so it can be unit-tested against a hand-made `AtomicBool` without a real binding behind it.
+#[cfg(safeguards_balanced)]
+#[inline(always)]
+fn assert_binding_live(initialized: &AtomicBool) {
+    if !initialized.load(Ordering::Acquire) {
+        not_live_panic();
+    }
+}
+
+/// Failure path for the live check; separated out and marked cold so the hot path stays a predicted-not-taken branch.
+#[cfg(safeguards_balanced)]
+#[cold]
+#[inline(never)]
+fn not_live_panic() -> ! {
+    panic!(
+        "Godot binding accessed before initialization or after deinitialization. \
+        This typically means a `#[ctor]`/`#[dtor]` constructor, a library destructor, or a leftover user thread touched the Godot API \
+        outside the engine's load/unload window."
+    )
+}
+
+#[cfg(all(test, safeguards_balanced))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn live_check_passes_when_initialized() {
+        // Must not panic.
+        assert_binding_live(&AtomicBool::new(true));
+    }
+
+    #[test]
+    #[should_panic(expected = "accessed before initialization or after deinitialization")]
+    fn live_check_panics_when_not_initialized() {
+        assert_binding_live(&AtomicBool::new(false));
+    }
+}
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/godot-ffi/src/lib.rs
+++ b/godot-ffi/src/lib.rs
@@ -762,6 +762,9 @@ pub unsafe fn classdb_construct_object(
     unsafe { f(class_name) }
 }
 
+pub const fn require_send<T: Send>() {}
+pub const fn require_send_sync<T: Send + Sync>() {}
+
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Macros to access low-level function bindings
 

--- a/itest/rust/src/engine_tests/mod.rs
+++ b/itest/rust/src/engine_tests/mod.rs
@@ -18,6 +18,7 @@ mod native_st_niche_pointer_test;
 mod native_structures_test;
 mod node_test;
 mod save_load_test;
+mod thread_safe_apis_test;
 mod translate_test;
 mod utilities_test;
 

--- a/itest/rust/src/engine_tests/thread_safe_apis_test.rs
+++ b/itest/rust/src/engine_tests/thread_safe_apis_test.rs
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use godot::builtin::{Callable, GString, GodotStringExt, StringName, Variant};
+use godot::global::{
+    PrintLevel, PrintRecord, godot_error, godot_print, godot_print_rich, godot_warn, print_custom,
+};
+
+use crate::framework::{itest, quick_thread};
+
+// The print group is thread-safe (see per-backend C++ rationale in `godot-core/src/global/print.rs`).
+// Tests only whether these functions don't panic (i.e. no is-main-thread validation).
+#[itest]
+fn thread_safe_apis_print() {
+    quick_thread(|| {
+        godot_print!("Info.");
+        godot_error!("Problem.");
+        godot_warn!("Caution.");
+        godot_print_rich!("Rich info.");
+
+        print_custom(PrintRecord {
+            level: PrintLevel::Info,
+            message: "Custom info.",
+            rationale: None,
+            source: None,
+            editor_notify: false,
+        });
+    })
+}
+
+#[itest]
+fn thread_safe_apis_gstring() {
+    // Test various operations: constructor, default, clone, drop, !=, <
+    let a = "Abc".to_gstring();
+    quick_thread(move || {
+        let b = "Abd".to_gstring();
+        let a = a.clone();
+        assert_eq!(a, "Abc");
+        assert_ne!(a, b);
+        assert_ne!(a, GString::default());
+        assert!(a < b);
+    })
+}
+
+#[itest]
+fn thread_safe_apis_string_name() {
+    let a = "Abc".to_string_name();
+    quick_thread(move || {
+        let b = "Abd".to_string_name();
+        let a = a.clone();
+        assert_eq!(a, "Abc");
+        assert_ne!(a, b);
+        assert_ne!(a, StringName::default());
+    })
+}
+
+// TODO(v0.6): Variant lifecycle stays on the main thread because a Variant can hold a reference type (Object), so dropping it from a worker thread
+// is not yet sound. Re-enable once the value-type cases can opt into thread-safe access.
+#[itest(skip)]
+fn thread_safe_apis_variant() {
+    quick_thread(|| {
+        // Make sure it's not a Copy/POD Variant that can be initialized Rust-side only.
+        let _v = Variant::from("hello");
+    })
+}
+
+#[itest(skip)]
+fn thread_safe_apis_callable() {
+    quick_thread(|| {
+        let _c = Callable::from_fn("on other thread", |_args| {});
+    })
+}
+
+// More to add:
+// * Array, Dict, Packed*Array
+// * Callable (from_sync_fn currently needs exp-threads, should from_fn be allowed as long as not Send?)


### PR DESCRIPTION
Moves some utility and lifecycle functions (like conversion constructors) into separate thread-safe method tables, which are no longer gated by an `is_main_thread` assertion.

This is, along with #1524, a first step toward bringing thread safety to the core library **without `experimental-threads` and its unsoundness**. Currently limited to a small part of the API -- the following functions and macros are now thread-safe:
- all `global::print*`
- `global::print_error`
- `global::str`
- `godot_print!`
- `godot_print_rich!`
- `godot_warn!`
- `godot_error!`
- `godot_str!`
- `GString`, `StringName`: `default()`, constructors, `clone()`, `drop()`, `==`, `<`
