### PR TITLE
`#[func(virtual)]` now supports `async fn` for GDScript coroutines

### DIFF
--- a/godot-core/src/meta/signature.rs
+++ b/godot-core/src/meta/signature.rs
@@ -225,27 +225,46 @@ impl<Params: OutParamTuple, Ret: EngineFromGodot> Signature<Params, Ret> {
         let call_ctx = CallContext::outbound(class_name, method_name);
         //$crate::out!("out_script_virtual_call: {call_ctx}");
 
-        let object_call_script_method = sys::interface_fn!(object_call_script_method);
-
-        let variant = args.with_variant_pointers(|sys_args| {
-            // SAFETY: TODO.
-            unsafe {
-                Variant::new_with_var_uninit(|return_ptr| {
-                    let mut err = sys::default_call_error();
-                    object_call_script_method(
-                        object_ptr,
-                        method_sname_ptr,
-                        sys_args.as_ptr(),
-                        sys_args.len() as i64,
-                        return_ptr,
-                        &raw mut err,
-                    );
-                })
-            }
-        });
+        // SAFETY: caller guarantees `object_ptr` is a live object with virtual method `method_sname_ptr`.
+        let variant =
+            unsafe { out_script_virtual_call_inner(&call_ctx, method_sname_ptr, object_ptr, args) };
 
         let result = <Ret as FromGodot>::try_from_variant(&variant);
         result.unwrap_or_else(|err| return_error_dyn(&call_ctx, std::any::type_name::<Ret>(), err))
+    }
+
+    /// Make a script-virtual call that may resolve asynchronously (GDScript `await`).
+    ///
+    /// Behaves like [`out_script_virtual_call`](Self::out_script_virtual_call), but if the GDScript override uses `await`, the engine returns a
+    /// coroutine handle instead of the final value. This function then awaits its completion and converts the eventual result to `Ret`.
+    ///
+    /// The synchronous engine call (which starts the coroutine) happens immediately; the returned future only keeps the coroutine handle alive,
+    /// so it does not borrow the calling object across `.await`.
+    ///
+    /// # Safety
+    /// Same as [`out_script_virtual_call`](Self::out_script_virtual_call).
+    #[cfg(since_api = "4.3")]
+    pub unsafe fn out_script_virtual_call_async(
+        // Separate parameters to reduce tokens in macro-generated API.
+        class_name: &'static str,
+        method_name: &'static str,
+        method_sname_ptr: sys::GDExtensionConstStringNamePtr,
+        object_ptr: sys::GDExtensionObjectPtr,
+        args: Params,
+    ) -> impl std::future::Future<Output = Ret>
+    where
+        Ret: FromGodot,
+    {
+        // Assumes that caller has previously checked existence of a virtual method.
+
+        let call_ctx = CallContext::outbound(class_name, method_name);
+
+        // The engine call (which may start a GDScript coroutine) runs eagerly here; only the coroutine handling is deferred to the future.
+        // SAFETY: caller guarantees `object_ptr` is a live object with virtual method `method_sname_ptr`.
+        let variant =
+            unsafe { out_script_virtual_call_inner(&call_ctx, method_sname_ptr, object_ptr, args) };
+
+        resolve_gdscript_coroutine::<Ret>(call_ctx, variant)
     }
 
     /// Make a ptrcall to the Godot engine for a utility function that has varargs.
@@ -562,6 +581,75 @@ unsafe fn ptrcall_return<R: EngineToGodot>(
 #[inline(never)]
 fn return_error_dyn(call_ctx: &CallContext, return_ty: &'static str, err: ConvertError) -> ! {
     panic!("in function `{call_ctx}` at return type {return_ty}: {err}");
+}
+
+/// Shared engine call for [`Signature::out_script_virtual_call`] and its async variant: performs the `object_call_script_method` varcall and
+/// surfaces a Godot-side call error as a panic. Returns the raw `Variant` result (a coroutine handle if the GDScript override used `await`).
+///
+/// # Safety
+/// `object_ptr` must be a live object with virtual method `method_sname_ptr`, and `args` must match that method's signature.
+#[cfg(since_api = "4.3")]
+unsafe fn out_script_virtual_call_inner<Params: OutParamTuple>(
+    call_ctx: &CallContext,
+    method_sname_ptr: sys::GDExtensionConstStringNamePtr,
+    object_ptr: sys::GDExtensionObjectPtr,
+    args: Params,
+) -> Variant {
+    let object_call_script_method = sys::interface_fn!(object_call_script_method);
+
+    let variant = args.with_variants(|call_args| {
+        let variant_ptrs: Vec<_> = call_args.iter().map(Variant::var_sys).collect();
+
+        // SAFETY: `object_ptr`/`method_sname_ptr` and the argument pointers are valid per the caller's guarantee; `return_ptr` is uninitialized
+        // result storage that the engine writes on success.
+        unsafe {
+            Variant::new_with_var_uninit_result(|return_ptr| {
+                let mut err = sys::default_call_error();
+                object_call_script_method(
+                    object_ptr,
+                    method_sname_ptr,
+                    variant_ptrs.as_ptr(),
+                    variant_ptrs.len() as i64,
+                    return_ptr,
+                    &raw mut err,
+                );
+
+                CallError::check_out_varcall(call_ctx, err, call_args, &[] as &[Variant])
+            })
+        }
+    });
+
+    variant.unwrap_or_else(|err| panic!("{err}"))
+}
+
+/// Converts the return value of a script-virtual call, awaiting completion if the GDScript override used `await`.
+///
+/// A GDScript function that uses `await` returns a `GDScriptFunctionState` object whose `completed` signal eventually carries the real return
+/// value. That type is not exposed in the GDExtension API, so it is detected by its class name.
+pub(crate) async fn resolve_gdscript_coroutine<Ret: FromGodot>(
+    call_ctx: CallContext<'static>,
+    variant: Variant,
+) -> Ret {
+    use crate::builtin::Signal;
+    use crate::classes::Object;
+    use crate::obj::Gd;
+
+    // `get_class()` (engine method) is used instead of `Gd::dynamic_class()`: the latter is backed by `object_get_class_name`, which only
+    // reports exposed extension classes and returns "RefCounted" for the hidden `GDScriptFunctionState`. `get_class()` returns the real name.
+    let result = if let Ok(state) = variant.try_to::<Gd<Object>>()
+        && state.get_class() == "GDScriptFunctionState"
+    {
+        let signal = Signal::from_object_signal(&state, "completed");
+        let (result,) = signal.to_future::<(Variant,)>().await;
+        // `state` is kept alive across the await point, so the coroutine isn't dropped before completion.
+        drop(state);
+        result
+    } else {
+        variant
+    };
+
+    <Ret as FromGodot>::try_from_variant(&result)
+        .unwrap_or_else(|err| return_error_dyn(&call_ctx, std::any::type_name::<Ret>(), err))
 }
 
 // Lazy Display, so we don't create tens of thousands of extra string literals.

--- a/godot-macros/src/class/data_models/inherent_impl.rs
+++ b/godot-macros/src/class/data_models/inherent_impl.rs
@@ -270,16 +270,18 @@ fn process_godot_fns(
             continue;
         };
 
+        // `async` is allowed for `#[func(virtual)]` (to await a GDScript coroutine override); all other qualifiers are rejected.
+        let async_allowed = matches!(&attr.ty, ItemAttrType::Func(func, _) if func.is_virtual);
         if function.qualifiers.tk_default.is_some()
             || function.qualifiers.tk_const.is_some()
-            || function.qualifiers.tk_async.is_some()
+            || (function.qualifiers.tk_async.is_some() && !async_allowed)
             || function.qualifiers.tk_unsafe.is_some()
             || function.qualifiers.tk_extern.is_some()
             || function.qualifiers.extern_abi.is_some()
         {
             return bail!(
                 &function.qualifiers,
-                "#[func]: fn qualifiers are not allowed"
+                "#[func]: fn qualifiers are not allowed (except `async` on `#[func(virtual)]`)"
             );
         }
 
@@ -322,17 +324,27 @@ fn process_godot_fns(
                 signature_info.optional_param_default_exprs =
                     validate_default_exprs(all_param_maybe_defaults, &signature_info.param_idents)?;
 
+                // Validity already enforced by the qualifier check above (only `#[func(virtual)]` may be async).
+                let is_async = function.qualifiers.tk_async.is_some();
+
                 // For virtual methods, rename/mangle existing user method and create a new method with the original name,
                 // which performs a dynamic dispatch.
                 let registered_name = if func.is_virtual {
-                    let registered_name = add_virtual_script_call(
+                    let (registered_name, early_bound_name) = add_virtual_script_call(
                         &mut virtual_functions,
                         function,
                         &signature_info,
                         class_name,
                         &func.rename,
                         gd_self_parameter,
+                        is_async,
                     );
+
+                    // For async virtuals, the engine-facing default impl must be synchronous, so the registered callback targets the
+                    // (sync) early-bound method directly instead of the async dispatcher. See `add_virtual_script_call`.
+                    if is_async {
+                        signature_info.method_name = early_bound_name;
+                    }
 
                     Some(registered_name)
                 } else {
@@ -446,7 +458,8 @@ fn process_godot_constants(decl: &mut venial::Impl) -> ParseResult<Vec<ConstDefi
 ///
 /// Appends the virtual function to `virtual_functions`.
 ///
-/// Returns the Godot-registered name of the virtual function, usually `_<name>` (but overridable with `#[func(rename = ...)]`).
+/// Returns `(godot_name, early_bound_name)`: the Godot-registered name of the virtual function (usually `_<name>`, but overridable with
+/// `#[func(rename = ...)]`) and the identifier of the synchronous early-bound default method.
 fn add_virtual_script_call(
     virtual_functions: &mut Vec<venial::Function>,
     function: &mut venial::Function,
@@ -454,7 +467,8 @@ fn add_virtual_script_call(
     class_name: &Ident,
     rename: &Option<String>,
     gd_self_parameter: Option<Ident>,
-) -> String {
+    is_async: bool,
+) -> (String, Ident) {
     #[allow(clippy::assertions_on_constants)]
     {
         // Without braces, clippy removes the #[allow] for some reason...
@@ -498,6 +512,13 @@ fn add_virtual_script_call(
         receiver = ident("self");
     };
 
+    // Async virtuals await a possibly-coroutine GDScript override; the early-bound default stays synchronous and is called without `.await`.
+    let (out_call, override_dispatch) = if is_async {
+        (quote! { out_script_virtual_call_async }, quote! { .await })
+    } else {
+        (quote! { out_script_virtual_call }, quote! {})
+    };
+
     let code = quote! {
         let object_ptr = #object_ptr;
         let method_sname = ::godot::builtin::StringName::__cstr(#method_name_cstr);
@@ -510,30 +531,34 @@ fn add_virtual_script_call(
             type CallRet = #call_ret;
             let args = (#( #arg_names, )*);
             unsafe {
-                ::godot::private::Signature::<CallParams, CallRet>::out_script_virtual_call(
+                ::godot::private::Signature::<CallParams, CallRet>::#out_call(
                     #class_name_str,
                     #method_name_str,
                     method_sname_ptr,
                     object_ptr,
                     args,
                 )
-            }
+            } #override_dispatch
         } else {
-            // Fall back to default implementation.
+            // Fall back to default implementation (synchronous, even for async virtuals).
             Self::#early_bound_name(#receiver, #( #arg_names ),*)
         }
     };
 
     let mut early_bound_function = venial::Function {
-        name: early_bound_name,
+        name: early_bound_name.clone(),
         body: Some(Group::new(Delimiter::Brace, code)),
         ..function.clone()
     };
 
     std::mem::swap(&mut function.body, &mut early_bound_function.body);
+
+    // The early-bound default is always invoked synchronously (also by the engine callback), so strip any `async` qualifier.
+    early_bound_function.qualifiers.tk_async = None;
+
     virtual_functions.push(early_bound_function);
 
-    method_name_str
+    (method_name_str, early_bound_name)
 }
 
 /// Validates that a function uses no reference types (`&T`, `&mut T`) in parameters or return type.

--- a/godot-macros/src/lib.rs
+++ b/godot-macros/src/lib.rs
@@ -1007,6 +1007,33 @@ pub fn derive_godot_class(input: TokenStream) -> TokenStream {
 ///
 /// Make sure you understand the limitations in the [tutorial](https://godot-rust.github.io/book/register/virtual-functions.html).
 ///
+/// ### Async virtual functions
+///
+/// A `#[func(virtual)]` may be declared `async fn`, to allow GDScript overrides that use `await`. The Rust caller then awaits the override's
+/// completion and receives its return value. Calling the method returns a future that integrates with [`task::spawn`](../task/fn.spawn.html).
+///
+/// ```no_run
+/// # #[cfg(since_api = "4.3")]
+/// # mod conditional {
+/// # use godot::prelude::*;
+/// # #[derive(GodotClass)]
+/// # #[class(init, base = Node)]
+/// # struct MyStruct { base: Base<Node> }
+/// #[godot_api]
+/// impl MyStruct {
+///     #[func(virtual, gd_self)]
+///     async fn compute(this: Gd<Self>, input: i64) -> i64 {
+///         input * 10
+///     }
+/// }
+/// # }
+/// ```
+///
+/// Limitations:
+/// - Only GDScript overrides may use `await`; other scripting languages are not supported.
+/// - The Rust default body (run when no script overrides the method) must be synchronous.
+/// - To await across `task::spawn` (not just inline), use `gd_self`, since `&self`/`&mut self` cannot be held across `.await`.
+///
 /// ## RPC attributes
 /// You can use the `#[rpc]` attribute to let your functions act as remote procedure calls (RPCs) in Godot. This is the Rust equivalent of
 /// GDScript's [`@rpc` annotation](https://docs.godotengine.org/en/stable/tutorials/networking/high_level_multiplayer.html#remote-procedure-calls).

--- a/itest/rust/src/register_tests/func_virtual_test.rs
+++ b/itest/rust/src/register_tests/func_virtual_test.rs
@@ -8,12 +8,15 @@
 // Needed for Clippy to accept #[cfg(all())]
 #![allow(clippy::non_minimal_cfg)]
 
-use godot::builtin::vslice;
 use godot::classes::GDScript;
 use godot::global::godot_str;
 use godot::prelude::*;
+use godot::task::{self, TaskHandle};
 
-use crate::framework::{create_gdscript, itest};
+use crate::framework::{TestContext, create_gdscript, itest};
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// Synchronous virtual functions
 
 #[derive(GodotClass)]
 #[class(init)]
@@ -165,4 +168,92 @@ func _get_thing():
     );
 
     script
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// Asynchronous virtual functions
+
+// Do NOT merge this class with the RefCounted-based `VirtualScriptCalls` above. The coroutine test relies on `Base<Node>` so the GDScript
+// override can `await get_tree().process_frame` -- the canonical scenario for async virtuals -- which is unavailable on `RefCounted`.
+#[derive(GodotClass)]
+#[class(init, base = Node)]
+struct AsyncVirtualNode {
+    base: Base<Node>,
+}
+
+#[godot_api]
+impl AsyncVirtualNode {
+    // `gd_self` is the recommended receiver for async virtuals: it avoids holding a `bind()` guard across the `.await`.
+    #[func(virtual, gd_self)]
+    async fn compute(_this: Gd<Self>, input: i64) -> i64 {
+        // Synchronous Rust default, used when no script overrides `_compute`.
+        input * 10
+    }
+}
+
+/// Script overriding `_compute` with an `await`, so the call returns a `GDScriptFunctionState` first.
+fn make_coroutine_script() -> Gd<GDScript> {
+    create_gdscript(
+        r#"
+extends AsyncVirtualNode
+
+func _compute(input: int) -> int:
+    await get_tree().process_frame
+    return input * 2
+"#,
+    )
+}
+
+/// Script overriding `_compute` synchronously (no `await`), returning the value directly.
+fn make_sync_async_script() -> Gd<GDScript> {
+    create_gdscript(
+        r#"
+extends AsyncVirtualNode
+
+func _compute(input: int) -> int:
+    return input * 2
+"#,
+    )
+}
+
+/// Attaches `script` (if any), awaits `compute(input)` and asserts the result, then cleans up.
+fn run_async_compute(
+    ctx: &TestContext,
+    script: Option<Gd<GDScript>>,
+    input: i64,
+    expected: i64,
+) -> TaskHandle {
+    let mut node = AsyncVirtualNode::new_alloc();
+    if let Some(script) = script {
+        node.set_script(&script);
+    }
+
+    let mut tree = ctx.scene_tree.clone();
+    tree.add_child(&node);
+
+    task::spawn(async move {
+        let result = AsyncVirtualNode::compute(node.clone(), input).await;
+        assert_eq!(result, expected);
+
+        tree.remove_child(&node);
+        node.free();
+    })
+}
+
+// No script attached -> the synchronous Rust default runs, but is still awaited through the async API.
+#[itest(async)]
+fn func_async_virtual_rust_sync(ctx: &TestContext) -> TaskHandle {
+    run_async_compute(ctx, None, 5, 50)
+}
+
+// GDScript override without `await`: the call returns the value directly (no coroutine).
+#[itest(async)]
+fn func_async_virtual_gdscript_sync(ctx: &TestContext) -> TaskHandle {
+    run_async_compute(ctx, Some(make_sync_async_script()), 21, 42)
+}
+
+// GDScript override with `await`: the call returns a coroutine handle, whose `completed` signal carries the eventual result.
+#[itest(async)]
+fn func_async_virtual_gdscript_coroutine(ctx: &TestContext) -> TaskHandle {
+    run_async_compute(ctx, Some(make_coroutine_script()), 21, 42)
 }


### PR DESCRIPTION
Proof-of-concept for
```rs
#[func(virtual)]
async fn script_virtual_fn(&mut self) { ... }
```
which is wired up with godot-rust's async executor and can call GDScript coroutines.
Closes #1640 from @fredericvauchelles.

PR will need some cleanup. I also have plans to generalize this method to allow reflection-style `call_async()` to arbitrary GDScript functions, not just script-virtual ones.