### PR TITLE
Suppress Godot errors in fallible functions

### DIFF
--- a/godot-core/src/global/mod.rs
+++ b/godot-core/src/global/mod.rs
@@ -45,7 +45,10 @@
 
 mod print;
 
-pub use print::{__threadsafe_print, PrintLevel, PrintRecord, PrintSource, print_custom};
+pub use print::{
+    __threadsafe_print, PrintLevel, PrintRecord, PrintSource, SuppressGuard, print_custom,
+    suppress_godot_errors,
+};
 
 // Some enums are directly re-exported from crate::builtin.
 pub use crate::r#gen::central::global_enums::*;

--- a/godot-core/src/global/print.rs
+++ b/godot-core/src/global/print.rs
@@ -32,7 +32,11 @@
 // exotic-platform `FileAccess` that buffers in its own non-thread-safe state could turn the formal `file` race into real torn writes. We accept
 // this -- it is not the default desktop/headless configuration -- rather than gate printing, which is a core cross-thread debugging tool.
 
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+
 use crate::builtin::Variant;
+use crate::classes::Engine;
+use crate::obj::Singleton;
 use crate::sys;
 
 // https://stackoverflow.com/a/40234666
@@ -413,4 +417,51 @@ macro_rules! godot_str {
             )
         ])
     };
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// Print suppress logic
+
+/// Number of active [`suppress_godot_errors()`] scopes; the flag toggles on the `0 <-> 1` transitions. For multithreading robustness.
+static SUPPRESS_DEPTH: AtomicU32 = AtomicU32::new(0);
+
+/// Value of `Engine::is_printing_error_messages()` captured when the outermost scope began, restored when it exits.
+static SUPPRESS_ORIG_STATE: AtomicBool = AtomicBool::new(true);
+
+/// RAII guard returned by [`suppress_godot_errors()`]; restores Godot error printing once the outermost scope drops.
+#[doc(hidden)]
+#[must_use = "keep RAII guard alive, e.g. `let _guard = suppress_godot_errors();`"]
+pub struct SuppressGuard {
+    _private: (),
+}
+
+impl Drop for SuppressGuard {
+    fn drop(&mut self) {
+        let prev = SUPPRESS_DEPTH.fetch_sub(1, Ordering::AcqRel);
+        sys::strict_assert!(prev >= 1, "suppress_godot_errors: depth underflow");
+        if prev == 1 {
+            let restore = SUPPRESS_ORIG_STATE.load(Ordering::Acquire);
+            Engine::singleton().set_print_error_messages(restore);
+        }
+    }
+}
+
+/// Disables Godot's console error printing until the returned [`SuppressGuard`] drops.
+///
+/// Silences expected, Rust-handled failures (e.g. [`try_load()`][crate::tools::try_load] returning `Err`). Panic-safe via the guard's
+/// `Drop`. The flag is process-wide: nested/concurrent scopes only toggle at the `0 <-> 1` boundary, and the outermost scope restores the
+/// prior state (races are self-healing -- worst case a transient cosmetic over/under-print). Genuine errors on other threads are hidden
+/// while any scope is active, so keep the suppressed region small.
+///
+/// Note: [`Engine::set_print_error_messages()`] uses the main-thread-asserting binding; off-thread use would be UB.
+#[doc(hidden)]
+pub fn suppress_godot_errors() -> SuppressGuard {
+    if SUPPRESS_DEPTH.fetch_add(1, Ordering::AcqRel) == 0 {
+        SUPPRESS_ORIG_STATE.store(
+            Engine::singleton().is_printing_error_messages(),
+            Ordering::Release,
+        );
+        Engine::singleton().set_print_error_messages(false);
+    }
+    SuppressGuard { _private: () }
 }

--- a/godot-core/src/tools/save_load.rs
+++ b/godot-core/src/tools/save_load.rs
@@ -7,7 +7,7 @@
 
 use crate::builtin::GString;
 use crate::classes::{Resource, ResourceLoader, ResourceSaver};
-use crate::global::Error as GodotError;
+use crate::global::{Error as GodotError, suppress_godot_errors};
 use crate::meta::error::IoError;
 use crate::meta::{AsArg, arg_into_ref};
 use crate::obj::{Gd, Inherits, Singleton};
@@ -50,6 +50,8 @@ where
 /// or by dragging the file from the _FileSystem_ dock into the script.
 ///
 /// The path must be absolute (typically starting with `res://`), a local path will fail.
+///
+/// On failure, Godot error printing is temporarily suppressed, so no console error appears.
 ///
 /// # Example
 /// Loads a scene called `Main` located in the `path/to` subdirectory of the Godot project and caches it in a variable.
@@ -165,6 +167,8 @@ where
 /// This function can fail if [`ResourceSaver`] can't save the resource to file, as it is a simplified version of
 /// [`ResourceSaver::save()`][crate::classes::ResourceSaver::save]. The underlying method can be used for more advances scenarios.
 ///
+/// On failure, Godot error printing is temporarily suppressed, so no console error appears.
+///
 /// # Note
 /// Target path must be presented in Godot-recognized format, mainly the ones beginning with `res://` and `user://`. Saving
 /// to `res://` is possible only when working with unexported project - after its export only `user://` is viable.
@@ -199,12 +203,14 @@ where
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Implementation of this file
 
-// Separate function, to avoid constructing string twice
-// Note that more optimizations than that likely make no sense, as loading is quite expensive
+// Separate function, to avoid constructing string twice.
+// Note that more optimizations than that likely make no sense, as loading is quite expensive.
 fn load_impl<T>(path: &GString) -> Result<Gd<T>, IoError>
 where
     T: Inherits<Resource>,
 {
+    let _guard = suppress_godot_errors();
+
     let loaded = ResourceLoader::singleton()
         .load_ex(path)
         .type_hint(&T::class_id().to_gstring())
@@ -295,6 +301,8 @@ fn save_impl<T>(obj: &Gd<T>, path: &GString) -> Result<(), IoError>
 where
     T: Inherits<Resource>,
 {
+    let _guard = suppress_godot_errors();
+
     let res = ResourceSaver::singleton().save_ex(obj).path(path).done();
 
     if res == GodotError::OK {

--- a/itest/rust/src/engine_tests/save_load_test.rs
+++ b/itest/rust/src/engine_tests/save_load_test.rs
@@ -69,7 +69,6 @@ fn load_test() {
 
     save(&resource, &res_path);
 
-    // TODO(v0.6): suppress "ERROR" print in API itself.
     let res = try_load::<SavedGame>(FAULTY_PATH);
     assert!(res.is_err());
 

--- a/itest/rust/src/engine_tests/utilities_test.rs
+++ b/itest/rust/src/engine_tests/utilities_test.rs
@@ -9,7 +9,9 @@
 // https://github.com/godotengine/godot-cpp/issues/1390.
 
 use godot::builtin::{GString, Variant, vslice};
+use godot::classes::Engine;
 use godot::global::*;
+use godot::obj::Singleton;
 
 use crate::framework::itest;
 
@@ -123,4 +125,34 @@ fn utilities_max() {
         vslice![-5.0, -7.0],
     );
     assert_eq!(output, Variant::from(-1.0));
+}
+
+#[itest]
+fn utilities_suppress_print() {
+    let suppressed = || !Engine::singleton().is_printing_error_messages();
+
+    // Assume at start of test, no suppression is active. Also detects not-cleaned-up global state from earlier tests.
+    assert!(!suppressed());
+
+    // Printing is disabled while a guard is alive, and restored to the original value once the outermost guard drops.
+    let outer = suppress_godot_errors();
+    assert!(suppressed());
+
+    {
+        let _inner = suppress_godot_errors();
+        assert!(suppressed());
+    }
+    // Inner drop must not re-enable while the outer guard is still active.
+    assert!(suppressed());
+
+    drop(outer);
+    assert!(!suppressed());
+
+    // When printing is already disabled, the guard must restore to disabled -- not enable it.
+    Engine::singleton().set_print_error_messages(false);
+    {
+        let _guard = suppress_godot_errors();
+        assert!(suppressed());
+    }
+    assert!(suppressed());
 }

--- a/itest/rust/src/framework/mod.rs
+++ b/itest/rust/src/framework/mod.rs
@@ -335,22 +335,12 @@ where
     }
 }
 
-/// Disable printing errors from Godot while running `f`.
+/// Disable printing errors from Godot while running `f`, restoring afterwards (panic-safe via RAII).
 ///
 /// Ideally we should catch and handle errors, ensuring they happen when expected. But that isn't always possible,
 /// so for now we can just disable printing the error to avoid spamming the terminal when tests should error.
-///
-/// This function is panic-safe via RAII; if the inner function `f` panics; error printing will be re-enabled.
 pub fn suppress_godot_print<R>(f: impl FnOnce() -> R) -> R {
-    struct RestoreGodotPrint;
-    impl Drop for RestoreGodotPrint {
-        fn drop(&mut self) {
-            Engine::singleton().set_print_error_messages(true); // Assume it was true before -> good enough.
-        }
-    }
-
-    Engine::singleton().set_print_error_messages(false);
-    let _guard = RestoreGodotPrint;
+    let _guard = godot::global::suppress_godot_errors();
     f()
 }
 


### PR DESCRIPTION
Some godot-rust APIs, like `try_load`/`try_save`, are explicitly designed to handle errors. But in many cases, underlying Godot APIs do not provide such a fallible path, or provide one only as multiple calls that are susceptible to TOCTOU issues.

Instead, this temporarily disables Godot error printing via RAII guard. It provides *some* (not perfect) robustness for multithreading scenarios.

Closes #1239.