### PR TITLE
Always use godot_error in panic hook

### DIFF
--- a/godot-core/src/init/mod.rs
+++ b/godot-core/src/init/mod.rs
@@ -174,16 +174,7 @@ pub unsafe fn __gdext_load_library<E: ExtensionLibrary>(
             sys::initialize(get_proc_address, library, config);
         }
 
-        // With experimental-features enabled, we can always print panics to godot_print!
-        #[cfg(feature = "experimental-threads")]
-        crate::private::set_gdext_hook(|| true);
-
-        // Without experimental-features enabled, we can only print panics with godot_print! if the panic occurs on the main (Godot) thread.
-        #[cfg(not(feature = "experimental-threads"))]
-        {
-            let main_thread = std::thread::current().id();
-            crate::private::set_gdext_hook(move || std::thread::current().id() == main_thread);
-        }
+        crate::private::install_godot_rust_hook();
 
         // Currently no way to express failure; could be exposed to E if necessary.
         // No early exit, unclear if Godot still requires output parameters to be set.

--- a/godot-core/src/lib.rs
+++ b/godot-core/src/lib.rs
@@ -34,7 +34,7 @@ pub mod tools;
 mod storage;
 pub use godot_ffi as sys;
 
-pub use crate::private::{fetch_last_panic_context, set_gdext_hook};
+pub use crate::private::{fetch_last_panic_context, install_godot_rust_hook};
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Validations (see also godot/lib.rs)

--- a/godot-core/src/private.rs
+++ b/godot-core/src/private.rs
@@ -319,21 +319,14 @@ macro_rules! format_backtrace {
     };
 }
 
-pub fn set_gdext_hook<F>(godot_print: F)
-where
-    F: Fn() -> bool + Send + Sync + 'static,
-{
+pub fn install_godot_rust_hook() {
     std::panic::set_hook(Box::new(move |panic_info| {
         // Flush, to make sure previous Rust output (e.g. test announcement, or debug prints during app) have been printed.
         let _ignored_result = std::io::stdout().flush();
 
         let message = format_panic_message(panic_info);
-        if godot_print() {
-            // Also prints to stdout/stderr -- do not print twice.
-            godot_error!("{message}");
-        } else {
-            eprintln!("{message}");
-        }
+        // Also prints to stdout/stderr -- do not print twice.
+        godot_error!("{message}");
 
         let backtrace = format_backtrace!("panic backtrace");
         eprintln!("{backtrace}");
@@ -529,7 +522,7 @@ where
     // (1)  ERROR: [panic hot-reload/rust/src/lib.rs:37]
     //      some panic message
     //      Context: MyClass::my_method
-    //       at: godot_core::private::set_gdext_hook::{{closure}} (/.../godot-core/src/private.rs:354)
+    //       at: godot_core::private::install_godot_rust_hook::{{closure}} (/.../godot-core/src/private.rs:354)
     //       GDScript backtrace (most recent call first):
     //           [0] _ready (res://script.gd:9)
     //     (backtrace disabled, run application with `RUST_BACKTRACE=1` environment variable)


### PR DESCRIPTION
Since #1632  prints are safe to do from any thread. So it's no longer necessary for the print inside the panic hook to be gated on experimental-threads.

(sidenote: is there a reason the backtrace isn't also printed in Godot?)