### PR TITLE
Make accidental access of `#[doc(hidden)]` symbols more explicit

### DIFF
--- a/godot-codegen/src/generator/signals.rs
+++ b/godot-codegen/src/generator/signals.rs
@@ -161,7 +161,7 @@ fn make_signal_collection(
             #[doc = #provider_docs]
             pub fn #signal_name(&mut self) -> #individual_struct_name<'c, C> {
                 #individual_struct_name {
-                    typed: TypedSignal::extract(&mut self.__internal_obj, #signal_name_str)
+                    typed: TypedSignal::__extract(&mut self.__internal_obj, #signal_name_str)
                 }
             }
         }

--- a/godot-core/Cargo.toml
+++ b/godot-core/Cargo.toml
@@ -26,7 +26,7 @@ experimental-godot-api = ["godot-codegen/experimental-godot-api"]
 experimental-threads = ["godot-ffi/experimental-threads", "godot-codegen/experimental-threads"]
 experimental-wasm-nothreads = ["godot-ffi/experimental-wasm-nothreads"]
 debug-log = ["godot-ffi/debug-log"]
-trace = []
+itest = []
 
 api-custom = ["godot-ffi/api-custom", "godot-codegen/api-custom"]
 api-custom-json = ["godot-codegen/api-custom-json"]

--- a/godot-core/src/builtin/callable.rs
+++ b/godot-core/src/builtin/callable.rs
@@ -203,7 +203,7 @@ impl Callable {
         )
     }
 
-    #[cfg(feature = "trace")] // Test only.
+    #[cfg(feature = "itest")]
     #[doc(hidden)]
     pub fn __once_fn<F, S>(name: S, rust_function: F) -> Self
     where
@@ -516,8 +516,7 @@ impl Callable {
         alleged_count.max(0) as usize
     }
 
-    #[doc(hidden)]
-    pub fn as_inner(&self) -> inner::InnerCallable<'_> {
+    pub(crate) fn as_inner(&self) -> inner::InnerCallable<'_> {
         inner::InnerCallable::from_outer(self)
     }
 }

--- a/godot-core/src/builtin/collections/any_array.rs
+++ b/godot-core/src/builtin/collections/any_array.rs
@@ -405,8 +405,7 @@ impl AnyArray {
 
     /// # Safety
     /// Must not be used for any "input" operations, moving elements into the array -- this would break covariance.
-    #[doc(hidden)]
-    pub unsafe fn as_inner_mut(&self) -> inner::InnerArray<'_> {
+    pub(crate) unsafe fn as_inner_mut(&self) -> inner::InnerArray<'_> {
         inner::InnerArray::from_outer_typed(&self.array)
     }
 

--- a/godot-core/src/builtin/collections/any_dictionary.rs
+++ b/godot-core/src/builtin/collections/any_dictionary.rs
@@ -360,8 +360,7 @@ impl AnyDictionary {
 
     /// # Safety
     /// Must not be used for any "input" operations, moving elements into the dictionary -- this would break covariance.
-    #[doc(hidden)]
-    pub unsafe fn as_inner_mut(&self) -> inner::InnerDictionary<'_> {
+    pub(crate) unsafe fn as_inner_mut(&self) -> inner::InnerDictionary<'_> {
         inner::InnerDictionary::from_outer(&self.dict)
     }
 

--- a/godot-core/src/builtin/collections/array.rs
+++ b/godot-core/src/builtin/collections/array.rs
@@ -854,8 +854,7 @@ impl<T: Element> Array<T> {
     ///
     /// In particular this means that all reads are fine, since all values can be converted to `Variant`. However, writes are only OK
     /// if they match the type `T`.
-    #[doc(hidden)]
-    pub unsafe fn as_inner_mut(&self) -> inner::InnerArray<'_> {
+    pub(crate) unsafe fn as_inner_mut(&self) -> inner::InnerArray<'_> {
         // The memory layout of `Array<T>` does not depend on `T`.
         inner::InnerArray::from_outer_typed(self)
     }

--- a/godot-core/src/builtin/collections/dictionary.rs
+++ b/godot-core/src/builtin/collections/dictionary.rs
@@ -496,8 +496,7 @@ impl<K: Element, V: Element> Dictionary<K, V> {
         );
     }
 
-    #[doc(hidden)]
-    pub fn as_inner(&self) -> inner::InnerDictionary<'_> {
+    pub(crate) fn as_inner(&self) -> inner::InnerDictionary<'_> {
         inner::InnerDictionary::from_outer_typed(self)
     }
 

--- a/godot-core/src/builtin/mod.rs
+++ b/godot-core/src/builtin/mod.rs
@@ -51,7 +51,7 @@ pub mod __prelude_reexport {
 
     pub use super::math::XformInv;
     pub use super::{EulerOrder, VariantOperator, VariantType};
-    #[cfg(feature = "trace")] // Test only.
+    #[cfg(feature = "itest")]
     pub use crate::static_sname;
     pub use crate::{array, dict, iarray, idict, real, reals, varray, vdict, vslice};
 }

--- a/godot-core/src/builtin/quaternion.rs
+++ b/godot-core/src/builtin/quaternion.rs
@@ -259,8 +259,7 @@ impl Quaternion {
         )
     }
 
-    #[doc(hidden)]
-    pub fn as_inner(&self) -> inner::InnerQuaternion<'_> {
+    pub(crate) fn as_inner(&self) -> inner::InnerQuaternion<'_> {
         inner::InnerQuaternion::from_outer(self)
     }
 

--- a/godot-core/src/builtin/signal.rs
+++ b/godot-core/src/builtin/signal.rs
@@ -183,8 +183,7 @@ impl Signal {
         self.as_inner().is_null()
     }
 
-    #[doc(hidden)]
-    pub fn as_inner(&self) -> inner::InnerSignal<'_> {
+    pub(crate) fn as_inner(&self) -> inner::InnerSignal<'_> {
         inner::InnerSignal::from_outer(self)
     }
 }

--- a/godot-core/src/builtin/strings/gstring.rs
+++ b/godot-core/src/builtin/strings/gstring.rs
@@ -250,8 +250,7 @@ impl GString {
         unsafe { self.move_return_ptr(dst, sys::PtrcallType::Standard) };
     }
 
-    #[doc(hidden)]
-    pub fn as_inner(&self) -> inner::InnerString<'_> {
+    pub(crate) fn as_inner(&self) -> inner::InnerString<'_> {
         inner::InnerString::from_outer(self)
     }
 }

--- a/godot-core/src/builtin/strings/node_path.rs
+++ b/godot-core/src/builtin/strings/node_path.rs
@@ -179,8 +179,7 @@ impl NodePath {
             .slice(begin, exclusive_end.unwrap_or(i32::MAX as i64))
     }
 
-    #[doc(hidden)]
-    pub fn as_inner(&self) -> inner::InnerNodePath<'_> {
+    pub(crate) fn as_inner(&self) -> inner::InnerNodePath<'_> {
         inner::InnerNodePath::from_outer(self)
     }
 }

--- a/godot-core/src/builtin/strings/string_name.rs
+++ b/godot-core/src/builtin/strings/string_name.rs
@@ -246,8 +246,7 @@ impl StringName {
         }
     }
 
-    #[doc(hidden)]
-    pub fn as_inner(&self) -> inner::InnerStringName<'_> {
+    pub(crate) fn as_inner(&self) -> inner::InnerStringName<'_> {
         inner::InnerStringName::from_outer(self)
     }
 

--- a/godot-core/src/builtin/vectors/vector2.rs
+++ b/godot-core/src/builtin/vectors/vector2.rs
@@ -11,9 +11,11 @@ use std::fmt;
 use godot_ffi as sys;
 use sys::{ExtVariantType, GodotFfi, ffi_methods};
 
+#[cfg(feature = "itest")]
+use crate::builtin::inner;
 use crate::builtin::math::{FloatExt, GlamConv, GlamType};
 use crate::builtin::vectors::Vector2Axis;
-use crate::builtin::{RAffine2, RVec2, Vector2i, inner, real};
+use crate::builtin::{RAffine2, RVec2, Vector2i, real};
 
 /// Vector used for 2D math using floating point coordinates.
 ///
@@ -158,6 +160,7 @@ impl Vector2 {
         self.rotated(angle * weight) * (result_length / start_length)
     }
 
+    #[cfg(feature = "itest")]
     #[doc(hidden)]
     #[inline]
     pub fn as_inner(&self) -> inner::InnerVector2<'_> {

--- a/godot-core/src/builtin/vectors/vector2i.rs
+++ b/godot-core/src/builtin/vectors/vector2i.rs
@@ -11,8 +11,10 @@ use std::fmt;
 use godot_ffi as sys;
 use sys::{ExtVariantType, GodotFfi, ffi_methods};
 
+#[cfg(feature = "itest")]
+use crate::builtin::inner;
 use crate::builtin::math::{GlamConv, GlamType};
-use crate::builtin::{RVec2, Vector2, Vector2Axis, inner, real};
+use crate::builtin::{RVec2, Vector2, Vector2Axis, real};
 
 /// Vector used for 2D math using integer coordinates.
 ///
@@ -76,6 +78,7 @@ impl Vector2i {
         RVec2::new(self.x as real, self.y as real)
     }
 
+    #[cfg(feature = "itest")]
     #[doc(hidden)]
     #[inline]
     pub fn as_inner(&self) -> inner::InnerVector2i<'_> {

--- a/godot-core/src/builtin/vectors/vector3.rs
+++ b/godot-core/src/builtin/vectors/vector3.rs
@@ -11,9 +11,11 @@ use std::fmt;
 use godot_ffi as sys;
 use sys::{ExtVariantType, GodotFfi, ffi_methods};
 
+#[cfg(feature = "itest")]
+use crate::builtin::inner;
 use crate::builtin::math::{FloatExt, GlamConv, GlamType};
 use crate::builtin::vectors::Vector3Axis;
-use crate::builtin::{Basis, RVec3, Vector2, Vector3i, inner, real};
+use crate::builtin::{Basis, RVec3, Vector2, Vector3i, real};
 
 /// Vector used for 3D math using floating point coordinates.
 ///
@@ -93,6 +95,7 @@ impl_vector_fns!(Vector3, RVec3, real, (x, y, z));
 
 /// # Specialized `Vector3` functions
 impl Vector3 {
+    #[cfg(feature = "itest")]
     #[doc(hidden)]
     #[inline]
     pub fn as_inner(&self) -> inner::InnerVector3<'_> {

--- a/godot-core/src/builtin/vectors/vector3i.rs
+++ b/godot-core/src/builtin/vectors/vector3i.rs
@@ -11,8 +11,10 @@ use std::fmt;
 use godot_ffi as sys;
 use sys::{ExtVariantType, GodotFfi, ffi_methods};
 
+#[cfg(feature = "itest")]
+use crate::builtin::inner;
 use crate::builtin::math::{GlamConv, GlamType};
-use crate::builtin::{RVec3, Vector3, Vector3Axis, inner, real};
+use crate::builtin::{RVec3, Vector3, Vector3Axis, real};
 
 /// Vector used for 3D math using integer coordinates.
 ///
@@ -81,6 +83,7 @@ impl Vector3i {
         RVec3::new(self.x as real, self.y as real, self.z as real)
     }
 
+    #[cfg(feature = "itest")]
     #[doc(hidden)]
     #[inline]
     pub fn as_inner(&self) -> inner::InnerVector3i<'_> {

--- a/godot-core/src/builtin/vectors/vector4.rs
+++ b/godot-core/src/builtin/vectors/vector4.rs
@@ -11,8 +11,10 @@ use std::fmt;
 use godot_ffi as sys;
 use sys::{ExtVariantType, GodotFfi, ffi_methods};
 
+#[cfg(feature = "itest")]
+use crate::builtin::inner;
 use crate::builtin::math::{FloatExt, GlamConv, GlamType};
-use crate::builtin::{RVec4, Vector4Axis, Vector4i, inner, real};
+use crate::builtin::{RVec4, Vector4Axis, Vector4i, real};
 
 /// Vector used for 4D math using floating point coordinates.
 ///
@@ -72,6 +74,7 @@ impl_vector_fns!(Vector4, RVec4, real, (x, y, z, w));
 
 /// # Specialized `Vector4` functions
 impl Vector4 {
+    #[cfg(feature = "itest")]
     #[doc(hidden)]
     #[inline]
     pub fn as_inner(&self) -> inner::InnerVector4<'_> {

--- a/godot-core/src/builtin/vectors/vector4i.rs
+++ b/godot-core/src/builtin/vectors/vector4i.rs
@@ -11,8 +11,10 @@ use std::fmt;
 use godot_ffi as sys;
 use sys::{ExtVariantType, GodotFfi, ffi_methods};
 
+#[cfg(feature = "itest")]
+use crate::builtin::inner;
 use crate::builtin::math::{GlamConv, GlamType};
-use crate::builtin::{RVec4, Vector4, Vector4Axis, inner, real};
+use crate::builtin::{RVec4, Vector4, Vector4Axis, real};
 
 /// Vector used for 4D math using integer coordinates.
 ///
@@ -85,6 +87,7 @@ impl Vector4i {
         )
     }
 
+    #[cfg(feature = "itest")]
     #[doc(hidden)]
     #[inline]
     pub fn as_inner(&self) -> inner::InnerVector4i<'_> {

--- a/godot-core/src/classes/class_runtime.rs
+++ b/godot-core/src/classes/class_runtime.rs
@@ -336,7 +336,7 @@ where
     // Slow path. Missing FFI binding makes a call UB -> turn that into a clean panic (covers global ctor/dtor). A `None` level with binding up
     // is the legit early-Core registration window: fall back to an uncached fetch, just don't cache.
     assert!(
-        sys::is_initialized(),
+        sys::is_godot_initialized(),
         "{}::singleton() called while the Godot FFI binding is unavailable (global init/deinit). \
         See is_singleton_available().",
         std::any::type_name::<T>(),

--- a/godot-core/src/docs.rs
+++ b/godot-core/src/docs.rs
@@ -112,7 +112,7 @@ struct AggregatedDocs {
 /// it is undesirable to merge them at compile time. Instead, they are being kept as a
 /// strings of not-yet-parented XML tags (or empty string if no method has been documented).
 #[doc(hidden)]
-pub fn gather_xml_docs() -> impl Iterator<Item = String> {
+pub fn __gather_xml_docs() -> impl Iterator<Item = String> {
     let mut map = HashMap::<ClassId, AggregatedDocs>::new();
 
     crate::private::iterate_docs_shards(|shard| {
@@ -194,7 +194,7 @@ fn wrap_in_xml_block(tag: &str, mut blocks: Vec<&'static str>) -> String {
 ///
 /// If "experimental-threads" is not enabled, then this must be called from the same thread that the bindings were initialized from.
 pub unsafe fn register() {
-    for xml in gather_xml_docs() {
+    for xml in __gather_xml_docs() {
         // SAFETY: `xml` being String means it's valid UTF-8. It's not null-terminated, but we provide its length.
         unsafe {
             crate::sys::interface_fn!(editor_help_load_xml_from_utf8_chars_and_len)(

--- a/godot-core/src/global/print.rs
+++ b/godot-core/src/global/print.rs
@@ -193,7 +193,7 @@ pub struct PrintRecord<'a> {
 #[track_caller]
 pub fn print_custom(record: PrintRecord<'_>) {
     // Engine not yet loaded -- fall back to stderr.
-    if !sys::is_initialized() {
+    if !sys::is_godot_initialized() {
         let level = record
             .level
             .godot_title()

--- a/godot-core/src/init/mod.rs
+++ b/godot-core/src/init/mod.rs
@@ -59,7 +59,7 @@ pub(crate) fn singleton_cache_generation() -> u64 {
 /// Test-only: bump the singleton-cache generation, forcing every singleton cache to miss on its next access (re-fetch via the slow path).
 ///
 /// Mirrors what a full Core deinit does, letting itests exercise the uncached path on demand without a real deinit/reinit cycle.
-#[cfg(feature = "trace")]
+#[cfg(feature = "itest")]
 #[doc(hidden)]
 pub fn __invalidate_singleton_caches() {
     SINGLETON_CACHE_GENERATION.fetch_add(1, Ordering::Release);

--- a/godot-core/src/meta/args/mod.rs
+++ b/godot-core/src/meta/args/mod.rs
@@ -22,10 +22,9 @@ pub use as_arg::{
     ArgPassing, AsArg, AsDirectElement, ByObject, ByOption, ByRef, ByValue, ByVariant, ToArg,
     owned_into_arg, ref_to_arg,
 };
-#[cfg(not(feature = "trace"))]
+#[cfg(not(feature = "itest"))]
 pub(crate) use cow_arg::{CowArg, FfiArg};
-// Integration test only.
-#[cfg(feature = "trace")]
+#[cfg(feature = "itest")]
 #[doc(hidden)]
 pub use cow_arg::{CowArg, FfiArg};
 pub use object_arg::ObjectArg;

--- a/godot-core/src/meta/class_id.rs
+++ b/godot-core/src/meta/class_id.rs
@@ -121,13 +121,13 @@ impl ClassId {
     }
 
     // Test-only APIs.
-    #[cfg(feature = "trace")] // itest only.
+    #[cfg(feature = "itest")]
     #[doc(hidden)]
     pub fn __cached<T: 'static>(init_fn: impl FnOnce() -> String) -> Self {
         Self::new_cached_inner::<T>(init_fn)
     }
 
-    #[cfg(feature = "trace")] // itest only.
+    #[cfg(feature = "itest")]
     #[doc(hidden)]
     pub fn __dynamic(class_name: &str) -> Self {
         Self::new_dynamic(class_name.to_string())
@@ -155,11 +155,6 @@ impl ClassId {
         let source = Cow::Borrowed(class_name_str);
         let mut cache = CLASS_ID_CACHE.lock();
         cache.insert_class_id(source, None, true)
-    }
-
-    #[doc(hidden)]
-    pub fn is_none(&self) -> bool {
-        self.global_index == 0
     }
 
     /// Returns the class name as a `GString`.
@@ -281,9 +276,9 @@ impl ClassIdCache {
         if expect_first {
             // From Rust edition 2024+, doctests are merged. Even with ```no_run, the link step (registration of class ID)
             // still happens on test startup, so classes in other codeblocks with the same name cause panics in tests. To address this, we
-            // rely on the fact that Godot is not run during unit-tests, and thus is_initialized() is false. We then return the existing ID,
+            // rely on the fact that Godot is not run during unit-tests, and thus is_godot_initialized() is false. We then return the existing ID,
             // which is wrong but doesn't matter as there's no runtime logic being performed. We do not support unit-tests without ```no_run.
-            if !sys::is_initialized()
+            if !sys::is_godot_initialized()
                 && let Some(&existing_index) = self.string_to_index.get(source.as_ref())
             {
                 return ClassId {

--- a/godot-core/src/meta/mod.rs
+++ b/godot-core/src/meta/mod.rs
@@ -75,7 +75,7 @@ pub use godot_convert::{EngineFromGodot, EngineToGodot, FromGodot, GodotConvert,
 pub use object_to_owned::ObjectToOwned;
 pub use param_tuple::{InParamTuple, OutParamTuple, ParamTuple};
 pub use raw_ptr::{FfiRawPointer, RawPtr};
-#[cfg(feature = "trace")]
+#[cfg(feature = "itest")]
 pub use signature::trace;
 pub use signed_range::{SignedRange, wrapped};
 pub use traits::{Element, GodotImmutable, GodotType, PackedElement, element_variant_type};

--- a/godot-core/src/meta/signature.rs
+++ b/godot-core/src/meta/signature.rs
@@ -104,7 +104,7 @@ where
         let arg_count = arg_count as usize;
         CallError::check_arg_count(call_ctx, arg_count, default_values.len(), Params::LEN)?;
 
-        #[cfg(feature = "trace")]
+        #[cfg(feature = "itest")]
         trace::push(true, false, call_ctx);
 
         // SAFETY: TODO.
@@ -133,7 +133,7 @@ where
     ) -> CallResult<()> {
         // $crate::out!("in_ptrcall: {call_ctx}");
 
-        #[cfg(feature = "trace")]
+        #[cfg(feature = "itest")]
         trace::push(true, true, call_ctx);
 
         // SAFETY: TODO.
@@ -700,7 +700,7 @@ impl fmt::Display for CallContext<'_> {
     }
 }
 
-#[cfg(feature = "trace")]
+#[cfg(feature = "itest")]
 pub mod trace {
     use std::cell::Cell;
 

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -240,7 +240,7 @@ where
     ///
     /// On Godot versions before 4.3 placeholder substitution does not exist; non-tool classes are instead filtered out at registration when the
     /// `tool_only_in_editor` config option is enabled (the default). This method then always returns `false`.
-    #[cfg(all(feature = "trace", feature = "upcoming-editor-placeholders"))]
+    #[cfg(all(feature = "itest", feature = "upcoming-editor-placeholders"))]
     pub fn is_editor_placeholder(&self) -> bool {
         self.raw.storage().is_none()
     }
@@ -419,7 +419,7 @@ impl<T: GodotClass> Gd<T> {
         std::mem::forget(self);
     }
 
-    #[cfg(feature = "trace")] // itest only.
+    #[cfg(feature = "itest")]
     #[doc(hidden)]
     pub fn test_refcount(&self) -> Option<usize> {
         self.maybe_refcount()
@@ -452,7 +452,7 @@ impl<T: GodotClass> Gd<T> {
     /// Equivalent to [`upcast::<Object>()`][Self::upcast], but without bounds.
     // Not yet public because it might need _mut/_ref overloads, and 6 upcast methods are a bit much...
     #[doc(hidden)] // no public API, but used by #[signal].
-    pub fn upcast_object(self) -> Gd<classes::Object> {
+    pub fn __upcast_object(self) -> Gd<classes::Object> {
         self.owned_cast()
             .expect("Upcast to Object failed. This is a bug; please report it.")
     }
@@ -791,7 +791,7 @@ impl<T: GodotClass> Gd<T> {
         unsafe { Self::from_obj_sys_weak_or_none(ptr).unwrap() }
     }
 
-    #[cfg(feature = "trace")] // itest only.
+    #[cfg(feature = "itest")]
     #[doc(hidden)]
     pub unsafe fn __from_obj_sys_weak(ptr: sys::GDExtensionObjectPtr) -> Self {
         unsafe { Self::from_obj_sys_weak(ptr) }

--- a/godot-core/src/obj/guards.rs
+++ b/godot-core/src/obj/guards.rs
@@ -109,8 +109,7 @@ impl<'a, D> DynGdRef<'a, D>
 where
     D: ?Sized + 'static,
 {
-    #[doc(hidden)]
-    pub fn from_guard<T: AsDyn<D>>(guard: GdRef<'a, T>) -> Self {
+    pub(crate) fn from_guard<T: AsDyn<D>>(guard: GdRef<'a, T>) -> Self {
         let obj = &*guard;
         let dyn_obj = obj.dyn_upcast();
 
@@ -155,8 +154,7 @@ impl<'a, D> DynGdMut<'a, D>
 where
     D: ?Sized + 'static,
 {
-    #[doc(hidden)]
-    pub fn from_guard<T: AsDyn<D>>(mut guard: GdMut<'a, T>) -> Self {
+    pub(crate) fn from_guard<T: AsDyn<D>>(mut guard: GdMut<'a, T>) -> Self {
         let obj = &mut *guard;
         let dyn_obj = obj.dyn_upcast_mut();
 

--- a/godot-core/src/obj/on_editor.rs
+++ b/godot-core/src/obj/on_editor.rs
@@ -280,7 +280,7 @@ impl<T: Var + FromGodot + PartialEq> OnEditor<T> {
     }
 
     #[doc(hidden)]
-    pub fn is_invalid(&self) -> bool {
+    pub fn __is_invalid(&self) -> bool {
         match self.state {
             OnEditorState::UninitNull | OnEditorState::UninitSentinel(_) => true,
             OnEditorState::Initialized(_) => false,

--- a/godot-core/src/private.rs
+++ b/godot-core/src/private.rs
@@ -28,7 +28,7 @@ mod reexport_pub {
     pub use crate::r#gen::classes::class_macros;
     pub use crate::r#gen::virtuals; // virtual fn names, hashes, signatures
     pub use crate::meta::private_reexport::*;
-    #[cfg(feature = "trace")]
+    #[cfg(feature = "itest")]
     pub use crate::meta::{CowArg, FfiArg, trace};
     pub use crate::obj::rpc::priv_re_export::*;
     pub use crate::obj::rtti::ObjectRtti;

--- a/godot-core/src/registry/class.rs
+++ b/godot-core/src/registry/class.rs
@@ -175,8 +175,9 @@ pub(crate) fn register_class<
         ..default_creation_info()
     };
 
-    assert!(
-        !T::class_id().is_none(),
+    assert_ne!(
+        T::class_id(),
+        ClassId::none(),
         "cannot register () or unnamed class"
     );
 

--- a/godot-core/src/registry/shard.rs
+++ b/godot-core/src/registry/shard.rs
@@ -601,7 +601,7 @@ impl DynTraitImpl {
             return Err(object);
         }
 
-        let object = object.upcast_object();
+        let object = object.__upcast_object();
 
         // SAFETY: `DynTraitImpl::new` ensures that this function is safe to call when `object` is castable to `self.class_name`.
         // Since the dynamic class of `object` is `self.class_name`, it must be castable to `self.class_name`.

--- a/godot-core/src/signal/signal_object.rs
+++ b/godot-core/src/signal/signal_object.rs
@@ -54,7 +54,7 @@ impl<'c, C: WithUserSignals> SignalObject<'c> for UserSignalObject<'c, C> {
     fn to_owned_object(&self) -> Gd<Object> {
         match self {
             // SignalObject::Internal { obj_mut } => crate::private::rebuild_gd(*obj_mut),
-            Self::Internal { self_mut } => <C as WithBaseField>::to_gd(self_mut).upcast_object(),
+            Self::Internal { self_mut } => <C as WithBaseField>::to_gd(self_mut).__upcast_object(),
             Self::External { gd } => gd.clone(),
         }
     }
@@ -71,7 +71,7 @@ impl<C: WithSignals> SignalObject<'_> for Gd<C> {
 
     #[inline]
     fn to_owned_object(&self) -> Gd<Object> {
-        self.clone().upcast_object()
+        self.clone().__upcast_object()
     }
 }
 

--- a/godot-core/src/signal/typed_signal.rs
+++ b/godot-core/src/signal/typed_signal.rs
@@ -134,7 +134,7 @@ pub struct TypedSignal<'c, C: WithSignals, Ps> {
 
 impl<'c, C: WithSignals, Ps: meta::ParamTuple> TypedSignal<'c, C, Ps> {
     #[doc(hidden)]
-    pub fn extract(
+    pub fn __extract(
         obj: &mut Option<C::__SignalObj<'c>>,
         signal_name: &'static str,
     ) -> TypedSignal<'c, C, Ps> {

--- a/godot-core/src/task/async_runtime.rs
+++ b/godot-core/src/task/async_runtime.rs
@@ -292,7 +292,7 @@ pub(crate) fn is_engine_exiting() -> bool {
     false
 }
 
-#[cfg(feature = "trace")]
+#[cfg(feature = "itest")]
 mod itest_only {
     use super::*;
 
@@ -319,7 +319,7 @@ mod itest_only {
         }
     }
 }
-#[cfg(feature = "trace")]
+#[cfg(feature = "itest")]
 pub use itest_only::*;
 
 /// The current state of a future inside the async runtime.
@@ -406,7 +406,7 @@ impl<T> FutureSlot<T> {
 struct AsyncRuntime {
     tasks: Vec<FutureSlot<Pin<Box<dyn Future<Output = ()>>>>>,
     next_task_id: u64,
-    #[cfg(feature = "trace")]
+    #[cfg(feature = "itest")]
     panicked_tasks: std::collections::HashSet<u64>,
 }
 
@@ -416,7 +416,7 @@ impl AsyncRuntime {
             // We only create a new async runtime inside a thread_local, which has lazy initialization on first use.
             tasks: Vec::with_capacity(16),
             next_task_id: 0,
-            #[cfg(feature = "trace")]
+            #[cfg(feature = "itest")]
             panicked_tasks: std::collections::HashSet::default(),
         }
     }
@@ -491,7 +491,7 @@ impl AsyncRuntime {
     /// Track that a future caused a panic.
     ///
     /// This is only available for itest.
-    #[cfg(feature = "trace")]
+    #[cfg(feature = "itest")]
     fn track_panic(&mut self, task_id: u64) {
         self.panicked_tasks.insert(task_id);
     }
@@ -576,7 +576,7 @@ fn poll_future(godot_waker: Arc<GodotWaker>) {
     let Ok((poll_result, future)) = panic_result else {
         // Polling the future caused a panic. The task state has to be cleaned up and we want track the panic if the trace feature is enabled.
         ASYNC_RUNTIME.with_runtime_mut(|rt| {
-            #[cfg(feature = "trace")]
+            #[cfg(feature = "itest")]
             rt.track_panic(godot_waker.task_id);
             rt.clear_task(godot_waker.runtime_index);
         });

--- a/godot-core/src/task/futures.rs
+++ b/godot-core/src/task/futures.rs
@@ -98,7 +98,7 @@ impl<R: IntoDynamicSend> Clone for SignalFutureResolver<R> {
 }
 
 /// For itest to construct and test a resolver.
-#[cfg(feature = "trace")]
+#[cfg(feature = "itest")]
 pub fn create_test_signal_future_resolver<R: IntoDynamicSend>() -> SignalFutureResolver<R> {
     SignalFutureResolver {
         data: Arc::new(Mutex::new(SignalFutureData::default())),

--- a/godot-core/src/task/mod.rs
+++ b/godot-core/src/task/mod.rs
@@ -21,7 +21,7 @@ pub use futures::{
 };
 
 // For use in integration tests.
-#[cfg(feature = "trace")]
+#[cfg(feature = "itest")]
 mod reexport_test {
     pub use super::async_runtime::{
         EngineExitingGuard, has_godot_task_panicked, simulate_engine_exiting,
@@ -29,7 +29,7 @@ mod reexport_test {
     pub use super::futures::{SignalFutureResolver, create_test_signal_future_resolver};
 }
 
-#[cfg(feature = "trace")]
+#[cfg(feature = "itest")]
 pub use reexport_test::*;
 
 // Crate-local re-exports.

--- a/godot-ffi/src/binding/mod.rs
+++ b/godot-ffi/src/binding/mod.rs
@@ -366,7 +366,7 @@ pub unsafe fn config() -> &'static GdextConfig {
 /// The bindings are initialized when the library is loaded and deinitialized when it is unloaded (which may happen e.g. during a hot reload).
 /// Do not use this as a general check whether certain Godot APIs can be used -- this is more complex and may depend on class/singleton.
 #[inline]
-pub fn is_initialized() -> bool {
+pub fn is_godot_initialized() -> bool {
     BindingStorage::is_initialized()
 }
 

--- a/godot-macros/src/class/data_models/signal.rs
+++ b/godot-macros/src/class/data_models/signal.rs
@@ -338,7 +338,7 @@ impl SignalCollection {
             // visibility that exceeds the class visibility). So, we can as well declare the visibility here.
             #vis_marker fn #signal_name(&mut self) -> #individual_struct_name<'c, C> {
                 #individual_struct_name {
-                    __typed: ::godot::signal::TypedSignal::<'c, C, _>::extract(&mut self.__internal_obj, #godot_name_str)
+                    __typed: ::godot::signal::TypedSignal::<'c, C, _>::__extract(&mut self.__internal_obj, #godot_name_str)
                 }
             }
         });
@@ -562,7 +562,7 @@ fn make_with_signals_impl(class_name: &Ident, collection_struct_name: &Ident) ->
             fn __signals_from_external(external: & ::godot::obj::Gd<Self>) -> Self::SignalCollection<'_, Self> {
                 Self::SignalCollection {
                     __internal_obj: Some(::godot::private::UserSignalObject::External {
-                        gd: external.clone().upcast_object()
+                        gd: external.clone().__upcast_object()
                     })
                 }
             }

--- a/godot-macros/src/class/derive_godot_class.rs
+++ b/godot-macros/src/class/derive_godot_class.rs
@@ -463,7 +463,7 @@ fn make_oneditor_panic_inits(class_name: &Ident, all_fields: &[Field]) -> TokenS
             let field_name_str = field.to_string();
 
             quote! {
-                if this.#field.is_invalid() {
+                if this.#field.__is_invalid() {
                     uninitialized_fields.push(#field_name_str);
                 }
             }

--- a/godot/Cargo.toml
+++ b/godot/Cargo.toml
@@ -49,7 +49,7 @@ default = ["__codegen-full"]
 # Private features, they are under no stability guarantee
 __codegen-full = ["godot-core/codegen-full", "godot-macros/codegen-full"]
 __debug-log = ["godot-core/debug-log"]
-__trace = ["godot-core/trace"]
+__itest = ["godot-core/itest"]
 
 [dependencies]
 godot-core = { path = "../godot-core", version = "=0.5.4" }

--- a/itest/rust/Cargo.toml
+++ b/itest/rust/Cargo.toml
@@ -24,7 +24,7 @@ test-gdextension-dependency = ["dep:itest-dependency"]
 # Instead, compile itest with `--features godot/my-feature`.
 
 [dependencies]
-godot = { path = "../../godot", default-features = false, features = ["__trace"] }
+godot = { path = "../../godot", default-features = false, features = ["__itest"] }
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 pin-project-lite = { workspace = true }

--- a/itest/rust/src/register_tests/register_docs_test.rs
+++ b/itest/rust/src/register_tests/register_docs_test.rs
@@ -404,7 +404,7 @@ fn test_register_docs() {
 
 fn find_class_docs(class_name: &str) -> String {
     let mut count = 0;
-    for xml in godot::docs::gather_xml_docs() {
+    for xml in godot::docs::__gather_xml_docs() {
         count += 1;
         if xml.contains(class_name) {
             return xml;


### PR DESCRIPTION
Symbols marked `#[doc(hidden)]` are explicitly *not* part of the public API, per lib.rs documentation. But sometimes they look like regular methods and users may accidentally use them, and be surprised about unannounced breaking changes.

Clarifies this in different ways:
* add `__` prefix for some internal APIs
* gate behind an internal feature for itests
* remove redundant methods such as `ClassId::is_none()`