### PR TITLE
Replace `godot-cell` borrow-state proptests with exhaustive model check

### DIFF
--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -234,21 +234,6 @@ jobs:
       - name: "Test tree borrows"
         run: MIRIFLAGS="-Zmiri-tree-borrows" cargo miri test -p godot-cell
 
-  proptest:
-    name: proptest
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: "Install Rust"
-        uses: ./.github/composite/rust
-
-      - name: "Compile tests"
-        run: cargo test -p godot-cell --features="proptest" --no-run
-
-      - name: "Test"
-        run: cargo test -p godot-cell --features="proptest"
-
   # For complex matrix workflow, see https://stackoverflow.com/a/65434401
   godot-itest:
     name: godot-itest (${{ matrix.name }})
@@ -554,7 +539,6 @@ jobs:
       - clippy
       - unit-test
       - miri-test
-      - proptest
       - godot-itest
       - cargo-deny-machete
       - license-guard

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,8 +54,7 @@ proc-macro2 = "1.0.106"
 quote = "1.0.45"
 venial = "0.6.1"
 
-# Testing (godot-cell, itest).
-proptest = "1.10.0"
+# Testing (itest).
 pin-project-lite = { version = "0.2" }
 
 # Note about Jetbrains IDEs: "IDE Sync" (Refresh Cargo projects) may cause static analysis errors such as

--- a/godot-cell/Cargo.toml
+++ b/godot-cell/Cargo.toml
@@ -10,12 +10,6 @@ description = "Internal crate used by godot-rust"
 repository = "https://github.com/godot-rust/gdext"
 homepage = "https://godot-rust.github.io"
 
-[features]
-proptest = ["dep:proptest"]
-
-[dependencies]
-proptest = { workspace = true, optional = true }
-
 # https://docs.rs/about/metadata
 [package.metadata.docs.rs]
 features = ["experimental-godot-api", "experimental-threads"]

--- a/godot-cell/src/borrow_state.rs
+++ b/godot-cell/src/borrow_state.rs
@@ -288,7 +288,7 @@ impl std::error::Error for BorrowStateErr {}
 
 impl<'a> From<&'a str> for BorrowStateErr {
     fn from(value: &'a str) -> Self {
-        Self::Custom(value.into())
+        Self::Custom(value.to_string())
     }
 }
 
@@ -298,363 +298,170 @@ impl From<String> for BorrowStateErr {
     }
 }
 
-#[cfg(all(test, feature = "proptest"))]
-mod proptests {
-    use proptest::arbitrary::Arbitrary;
-    use proptest::collection::vec;
-    use proptest::prelude::*;
-
-    use super::*;
-
-    impl BorrowState {
-        fn has_shared_reference(&self) -> bool {
-            self.shared_count > 0
-        }
-    }
-
-    #[derive(Copy, Clone, Eq, PartialEq, Debug)]
-    enum Operation {
-        IncShared,
-        DecShared,
-        IncMut,
-        DecMut,
-        SetInaccessible,
-        UnsetInaccessible,
-    }
-
-    impl Operation {
-        fn execute(&self, state: &mut BorrowState) -> Result<(), BorrowStateErr> {
-            use Operation as Op;
-
-            let result = match self {
-                Op::IncShared => state.increment_shared(),
-                Op::DecShared => state.decrement_shared(),
-                Op::IncMut => state.increment_mut(),
-                Op::DecMut => state.decrement_mut(),
-                Op::SetInaccessible => state.set_inaccessible(),
-                Op::UnsetInaccessible => state.unset_inaccessible(),
-            };
-
-            result.map(|_| ())
-        }
-    }
-
-    prop_compose! {
-        fn arbitrary_op()(id in 0..6) -> Operation {
-            use Operation as Op;
-
-            match id {
-                0 => Op::IncShared,
-                1 => Op::DecShared,
-                2 => Op::IncMut,
-                3 => Op::DecMut,
-                4 => Op::SetInaccessible,
-                5 => Op::UnsetInaccessible,
-                _ => unreachable!()
-            }
-        }
-    }
-
-    impl Arbitrary for Operation {
-        type Parameters = ();
-
-        type Strategy = BoxedStrategy<Self>;
-
-        fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
-            Strategy::boxed(arbitrary_op())
-        }
-    }
-
-    #[derive(Clone, Eq, PartialEq, Debug)]
-    struct OperationExecutor {
-        vec: Vec<Operation>,
-    }
-
-    impl OperationExecutor {
-        fn execute_all(&self, state: &mut BorrowState) {
-            for op in self.vec.iter() {
-                _ = op.execute(state);
-            }
-        }
-
-        fn remove_shared_inc_dec_pairs(mut self) -> Self {
-            loop {
-                let mut inc_index = None;
-                let mut just_saw_inc = false;
-
-                for (i, op) in self.vec.iter().enumerate() {
-                    match op {
-                        Operation::IncShared => just_saw_inc = true,
-                        Operation::DecShared if just_saw_inc => {
-                            inc_index = Some(i - 1);
-                            break;
-                        }
-                        _ => just_saw_inc = false,
-                    }
-                }
-
-                match inc_index {
-                    Some(i) => {
-                        self.vec.remove(i + 1);
-                        self.vec.remove(i);
-                    }
-                    None => break,
-                }
-            }
-
-            self
-        }
-    }
-
-    impl From<Vec<Operation>> for OperationExecutor {
-        fn from(vec: Vec<Operation>) -> Self {
-            Self { vec }
-        }
-    }
-
-    prop_compose! {
-        fn arbitrary_ops(max_len: usize)(len in 0..max_len)(operations in vec(any::<Operation>(), len)) -> Vec<Operation> {
-            operations
-        }
-    }
-
-    proptest! {
-        #[test]
-        fn operations_do_only_whats_expected_or_nothing(operations in arbitrary_ops(50)) {
-            use Operation as Op;
-            let mut state = BorrowState::new();
-            for op in operations {
-                let expected_on_success = match op {
-                    Op::IncShared => |mut original: BorrowState| {
-                        original.shared_count += 1;
-                        original
-                    },
-                    Op::DecShared => |mut original: BorrowState| {
-                        original.shared_count -= 1;
-                        original
-                    },
-                    Op::IncMut => |mut original: BorrowState| {
-                        original.mut_count += 1;
-                        original
-                    },
-                    Op::DecMut => |mut original: BorrowState| {
-                        original.mut_count -= 1;
-                        original
-                    },
-                    Op::SetInaccessible => |mut original: BorrowState| {
-                        original.inaccessible_count += 1;
-                        original
-                    },
-                    Op::UnsetInaccessible => |mut original: BorrowState| {
-                        original.inaccessible_count -= 1;
-                        original
-                    },
-                };
-
-                let original = state.clone();
-                if op.execute(&mut state).is_ok() {
-                    assert_eq!(state, expected_on_success(original));
-                } else {
-                    assert_eq!(state, original);
-                }
-            }
-        }
-    }
-
-    proptest! {
-        #[test]
-        fn no_poison(operations in arbitrary_ops(50)) {
-            let mut state = BorrowState::new();
-            for op in operations {
-                if let Err(err) = op.execute(&mut state) {
-                    assert_ne!(err, BorrowStateErr::IsPoisoned);
-                    assert!(!matches!(err, BorrowStateErr::Poisoned(_)));
-                }
-
-                assert!(!state.is_poisoned());
-            }
-        }
-    }
-
-    proptest! {
-        #[test]
-        fn no_shared_and_mut(operations in arbitrary_ops(50)) {
-            let mut state = BorrowState::new();
-            for op in operations {
-                _ = op.execute(&mut state);
-                if state.has_shared_reference() {
-                    assert!(!state.has_accessible())
-                }
-            }
-        }
-    }
-
-    proptest! {
-        #[test]
-        fn can_borrow_shared_when_borrowed_shared(operations in arbitrary_ops(50)) {
-            let mut state = BorrowState::new();
-
-            for op in operations {
-                _ = op.execute(&mut state);
-                if state.has_shared_reference() {
-                    assert!(state.increment_shared().is_ok());
-                    assert!(state.decrement_shared().is_ok());
-                }
-            }
-        }
-    }
-
-    proptest! {
-        #[test]
-        fn cannot_borrow_shared_when_borrowed_accessible(operations in arbitrary_ops(50)) {
-            let mut state = BorrowState::new();
-
-            for op in operations {
-                _ = op.execute(&mut state);
-                if state.has_accessible() {
-                    assert!(state.increment_shared().is_err());
-                }
-            }
-        }
-    }
-
-    proptest! {
-        #[test]
-        fn can_borrow_shared_when_not_borrowed_accessible(operations in arbitrary_ops(50)) {
-            let mut state = BorrowState::new();
-
-            for op in operations {
-                _ = op.execute(&mut state);
-                if !state.has_accessible() {
-                    assert!(state.increment_shared().is_ok());
-                    assert!(state.decrement_shared().is_ok());
-                }
-            }
-        }
-    }
-
-    proptest! {
-        #[test]
-        fn can_borrow_mut_when_no_shared_and_no_accessible(operations in arbitrary_ops(50)) {
-            let mut state = BorrowState::new();
-
-            for op in operations {
-                _ = op.execute(&mut state);
-                if !state.has_accessible() && !state.has_shared_reference() {
-                    assert!(state.increment_mut().is_ok());
-                    assert!(state.decrement_mut().is_ok());
-                }
-            }
-        }
-    }
-
-    proptest! {
-        #[test]
-        fn cannot_borrow_mut_when_shared(operations in arbitrary_ops(50)) {
-            let mut state = BorrowState::new();
-
-            for op in operations {
-                _ = op.execute(&mut state);
-                if state.has_shared_reference() {
-                    assert!(state.increment_mut().is_err());
-                }
-            }
-        }
-    }
-
-    proptest! {
-        #[test]
-        fn cannot_borrow_mut_when_has_accessible(operations in arbitrary_ops(50)) {
-            let mut state = BorrowState::new();
-
-            for op in operations {
-                _ = op.execute(&mut state);
-                if state.has_accessible() {
-                    assert!(state.increment_mut().is_err());
-                }
-            }
-        }
-    }
-
-    proptest! {
-        #[test]
-        fn can_set_inaccessible_when_accessible(operations in arbitrary_ops(50)) {
-            let mut state = BorrowState::new();
-
-            for op in operations {
-                _ = op.execute(&mut state);
-                if state.has_accessible() {
-                    assert!(state.set_inaccessible().is_ok());
-                    assert!(state.unset_inaccessible().is_ok());
-                }
-            }
-        }
-    }
-
-    proptest! {
-        #[test]
-        fn cannot_set_inaccessible_when_shared(operations in arbitrary_ops(50)) {
-            let mut state = BorrowState::new();
-
-            for op in operations {
-                _ = op.execute(&mut state);
-                if state.has_shared_reference() {
-                    assert!(state.set_inaccessible().is_err());
-                }
-            }
-        }
-    }
-
-    proptest! {
-        #[test]
-        fn cannot_set_inaccessible_when_inaccessible(operations in arbitrary_ops(50)) {
-            let mut state = BorrowState::new();
-
-            for op in operations {
-                _ = op.execute(&mut state);
-                if !state.has_accessible() {
-                    assert!(state.set_inaccessible().is_err());
-                }
-            }
-        }
-    }
-
-    proptest! {
-        #[test]
-        fn remove_shared_inc_dec_pairs_is_noop(operations in arbitrary_ops(50)) {
-            let mut state_all = BorrowState::new();
-            let executor_all = OperationExecutor::from(operations);
-            executor_all.execute_all(&mut state_all);
-
-            let mut state_no_shared_pairs = BorrowState::new();
-            let executor_no_shared_pairs = executor_all.clone().remove_shared_inc_dec_pairs();
-            executor_no_shared_pairs.execute_all(&mut state_no_shared_pairs);
-
-            assert_eq!(state_all, state_no_shared_pairs);
-        }
-    }
-}
-
 #[cfg(test)]
 mod test {
+    use std::collections::HashSet;
+
     use super::*;
+
+    /// `(shared, mut, inaccessible)` counts; uniquely identifies a non-poisoned `BorrowState`.
+    type State = (usize, usize, usize);
+
+    /// Caps each counter so the unbounded increment ops yield a finite, terminating search. 2 lets exploration cross the 1<->2 boundary,
+    /// catching any accidental special-casing of "exactly one"; impl only branches on `== 0` / `> 0` / `has_accessible`, so 3+ adds nothing.
+    const MAX_COUNT: usize = 2;
+
+    /// One operation under test, with an independent model of when it succeeds, how state changes, and what it returns.
+    struct Op {
+        name: &'static str,
+        /// The real method under test, referenced directly.
+        method: fn(&mut BorrowState) -> Result<usize, BorrowStateErr>,
+        /// Independently restated success condition, validated against the real implementation.
+        expected_success: fn(&BorrowState) -> bool,
+        /// Field change applied to a model clone on success.
+        expected_change: fn(&mut BorrowState),
+        /// Counter the method returns on success, read from the post-op state.
+        expected_result: fn(&BorrowState) -> usize,
+    }
+
+    const OPS: &[Op] = &[
+        Op {
+            name: "increment_shared",
+            method: BorrowState::increment_shared,
+            expected_success: |s| !s.has_accessible(),
+            expected_change: |s| s.shared_count += 1,
+            expected_result: |s| s.shared_count,
+        },
+        Op {
+            name: "decrement_shared",
+            method: BorrowState::decrement_shared,
+            expected_success: |s| s.shared_count > 0,
+            expected_change: |s| s.shared_count -= 1,
+            expected_result: |s| s.shared_count,
+        },
+        Op {
+            name: "increment_mut",
+            method: BorrowState::increment_mut,
+            expected_success: |s| !s.has_accessible() && s.shared_count == 0,
+            expected_change: |s| s.mut_count += 1,
+            expected_result: |s| s.mut_count,
+        },
+        Op {
+            name: "decrement_mut",
+            method: BorrowState::decrement_mut,
+            expected_success: |s| s.has_accessible(),
+            expected_change: |s| s.mut_count -= 1,
+            expected_result: |s| s.mut_count,
+        },
+        Op {
+            name: "set_inaccessible",
+            method: BorrowState::set_inaccessible,
+            expected_success: |s| s.has_accessible(),
+            expected_change: |s| s.inaccessible_count += 1,
+            expected_result: |s| s.inaccessible_count,
+        },
+        Op {
+            name: "unset_inaccessible",
+            method: BorrowState::unset_inaccessible,
+            expected_success: |s| {
+                !s.has_accessible() && s.shared_count == 0 && s.inaccessible_count > 0
+            },
+            expected_change: |s| s.inaccessible_count -= 1,
+            expected_result: |s| s.inaccessible_count,
+        },
+    ];
+
+    fn build((shared, mutable, inaccessible): State) -> BorrowState {
+        BorrowState {
+            shared_count: shared,
+            mut_count: mutable,
+            inaccessible_count: inaccessible,
+            poisoned: false,
+        }
+    }
+
+    /// Exhaustively explores every state reachable from `new()` (counts bounded by [`MAX_COUNT`]) and validates all operations.
+    #[test]
+    fn exhaustive_model_check() {
+        // DFS reachability traversal (LIFO `Vec`), not nested `0..=MAX_COUNT` loops: the latter would visit invalid
+        // states like `(mut=0, inaccessible=2)`, where `has_accessible()` underflows `mut_count - inaccessible_count`.
+        let mut visited = HashSet::from([(0, 0, 0)]);
+        let mut queue = vec![(0, 0, 0)];
+
+        while let Some(state) = queue.pop() {
+            let initial = build(state);
+
+            // Structural invariants that must hold for every reachable state.
+            assert!(
+                !initial.is_poisoned(),
+                "reachable state {state:?} is poisoned"
+            );
+            assert!(
+                initial.mut_count - initial.inaccessible_count <= 1,
+                "more than one accessible mut: {state:?}"
+            );
+            assert!(
+                !(initial.shared_count > 0 && initial.has_accessible()),
+                "shared and accessible mut coexist: {state:?}"
+            );
+
+            for op in OPS {
+                let name = op.name;
+
+                let mut actual = initial.clone();
+                let result = (op.method)(&mut actual);
+                let succeeded = result.is_ok();
+
+                assert_eq!(
+                    succeeded,
+                    (op.expected_success)(&initial),
+                    "`{name}` success mismatch in {state:?}"
+                );
+
+                // On success: exactly the documented field delta and the post-op counter returned. On failure: no change at all.
+                let mut expected = initial.clone();
+                if succeeded {
+                    (op.expected_change)(&mut expected);
+                    let expected_result = Ok((op.expected_result)(&expected));
+                    assert_eq!(
+                        result, expected_result,
+                        "`{name}` wrong return value in {state:?}"
+                    );
+                }
+                assert_eq!(
+                    actual, expected,
+                    "`{name}` produced wrong state in {state:?}"
+                );
+                assert!(!actual.is_poisoned(), "`{name}` poisoned state {state:?}");
+
+                // Explore successful transitions within the modeled bound.
+                let next = (
+                    actual.shared_count,
+                    actual.mut_count,
+                    actual.inaccessible_count,
+                );
+                if succeeded && next.0 <= MAX_COUNT && next.1 <= MAX_COUNT && visited.insert(next) {
+                    queue.push(next);
+                }
+            }
+        }
+    }
 
     #[test]
     fn poisoned_unset_shared_ref() {
         let mut state = BorrowState::new();
         assert!(!state.is_poisoned());
 
-        _ = state.increment_mut();
-        assert!(!state.is_poisoned());
-        _ = state.set_inaccessible();
-        assert!(!state.is_poisoned());
-        _ = state.increment_shared();
-        assert!(!state.is_poisoned());
-        _ = state.unset_inaccessible();
-        assert!(!state.is_poisoned());
-        _ = state.increment_shared();
-        assert!(!state.is_poisoned());
-        _ = state.decrement_shared();
-        assert!(!state.is_poisoned());
+        for step in [
+            BorrowState::increment_mut,
+            BorrowState::set_inaccessible,
+            BorrowState::increment_shared,
+            BorrowState::unset_inaccessible,
+            BorrowState::increment_shared,
+            BorrowState::decrement_shared,
+        ] {
+            _ = step(&mut state);
+            assert!(!state.is_poisoned());
+        }
     }
 }


### PR DESCRIPTION
The borrow state machine has a very small design space and pure functions (only three counters), so randomized property tests were both wasteful and weaker than they looked. Most random operations are rejected and leave the state unchanged, so the walks tended to stay near the empty state and rarely reached the more complex ones.

This PR replaces the whole `proptest` suite with a deterministic DFS that explores every reachable state (bounded counts) and checks each operation against an "expected" model of when it may succeed and how it changes the state.

Related changes:
* Remove `proptest` dev-dependency + godot-cell `proptest` feature.
* Remove the dedicated `proptest` CI job.
   The new test runs in the normal `unit-test` and `miri-test` jobs, decreasing full-ci compile time.