### PR TITLE
Rename `cast_int/cast_float` to `to_vector*/to_rect*`

### DIFF
--- a/godot-core/src/builtin/rect2.rs
+++ b/godot-core/src/builtin/rect2.rs
@@ -23,7 +23,7 @@ use crate::builtin::{Rect2i, Side, Vector2, real};
 /// | 2D        | **`Rect2`**     | [`Rect2i`]   |
 /// | 3D        | [`Aabb`]        |              |
 ///
-/// <br>You can convert to `Rect2i` using [`cast_int()`][Self::cast_int].
+/// <br>You can convert to `Rect2i` using [`to_rect2i()`][Self::to_rect2i].
 ///
 /// [`Aabb`]: crate::builtin::Aabb
 ///
@@ -78,11 +78,17 @@ impl Rect2 {
     ///
     /// _Godot equivalent: `Rect2i(Rect2 from)`_
     #[inline]
-    pub const fn cast_int(self) -> Rect2i {
+    pub const fn to_rect2i(self) -> Rect2i {
         Rect2i {
-            position: self.position.cast_int(),
-            size: self.size.cast_int(),
+            position: self.position.to_vector2i(),
+            size: self.size.to_vector2i(),
         }
+    }
+
+    #[deprecated = "Renamed to `to_rect2i()`."]
+    #[inline]
+    pub const fn cast_int(self) -> Rect2i {
+        self.to_rect2i()
     }
 
     /// Returns a rectangle with the same geometry, with top-left corner as `position` and non-negative size.

--- a/godot-core/src/builtin/rect2i.rs
+++ b/godot-core/src/builtin/rect2i.rs
@@ -24,7 +24,7 @@ use crate::builtin::{Rect2, Side, Vector2i};
 /// | 2D        | [`Rect2`]       | **`Rect2i`** |
 /// | 3D        | [`Aabb`]        |              |
 ///
-/// <br>You can convert to `Rect2` using [`cast_float()`][Self::cast_float].
+/// <br>You can convert to `Rect2` using [`to_rect2()`][Self::to_rect2].
 ///
 /// [`Aabb`]: crate::builtin::Aabb
 ///
@@ -84,11 +84,17 @@ impl Rect2i {
     ///
     /// _Godot equivalent: `Rect2(Rect2i from)`_
     #[inline]
-    pub const fn cast_float(self) -> Rect2 {
+    pub const fn to_rect2(self) -> Rect2 {
         Rect2 {
-            position: self.position.cast_float(),
-            size: self.size.cast_float(),
+            position: self.position.to_vector2(),
+            size: self.size.to_vector2(),
         }
+    }
+
+    #[deprecated = "Renamed to `to_rect2()`."]
+    #[inline]
+    pub const fn cast_float(self) -> Rect2 {
+        self.to_rect2()
     }
 
     /// The end of the `Rect2i` calculated as `position + size`.
@@ -315,7 +321,7 @@ mod test {
         let zero = Rect2i::default();
         let new = Rect2i::new(Vector2i::new(0, 100), Vector2i::new(1280, 720));
         let from_components = Rect2i::from_components(0, 100, 1280, 720);
-        let from_rect2 = Rect2::from_components(0.1, 100.3, 1280.1, 720.42).cast_int();
+        let from_rect2 = Rect2::from_components(0.1, 100.3, 1280.1, 720.42).to_rect2i();
         let from_position_end =
             Rect2i::from_position_end(Vector2i::new(0, 100), Vector2i::new(1280, 820));
 

--- a/godot-core/src/builtin/vectors/vector2.rs
+++ b/godot-core/src/builtin/vectors/vector2.rs
@@ -46,7 +46,7 @@ use crate::builtin::{RAffine2, RVec2, Vector2i, real};
 /// | 3D        | [`Vector3`][crate::builtin::Vector3] | [`Vector3i`][crate::builtin::Vector3i] |
 /// | 4D        | [`Vector4`][crate::builtin::Vector4] | [`Vector4i`][crate::builtin::Vector4i] |
 ///
-/// <br>You can convert to `Vector2i` using [`cast_int()`][Self::cast_int].
+/// <br>You can convert to `Vector2i` using [`to_vector2i()`][Self::to_vector2i].
 ///
 /// # Godot docs
 ///
@@ -168,7 +168,7 @@ impl Vector2 {
     }
 }
 
-impl_float_vector_fns!(Vector2, Vector2i, (x, y));
+impl_float_vector_fns!(Vector2, Vector2i, to_vector2i, (x, y));
 impl_vector2x_fns!(Vector2, Vector3, real);
 impl_vector2_vector3_fns!(Vector2, (x, y));
 

--- a/godot-core/src/builtin/vectors/vector2i.rs
+++ b/godot-core/src/builtin/vectors/vector2i.rs
@@ -44,7 +44,7 @@ use crate::builtin::{RVec2, Vector2, Vector2Axis, real};
 /// | 3D        | [`Vector3`][crate::builtin::Vector3] | [`Vector3i`][crate::builtin::Vector3i] |
 /// | 4D        | [`Vector4`][crate::builtin::Vector4] | [`Vector4i`][crate::builtin::Vector4i] |
 ///
-/// <br>You can convert to `Vector2` using [`cast_float()`][Self::cast_float].
+/// <br>You can convert to `Vector2` using [`to_vector2()`][Self::to_vector2].
 ///
 /// # Godot docs
 ///
@@ -69,7 +69,7 @@ impl Vector2i {
 
 /// # Specialized `Vector2i` functions
 impl Vector2i {
-    inline_impl_integer_vector_fns!(Vector2, x, y);
+    inline_impl_integer_vector_fns!(Vector2, to_vector2, x, y);
 
     /// Converts `self` to the corresponding [`real`] `glam` type.
     #[doc(hidden)]

--- a/godot-core/src/builtin/vectors/vector3.rs
+++ b/godot-core/src/builtin/vectors/vector3.rs
@@ -47,7 +47,7 @@ use crate::builtin::{Basis, RVec3, Vector2, Vector3i, real};
 /// | 3D        | **`Vector3`**                        | [`Vector3i`][crate::builtin::Vector3i] |
 /// | 4D        | [`Vector4`][crate::builtin::Vector4] | [`Vector4i`][crate::builtin::Vector4i] |
 ///
-/// <br>You can convert to `Vector3i` using [`cast_int()`][Self::cast_int].
+/// <br>You can convert to `Vector3i` using [`to_vector3i()`][Self::to_vector3i].
 ///
 /// # Godot docs
 ///
@@ -238,7 +238,7 @@ impl Vector3 {
     }
 }
 
-impl_float_vector_fns!(Vector3, Vector3i, (x, y, z));
+impl_float_vector_fns!(Vector3, Vector3i, to_vector3i, (x, y, z));
 impl_vector3x_fns!(Vector3, Vector2, real);
 impl_vector2_vector3_fns!(Vector3, (x, y, z));
 impl_vector3_vector4_fns!(Vector3, (x, y, z));

--- a/godot-core/src/builtin/vectors/vector3i.rs
+++ b/godot-core/src/builtin/vectors/vector3i.rs
@@ -44,7 +44,7 @@ use crate::builtin::{RVec3, Vector3, Vector3Axis, real};
 /// | 3D        | [`Vector3`][crate::builtin::Vector3] | **`Vector3i`**                         |
 /// | 4D        | [`Vector4`][crate::builtin::Vector4] | [`Vector4i`][crate::builtin::Vector4i] |
 ///
-/// <br>You can convert to `Vector3` using [`cast_float()`][Self::cast_float].
+/// <br>You can convert to `Vector3` using [`to_vector3()`][Self::to_vector3].
 ///
 /// # Godot docs
 ///
@@ -74,7 +74,7 @@ impl_vector_fns!(Vector3i, glam::IVec3, i32, (x, y, z));
 
 /// # Specialized `Vector3i` functions
 impl Vector3i {
-    inline_impl_integer_vector_fns!(Vector3, x, y, z);
+    inline_impl_integer_vector_fns!(Vector3, to_vector3, x, y, z);
 
     /// Converts `self` to the corresponding [`real`] `glam` type.
     #[doc(hidden)]

--- a/godot-core/src/builtin/vectors/vector4.rs
+++ b/godot-core/src/builtin/vectors/vector4.rs
@@ -82,7 +82,7 @@ impl Vector4 {
     }
 }
 
-impl_float_vector_fns!(Vector4, Vector4i, (x, y, z, w));
+impl_float_vector_fns!(Vector4, Vector4i, to_vector4i, (x, y, z, w));
 impl_vector4x_fns!(Vector4, real);
 impl_vector3_vector4_fns!(Vector4, (x, y, z, w));
 

--- a/godot-core/src/builtin/vectors/vector4i.rs
+++ b/godot-core/src/builtin/vectors/vector4i.rs
@@ -73,7 +73,7 @@ impl_vector_fns!(Vector4i, glam::IVec4, i32, (x, y, z, w));
 
 /// # Specialized `Vector4i` functions
 impl Vector4i {
-    inline_impl_integer_vector_fns!(Vector4, x, y, z, w);
+    inline_impl_integer_vector_fns!(Vector4, to_vector4, x, y, z, w);
 
     /// Converts `self` to the corresponding [`real`] `glam` type.
     #[doc(hidden)]

--- a/godot-core/src/builtin/vectors/vector_macros.rs
+++ b/godot-core/src/builtin/vectors/vector_macros.rs
@@ -535,6 +535,8 @@ macro_rules! inline_impl_integer_vector_fns {
     (
         // Name of the float-equivalent vector type.
         $VectorFloat:ty,
+        // Name of the conversion method to the float-equivalent vector type.
+        $to_float_fn:ident,
         // Names of the components, for example `x, y`.
         $($comp:ident),*
     ) => {
@@ -617,8 +619,14 @@ macro_rules! inline_impl_integer_vector_fns {
 
         /// Converts to a vector with floating-point [`real`](type.real.html) components, using `as` casts.
         #[inline]
-        pub const fn cast_float(self) -> $VectorFloat {
+        pub const fn $to_float_fn(self) -> $VectorFloat {
             <$VectorFloat>::new( $(self.$comp as real),* )
+        }
+
+        #[deprecated = concat!("Renamed to `", stringify!($to_float_fn), "()`.")]
+        #[inline]
+        pub const fn cast_float(self) -> $VectorFloat {
+            self.$to_float_fn()
         }
     };
 }
@@ -629,6 +637,8 @@ macro_rules! impl_float_vector_fns {
         $Vector:ty,
         // Name of the integer-equivalent vector type.
         $VectorInt:ty,
+        // Name of the conversion method to the integer-equivalent vector type.
+        $to_int_fn:ident,
         // Names of the components, with parentheses, for example `(x, y)`.
         ($($comp:ident),*)
     ) => {
@@ -637,8 +647,13 @@ macro_rules! impl_float_vector_fns {
         /// The following methods are only available on floating-point vectors.
         impl $Vector {
             /// Converts to a vector with integer components, using `as` casts.
-            pub const fn cast_int(self) -> $VectorInt {
+            pub const fn $to_int_fn(self) -> $VectorInt {
                 <$VectorInt>::new( $(self.$comp as i32),* )
+            }
+
+            #[deprecated = concat!("Renamed to `", stringify!($to_int_fn), "()`.")]
+            pub const fn cast_int(self) -> $VectorInt {
+                self.$to_int_fn()
             }
 
             /// Returns a new vector with all components rounded down (towards negative infinity).


### PR DESCRIPTION
Probably more discoverable, and in line with other conversions such as `Array::to_packed_array` or `Color::to_hsv`, etc.