### PR TITLE
Fix RPC borrow panic for `call_local`

### DIFF
--- a/godot-core/src/obj/rpc/rpc_object.rs
+++ b/godot-core/src/obj/rpc/rpc_object.rs
@@ -29,7 +29,13 @@ where
     /// Consumes [`Self`], calling the RPC with the provided arguments.
     pub fn call_rpc(self, name: &str, args: &[Variant]) -> Result<(), RpcError> {
         let error = match self {
-            UserRpcObject::Internal(self_mut) => self_mut.to_gd().upcast::<Node>().rpc(name, args),
+            UserRpcObject::Internal(self_mut) => {
+                let mut node = self_mut.to_gd().upcast::<Node>();
+
+                // base_mut(), not to_gd(): call_local RPC runs its body synchronously inside rpc(). base_mut() allows re_borrow without panic.
+                let _reentrant_guard = self_mut.base_mut();
+                node.rpc(name, args)
+            }
             UserRpcObject::External(mut gd) => gd.upcast_mut::<Node>().rpc(name, args),
         };
 
@@ -44,7 +50,11 @@ where
     pub fn call_rpc_id(self, name: &str, id: i64, args: &[Variant]) -> Result<(), RpcError> {
         let error = match self {
             UserRpcObject::Internal(self_mut) => {
-                self_mut.to_gd().upcast::<Node>().rpc_id(id, name, args)
+                let mut node = self_mut.to_gd().upcast::<Node>();
+
+                // base_mut(), not to_gd(): see call_rpc().
+                let _reentrant_guard = self_mut.base_mut();
+                node.rpc_id(id, name, args)
             }
             UserRpcObject::External(mut gd) => gd.upcast_mut::<Node>().rpc_id(id, name, args),
         };

--- a/itest/rust/src/builtin_tests/containers/rpc_test.rs
+++ b/itest/rust/src/builtin_tests/containers/rpc_test.rs
@@ -152,3 +152,27 @@ fn rpc_call_local_side_effects(context: &TestContext) {
     context.scene_tree.clone().remove_child(&node);
     node.free();
 }
+
+/// Internal path (`self.rpcs()`) + `call_local` targeting own peer: the RPC body re-enters the `GdCell` while the outer `bind_mut()` borrow is
+/// still held. Must not panic.
+///
+/// Regression test, see https://github.com/godot-rust/gdext/pull/1643.
+#[cfg(feature = "codegen-full")]
+#[itest]
+fn rpc_internal_call_local_reentrant(context: &TestContext) {
+    let mut node = RpcCallableNode::new_alloc();
+    context.scene_tree.clone().add_child(&node);
+    let own_id = node
+        .get_multiplayer()
+        .expect("multiplayer should exist")
+        .get_unique_id() as i64;
+
+    {
+        let mut guard = node.bind_mut();
+        assert_eq!(guard.rpcs().rpc_local_also().call_id(own_id), Ok(()));
+    }
+    assert_eq!(node.bind().call_count, 1);
+
+    context.scene_tree.clone().remove_child(&node);
+    node.free();
+}


### PR DESCRIPTION
Needs to use `base_mut()` rather than `to_gd()` internally.