### PR TITLE
Type-safe RPCs: align with signal impl, fix registration bug

### DIFF
--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -20,7 +20,7 @@ use crate::meta::{
 };
 use crate::obj::{
     Bounds, DynGd, GdDerefTarget, GdMut, GdRef, GodotClass, Inherits, InstanceId, OnEditor, RawGd,
-    WithBaseField, WithSignals, bounds, cap,
+    WithBaseField, WithSignals, WithUserRpcs, bounds, cap,
 };
 use crate::private::{PanicPayload, callbacks};
 use crate::registry::class::try_dynify_object;
@@ -1069,6 +1069,22 @@ where
     /// [`WithUserSignals::signals()`]: crate::obj::WithUserSignals::signals()
     pub fn signals(&self) -> T::SignalCollection<'_, T> {
         T::__signals_from_external(self)
+    }
+}
+
+impl<T> Gd<T>
+where
+    T: WithUserRpcs,
+{
+    /// Access type-safe RPCs of this object.
+    ///
+    /// For classes that have at least one `#[rpc]` defined, returns a collection with one method per RPC, allowing them to be called in a
+    /// type-safe way. This method is the equivalent of [`WithUserRpcs::rpcs()`][crate::obj::WithUserRpcs::rpcs], but when called externally
+    /// (not from `self`).
+    ///
+    /// When you are within the `impl` of a class, use `self.rpcs()` directly instead.
+    pub fn rpcs(&self) -> T::RpcCollection<'_> {
+        T::__rpcs_from_external(self)
     }
 }
 

--- a/godot-core/src/obj/rpc/builder.rs
+++ b/godot-core/src/obj/rpc/builder.rs
@@ -8,11 +8,14 @@
 use crate::builtin::Variant;
 use crate::r#gen::classes::Node;
 use crate::meta::error::RpcError;
-use crate::obj::rpc::{GodotClass, UserRpcObject};
-use crate::obj::{Inherits, WithBaseField};
+use crate::obj::rpc::UserRpcObject;
+use crate::obj::{GodotClass, Inherits, WithBaseField};
 
-/// Represents an RPC, and the object that it can be called on, and is usually obtained through the type-safe RPC API. See
-/// the [relevant section]() in the book for more information about type-safe RPC calls.
+/// Pending type-safe RPC call, holding the target object, RPC name and arguments until the call is dispatched.
+///
+/// You generally do not construct this directly. It is returned by the per-RPC methods on the collection from
+/// [`WithUserRpcs::rpcs()`][crate::obj::WithUserRpcs::rpcs] (or [`Gd::rpcs()`][crate::obj::Gd::rpcs]). Finalize the call with
+/// [`call()`][Self::call] to broadcast, or [`call_id()`][Self::call_id] to target a specific peer.
 pub struct RpcBuilder<'c, C: GodotClass> {
     object: UserRpcObject<'c, C>,
     rpc_name: &'c str,

--- a/godot-core/src/obj/rpc/mod.rs
+++ b/godot-core/src/obj/rpc/mod.rs
@@ -6,18 +6,16 @@
  */
 
 pub use builder::*;
-pub use rpc_object::*;
-
-use crate::obj::GodotClass;
 
 mod builder;
 mod rpc_object;
 
-/// Represents a collection of RPCs that can be constructed with a [`UserRpcObject`].
-pub trait RpcCollection<'c, C>
-where
-    C: GodotClass,
-{
-    #[doc(hidden)]
-    fn from_user_rpc_object(object: UserRpcObject<'c, C>) -> Self;
+// `UserRpcObject` is plumbing for macro-generated code, never named by users; kept off the public path. Used internally via the crate path,
+// and by macro expansion through the `godot::private` bridge below. Mirrors `signal::priv_re_export`.
+pub(crate) use rpc_object::UserRpcObject;
+
+// Bridge for `godot::private` (proc-macro internals).
+#[doc(hidden)]
+pub mod priv_re_export {
+    pub use super::rpc_object::UserRpcObject;
 }

--- a/godot-core/src/obj/rpc/rpc_object.rs
+++ b/godot-core/src/obj/rpc/rpc_object.rs
@@ -28,7 +28,6 @@ where
 {
     /// Consumes [`Self`], calling the RPC with the provided arguments.
     pub fn call_rpc(self, name: &str, args: &[Variant]) -> Result<(), RpcError> {
-        // `C: Inherits<Node>` guarantees the upcast is infallible.
         let error = match self {
             UserRpcObject::Internal(self_mut) => self_mut.to_gd().upcast::<Node>().rpc(name, args),
             UserRpcObject::External(mut gd) => gd.upcast_mut::<Node>().rpc(name, args),
@@ -43,7 +42,6 @@ where
 
     /// Consumes [`Self`], calling the RPC by a specific ID with the provided arguments.
     pub fn call_rpc_id(self, name: &str, id: i64, args: &[Variant]) -> Result<(), RpcError> {
-        // `C: Inherits<Node>` guarantees the upcast is infallible.
         let error = match self {
             UserRpcObject::Internal(self_mut) => {
                 self_mut.to_gd().upcast::<Node>().rpc_id(id, name, args)

--- a/godot-core/src/obj/rpc/rpc_object.rs
+++ b/godot-core/src/obj/rpc/rpc_object.rs
@@ -7,17 +7,18 @@
 
 use crate::builtin::Variant;
 use crate::r#gen::classes::Node;
-use crate::r#gen::virtuals::RefCounted::Gd;
 use crate::meta::error::RpcError;
-use crate::obj::{GodotClass, Inherits, WithBaseField};
+use crate::obj::{Gd, GodotClass, Inherits, WithBaseField};
 
-/// Represents an object that RPCs can be called on.
+/// The object a type-safe RPC is dispatched on, abstracting over the two ways RPCs are accessed: borrowed `&mut self` from within the class
+/// ([`Internal`][Self::Internal]), or a `Gd` pointer from the outside ([`External`][Self::External]). Both converge on the same dispatch.
 ///
-/// You generally do not need to create this manually, rather it used internally by the type-safe RPC API.
+/// You do not construct this manually; it is held by an [`RpcBuilder`] created through the type-safe RPC API.
+#[doc(hidden)]
 pub enum UserRpcObject<'c, C: GodotClass> {
-    /// Used in [`Self::call_rpc`] and [`Self::call_rpc_id`] to access the base class and call an RPC.
+    /// Borrowed access from within the class, via `self.rpcs()`.
     Internal(&'c mut C),
-    /// RPCs are called on this object directly in [`Self::call_rpc`] and [`Self::call_rpc_id`].
+    /// External access via `gd.rpcs()`, holding the `Gd` pointer directly.
     External(Gd<C>),
 }
 
@@ -27,13 +28,9 @@ where
 {
     /// Consumes [`Self`], calling the RPC with the provided arguments.
     pub fn call_rpc(self, name: &str, args: &[Variant]) -> Result<(), RpcError> {
+        // `C: Inherits<Node>` guarantees the upcast is infallible.
         let error = match self {
-            UserRpcObject::Internal(self_mut) => self_mut
-                .base_mut()
-                .clone()
-                .owned_cast::<Node>()
-                .expect("This is a bug, please report it.")
-                .rpc(name, args),
+            UserRpcObject::Internal(self_mut) => self_mut.to_gd().upcast::<Node>().rpc(name, args),
             UserRpcObject::External(mut gd) => gd.upcast_mut::<Node>().rpc(name, args),
         };
 
@@ -46,13 +43,11 @@ where
 
     /// Consumes [`Self`], calling the RPC by a specific ID with the provided arguments.
     pub fn call_rpc_id(self, name: &str, id: i64, args: &[Variant]) -> Result<(), RpcError> {
+        // `C: Inherits<Node>` guarantees the upcast is infallible.
         let error = match self {
-            UserRpcObject::Internal(self_mut) => self_mut
-                .base_mut()
-                .clone()
-                .owned_cast::<Node>()
-                .expect("This is a bug, please report it.")
-                .rpc_id(id, name, args),
+            UserRpcObject::Internal(self_mut) => {
+                self_mut.to_gd().upcast::<Node>().rpc_id(id, name, args)
+            }
             UserRpcObject::External(mut gd) => gd.upcast_mut::<Node>().rpc_id(id, name, args),
         };
 

--- a/godot-core/src/obj/traits.rs
+++ b/godot-core/src/obj/traits.rs
@@ -12,7 +12,6 @@ use crate::builtin::GString;
 use crate::init::InitLevel;
 use crate::meta::ClassId;
 use crate::meta::inspect::EnumConstant;
-use crate::obj::rpc::{RpcCollection, UserRpcObject};
 use crate::obj::{Base, BaseMut, BaseRef, BorrowedGd, Bounds, Gd, bounds};
 use crate::signal::SignalObject;
 use crate::storage::Storage;
@@ -630,22 +629,25 @@ pub trait WithUserSignals: WithSignals + WithBaseField {
     fn signals(&mut self) -> Self::SignalCollection<'_, Self>;
 }
 
-/// Represents an object, generally a node, that can provide a [collection](RpcCollection) of RPCs available on this object.
+/// Implemented for user-defined classes with at least one `#[rpc]` declaration.
 ///
-/// Implemented by default for classes that inherit [`Node`](crate::classes::Node) and contain at least one `#[rpc]`.
-pub trait WithUserRpcs<'c, C>
-where
-    C: GodotClass,
-{
-    type Collection: RpcCollection<'c, C>;
+/// Allows accessing type-safe RPCs from within the class, as `self.rpcs()`. This requires a `Base<T>` field and a `Node`-derived class.
+/// To access RPCs from outside (given a `Gd` pointer), use [`Gd::rpcs()`] instead.
+// `Inherits<Node>` supertrait makes the up-casting to `Node` in the RPC implementation possible, and avoids repeating the bound in
+// generic user code. There is no scenario where user-defined RPCs can be used if the class isn't `Node`-based.
+pub trait WithUserRpcs: WithBaseField + Inherits<crate::classes::Node> {
+    /// The associated struct listing all RPCs of this class.
+    ///
+    /// `'c` denotes the lifetime during which the class instance is borrowed and its RPCs can be called.
+    type RpcCollection<'c>;
 
-    /// Returns [`Self::Collection`], which generally holds a reference to [`Self`].
-    /// Refer to the [chapter about RPCs]() in the book for more information.
+    /// Access type-safe RPCs of the current object `self`.
+    ///
+    /// For classes that have at least one `#[rpc]` defined, returns a collection with one method per RPC. If you need to access RPCs from
+    /// outside (given a `Gd` pointer), use [`Gd::rpcs()`] instead.
     ///
     /// # Provided API
-    ///
-    /// The returned collection provides an API for calling all defined RPCs.
-    ///
+    /// The returned collection provides a method for each RPC, with the same name as the corresponding `#[rpc]`.  \
     /// For example, the following RPC:
     ///
     /// ```ignore
@@ -661,19 +663,13 @@ where
     /// my_node.rpcs().say_hello_to("world".to_string()).call();
     /// my_node.rpcs().say_hello_to("world".to_string()).call_id(1); // call RPC on specific peer
     /// ```
-    fn rpcs(&'c mut self) -> Self::Collection;
-}
+    fn rpcs(&mut self) -> Self::RpcCollection<'_>;
 
-impl<'c, C> WithUserRpcs<'c, C> for Gd<C>
-where
-    C: Inherits<crate::classes::Node> + WithUserRpcs<'c, C>,
-{
-    type Collection = <C as WithUserRpcs<'c, C>>::Collection;
-
-    /// Returns `Self::Collection`, which generally holds a [`Gd`] pointer to [`Self`].
-    fn rpcs(&'c mut self) -> Self::Collection {
-        Self::Collection::from_user_rpc_object(UserRpcObject::External(self.clone()))
-    }
+    /// Create from existing `Gd`, to enable [`Gd::rpcs()`].
+    ///
+    /// Only used for constructing from a concrete class, so `C = Self`. Takes by reference to retain the lifetime chain.
+    #[doc(hidden)]
+    fn __rpcs_from_external(external: &Gd<Self>) -> Self::RpcCollection<'_>;
 }
 
 /// Extension trait for all reference-counted classes.

--- a/godot-core/src/obj/traits.rs
+++ b/godot-core/src/obj/traits.rs
@@ -605,7 +605,6 @@ pub trait WithUserSignals: WithSignals + WithBaseField {
     /// walkthrough.
     ///
     /// # Provided API
-    ///
     /// The returned collection provides a method for each signal, with the same name as the corresponding `#[signal]`.  \
     /// For example, if you have...
     /// ```ignore

--- a/godot-core/src/private.rs
+++ b/godot-core/src/private.rs
@@ -29,6 +29,7 @@ mod reexport_pub {
     pub use crate::meta::private_reexport::*;
     #[cfg(feature = "trace")]
     pub use crate::meta::{CowArg, FfiArg, trace};
+    pub use crate::obj::rpc::priv_re_export::*;
     pub use crate::obj::rtti::ObjectRtti;
     pub use crate::registry::callbacks;
     pub use crate::registry::shard::{

--- a/godot-core/src/signal/signal_object.rs
+++ b/godot-core/src/signal/signal_object.rs
@@ -38,24 +38,6 @@ pub enum UserSignalObject<'c, C> {
     External { gd: Gd<Object> },
 }
 
-impl<'c, C> UserSignalObject<'c, C>
-where
-    // 2nd bound necessary, so generics match for TypedSignal construction.
-    C: WithUserSignals + WithSignals<__SignalObj<'c> = UserSignalObject<'c, C>>,
-{
-    #[inline]
-    pub fn from_external(object: Gd<C>) -> Self {
-        Self::External {
-            gd: object.upcast(),
-        }
-    }
-
-    #[inline]
-    pub fn from_internal(self_mut: &'c mut C) -> Self {
-        Self::Internal { self_mut }
-    }
-}
-
 impl<'c, C: WithUserSignals> SignalObject<'c> for UserSignalObject<'c, C> {
     #[inline]
     fn with_object_mut(&mut self, f: impl FnOnce(&mut Object)) {

--- a/godot-macros/src/class/data_models/interface_trait_impl.rs
+++ b/godot-macros/src/class/data_models/interface_trait_impl.rs
@@ -588,7 +588,7 @@ impl<'a> InterfaceBuilder<'a> {
 /// `#[godot_api]` has currently no way of checking base class at macro-resolve time, so the `_ready` branch is unconditionally
 /// added, even for classes that don't inherit from `Node`. As a best-effort, we exclude some very common non-Node classes explicitly, to
 /// generate less useless code.
-fn is_possibly_node_class(trait_base_class: &Ident) -> bool {
+pub(crate) fn is_possibly_node_class(trait_base_class: &Ident) -> bool {
     !matches!(
         trait_base_class.to_string().as_str(), //.
         "Object"

--- a/godot-macros/src/class/data_models/rpc.rs
+++ b/godot-macros/src/class/data_models/rpc.rs
@@ -183,7 +183,9 @@ fn make_rpc_registration(func_def: &FuncDefinition) -> Option<TokenStream> {
     Some(registration)
 }
 
-// TODO: respect function visibility when generating builders
+// TODO(v0.7): cap per-RPC methods at the actual #[rpc] fn visibility instead of `pub(crate)`. Consider reusing `SignalVisibility` from
+// `signal.rs`; requires threading the fn's `vis_marker` into `FuncDefinition`. The collection struct must remain `pub` (it's the return
+// type of public `Gd::rpcs()`), only the generated methods are affected.
 pub fn make_rpc_api(class_name: &Ident, rpcs: Vec<&FuncDefinition>) -> Option<TokenStream> {
     if rpcs.is_empty() {
         return None;
@@ -206,8 +208,10 @@ pub fn make_rpc_api(class_name: &Ident, rpcs: Vec<&FuncDefinition>) -> Option<To
             });
 
         collection_impl_methods.append_all(quote! {
+            // `pub(crate)`, not `pub`: these are invoked through `.rpcs()` within the declaring crate, so crate visibility suffices. Keeping
+            // them out of `pub` avoids leaking one method per `#[rpc]` into the user's public API surface and downstream crates.
             #[must_use]
-            pub fn #rust_name(self, #( #rpc_typed_args ),*) -> RpcBuilder<'c, #class_name> {
+            pub(crate) fn #rust_name(self, #( #rpc_typed_args ),*) -> RpcBuilder<'c, #class_name> {
                 RpcBuilder::new(
                     self.object,
                     #rpc_name,
@@ -224,7 +228,8 @@ pub fn make_rpc_api(class_name: &Ident, rpcs: Vec<&FuncDefinition>) -> Option<To
         #[allow(non_camel_case_types)]
         mod #rpc_mod {
             use super::*;
-            use ::godot::obj::rpc::{RpcCollection, UserRpcObject, RpcBuilder};
+            use ::godot::obj::rpc::RpcBuilder;
+            use ::godot::private::UserRpcObject;
 
             #[doc(hidden)]
             pub struct #collection_name<'c> {
@@ -235,24 +240,20 @@ pub fn make_rpc_api(class_name: &Ident, rpcs: Vec<&FuncDefinition>) -> Option<To
                 #collection_impl_methods
             }
 
-            impl<'c> RpcCollection<'c, #class_name> for #collection_name<'c> {
-                fn from_user_rpc_object(object: UserRpcObject<'c, #class_name>) -> Self {
+            impl ::godot::obj::WithUserRpcs for #class_name {
+                type RpcCollection<'c> = #collection_name<'c>;
+
+                fn rpcs(&mut self) -> Self::RpcCollection<'_> {
                     #collection_name {
-                        object,
+                        object: UserRpcObject::Internal(self),
                     }
                 }
-            }
 
-            impl<'c> ::godot::obj::WithUserRpcs<'c, #class_name> for #class_name
-            where
-                #class_name: ::godot::obj::WithBaseField,
-            {
-                type Collection = #collection_name<'c>;
-
-                fn rpcs(&'c mut self) -> Self::Collection {
-                    Self::Collection::from_user_rpc_object(
-                        UserRpcObject::Internal(self)
-                    )
+                #[doc(hidden)]
+                fn __rpcs_from_external(external: & ::godot::obj::Gd<Self>) -> Self::RpcCollection<'_> {
+                    #collection_name {
+                        object: UserRpcObject::External(external.clone()),
+                    }
                 }
             }
         }

--- a/godot-macros/src/class/derive_godot_class.rs
+++ b/godot-macros/src/class/derive_godot_class.rs
@@ -510,7 +510,14 @@ fn make_user_class_impl(
     let onready_inits = make_onready_init(all_fields);
     let oneditor_panic_inits = make_oneditor_panic_inits(class_name, all_fields);
 
-    let run_before_ready = !onready_inits.is_empty() || !oneditor_panic_inits.is_empty();
+    // `#[rpc]` methods register inside `__before_ready()`, which only runs if a `_ready` virtual is installed. The derive-macro can't see the
+    // `#[godot_api]` block to know whether RPCs exist, so install `_ready` for any possible-`Node` class (no-op if there are none). This mirrors
+    // the `I*` path, which also adds `_ready` unconditionally. Only under `codegen-full`, where RPCs are actually registered with Godot.
+    let needs_rpc_registration =
+        cfg!(feature = "codegen-full") && crate::class::is_possibly_node_class(trait_base_class);
+
+    let run_before_ready =
+        !onready_inits.is_empty() || !oneditor_panic_inits.is_empty() || needs_rpc_registration;
 
     let default_virtual_fn = if run_before_ready {
         let tool_check = util::make_virtual_tool_check();

--- a/itest/rust/src/builtin_tests/containers/rpc_test.rs
+++ b/itest/rust/src/builtin_tests/containers/rpc_test.rs
@@ -9,11 +9,21 @@ use godot::meta::error::RpcError;
 use godot::prelude::*;
 use godot::test::itest;
 
+#[cfg(feature = "codegen-full")]
 use crate::framework::TestContext;
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// Class under test
 
 #[derive(GodotClass)]
 #[class(init, base = Node)]
 pub struct RpcCallableNode {
+    /// How many times a `call_local` RPC body has executed on this object.
+    call_count: usize,
+    /// Last value received by [`rpc_local_with_arg`][Self::rpc_local_with_arg]; checks POD argument roundtrip.
+    last_arg: i32,
+    /// Last string received by [`rpc_local_with_string`][Self::rpc_local_with_string]; checks heap-allocated argument roundtrip.
+    last_text: GString,
     base: Base<Node>,
 }
 
@@ -22,87 +32,123 @@ impl INode for RpcCallableNode {}
 
 #[godot_api]
 impl RpcCallableNode {
+    /// No `call_local` -- Godot rejects targeting own peer ID with this RPC.
     #[rpc]
-    pub fn say_hello_world(&mut self) {
-        godot_print!("hello, world");
+    pub fn rpc_remote_only(&mut self) {
+        self.call_count += 1;
     }
 
+    /// With `call_local` -- body executes locally when targeting own peer ID.
     #[rpc(call_local)]
-    pub fn say_hello_world_everywhere(&mut self) {
-        godot_print!("hello, world");
+    pub fn rpc_local_also(&mut self) {
+        self.call_count += 1;
     }
 
-    #[rpc]
-    pub fn say_hello_to(&mut self, to: String) {
-        godot_print!("hello, {to}");
+    /// `call_local` with a POD argument -- verifies `i32` roundtrip through Variant serialization.
+    #[rpc(call_local)]
+    pub fn rpc_local_with_arg(&mut self, value: i32) {
+        self.call_count += 1;
+        self.last_arg = value;
     }
 
-    #[rpc]
-    pub fn say_number(&self, number: i32) {
-        godot_print!("{number}");
+    /// `call_local` with a heap-allocated argument -- verifies `GString` roundtrip through Variant serialization.
+    #[rpc(call_local)]
+    pub fn rpc_local_with_string(&mut self, text: GString) {
+        self.call_count += 1;
+        self.last_text = text;
     }
 
+    /// Verifies that a function renamed via `#[func(rename = ...)]` is still reachable by its Rust name.
     #[rpc]
     #[func(rename = renamed_rpc_function)]
     pub fn rpc_function(&self) {}
 }
 
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// Tests
+
+/// Both the External path (`Gd::rpcs()`) and Internal path (`self.rpcs()`) must return `Unconfigured`
+/// before the node is part of a scene tree with a resolvable `MultiplayerApi`.
 #[itest]
-fn type_safe_rpc_test(context: &TestContext) {
-    // This peer id doesn't, or at least shouldn't, exist.
-    const NON_EXISTENT_ID: i64 = 100000;
-
+fn rpc_unconfigured_before_tree() {
     let mut node = RpcCallableNode::new_alloc();
+    const PEER_ID: i64 = 100_000;
 
-    let mut root = context.scene_tree.clone();
-
-    // Before we add the node to the tree, RPCs will fail.
+    // External path: call() and call_id() both fail.
     assert_eq!(
-        Err(RpcError::Unconfigured),
-        node.bind_mut().rpcs().say_hello_world().call()
+        node.rpcs().rpc_local_also().call(),
+        Err(RpcError::Unconfigured)
     );
-    // We'll still fail with `Unconfigured` here even if the ID passed here doesn't belong to an existing node.
     assert_eq!(
-        Err(RpcError::Unconfigured),
-        node.bind_mut()
-            .rpcs()
-            .say_hello_world()
-            .call_id(NON_EXISTENT_ID)
+        node.rpcs().rpc_local_also().call_id(PEER_ID),
+        Err(RpcError::Unconfigured)
     );
 
-    root.add_child(&node);
+    // Internal path: same failures, different code path.
+    assert_eq!(
+        node.bind_mut().rpcs().rpc_local_also().call(),
+        Err(RpcError::Unconfigured)
+    );
+    assert_eq!(
+        node.bind_mut().rpcs().rpc_local_also().call_id(PEER_ID),
+        Err(RpcError::Unconfigured)
+    );
 
-    #[cfg(feature = "codegen-full")]
-    {
-        assert_eq!(Ok(()), node.rpcs().say_hello_world().call());
+    node.free();
+}
 
-        let arg = "godot".to_string();
-        assert_eq!(Ok(()), node.rpcs().say_hello_to(arg.clone()).call());
-        assert_eq!(Ok(()), node.bind_mut().rpcs().say_hello_to(arg).call());
-        assert_eq!(Ok(()), node.rpcs().say_number(3).call());
+/// Verifies the `call_local` flag controls whether the local body runs when targeting own peer ID, that POD and
+/// heap-allocated arguments survive the Variant roundtrip, and that both External and Internal entry points dispatch.
+///
+/// A `call_local` body runs synchronously during `call_id()` and mutates `self` through the dispatcher's `&mut self`,
+/// which also proves the `GdCell` is writeable from inside an External-path callback.
+///
+/// Requires `codegen-full` because RPC registration (`Node::rpc_config`) is only wired up under that feature.
+#[cfg(feature = "codegen-full")]
+#[itest]
+fn rpc_call_local_side_effects(context: &TestContext) {
+    let mut node = RpcCallableNode::new_alloc();
+    context.scene_tree.clone().add_child(&node);
+    let own_id = node
+        .get_multiplayer()
+        .expect("multiplayer should exist")
+        .get_unique_id() as i64;
 
-        // Calling the renamed function should work.
-        assert_eq!(Ok(()), node.rpcs().rpc_function().call());
+    // Without call_local, targeting own peer ID is rejected by Godot; body does not execute.
+    assert_eq!(
+        node.rpcs().rpc_remote_only().call_id(own_id),
+        Err(RpcError::InvalidArguments)
+    );
+    assert_eq!(node.bind().call_count, 0);
 
-        // Even though the node with the ID doesn't exist, godot will still report the RPC as a success.
-        assert_eq!(Ok(()), node.rpcs().say_number(5).call_id(NON_EXISTENT_ID));
+    // With call_local, targeting own peer ID succeeds and the body runs synchronously, mutating self.
+    assert_eq!(node.rpcs().rpc_local_also().call_id(own_id), Ok(()));
+    assert_eq!(node.bind().call_count, 1);
 
-        // Gets the peer ID for this node.
-        let node_id = node
-            .get_multiplayer()
-            .expect("Multiplayer should exist")
-            .get_unique_id() as i64;
-        // The `say_hello_world` RPC does not define `call_local` meaning it will error when called upon itself.
-        assert_eq!(
-            Err(RpcError::InvalidArguments),
-            node.rpcs().say_hello_world().call_id(node_id)
-        );
-        // The `say_hello_world_everywhere` RPC does define `call_local` so it won't error when called upon itself.
-        assert_eq!(
-            Ok(()),
-            node.rpcs().say_hello_world_everywhere().call_id(node_id)
-        );
-    }
-    root.remove_child(&node);
+    // POD argument roundtrip through Variant serialization.
+    assert_eq!(node.rpcs().rpc_local_with_arg(42).call_id(own_id), Ok(()));
+    assert_eq!(node.bind().call_count, 2);
+    assert_eq!(node.bind().last_arg, 42);
+
+    // Heap-allocated argument roundtrip through Variant serialization.
+    assert_eq!(
+        node.rpcs().rpc_local_with_string("godot").call_id(own_id),
+        Ok(())
+    );
+    assert_eq!(node.bind().call_count, 3);
+    assert_eq!(node.bind().last_text.to_string(), "godot");
+
+    // Internal path (`self.rpcs()` via bind_mut): a non-`call_local` broadcast does not execute locally, so dispatching
+    // while `bind_mut()` is held does not re-enter the GdCell. Returns Ok without running the body (count unchanged).
+    assert_eq!(node.bind_mut().rpcs().rpc_remote_only().call(), Ok(()));
+    assert_eq!(node.bind().call_count, 3);
+
+    // Renamed function is reachable by its Rust name.
+    assert_eq!(node.rpcs().rpc_function().call(), Ok(()));
+
+    // Godot does not validate peer existence at dispatch time; non-existent peer ID returns Ok.
+    assert_eq!(node.rpcs().rpc_local_also().call_id(100_000), Ok(()));
+
+    context.scene_tree.clone().remove_child(&node);
     node.free();
 }

--- a/itest/rust/src/register_tests/rpc_test.rs
+++ b/itest/rust/src/register_tests/rpc_test.rs
@@ -84,13 +84,16 @@ impl RpcTest {
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Tests
 
-// There's no way to check if the method was registered as an RPC.
-// We could set up a multiplayer environment to test this in practice, but that would be a lot of work.
+/// Verifies that a class with many `#[rpc]` attribute variants can be added to a tree without panicking.
+/// RPC registration runs inside `__before_ready()` and requires a `MultiplayerApi` to be present.
+///
+/// Unlike `RpcCallableNode` (in `builtin_tests::containers::rpc_test`), `RpcTest` has no `impl INode` block and no `OnReady` fields, so the
+/// derive-macro's default `_ready` is the only thing that can trigger registration -- this is the regression test for that path. Dispatch
+/// behavior itself (`call_local`, argument roundtrips) is covered there; here we only assert that registration happened at all.
 #[itest]
-fn node_enters_tree() {
+fn rpc_registration_all_attr_variants() {
     let node = RpcTest::new_alloc();
 
-    // Registering is done in `UserClass::__before_ready()`, and it requires a multiplayer API to exist.
     let mut scene_tree = Engine::singleton()
         .get_main_loop()
         .unwrap()
@@ -102,6 +105,19 @@ fn node_enters_tree() {
     #[cfg(before_api = "4.7")]
     let mut root = scene_tree.get_root().unwrap();
     root.add_child(&node);
+
+    #[cfg(feature = "codegen-full")]
+    {
+        let own_id = node
+            .get_multiplayer()
+            .expect("multiplayer should exist")
+            .get_unique_id() as i64;
+
+        // `arg_call_local` has `call_local = true`, so targeting own peer ID succeeds -- but only if the RPC was actually registered.
+        // Without registration, Godot rejects the call with `InvalidArguments`, which is what this assertion guards against.
+        assert_eq!(node.rpcs().arg_call_local().call_id(own_id), Ok(()));
+    }
+
     root.remove_child(&node);
     node.free();
 }


### PR DESCRIPTION
Follow-up to #1535.


### Consistent trait APIs: `WithUserRpcs` <-> `WithUserSignals`

Calling RPCs from outside a class now works through an inherent `Gd::rpcs()` method, mirroring how `Gd::signals()` already works. Inside a class you keep using `self.rpcs()`. The access shape is more consistent with the signals way, and the call itself is unchanged:

```rs
my_node.rpcs().say_hello_to("world").call();      // broadcast
my_node.rpcs().say_hello_to("world").call_id(1);  // to a specific peer
```


### Fixed: some RPCs were never registered

If a class declared `#[rpc]` methods but had no on-ready fields and didn't override `ready()`, its RPCs were silently never registered with Godot, and calling them failed at runtime with an error like "Unable to get the RPC configuration for the function ...". This was easy to hit with a class that only contains RPCs. Such classes now register correctly, so the calls work as expected -- no changes needed on your side.
