### PR TITLE
Validate class registrations against `ClassDB`

### DIFF
--- a/godot-core/src/init/mod.rs
+++ b/godot-core/src/init/mod.rs
@@ -125,6 +125,9 @@ unsafe extern "C" fn startup_func<E: ExtensionLibrary>() {
 
     // Now that editor UI is ready, display all warnings/error collected so far.
     sys::print_deferred_startup_messages();
+
+    // Terminal init point: abort if a fatal startup error was collected.
+    abort_if_startup_fatal();
 }
 
 #[cfg(since_api = "4.5")]
@@ -343,6 +346,51 @@ unsafe fn gdext_on_level_init(level: InitLevel, _userdata: &InitUserData) {
 
     crate::registry::class::auto_register_classes(level);
     CURRENT_INIT_LEVEL.store(Some(level));
+}
+
+/// Aborts the process if a fatal startup error was collected -- unless in an interactive editor, which stays alive so the developer can read the
+/// errors and hot-reload a fix. A headless editor (CI, `--export-release`, `--import`) has no one to read them and aborts like a game run.
+///
+/// `SceneTree::quit()` only requests a shutdown, so a few frames may still run with the broken class set, possibly causing follow-up errors.
+/// Without a `SceneTree`, `process::exit()` ends the process right away.
+#[cfg(since_api = "4.5")]
+fn abort_if_startup_fatal() {
+    if !sys::take_startup_fatal() {
+        return;
+    }
+
+    // Interactive editor: keep running, the developer can read the errors and hot-reload a fix.
+    if is_editor_hint() && !is_headless() {
+        return;
+    }
+
+    // Exit code within Godot's recommended 0..=125 range for `SceneTree::quit()`.
+    let exit_code = 111;
+    if let Some(main_loop) = classes::Engine::singleton().get_main_loop()
+        && let Ok(mut scene_tree) = main_loop.try_cast::<classes::SceneTree>()
+    {
+        // Request graceful shutdown, running normal teardown. Main loop exists from `MainLoop` init on.
+        scene_tree.quit_ex().exit_code(exit_code).done();
+    } else {
+        // No SceneTree (e.g. a custom MainLoop set via the `application/run/main_loop_type` project setting).
+        std::process::exit(exit_code);
+    }
+}
+
+/// Whether Godot runs without a visual display -- `--headless`, `--display-driver headless`, or an export/import run, which force it.
+///
+/// Queried dynamically because `DisplayServer` is not part of the minimal codegen. A missing singleton counts as headless.
+#[cfg(since_api = "4.5")]
+fn is_headless() -> bool {
+    // Absent singleton or a failing call -> headless. Dynamic call for minimal codegen.
+    if let Some(mut display_server) = classes::Engine::singleton().get_singleton("DisplayServer")
+        && let Ok(name) = display_server.try_call("get_name", &[])
+        && let Ok(name) = name.try_to::<GString>()
+    {
+        name == "headless"
+    } else {
+        true
+    }
 }
 
 /// Tasks needed to be done by gdext internally upon unloading an initialization level. Called after user code.

--- a/godot-core/src/init/mod.rs
+++ b/godot-core/src/init/mod.rs
@@ -126,7 +126,7 @@ unsafe extern "C" fn startup_func<E: ExtensionLibrary>() {
     // Now that editor UI is ready, display all warnings/error collected so far.
     sys::print_deferred_startup_messages();
 
-    // Terminal init point: abort if a fatal startup error was collected.
+    // If any of the errors were fatal, exit here.
     abort_if_startup_fatal();
 }
 
@@ -348,11 +348,13 @@ unsafe fn gdext_on_level_init(level: InitLevel, _userdata: &InitUserData) {
     CURRENT_INIT_LEVEL.store(Some(level));
 }
 
-/// Aborts the process if a fatal startup error was collected -- unless in an interactive editor, which stays alive so the developer can read the
-/// errors and hot-reload a fix. A headless editor (CI, `--export-release`, `--import`) has no one to read them and aborts like a game run.
+/// Aborts the process if a fatal startup error was collected (depending on runtime target).
 ///
-/// `SceneTree::quit()` only requests a shutdown, so a few frames may still run with the broken class set, possibly causing follow-up errors.
-/// Without a `SceneTree`, `process::exit()` ends the process right away.
+/// Behavior:
+/// - An _interactive_ editor is not aborted, so the developer can read the errors and hot-reload a fix.
+/// - A _headless_ editor (CI, `--export-release`, `--import`) has no one to read them and aborts like a game run.
+/// - A _game_ runs `SceneTree::quit()` (frames may still run with the broken class set, possibly causing follow-up errors)
+/// - A game without a `SceneTree` (e.g. a custom `MainLoop`) calls `process::exit()`.
 #[cfg(since_api = "4.5")]
 fn abort_if_startup_fatal() {
     if !sys::take_startup_fatal() {
@@ -369,17 +371,13 @@ fn abort_if_startup_fatal() {
     if let Some(main_loop) = classes::Engine::singleton().get_main_loop()
         && let Ok(mut scene_tree) = main_loop.try_cast::<classes::SceneTree>()
     {
-        // Request graceful shutdown, running normal teardown. Main loop exists from `MainLoop` init on.
         scene_tree.quit_ex().exit_code(exit_code).done();
     } else {
-        // No SceneTree (e.g. a custom MainLoop set via the `application/run/main_loop_type` project setting).
         std::process::exit(exit_code);
     }
 }
 
 /// Whether Godot runs without a visual display -- `--headless`, `--display-driver headless`, or an export/import run, which force it.
-///
-/// Queried dynamically because `DisplayServer` is not part of the minimal codegen. A missing singleton counts as headless.
 #[cfg(since_api = "4.5")]
 fn is_headless() -> bool {
     // Absent singleton or a failing call -> headless. Dynamic call for minimal codegen.

--- a/godot-core/src/private.rs
+++ b/godot-core/src/private.rs
@@ -33,6 +33,7 @@ mod reexport_pub {
     pub use crate::obj::rpc::priv_re_export::*;
     pub use crate::obj::rtti::ObjectRtti;
     pub use crate::registry::callbacks;
+    pub use crate::registry::reg_validation::validate_signal;
     pub use crate::registry::shard::{
         ClassShard, DynTraitImpl, ErasedDynGd, ErasedRegisterFn, ITraitImpl, InherentImpl,
         ShardItem, Struct,

--- a/godot-core/src/registry/class.rs
+++ b/godot-core/src/registry/class.rs
@@ -16,8 +16,8 @@ use crate::meta::ClassId;
 use crate::meta::error::FromGodotError;
 use crate::obj::{DynGd, Gd, GodotClass, Singleton, cap};
 use crate::private::{ClassShard, ShardItem};
-use crate::registry::callbacks;
 use crate::registry::shard::{DynTraitImpl, ErasedRegisterFn, ITraitImpl, InherentImpl, Struct};
+use crate::registry::{callbacks, reg_validation};
 use crate::{godot_error, godot_warn, sys};
 
 /// Returns a lock to a global map of loaded classes, by initialization level.
@@ -585,13 +585,13 @@ fn fill_into<T>(dst: &mut Option<T>, src: Option<T>) -> Result<(), ()> {
 fn register_class_raw(mut info: ClassRegistrationInfo) {
     // Some metadata like dynify fns are already emptied at this point. Only consider registrations for Godot.
 
-    // First register class...
-    validate_class_constraints(&info);
-
     let class_name = info.class_name;
     let parent_class_name = info
         .parent_class_name
         .expect("class defined (parent_class_name)");
+
+    // First register class...
+    precheck_class_registration(&info, parent_class_name);
 
     // Register virtual functions -- if the user provided some via #[godot_api], take those; otherwise, use the
     // ones generated alongside #[derive(GodotClass)]. The latter can also be null, if no OnReady is provided.
@@ -622,14 +622,14 @@ fn register_class_raw(mut info: ClassRegistrationInfo) {
             ptr::addr_of!(info.godot_params),
         );
 
-        // ...then see if it worked.
-        // This is necessary because the above registration does not report errors (apart from console output).
+        // ...then see if it worked. The registration above does not report errors (apart from console output), and precheck may miss something.
         let tag = interface_fn!(classdb_get_class_tag)(class_name.string_sys());
         tag.is_null()
     };
 
     // Do not panic here; otherwise lock is poisoned and the whole extension becomes unusable.
     // This can happen during hot reload if a class changes base type in an incompatible way (e.g. RefCounted -> Node).
+    // Also, the pre-validation only runs under strict safeguards, there may be registrations that Godot rejects but godot-rust doesn't catch.
     if registration_failed {
         godot_error!(
             "Failed to register class `{class_name}`; check preceding Godot stderr messages."
@@ -661,8 +661,11 @@ fn register_class_raw(mut info: ClassRegistrationInfo) {
     }
 }
 
-fn validate_class_constraints(_class: &ClassRegistrationInfo) {
-    // TODO: if we add builder API, the proc-macro checks in parse_struct_attributes() etc. should be duplicated here.
+/// Validates a class registration before it is handed to Godot, which reports errors only to stderr.
+fn precheck_class_registration(class_info: &ClassRegistrationInfo, parent_class_id: ClassId) {
+    // TODO(v0.7): if we add builder API, the proc-macro checks in parse_struct_attributes() etc. should be duplicated here.
+
+    reg_validation::validate_class(class_info.class_name, parent_class_id);
 }
 
 fn unregister_class_raw(class: LoadedClass) {

--- a/godot-core/src/registry/constant.rs
+++ b/godot-core/src/registry/constant.rs
@@ -31,6 +31,8 @@ impl IntegerConstant {
     }
 
     fn register(&self, class_name: ClassId, enum_name: &StringName, is_bitfield: bool) {
+        crate::registry::reg_validation::validate_constant(class_name, &self.name);
+
         unsafe {
             interface_fn!(classdb_register_extension_class_integer_constant)(
                 sys::get_library(),

--- a/godot-core/src/registry/godot_register_wrappers.rs
+++ b/godot-core/src/registry/godot_register_wrappers.rs
@@ -84,6 +84,13 @@ fn register_var_or_export_inner(
     let getter_name = StringName::from(getter_name);
     let setter_name = StringName::from(setter_name);
 
+    crate::registry::reg_validation::validate_property(
+        class_name,
+        &info.property_name,
+        &getter_name,
+        &setter_name,
+    );
+
     let property_info_sys = info.property_sys();
 
     unsafe {

--- a/godot-core/src/registry/method.rs
+++ b/godot-core/src/registry/method.rs
@@ -153,6 +153,9 @@ impl ClassMethodInfo {
     }
 
     fn register_nonvirtual_class_method(&self, method_info_sys: sys::GDExtensionClassMethodInfo) {
+        // Only for non-virtual methods. Godot keeps virtual methods in a separate map, which isn't exposed through ClassDB.
+        crate::registry::reg_validation::validate_method(self.class_id, &self.method_name);
+
         // SAFETY: The lifetime of the data we use here is at least as long as this function's scope. So we can
         // safely call this function without issue.
         //

--- a/godot-core/src/registry/mod.rs
+++ b/godot-core/src/registry/mod.rs
@@ -30,6 +30,7 @@ pub mod constant;
 pub mod info;
 pub mod method;
 pub mod property;
+pub mod reg_validation;
 pub mod shard;
 
 // RpcConfig uses MultiplayerPeer::TransferMode and MultiplayerApi::RpcMode, which are only enabled in `codegen-full` feature.

--- a/godot-core/src/registry/reg_validation.rs
+++ b/godot-core/src/registry/reg_validation.rs
@@ -1,0 +1,274 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+//! Pre-registration validation of class symbols against Godot's `ClassDB`.
+//!
+//! `classdb_register_extension_class*` returns `void` and only prints to stderr on failure, so this module queries `ClassDB` *before* each
+//! registration; see [issue #1024](https://github.com/godot-rust/gdext/issues/1024). Active under `safeguards_strict` and Godot 4.5+, no-op
+//! otherwise. Problems are reported via `defer_startup_fatal!`/`defer_startup_warn!` rather than panics, which mid-registration would poison the
+//! registration locks (see `register_class_raw`). Godot's own checks run in all builds, except a few gated behind `DEBUG_ENABLED` (e.g.
+//! `ClassDB::add_property` verifying that accessors exist).
+//!
+//! # Limitations
+//! Godot rejects a symbol only if the *own* class declares it (except signals, which share the base's namespace). Reusing a base-class name thus
+//! only warns: both symbols stay registered, and the static type at the call site decides which applies.
+//!
+//! Cases Godot rejects but this module cannot detect:
+//! - Symbols registered at `InitLevel::Core` up to Godot 4.6, where the `ClassDB` singleton appears only after `Core`-level extension init.
+//!   Needs an explicit `ExtensionLibrary::min_level()` override, since the default is `Scene`. Godot 4.7+ covers all levels.
+//! - A class registered by *another* extension: `class_get_api_type()` reveals only that a class stems from *some* extension, not which one.
+//! - A type whose `init_state` has left `MUTABLE`: that state cannot be queried.
+//! - A property registered with neither getter nor setter (`#[var]`/`#[export]` always emit at least one).
+// TODO(v0.6): promote shadowing warnings to hard errors, possibly with `#[var(override)] escape hatch if true use-case found.
+
+#[cfg(not(all(safeguards_strict, since_api = "4.5")))]
+pub use noop::*;
+#[cfg(all(safeguards_strict, since_api = "4.5"))]
+pub use strict::*;
+
+#[cfg(all(safeguards_strict, since_api = "4.5"))]
+mod strict {
+    use crate::builtin::{GString, StringName};
+    use crate::classes::ClassDb;
+    use crate::meta::ClassId;
+    use crate::obj::Singleton;
+    use crate::sys::{defer_startup_fatal, defer_startup_warn};
+
+    // `ClassDB` is queried afresh in each function rather than mirrored in Rust: registrations are immediately visible there, so one query
+    // catches both duplicates within the class and names already taken by Godot. Most queries walk the inheritance chain, so a miss (common
+    // case) exits early without allocations; only a hit runs the own-class query that separates duplicate (error) from shadowing (warning).
+
+    /// Early-returns from a `validate_*` function when the `ClassDB` singleton cannot be queried at the current init level.
+    ///
+    /// Godot 4.6 and earlier add the singleton only after `Core`-level extension init, so its presence must be checked at runtime.
+    #[cfg(before_api = "4.7")]
+    macro_rules! return_if_unavailable {
+        () => {
+            if !crate::init::is_singleton_available::<ClassDb>() {
+                return;
+            }
+        };
+    }
+
+    /// Godot 4.7+ adds `ClassDB` before `Core`-level extension init, so it is available at every level.
+    #[cfg(since_api = "4.7")]
+    macro_rules! return_if_unavailable {
+        () => {};
+    }
+
+    /// Checks the preconditions of `classdb_register_extension_class*`, before the class itself is registered.
+    pub(crate) fn validate_class(class_id: ClassId, parent_class_id: ClassId) {
+        return_if_unavailable!();
+
+        let class_db = ClassDb::singleton();
+        let class_name = class_id.to_string_name();
+
+        // Godot rejects a class whose name is taken. ClassRegistrationInfo::validate_unique() only sees Rust-side shards, so a name used by an
+        // engine or other-extension class slips through it. Not a hot-reload false positive, see unregister_classes().
+        if class_db.class_exists(&class_name) {
+            defer_startup_fatal!(
+                "Class `{class_id}` cannot be registered: a class of that name already exists in ClassDB.\n\
+                 Rename it with #[class(rename = ...)]."
+            );
+        }
+
+        // Godot rejects a class whose base does not exist. Rust classes can only derive engine classes, so this is never an ordering problem
+        // between user classes; it fires when the base is not yet available at this init level.
+        let parent_class_name = parent_class_id.to_string_name();
+        if !class_db.class_exists(&parent_class_name) {
+            defer_startup_fatal!(
+                "Class `{class_id}` cannot be registered: its base class `{parent_class_id}` does not exist in ClassDB.\n\
+                 The base class may belong to a later initialization level than `{class_id}`."
+            );
+        }
+    }
+
+    /// Checks the preconditions of `classdb_register_extension_class_method`.
+    ///
+    /// Not applicable to `classdb_register_extension_class_virtual_method`: Godot stores virtual methods in a separate map, which `ClassDB` does
+    /// not expose. Callers must skip this check for virtual methods, or it would query the wrong map.
+    pub(crate) fn validate_method(class_id: ClassId, method_name: &StringName) {
+        return_if_unavailable!();
+
+        let class_db = ClassDb::singleton();
+        let class_name = class_id.to_string_name();
+
+        if !class_db.class_has_method(&class_name, method_name) {
+            return;
+        }
+
+        // Godot rejects a method name already declared in the own class only, hence `no_inheritance = true`.
+        let is_own_duplicate = class_db
+            .class_has_method_ex(&class_name, method_name)
+            .no_inheritance(true)
+            .done();
+
+        if is_own_duplicate {
+            defer_startup_fatal!(
+                "Method `{class_id}::{method_name}` is already registered; overloading is not supported by Godot. Common causes:\n\
+                 * two #[func]s mapping to the same Godot name via #[func(rename = ...)]\n\
+                 * a #[func] colliding with the `get_*`/`set_*` accessor generated by a #[var] or #[export] field\n\
+                 * the same name in a primary and secondary #[godot_api] block."
+            );
+        } else {
+            // The base method stays reachable through a base-typed reference, so the two coexist and dispatch depends on the caller's static type.
+            defer_startup_warn!(
+                id: "shadowed_method",
+                "Method `{class_id}::{method_name}` shadows a method of a base class.\n\
+                 Both stay registered -- either your method or the base one is called, depending on the static type at the call site.\n\
+                 Rename the Rust fn or use #[func(rename = ...)]. This will become a hard error in godot-rust v0.6."
+            );
+        }
+    }
+
+    /// Checks the preconditions of `classdb_register_extension_class_integer_constant`.
+    pub(crate) fn validate_constant(class_id: ClassId, constant_name: &StringName) {
+        return_if_unavailable!();
+
+        // Godot rejects a constant name already declared in the own class. `class_has_integer_constant()` lacks a `no_inheritance` parameter,
+        // so the own-class list is fetched on a hit.
+        let class_db = ClassDb::singleton();
+        let class_name = class_id.to_string_name();
+
+        if !class_db.class_has_integer_constant(&class_name, constant_name) {
+            return;
+        }
+
+        let constants = class_db
+            .class_get_integer_constant_list_ex(&class_name)
+            .no_inheritance(true)
+            .done();
+
+        if constants.as_slice().contains(&GString::from(constant_name)) {
+            defer_startup_fatal!(
+                "Constant `{class_id}::{constant_name}` is already registered.\n\
+                 Note that Godot stores all integer constants of a class in one namespace, even those belonging to different enums."
+            );
+        } else {
+            defer_startup_warn!(
+                id: "shadowed_constant",
+                "Constant `{class_id}::{constant_name}` shadows a constant of a base class.\n\
+                 Both stay registered -- yours or the base one is read, depending on the static type at the access site.\n\
+                 Rename it. This will become a hard error in godot-rust v0.6."
+            );
+        }
+    }
+
+    /// Checks the preconditions of `classdb_register_extension_class_property`.
+    ///
+    /// `getter_name`/`setter_name` may be empty, in which case they are not checked.
+    pub(crate) fn validate_property(
+        class_id: ClassId,
+        property_name: &StringName,
+        getter_name: &StringName,
+        setter_name: &StringName,
+    ) {
+        return_if_unavailable!();
+
+        let mut class_db = ClassDb::singleton();
+        let class_name = class_id.to_string_name();
+
+        validate_property_uniqueness(&mut class_db, class_id, &class_name, property_name);
+
+        // Godot resolves setter/getter through the inheritance chain, so the inheriting `class_has_method()` is correct here, unlike above.
+        // register_class_raw() guarantees that methods are registered before properties.
+        for (accessor_name, role) in [(getter_name, "getter"), (setter_name, "setter")] {
+            if accessor_name.is_empty() {
+                continue;
+            }
+
+            if !class_db.class_has_method(&class_name, accessor_name) {
+                defer_startup_fatal!(
+                    "Property `{class_id}::{property_name}` declares {role} `{accessor_name}`, which is not a registered method.\n\
+                     Declare the accessor as #[func]."
+                );
+            }
+        }
+    }
+
+    /// Detects properties that are already registered in the same class, or that shadow one of a base class.
+    fn validate_property_uniqueness(
+        class_db: &mut ClassDb,
+        class_id: ClassId,
+        class_name: &StringName,
+        property_name: &StringName,
+    ) {
+        // Godot rejects a property name already declared in the own class. Lacking a `class_has_property()`, the getter/setter queries stand in
+        // for it; the own-class list is fetched on a hit.
+        let exists_in_chain = !class_db
+            .class_get_property_getter(class_name, property_name)
+            .is_empty()
+            || !class_db
+                .class_get_property_setter(class_name, property_name)
+                .is_empty();
+
+        if !exists_in_chain {
+            return;
+        }
+
+        let properties = class_db
+            .class_get_property_list_ex(class_name)
+            .no_inheritance(true)
+            .done();
+
+        let property_name_str = GString::from(property_name);
+        let is_own_duplicate = properties.iter_shared().any(|dict| {
+            dict.get("name")
+                .and_then(|name| name.try_to::<GString>().ok())
+                .is_some_and(|name| name == property_name_str)
+        });
+
+        if is_own_duplicate {
+            defer_startup_fatal!("Property `{class_id}::{property_name}` is already registered.");
+        } else {
+            // The inherited property keeps its own accessors, so the two disagree about which storage a name refers to.
+            defer_startup_warn!(
+                id: "shadowed_property",
+                "Property `{class_id}::{property_name}` shadows a property of a base class.\n\
+                 Both stay registered, with separate accessors -- reads/writes access your field or the base one,\n\
+                 depending on the static type at the access site.\n\
+                 Rename the Rust field or use #[var(rename = ...)]. This will become a hard error in godot-rust v0.6."
+            );
+        }
+    }
+
+    /// Checks the preconditions of `classdb_register_extension_class_signal`.
+    ///
+    /// Public because signals are registered by proc-macro generated code, not by `godot-core`; re-exported through `godot::private`.
+    #[doc(hidden)]
+    pub fn validate_signal(class_id: ClassId, signal_name: &StringName) {
+        return_if_unavailable!();
+
+        // Godot's signal namespace includes inherited signals -- unlike methods and constants -- so the inheriting `class_has_signal()` is correct.
+        if ClassDb::singleton().class_has_signal(&class_id.to_string_name(), signal_name) {
+            defer_startup_fatal!(
+                "Signal `{class_id}::{signal_name}` is already registered.\n\
+                 Unlike methods, signals share a namespace with the base class, so a signal cannot shadow one of a base class."
+            );
+        }
+    }
+}
+
+#[cfg(not(all(safeguards_strict, since_api = "4.5")))]
+mod noop {
+    use crate::builtin::StringName;
+    use crate::meta::ClassId;
+
+    pub(crate) fn validate_class(_class_id: ClassId, _parent_class_id: ClassId) {}
+    pub(crate) fn validate_method(_class_id: ClassId, _method_name: &StringName) {}
+    pub(crate) fn validate_constant(_class_id: ClassId, _constant_name: &StringName) {}
+
+    pub(crate) fn validate_property(
+        _class_id: ClassId,
+        _property_name: &StringName,
+        _getter_name: &StringName,
+        _setter_name: &StringName,
+    ) {
+    }
+
+    pub fn validate_signal(_class_id: ClassId, _signal_name: &StringName) {}
+}

--- a/godot-ffi/src/lib.rs
+++ b/godot-ffi/src/lib.rs
@@ -124,18 +124,25 @@ static MAIN_THREAD_ID: ManualInitCell<std::thread::ThreadId> = ManualInitCell::n
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Deferred editor messages
 
-/// Warnings/errors collected during startup, and deferred until editor UI is ready.
-static STARTUP_MESSAGES: Global<Vec<StartupMessage>> = Global::default();
+/// Startup diagnostics, deferred until the editor UI is ready. Lives for the whole process, thus not reset by [`deinitialize`].
+static STARTUP_MESSAGES: Global<StartupMessages> = Global::default();
 
-/// Set to `true` after [`print_deferred_startup_messages`] has flushed once. From then on, new messages are printed directly instead
-/// of queued, so warnings/errors emitted later are not silently dropped.
-static STARTUP_MESSAGES_FLUSHED: std::sync::atomic::AtomicBool =
-    std::sync::atomic::AtomicBool::new(false);
+/// State behind [`STARTUP_MESSAGES`], all fields under the same lock.
+#[derive(Default)]
+struct StartupMessages {
+    /// Messages collected so far. Drained by [`print_deferred_startup_messages`].
+    deferred: Vec<StartupMessage>,
 
-/// Tracks message keys already emitted via the `once` flag of `defer_startup_warn!`/`defer_startup_error!`.
-/// Ensures each message is only shown once even if the code path fires multiple times. Keys are prefixed
-/// per source (`w:` warn, `e:` error explicit id, `e@` error implicit call site) to avoid collisions.
-static ONCE_EMITTED_MESSAGES: Global<std::collections::HashSet<&'static str>> = Global::default();
+    /// Set after the first flush. From then on, new messages are printed directly instead of queued, so late ones are not silently dropped.
+    flushed: bool,
+
+    /// Set once a fatal message is collected (see `defer_startup_fatal!`); consumed by [`take_startup_fatal`] at the terminal init point.
+    has_fatal: bool,
+
+    /// Message keys already emitted via the `once` flag, so each is shown only once. Keys are namespaced per level (`w`/`e`/`f`), with `:`
+    /// for an explicit ID and `@` for an implicit call site, to avoid collisions.
+    once_emitted: std::collections::HashSet<&'static str>,
+}
 
 /// A message to be displayed in the Godot editor once UI is ready.
 struct StartupMessage {
@@ -146,12 +153,14 @@ struct StartupMessage {
     level: StartupMessageLevel,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum StartupMessageLevel {
-    /// Warning with an ID that can be suppressed via `GDRUST_SUPPRESSED_WARNINGS`.
-    Warn { id: &'static str },
+    /// Warning, suppressible via `GDRUST_SUPPRESSED_WARNINGS` if it carries an ID.
+    Warn,
     /// Error that cannot be suppressed.
     Error,
+    /// Like `Error`, but also marks the process for termination at the terminal init point (unless in the editor).
+    Fatal,
 }
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
@@ -344,10 +353,11 @@ pub fn collect_startup_message(
     file: &str,
     line: u32,
     module_path: &str,
+    id: Option<&'static str>,
     once_id: Option<&'static str>,
 ) {
     // Check if this warning should be suppressed (only warnings can be suppressed, not errors).
-    if let StartupMessageLevel::Warn { id } = &level {
+    if let (StartupMessageLevel::Warn, Some(id)) = (level, id) {
         if is_message_suppressed(id) {
             return;
         } else {
@@ -355,13 +365,6 @@ pub fn collect_startup_message(
                 "{message}\n(Suppress this warning with env-var `GDRUST_SUPPRESSED_WARNINGS={id},...`)",
             );
         }
-    }
-
-    // Once-check (after suppression check).
-    if let Some(id) = once_id
-        && !ONCE_EMITTED_MESSAGES.lock().insert(id)
-    {
-        return;
     }
 
     let msg = StartupMessage {
@@ -372,22 +375,33 @@ pub fn collect_startup_message(
         level,
     };
 
-    // Check the flushed-flag while holding the lock: otherwise, a concurrent flush could drain and set the flag between our load and push,
-    // leaving the message in the queue with no further flush to deliver it. Holding the lock serializes us against the flusher.
-    let mut messages = STARTUP_MESSAGES.lock();
-    if STARTUP_MESSAGES_FLUSHED.load(std::sync::atomic::Ordering::Acquire) {
-        drop(messages);
+    // Flushed-check and push must not be interleaved with a flush; the message would stay queued with nothing left to deliver it.
+    let mut state = STARTUP_MESSAGES.lock();
+
+    if msg.level == StartupMessageLevel::Fatal {
+        state.has_fatal = true;
+    }
+
+    // After the suppression check above, so a suppressed warning does not consume the once-slot.
+    if let Some(id) = once_id
+        && !state.once_emitted.insert(id)
+    {
+        return;
+    }
+
+    if state.flushed {
+        drop(state);
         print_message(&msg);
     } else {
-        messages.push(msg);
+        state.deferred.push(msg);
     }
 }
 
 /// Print a single message to the editor UI via the FFI interface.
 fn print_message(msg: &StartupMessage) {
     let print_fn = match msg.level {
-        StartupMessageLevel::Warn { .. } => interface_fn!(print_warning),
-        StartupMessageLevel::Error => interface_fn!(print_error),
+        StartupMessageLevel::Warn => interface_fn!(print_warning),
+        StartupMessageLevel::Error | StartupMessageLevel::Fatal => interface_fn!(print_error),
     };
 
     // SAFETY: The binding has been initialized, so we can use interface functions.
@@ -413,21 +427,27 @@ fn is_message_suppressed(id: &str) -> bool {
     }
 }
 
+/// Whether a fatal startup message has been collected (see `defer_startup_fatal!`), clearing the flag.
+///
+/// Clearing keeps a hot reload from re-evaluating fatals of a previous load (if library is not fully unloaded).
+pub fn take_startup_fatal() -> bool {
+    std::mem::take(&mut STARTUP_MESSAGES.lock().has_fatal)
+}
+
 /// Flush all deferred messages to the Godot editor. Called during `MainLoop` initialization, when editor UI is ready.
 ///
 /// After this returns, [`collect_startup_message`] switches to direct printing so late-firing sites
 /// (property accessors, `_ready` callbacks, etc.) are not silently dropped.
 pub fn print_deferred_startup_messages() {
-    let mut messages = STARTUP_MESSAGES.lock();
+    let mut state = STARTUP_MESSAGES.lock();
 
-    for msg in messages.iter() {
+    for msg in state.deferred.iter() {
         print_message(msg);
     }
-    messages.clear();
+    state.deferred.clear();
 
-    // Flip flag while holding the lock, so any collector racing with us either pushes before us
-    // (and gets flushed above) or sees the flag set (and prints directly). Either path delivers.
-    STARTUP_MESSAGES_FLUSHED.store(true, std::sync::atomic::Ordering::Release);
+    // Only after draining: a collector racing with us then either got flushed above, or prints directly.
+    state.flushed = true;
 }
 
 fn print_preamble(version: GDExtensionGodotVersion) {
@@ -779,7 +799,7 @@ macro_rules! builtin_fn {
 #[macro_export]
 #[doc(hidden)]
 macro_rules! builtin_call {
-        ($name:ident ( $($args:expr_2021),* $(,)? )) => {
+        ($name:ident ( $($args:expr),* $(,)? )) => {
             ($crate::builtin_lifecycle_api().$name)( $($args),* )
         };
     }
@@ -795,6 +815,39 @@ macro_rules! interface_fn {
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Deferred editor message macros
+
+/// Shared body of the `defer_startup_*` macros: parses the optional `once;` and `id:` prefixes.
+///
+/// `$level` is the [`StartupMessageLevel`] variant, `$ns` a per-level namespace for once-keys, to avoid collisions between levels.
+/// `file!()`/`line!()` resolve to the outermost call site, so nesting does not affect the reported location.
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __defer_startup_message {
+    ($level:ident, $ns:literal, once; id: $id:literal, $($fmt:tt)+) => {
+        $crate::__defer_startup_message!(@emit $level, Some($id), Some(concat!($ns, ":", $id)), $($fmt)+)
+    };
+    ($level:ident, $ns:literal, once; $($fmt:tt)+) => {
+        $crate::__defer_startup_message!(@emit $level, None, Some(concat!($ns, "@", file!(), ":", line!())), $($fmt)+)
+    };
+    ($level:ident, $ns:literal, id: $id:literal, $($fmt:tt)+) => {
+        $crate::__defer_startup_message!(@emit $level, Some($id), None, $($fmt)+)
+    };
+    ($level:ident, $ns:literal, $($fmt:tt)+) => {
+        $crate::__defer_startup_message!(@emit $level, None, None, $($fmt)+)
+    };
+
+    (@emit $level:ident, $id:expr, $once_id:expr, $fmt:literal $(, $args:expr)* $(,)?) => {
+        $crate::collect_startup_message(
+            format!($fmt $(, $args)*),
+            $crate::StartupMessageLevel::$level,
+            file!(),
+            line!(),
+            module_path!(),
+            $id,
+            $once_id,
+        )
+    };
+}
 
 /// Store a warning for display in Godot editor UI.
 ///
@@ -813,28 +866,13 @@ macro_rules! interface_fn {
 /// ```
 #[macro_export]
 macro_rules! defer_startup_warn {
-    (once; id: $id:literal, $fmt:literal $(, $args:expr_2021)* $(,)?) => {{
-        let message = format!($fmt $(, $args)*);
-        $crate::collect_startup_message(
-            message,
-            $crate::StartupMessageLevel::Warn { id: $id },
-            file!(),
-            line!(),
-            module_path!(),
-            Some(concat!("w:", $id)),
-        );
-    }};
-    (id: $id:literal, $fmt:literal $(, $args:expr_2021)* $(,)?) => {{
-        let message = format!($fmt $(, $args)*);
-        $crate::collect_startup_message(
-            message,
-            $crate::StartupMessageLevel::Warn { id: $id },
-            file!(),
-            line!(),
-            module_path!(),
-            None,
-        );
-    }};
+    // Only the `id:` forms; warnings need an ID for suppression.
+    (once; id: $($tt:tt)+) => {
+        $crate::__defer_startup_message!(Warn, "w", once; id: $($tt)+)
+    };
+    (id: $($tt:tt)+) => {
+        $crate::__defer_startup_message!(Warn, "w", id: $($tt)+)
+    };
 }
 
 /// Store an error for display in Godot editor UI.
@@ -856,37 +894,17 @@ macro_rules! defer_startup_warn {
 /// ```
 #[macro_export]
 macro_rules! defer_startup_error {
-    (once; id: $id:literal, $fmt:literal $(, $args:expr_2021)* $(,)?) => {{
-        let message = format!($fmt $(, $args)*);
-        $crate::collect_startup_message(
-            message,
-            $crate::StartupMessageLevel::Error,
-            file!(),
-            line!(),
-            module_path!(),
-            Some(concat!("e:", $id)),
-        );
-    }};
-    (once; $fmt:literal $(, $args:expr_2021)* $(,)?) => {{
-        let message = format!($fmt $(, $args)*);
-        $crate::collect_startup_message(
-            message,
-            $crate::StartupMessageLevel::Error,
-            file!(),
-            line!(),
-            module_path!(),
-            Some(concat!("e@", file!(), ":", line!())),
-        );
-    }};
-    ($fmt:literal $(, $args:expr_2021)* $(,)?) => {{
-        let message = format!($fmt $(, $args)*);
-        $crate::collect_startup_message(
-            message,
-            $crate::StartupMessageLevel::Error,
-            file!(),
-            line!(),
-            module_path!(),
-            None,
-        );
-    }};
+    ($($tt:tt)+) => {
+        $crate::__defer_startup_message!(Error, "e", $($tt)+)
+    };
+}
+
+/// Store a fatal error for display in the Godot editor UI, and mark the process for termination.
+///
+/// Like [`defer_startup_error!`], but once all errors are collected (in MainLoop init), godot-rust aborts the process (except in editor).
+#[macro_export]
+macro_rules! defer_startup_fatal {
+    ($($tt:tt)+) => {
+        $crate::__defer_startup_message!(Fatal, "f", $($tt)+)
+    };
 }

--- a/godot-macros/src/class/data_models/signal.rs
+++ b/godot-macros/src/class/data_models/signal.rs
@@ -290,6 +290,9 @@ fn make_signal_registration(details: &SignalDetails, class_name_obj: &TokenStrea
 
             let signal_name = ::godot::builtin::StringName::from(#godot_name_str);
 
+            // Godot's registration below reports errors to stderr only; pre-check so they are visible. No-op outside safeguards_strict.
+            ::godot::private::validate_signal(#class_name_obj, &signal_name);
+
             sys::interface_fn!(classdb_register_extension_class_signal)(
                 sys::get_library(),
                 #class_name_obj.string_sys(),


### PR DESCRIPTION
Godot's `classdb_register_extension_class*` functions return void and only print to stderr on failure, so a rejected class, method, property, signal or constant is silently missing at runtime. The printed Godot error may vary in detail.

New `registry::reg_validation` module queries `ClassDB` before each registration and reports a precise error via `godot_error!` (and in a potential future builder API would allow programmatic check). 

In addition, it exits Godot after collecting all errors. Validation runs only under strict safeguards (default in Debug).

`#[var]` and `#[func]` are allowed to collide in Godot, but there aren't many use cases, and an explicit `#[var(override)]` or so might be better. For now warn (no breaking change), will become hard error in v0.6.


<details>
<summary>Here's a small manual test.</summary>

```rs
//! Deliberately broken registrations, to see diagnostics of `godot_core::registry::reg_validation`.
//!
//! Diagnostics only go to stderr (not tested). Enable the `mod` in the parent module, run `check.sh itest` and check stderr.
//! Both classes derive `Node`, since `ClassDB` is not reachable at `Core` init level.

use godot::prelude::*;

/// Error: class name already exists. Separate class, as the failed registration aborts before its symbols.
#[derive(GodotClass)]
#[class(init, base = Node, rename = Camera2D)]
struct DemoClassClash {}

/// Errors: duplicate method, property, signal.
/// Warnings: `duplicate`, `owner` and its accessors shadow `Node`.
#[derive(GodotClass)]
#[class(init, base = Node)]
struct DemoSymbolClashes {
    base: Base<Node>,

    #[var]
    same_prop: i32,

    // Explicit accessors: `rename` also renames generated ones, which would already clash at Rust level.
    #[var(get = get_other, set = set_other, rename = same_prop)]
    other_prop: i32,

    #[var]
    owner: i32,
}

#[godot_api]
impl DemoSymbolClashes {
    #[func]
    fn same_name(&self) {}

    #[func(rename = same_name)]
    fn other_name(&self) {}

    #[func]
    fn get_other(&self) -> i32 {
        self.other_prop
    }

    #[func]
    fn set_other(&mut self, value: i32) {
        self.other_prop = value;
    }

    #[func]
    fn duplicate(&self) {}

    #[signal]
    fn ready();
}
``` 

</details>

Closes #1024.