### PR TITLE
Fix memory leak for `connect_self()` on `RefCounted`

### DIFF
--- a/godot-core/src/builtin/callable.rs
+++ b/godot-core/src/builtin/callable.rs
@@ -311,15 +311,17 @@ impl Callable {
         let name = name.into();
 
         let wrapper = FnWrapper {
+            meta: FnWrapperHeader {
+                name,
+                name_cached: OnceLock::new(),
+                #[cfg(safeguards_balanced)]
+                thread_id: _thread_id,
+                linked_object_id,
+            },
             rust_function,
-            name,
-            name_cached: OnceLock::new(),
-            #[cfg(safeguards_balanced)]
-            thread_id: _thread_id,
-            linked_object_id,
         };
 
-        let object_id = wrapper.linked_object_id();
+        let object_id = wrapper.meta.linked_object_id();
         let userdata = CallableUserdata::new(wrapper);
 
         let info = CallableCustomInfo {
@@ -327,7 +329,7 @@ impl Callable {
             callable_userdata: Box::into_raw(Box::new(userdata)) as *mut std::ffi::c_void,
             call_func: Some(rust_callable_call_fn::<F, R>),
             free_func: Some(rust_callable_destroy::<FnWrapper<F>>),
-            to_string_func: Some(rust_callable_to_string_named::<F>),
+            to_string_func: Some(rust_callable_to_string_named),
             is_valid_func: Some(rust_callable_is_valid),
             ..Self::default_callable_custom_info()
         };
@@ -600,6 +602,8 @@ mod custom_callable {
     use super::*;
     use crate::builtin::GString;
 
+    // repr(transparent), so that for T = FnWrapper<F>, the userdata pointer can be read as `FnWrapperHeader` (see there).
+    #[repr(transparent)]
     pub struct CallableUserdata<T> {
         pub inner: T,
     }
@@ -618,9 +622,12 @@ mod custom_callable {
         }
     }
 
-    pub(crate) struct FnWrapper<F> {
-        pub(super) rust_function: F,
-
+    /// Non-generic part of [`FnWrapper`], must remain its first field.
+    ///
+    /// Since `FnWrapper` is `repr(C)` and `CallableUserdata` is `repr(transparent)`, this struct sits at offset 0 of the userdata pointer,
+    /// regardless of `F`. FFI functions that only need metadata ([`rust_callable_is_valid`], [`rust_callable_to_string_named`]) can thus
+    /// remain non-generic, avoiding one monomorphized function per closure type.
+    pub(crate) struct FnWrapperHeader {
         /// Stored as `Cow<'static, str>` to optimize the hot path (callable invocation, needing call context), vs. cold path (`to_string`).
         pub(super) name: CowStr,
 
@@ -628,7 +635,7 @@ mod custom_callable {
         /// `Sync`. Could be split into separate single/multi-threaded locks, but atomic overhead of `OnceLock` is good enough for now.
         pub(super) name_cached: OnceLock<GString>,
 
-        /// `None` if the callable is multi-threaded ([`Callable::from_sync_fn`]).       
+        /// `None` if the callable is multi-threaded ([`Callable::from_sync_fn`]).
         #[cfg(safeguards_balanced)]
         pub(super) thread_id: Option<std::thread::ThreadId>,
 
@@ -636,10 +643,26 @@ mod custom_callable {
         pub(super) linked_object_id: Option<InstanceId>,
     }
 
-    impl<F> FnWrapper<F> {
+    impl FnWrapperHeader {
+        /// # Safety
+        /// `void_ptr` must be a valid pointer to a `CallableUserdata<FnWrapper<F>>`, for an arbitrary `F`.
+        unsafe fn from_raw<'a>(void_ptr: *mut std::ffi::c_void) -> &'a FnWrapperHeader {
+            // CallableUserdata is repr(transparent) and FnWrapper is repr(C) with `meta` as first field, so all three share offset 0.
+            let ptr = void_ptr as *mut FnWrapperHeader;
+            unsafe { &*ptr }
+        }
+
         pub(crate) fn linked_object_id(&self) -> GDObjectInstanceID {
             self.linked_object_id.map(InstanceId::to_u64).unwrap_or(0)
         }
+    }
+
+    // repr(C), so that `meta` is guaranteed at offset 0, independently of `F`. See FnWrapperHeader.
+    #[repr(C)]
+    pub(crate) struct FnWrapper<F> {
+        /// Must remain the first field, see [`FnWrapperHeader`].
+        pub(super) meta: FnWrapperHeader,
+        pub(super) rust_function: F,
     }
 
     /// Represents a custom callable object defined in Rust.
@@ -722,7 +745,7 @@ mod custom_callable {
             unsafe { Variant::borrow_ref_slice(p_args, p_argument_count as usize) };
 
         let w: &FnWrapper<F> = unsafe { CallableUserdata::inner_from_raw(callable_userdata) };
-        let ctx = meta::CallContext::custom_callable(&w.name);
+        let ctx = meta::CallContext::custom_callable(&w.meta.name);
 
         let err = unsafe { &mut *r_error };
         crate::private::handle_fallible_varcall(&ctx, err, || {
@@ -733,10 +756,10 @@ mod custom_callable {
             // NOTE: this panic is currently not propagated to the caller, but results in an error message and Nil return.
             // See comments in itest callable_call() for details.
             sys::balanced_assert!(
-                w.thread_id.is_none() || w.thread_id == Some(std::thread::current().id()),
+                w.meta.thread_id.is_none() || w.meta.thread_id == Some(std::thread::current().id()),
                 "Callable '{}' created with from_fn() must be called from the same thread it was created in.\n\
                 If you need to call it from any thread, use from_sync_fn() instead (requires `experimental-threads` feature).",
-                w.name
+                w.meta.name
             );
 
             let result = (w.rust_function)(arg_refs).to_variant();
@@ -788,15 +811,17 @@ mod custom_callable {
     }
 
     #[allow(unsafe_op_in_unsafe_fn)] // Pointer validity asserted by Godot.
-    pub unsafe extern "C" fn rust_callable_to_string_named<F>(
+    pub unsafe extern "C" fn rust_callable_to_string_named(
         callable_userdata: *mut std::ffi::c_void,
         r_is_valid: *mut sys::GDExtensionBool,
         r_out: sys::GDExtensionStringPtr,
     ) {
-        let w: &FnWrapper<F> = CallableUserdata::inner_from_raw(callable_userdata);
+        let meta = FnWrapperHeader::from_raw(callable_userdata);
 
         // Use cached GString if available, otherwise create and cache it (rare cold path).
-        let gstring = w.name_cached.get_or_init(|| GString::from(w.name.as_ref()));
+        let gstring = meta
+            .name_cached
+            .get_or_init(|| GString::from(meta.name.as_ref()));
         gstring.clone().move_into_string_ptr(r_out);
         *r_is_valid = sys::conv::SYS_TRUE;
     }

--- a/godot-core/src/builtin/callable.rs
+++ b/godot-core/src/builtin/callable.rs
@@ -837,11 +837,21 @@ mod custom_callable {
     }
 
     // Implementing this is necessary because the default (nullptr) may consider custom callables as invalid in some cases.
+    //
+    // Linked callables (`from_linked_fn()`/`Gd::linked_callable()`, used e.g. by `connect_self()`) capture only the instance ID, so they can
+    // outlive their object. Signal emission and the deferred queue skip dead connections via `CallableCustomInfo::object_id`, but Godot's
+    // `is_valid_func` ignores that field, so a direct `Callable::is_valid()` query (e.g. from GDScript) would lie unless we check liveness here.
+    // Unlinked callables have no object to check, hence always valid.
     pub unsafe extern "C" fn rust_callable_is_valid(
-        _callable_userdata: *mut std::ffi::c_void,
+        callable_userdata: *mut std::ffi::c_void,
     ) -> sys::GDExtensionBool {
-        // If we had an object (CallableCustomInfo::object_id field), we could check whether that object is alive.
-        // But since we just take a Rust function/closure, not knowing what happens inside, we assume always valid.
-        sys::conv::SYS_TRUE
+        let meta = unsafe { FnWrapperHeader::from_raw(callable_userdata) };
+
+        let valid = match meta.linked_object_id {
+            Some(id) => id.lookup_validity(),
+            None => true,
+        };
+
+        sys::conv::bool_to_sys(valid)
     }
 }

--- a/godot-core/src/signal/connect_builder.rs
+++ b/godot-core/src/signal/connect_builder.rs
@@ -184,9 +184,14 @@ impl<C: WithSignals, Ps: InParamTuple + 'static> ConnectBuilder<'_, '_, C, Ps> {
         for<'c_rcv> F: SignalReceiver<&'c_rcv mut C, Ps>,
         for<'c_rcv> IndirectSignalReceiver<'c_rcv, &'c_rcv mut C, Ps, F>: From<&'c_rcv mut F>,
     {
-        let mut gd = self.parent_sig.receiver_object();
+        // Weak capture via instance ID, to avoid a reference cycle keeping RefCounted objects alive. See TypedSignal::connect_self().
+        let instance_id = self.parent_sig.receiver_object().instance_id();
 
         let godot_fn = make_godot_fn(move |args| {
+            let Ok(mut gd) = Gd::<C>::try_from_instance_id(instance_id) else {
+                return;
+            };
+
             let mut guard = Gd::bind_mut(&mut gd);
             IndirectSignalReceiver::from(&mut function)
                 .function()
@@ -210,15 +215,20 @@ impl<C: WithSignals, Ps: InParamTuple + 'static> ConnectBuilder<'_, '_, C, Ps> {
         F: SignalReceiver<Gd<C>, Ps>,
         for<'c_rcv> IndirectSignalReceiver<'c_rcv, Gd<C>, Ps, F>: From<&'c_rcv mut F>,
     {
-        let gd = self.parent_sig.receiver_object();
-        let bound = gd.clone();
+        // Weak capture via instance ID, to avoid a reference cycle keeping RefCounted objects alive. See TypedSignal::connect_self().
+        let instance_id = self.parent_sig.receiver_object().instance_id();
 
         let godot_fn = make_godot_fn(move |args| {
+            let Ok(gd) = Gd::<C>::try_from_instance_id(instance_id) else {
+                return;
+            };
+
             IndirectSignalReceiver::from(&mut function)
                 .function()
-                .call(gd.clone(), args);
+                .call(gd, args);
         });
 
+        let bound = self.parent_sig.receiver_object();
         self.inner_connect_godot_fn::<F>(godot_fn, &bound)
     }
 
@@ -245,6 +255,7 @@ impl<C: WithSignals, Ps: InParamTuple + 'static> ConnectBuilder<'_, '_, C, Ps> {
         for<'c_rcv> F: SignalReceiver<&'c_rcv mut OtherC, Ps>,
         for<'c_rcv> IndirectSignalReceiver<'c_rcv, &'c_rcv mut OtherC, Ps, F>: From<&'c_rcv mut F>,
     {
+        // Strong capture: the connection keeps the receiver alive. Deliberate, see TypedSignal::connect_other().
         let mut gd = object.object_to_owned();
 
         let godot_fn = make_godot_fn(move |args| {
@@ -278,6 +289,7 @@ impl<C: WithSignals, Ps: InParamTuple + 'static> ConnectBuilder<'_, '_, C, Ps> {
         F: SignalReceiver<Gd<OtherC>, Ps>,
         for<'c_rcv> IndirectSignalReceiver<'c_rcv, Gd<OtherC>, Ps, F>: From<&'c_rcv mut F>,
     {
+        // Strong capture: the connection keeps the receiver alive. Deliberate, see TypedSignal::connect_other().
         let gd = object.object_to_owned();
 
         let godot_fn = make_godot_fn(move |args| {

--- a/godot-core/src/signal/typed_signal.rs
+++ b/godot-core/src/signal/typed_signal.rs
@@ -264,6 +264,9 @@ impl<C: WithSignals, Ps: InParamTuple + 'static> TypedSignal<'_, C, Ps> {
 
     /// Connect a method (member function) with `&mut self` as the first parameter.
     ///
+    /// The connection does not keep the object alive: if all other references are dropped, a `RefCounted` object is destroyed and the
+    /// connection is automatically disconnected (same behavior as GDScript method callables).
+    ///
     /// - To connect to methods on other objects, use [`connect_other()`][Self::connect_other].
     /// - If you need [`connect flags`](ConnectFlags) or cross-thread signals, use [`builder()`][Self::builder].
     pub fn connect_self<F, Declarer>(&self, mut function: F) -> ConnectHandle
@@ -272,8 +275,19 @@ impl<C: WithSignals, Ps: InParamTuple + 'static> TypedSignal<'_, C, Ps> {
         for<'c_rcv> IndirectSignalReceiver<'c_rcv, &'c_rcv mut C, Ps, F>: From<&'c_rcv mut F>,
         C: UniformObjectDeref<Declarer>,
     {
-        let mut gd = self.receiver_object();
+        // Weak capture (instance ID, not strong Gd) to avoid a reference cycle: object -> connection -> callable -> closure -> Gd -> object.
+        // Look up the object on each emission, matching Godot method-callable semantics.
+        let instance_id = self.receiver_object().instance_id();
         let godot_fn = make_godot_fn(move |args| {
+            // Lookup is infallible during normal and deferred emission (object alive by construction; dead deferred callables are skipped by
+            // Godot before reaching here). Only fails for a stale Callable clone invoked manually after the object died -> no-op, like Godot.
+            //
+            // Edge case: emission during object destruction (e.g. PREDELETE) -- ObjectDB lookup succeeds, but re-creating a Gd for a RefCounted
+            // at refcount 0 panics in maybe_init_ref(). Pre-existing limitation shared with Gd::from_instance_id().
+            let Ok(mut gd) = Gd::<C>::try_from_instance_id(instance_id) else {
+                return;
+            };
+
             let mut target = C::object_as_mut(&mut gd);
             let target_mut = target.deref_mut();
             IndirectSignalReceiver::from(&mut function)
@@ -293,6 +307,10 @@ impl<C: WithSignals, Ps: InParamTuple + 'static> TypedSignal<'_, C, Ps> {
     ///   [`WithBaseField`][crate::obj::WithBaseField] trait).
     /// ---
     ///
+    /// The connection keeps the receiver `object` alive: a `RefCounted` receiver lives at least as long as the emitter (or until
+    /// disconnected), even if all other references are dropped. Beware of reference cycles: if the receiver in turn stores a strong
+    /// reference back to the emitter, neither object is ever destroyed (memory leak).
+    ///
     /// - To connect to methods on the object that owns this signal, use [`connect_self()`][Self::connect_self].
     /// - If you need [`connect flags`](ConnectFlags) or cross-thread signals, use [`builder()`][Self::builder].
     pub fn connect_other<F, OtherC, Declarer>(
@@ -305,6 +323,9 @@ impl<C: WithSignals, Ps: InParamTuple + 'static> TypedSignal<'_, C, Ps> {
         for<'c_rcv> F: SignalReceiver<&'c_rcv mut OtherC, Ps> + 'static,
         for<'c_rcv> IndirectSignalReceiver<'c_rcv, &'c_rcv mut OtherC, Ps, F>: From<&'c_rcv mut F>,
     {
+        // Strong Gd capture (unlike connect_self), so the connection keeps the receiver alive: fire-and-forget receivers live as long as the
+        // emitter. Weak would silently drop a RefCounted receiver whose last reference falls out of scope after connecting. Diverges from
+        // GDScript (weak there); cost is a leak on receiver<->emitter cycles. connect_self uses weak since receiver == emitter is always such a cycle.
         let mut gd = object.object_to_owned();
 
         let godot_fn = make_godot_fn(move |args| {

--- a/itest/rust/src/builtin_tests/containers/callable_test.rs
+++ b/itest/rust/src/builtin_tests/containers/callable_test.rs
@@ -522,6 +522,22 @@ pub mod custom_callable {
         args.iter().map(|arg| arg.to::<i32>()).sum()
     }
 
+    // A linked callable (`Gd::linked_callable()`, used e.g. by `connect_self()`) captures only the object's instance ID, so it can outlive the
+    // object. Once freed, `is_valid()` must report false. Godot's `is_valid_func` ignores the `object_id` we set, so `rust_callable_is_valid()`
+    // performs the liveness check itself; this is the regression test for it.
+    #[itest]
+    fn callable_linked_invalidated_after_free() {
+        let receiver = godot::classes::Node::new_alloc();
+        let linked = receiver.linked_callable("nop", |_args| {});
+
+        assert!(linked.is_valid());
+        receiver.free();
+        assert!(
+            !linked.is_valid(),
+            "linked callable invalid after freeing its object"
+        );
+    }
+
     #[itest]
     fn callable_custom_invoke() {
         let my_rust_callable = Adder::new(0);

--- a/itest/rust/src/builtin_tests/containers/signal_test.rs
+++ b/itest/rust/src/builtin_tests/containers/signal_test.rs
@@ -571,6 +571,66 @@ fn enums_as_signal_args() {
     object.signals().game_event().emit(event);
 }
 
+#[itest]
+fn signal_engine_no_leak() {
+    let f = RefCounted::new_gd();
+
+    f.signals().script_changed().connect_self(|_this| {});
+}
+
+#[itest]
+fn signal_user_no_leak() {
+    #[derive(GodotClass)]
+    #[class(base = RefCounted, init)]
+    struct RefcountedSignaller {
+        base: Base<RefCounted>,
+    }
+
+    #[godot_api]
+    impl RefcountedSignaller {
+        #[signal]
+        fn game_event();
+    }
+
+    let f = RefcountedSignaller::new_gd();
+
+    // TODO game_event() should be #[must_use].
+    f.signals().game_event().connect_self(|_this| {});
+}
+
+// Ensures that despite the weak capture in connect_self() (instance ID instead of Gd, to avoid leaks), the receiver is still invoked on emit.
+#[itest]
+fn signal_self_weak_connection_invoked() {
+    #[derive(GodotClass)]
+    #[class(base = RefCounted, init)]
+    struct HitCounter {
+        hits: i32,
+        base: Base<RefCounted>,
+    }
+
+    #[godot_api]
+    impl HitCounter {
+        #[signal]
+        fn game_event();
+    }
+
+    let f = HitCounter::new_gd();
+    f.signals().game_event().connect_self(|this| this.hits += 1);
+    f.signals()
+        .game_event()
+        .builder()
+        .connect_self_mut(|this| this.hits += 10);
+    f.signals()
+        .game_event()
+        .builder()
+        .connect_self_gd(|mut this| this.bind_mut().hits += 100);
+
+    f.signals().game_event().emit();
+    f.signals().game_event().emit();
+
+    assert_eq!(f.bind().hits, 222);
+}
+
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Helper types
 


### PR DESCRIPTION
A closure passed to `TypedSignal::connect_self()` (and its variants in the builder) capture a `Gd<T>`. This is fine for manually managed `T`, but for ones inheriting `RefCounted`, it means that the closure keeps the object alive. The object is then never destroyed -> signals not disconnected -> closures not destroyed -> reference cycle -> memory leak.

Also reduces unnecessary monomorphization on `Callable`'s FFI callbacks such as `to_string_func` -- they can use the userdata pointer instead of an `F` generic argument. This reduces code bloat (one less extra function generated for each Rust closure).