### PR TITLE
Cache user singleton pointers

### DIFF
--- a/godot-core/src/classes/class_runtime.rs
+++ b/godot-core/src/classes/class_runtime.rs
@@ -275,14 +275,17 @@ where
     }
 }
 
-/// Per-singleton cache for built-in engine singletons.
+/// Per-singleton cache for engine and user singletons.
 ///
 /// `level == None` means "not cached"; otherwise it holds the level at which `ptr` was fetched and `generation` the deinit generation then. `ptr` is
 /// trusted only while the current level still covers `level` and no full deinit happened since (see [`init::singleton_cache_generation`]).
 ///
 /// Ordering: the slow path writes `ptr`/`generation` `Relaxed`, then stores `level` last with `Release`. The fast path reads `level` first with
 /// `Acquire`; that pairs with the store, making the earlier `ptr`/`generation` writes visible, so they can be read `Relaxed`.
-pub(crate) struct SingletonCache {
+///
+/// Public (doc-hidden) only so that `#[class(singleton)]`-generated code can declare a per-type static; not part of the supported API.
+#[doc(hidden)]
+pub struct SingletonCache {
     ptr: AtomicPtr<std::ffi::c_void>,
     generation: AtomicU64,
     level: sys::AtomicEnum<Option<init::InitLevel>>,
@@ -290,6 +293,7 @@ pub(crate) struct SingletonCache {
 
 impl SingletonCache {
     // Not Default::default() because of const.
+    #[allow(clippy::new_without_default)]
     pub const fn new() -> Self {
         Self {
             ptr: AtomicPtr::new(std::ptr::null_mut()),
@@ -299,14 +303,13 @@ impl SingletonCache {
     }
 }
 
-/// Cached variant of [`singleton_unchecked_type`], for built-in engine singletons.
+/// Cached variant of [`singleton_unchecked_type`], for engine and user (`#[class(singleton)]`) singletons alike.
 ///
-/// Engine singletons have a stable pointer for as long as their init level is loaded, so the `global_get_singleton()` lookup (plus `StringName`
-/// construction) is just overhead. This caches the ptr per singleton type, gated on the init level to structurally prevent stale-pointer use.
+/// A singleton's pointer is stable while its init level is loaded, so the `global_get_singleton()` lookup + `StringName` construction is just
+/// overhead. This caches the ptr per type, gated on the init level (and a deinit generation) to structurally prevent stale-pointer use.
 ///
 /// # Safety
-/// Same as [`singleton_unchecked_type`]: `make_class_name` must yield the class name matching type `T`, and this must only be used for engine
-/// singletons (stable pointer for their level's lifetime).
+/// Same as [`singleton_unchecked_type`]: `make_class_name` must yield `T` class name, and its pointer must be stable during its level lifetime.
 pub(crate) unsafe fn cached_singleton<T>(
     cache: &SingletonCache,
     make_class_name: impl FnOnce() -> StringName,

--- a/godot-core/src/classes/mod.rs
+++ b/godot-core/src/classes/mod.rs
@@ -40,4 +40,7 @@ pub mod native {
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Crate-local utilities
 
+// Re-exported (doc-hidden) so that `#[class(singleton)]`-generated code can reference it via `godot::private`.
+#[doc(hidden)]
+pub use class_runtime::SingletonCache;
 pub(crate) use class_runtime::*;

--- a/godot-core/src/obj/traits.rs
+++ b/godot-core/src/obj/traits.rs
@@ -786,6 +786,14 @@ pub trait Singleton: GodotClass {
 pub trait UserSingleton:
     GodotClass + Bounds<Declarer = bounds::DeclUser, Memory = bounds::MemManual>
 {
+    /// Per-type cache for [`cached_singleton`](crate::classes::cached_singleton), or `None` to opt out.
+    ///
+    /// `#[class(singleton)]` overrides this with a `static`; manual `impl UserSingleton` keeps the default `None`, since its registration
+    /// lifetime is not guaranteed to match the cache invariants. Dispatch lives here because the blanket `Singleton` impl below cannot specialize.
+    #[doc(hidden)]
+    fn __singleton_cache() -> Option<&'static crate::private::SingletonCache> {
+        None
+    }
 }
 
 impl<T> Singleton for T
@@ -793,12 +801,18 @@ where
     T: UserSingleton + Inherits<crate::classes::Object>,
 {
     fn singleton() -> Gd<T> {
-        // Note: Under any safeguards level `singleton_unchecked_type` will panic if Singleton can't be retrieved.
+        // Note: under all safeguard levels, both paths will panic if the singleton can't be retrieved.
+        // Both functions called below are unsafe: they require the passed class name to name `T`'s class -- guaranteed by ::class_id().
+        let make_class_name = || T::class_id().to_string_name();
 
-        let class_name = <T as GodotClass>::class_id().to_string_name();
-        // SAFETY: The caller must ensure that `class_name` corresponds to the actual class name of type `T`.
-        // This is always true for `#[class(singleton)]`.
-        unsafe { crate::classes::singleton_unchecked_type(&class_name) }
+        match T::__singleton_cache() {
+            // SAFETY: a cache is only present for `#[class(singleton)]`, whose level-gated registration matches the cache's stable-pointer
+            // invariant; `make_class_name` yields `T`'s class name.
+            Some(cache) => unsafe { crate::classes::cached_singleton::<T>(cache, make_class_name) },
+
+            // SAFETY: `make_class_name` yields `T`'s class name.
+            None => unsafe { crate::classes::singleton_unchecked_type(&make_class_name()) },
+        }
     }
 }
 

--- a/godot-core/src/private.rs
+++ b/godot-core/src/private.rs
@@ -22,6 +22,7 @@ use crate::{classes, sys};
 
 mod reexport_pub {
     pub use crate::arg_into_owned;
+    pub use crate::classes::SingletonCache;
     #[cfg(all(since_api = "4.3", feature = "register-docs"))]
     pub use crate::docs::{DocsItem, DocsShard, InherentImplDocs, StructDocs};
     pub use crate::r#gen::classes::class_macros;

--- a/godot-macros/src/class/derive_godot_class.rs
+++ b/godot-macros/src/class/derive_godot_class.rs
@@ -250,7 +250,12 @@ fn make_with_base_impl(base_field: &Option<Field>, class_name: &Ident) -> TokenS
 fn make_singleton_impl(class_name: &Ident) -> (TokenStream, TokenStream) {
     (
         quote! {
-            impl ::godot::obj::UserSingleton for #class_name {}
+            impl ::godot::obj::UserSingleton for #class_name {
+                fn __singleton_cache() -> Option<&'static ::godot::private::SingletonCache> {
+                    static CACHE: ::godot::private::SingletonCache = ::godot::private::SingletonCache::new();
+                    Some(&CACHE)
+                }
+            }
         },
         quote! {
             const INIT_LEVEL: ::godot::init::InitLevel = ::godot::init::InitLevel::Scene;

--- a/itest/rust/src/object_tests/init_stage_test.rs
+++ b/itest/rust/src/object_tests/init_stage_test.rs
@@ -111,29 +111,6 @@ fn assert_singleton_present<T: Singleton + GodotClass>(present: bool) {
     }
 }
 
-// Verify cached singleton pointers return same live instance, never stale or wrong.
-#[itest]
-fn singleton_caching_stable_instance() {
-    let engine = Engine::singleton();
-    let engine_id = engine.instance_id();
-    assert_eq!(engine_id, Engine::singleton().instance_id());
-
-    let os = Os::singleton();
-    let os_id = os.instance_id();
-    assert_eq!(os_id, Os::singleton().instance_id());
-
-    let time_id = Time::singleton().instance_id();
-    assert_eq!(time_id, Time::singleton().instance_id());
-
-    assert_ne!(engine_id, os_id);
-    assert_ne!(engine_id, time_id);
-    assert_ne!(os_id, time_id);
-
-    // Functional sanity checks.
-    assert!(engine.get_physics_ticks_per_second() > 0);
-    assert!(!os.get_name().is_empty());
-}
-
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Stage-specific callbacks
 

--- a/itest/rust/src/object_tests/singleton_test.rs
+++ b/itest/rust/src/object_tests/singleton_test.rs
@@ -6,22 +6,11 @@
  */
 
 use godot::builtin::GString;
-use godot::classes::{Input, Os};
+use godot::classes::{Engine, Os, Time};
 use godot::obj::{Gd, Singleton};
 use godot::register::{GodotClass, godot_api};
 
 use crate::framework::itest;
-
-#[itest]
-fn singleton_is_unique() {
-    let a: Gd<Input> = Input::singleton();
-    let id_a = a.instance_id();
-
-    let b: Gd<Input> = Input::singleton();
-    let id_b = b.instance_id();
-
-    assert_eq!(id_a, id_b, "Singletons have same instance ID");
-}
 
 #[itest]
 fn singleton_from_instance_id() {
@@ -51,6 +40,45 @@ fn user_singleton() {
     // Must be registered with the library and accessible at this point.
     let value = SomeUserSingleton::singleton().bind().some_method();
     assert_eq!(value, 42);
+}
+
+// Cached singleton pointers must return the same live instance, never stale or wrong. Same shape as `user_singleton_caching`:
+// cached fetches resolve to the same live instance, also after a cache reset.
+#[itest]
+fn engine_singleton_caching() {
+    let engine_id = Engine::singleton().instance_id();
+    let os_id = Os::singleton().instance_id();
+    let time_id = Time::singleton().instance_id();
+    assert_eq!(Engine::singleton().instance_id(), engine_id);
+    assert_eq!(Os::singleton().instance_id(), os_id);
+    assert_eq!(Time::singleton().instance_id(), time_id);
+
+    // Distinct singletons must resolve to distinct instances (cache must not mix up types).
+    assert_ne!(engine_id, os_id);
+    assert_ne!(engine_id, time_id);
+    assert_ne!(os_id, time_id);
+
+    godot::init::__invalidate_singleton_caches();
+    assert_eq!(Engine::singleton().instance_id(), engine_id);
+    assert_eq!(Os::singleton().instance_id(), os_id);
+    assert_eq!(Time::singleton().instance_id(), time_id);
+
+    // Functional sanity checks on the cached instances.
+    assert!(Engine::singleton().get_physics_ticks_per_second() > 0);
+    assert!(!Os::singleton().get_name().is_empty());
+}
+
+// User singletons (`#[class(singleton)]`) are cached just like engine singletons. Same shape as `engine_singleton_caching`.
+#[itest]
+fn user_singleton_caching() {
+    let id = SomeUserSingleton::singleton().instance_id();
+    assert_eq!(SomeUserSingleton::singleton().instance_id(), id);
+
+    godot::init::__invalidate_singleton_caches();
+    assert_eq!(SomeUserSingleton::singleton().instance_id(), id);
+
+    // Functional: the cached pointer is usable, not just identity-stable.
+    assert_eq!(SomeUserSingleton::singleton().bind().some_method(), 42);
 }
 
 #[derive(GodotClass)]


### PR DESCRIPTION
Extend per-type singleton cache (#1636) to `#[class(singleton)]`, which have a stable pointer for their init level's lifetime, just like engine singletons.

Small test reorganization:
- Move `singleton_caching_stable_instance` -> `engine_singleton_caching` (`singleton_test.rs`)
- Add `user_singleton_caching`
- Remove redundant `singleton_is_unique`