### PR TITLE
Cheaper refcount operations

### DIFF
--- a/godot-codegen/src/generator/classes.rs
+++ b/godot-codegen/src/generator/classes.rs
@@ -21,7 +21,7 @@ use crate::models::domain::{
     ModName, TyName,
 };
 use crate::util::{ident, make_string_name};
-use crate::{SubmitFn, util};
+use crate::{SubmitFn, special_cases, util};
 
 pub fn generate_class_files(
     api: &ExtensionApi,
@@ -596,6 +596,8 @@ fn make_class_method_definition(
 
     let validated_obj = if method.qualifier() == FnQualifier::Static {
         quote! { None }
+    } else if special_cases::is_class_method_unvalidated(class.name(), godot_method_name) {
+        quote! { Some(crate::obj::ValidatedObject::unvalidated(self.object_ptr)) }
     } else {
         quote! { Some(self.__validated_obj()) }
     };

--- a/godot-codegen/src/special_cases/special_cases.rs
+++ b/godot-codegen/src/special_cases/special_cases.rs
@@ -450,6 +450,7 @@ pub fn is_class_method_unvalidated(class_ty: &TyName, godot_method_name: &str) -
         | ("RefCounted", "init_ref")
         | ("RefCounted", "reference")
         | ("RefCounted", "unreference")
+        | ("RefCounted", "get_reference_count")
 
         => true, _ => false
     }

--- a/godot-codegen/src/special_cases/special_cases.rs
+++ b/godot-codegen/src/special_cases/special_cases.rs
@@ -442,6 +442,19 @@ pub fn is_method_private(class_or_builtin_ty: &TyName, godot_method_name: &str) 
     }
 }
 
+/// Methods whose object pointer is passed to the engine without the usual liveness check.
+// TODO(v0.6): extend to all RefCounted (and derived) methods.
+#[rustfmt::skip]
+pub fn is_class_method_unvalidated(class_ty: &TyName, godot_method_name: &str) -> bool {
+    match (class_ty.godot_ty.as_str(), godot_method_name) {
+        | ("RefCounted", "init_ref")
+        | ("RefCounted", "reference")
+        | ("RefCounted", "unreference")
+
+        => true, _ => false
+    }
+}
+
 /// Lists methods that are replaced with manual, more type-safe equivalents. See `type_safe_replacements.rs`.
 ///
 /// See also [`get_class_method_enum_param_replacement()`] for a more automated approach specifically for enum parameters.

--- a/godot-core/src/classes/class_runtime.rs
+++ b/godot-core/src/classes/class_runtime.rs
@@ -73,7 +73,7 @@ pub(crate) fn debug_string_variant(
                 .try_to_relaxed::<i32>()
                 .expect("get_reference_count() must return integer");
 
-            Ok(count as usize)
+            count as usize
         });
 
         debug_string_parts(f, ty, id, class, refcount, None)
@@ -97,11 +97,7 @@ pub(crate) fn debug_string_variant(
             let class = obj.dynamic_class_string();
 
             // Refcount is off-by-one due to now-created Gd<T> from conversion; correct by -1.
-            let refcount = match obj.maybe_refcount() {
-                Some(Ok(rc)) => Some(Ok(rc.saturating_sub(1))),
-                Some(Err(e)) => Some(Err(e)),
-                None => None,
-            };
+            let refcount = obj.maybe_refcount().map(|rc| rc.saturating_sub(1));
 
             debug_string_parts(f, ty, id, class, refcount, None)
         }
@@ -147,7 +143,7 @@ fn debug_string_parts(
     ty: &str,
     id: InstanceId,
     class: StringName,
-    refcount: Option<Result<usize, ()>>,
+    refcount: Option<usize>,
     trait_name: Option<&str>,
 ) -> std::fmt::Result {
     let mut builder = f.debug_struct(ty);
@@ -159,14 +155,8 @@ fn debug_string_parts(
         builder.field("trait", &format_args!("{trait_name}"));
     }
 
-    match refcount {
-        Some(Ok(refcount)) => {
-            builder.field("refc", &refcount);
-        }
-        Some(Err(_)) => {
-            builder.field("refc", &"(N/A during init or drop)");
-        }
-        None => {}
+    if let Some(refcount) = refcount {
+        builder.field("refc", &refcount);
     }
 
     builder.finish()

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -382,24 +382,8 @@ impl<T: GodotClass> Gd<T> {
     }
 
     /// Returns the reference count, if the dynamic object inherits `RefCounted`; and `None` otherwise.
-    ///
-    /// Returns `Err(())` if obtaining reference count failed, due to being called during init/drop.
-    pub(crate) fn maybe_refcount(&self) -> Option<Result<usize, ()>> {
-        // May become infallible if implemented via call() on Object, if ref-count bit of instance ID is set.
-        // This would likely be more efficient, too.
-
-        // Fast check if ref-counted without downcast.
-        if !self.instance_id().is_ref_counted() {
-            return None;
-        }
-
-        // Optimization: call `get_reference_count()` directly. Might also increase reliability and obviate the need for Result.
-
-        let rc = self
-            .raw
-            .try_with_ref_counted(|refc| refc.get_reference_count());
-
-        Some(rc.map(|i| i as usize))
+    pub(crate) fn maybe_refcount(&self) -> Option<usize> {
+        self.raw.maybe_refcount()
     }
 
     /// Create a non-owning pointer from this.
@@ -423,8 +407,6 @@ impl<T: GodotClass> Gd<T> {
     #[doc(hidden)]
     pub fn test_refcount(&self) -> Option<usize> {
         self.maybe_refcount()
-            .transpose()
-            .expect("failed to obtain refcount")
     }
 
     /// **Upcast:** convert into a smart pointer to a base class. Always succeeds.

--- a/godot-core/src/obj/raw_gd.rs
+++ b/godot-core/src/obj/raw_gd.rs
@@ -261,6 +261,26 @@ impl<T: GodotClass> RawGd<T> {
         apply(borrow.as_target_mut())
     }
 
+    /// Reinterprets this object as `RefCounted`, for the `refc_*` operations below.
+    ///
+    /// Unlike [`as_upcast_ref()`][Self::as_upcast_ref], this runs no liveness check, and a method invoked on the result need not
+    /// run one either (see `special_cases::is_class_method_unvalidated()` in godot-codegen). Skipping liveness is sound, since
+    /// `refc_*` only runs on a `RawGd` that already holds a strong-ref.
+    ///
+    /// # Safety
+    /// Caller must guarantee that `T` inherits from `RefCounted`, and that `self` is non-null and a strong reference.
+    unsafe fn as_ref_counted(&self) -> &classes::RefCounted {
+        // SAFETY: layout reasoning as in as_upcast_ref(); RefCounted is an engine class.
+        unsafe { std::mem::transmute::<&Self, &classes::RefCounted>(self) }
+    }
+
+    /// # Safety
+    /// See [`as_ref_counted()`][Self::as_ref_counted].
+    unsafe fn as_ref_counted_mut(&mut self) -> &mut classes::RefCounted {
+        // SAFETY: layout reasoning as in as_upcast_mut(); RefCounted is an engine class.
+        unsafe { std::mem::transmute::<&mut Self, &mut classes::RefCounted>(self) }
+    }
+
     /// Whether this object is non-null and ref-counted, i.e. the `refc_*` operations below have an effect.
     ///
     /// For `T=Object` this is a runtime query; for all other classes it's known statically and the branch compiles away.
@@ -281,8 +301,8 @@ impl<T: GodotClass> RawGd<T> {
         out!("  RawGd::refc_init: {self:?}");
 
         // SAFETY: object is ref-counted, as checked above.
-        let success = unsafe { self.with_ref_counted_unchecked(|refc| refc.init_ref()) };
-        assert!(success, "init_ref() failed");
+        let success = unsafe { self.as_ref_counted_mut().init_ref() };
+        assert!(success, "RefCounted::init_ref() failed");
     }
 
     /// Increments the reference count, for objects which are already referenced.
@@ -296,8 +316,8 @@ impl<T: GodotClass> RawGd<T> {
         out!("  RawGd::refc_inc:  {self:?}");
 
         // SAFETY: object is ref-counted, as checked above.
-        let success = unsafe { self.with_ref_counted_unchecked(|refc| refc.reference()) };
-        assert!(success, "reference() failed");
+        let success = unsafe { self.as_ref_counted_mut().reference() };
+        assert!(success, "RefCounted::reference() failed");
     }
 
     /// Decrements the reference count. Returns `true` if the count hit 0 and the object can be safely freed.
@@ -315,7 +335,7 @@ impl<T: GodotClass> RawGd<T> {
         out!("  RawGd::refc_dec:  {self:?}");
 
         // SAFETY: object is ref-counted, as checked above.
-        let is_last = unsafe { self.with_ref_counted_unchecked(|refc| refc.unreference()) };
+        let is_last = unsafe { self.as_ref_counted_mut().unreference() };
         out!("  +-- was last={is_last}");
         is_last
     }
@@ -516,8 +536,7 @@ where
         );
 
         // SAFETY: Memory=MemRefCounted statically guarantees T inherits RefCounted.
-        let ref_count =
-            unsafe { self.with_ref_counted_unchecked(|refc| refc.get_reference_count()) };
+        let ref_count = unsafe { self.as_ref_counted().get_reference_count() };
 
         // TODO find a safer cast alternative, e.g. num-traits crate with ToPrimitive (Debug) + AsPrimitive (Release).
         ref_count as usize
@@ -888,6 +907,16 @@ impl ValidatedObject {
         Self {
             object_ptr: raw_gd.obj_sys(),
         }
+    }
+
+    /// Skips validation, for the ref-count methods of `RefCounted`.
+    ///
+    /// A liveness check is pointless there: `refc_inc()`/`refc_dec()` are only reachable through a `RawGd` that holds a share of the
+    /// reference count, so the object cannot be dead unless the count was already corrupted outside the safe API.
+    #[doc(hidden)]
+    #[inline]
+    pub fn unvalidated(object_ptr: sys::GDExtensionObjectPtr) -> Self {
+        Self { object_ptr }
     }
 
     /// Extracts the object pointer from an `Option<ValidatedObject>`.

--- a/godot-core/src/obj/raw_gd.rs
+++ b/godot-core/src/obj/raw_gd.rs
@@ -179,96 +179,29 @@ impl<T: GodotClass> RawGd<T> {
         }
     }
 
-    /// Executes a function, assuming that `self` inherits `RefCounted`.
+    /// Returns the reference count, if the dynamic object inherits `RefCounted`; and `None` otherwise.
     ///
-    /// This function is unreliable when invoked _during_ destruction (e.g. C++ `~RefCounted()` destructor). This can occur when debug-logging
-    /// instances during cleanups. `Object::object_cast_to()` is a virtual function, but virtual dispatch during destructor doesn't work in C++.
-    ///
-    /// # Panics
-    /// If `self` does not inherit `RefCounted` or is null.
-    pub fn with_ref_counted<R>(&self, apply: impl FnOnce(&mut classes::RefCounted) -> R) -> R {
-        // Note: this previously called Declarer::scoped_mut() - however, no need to go through bind() for changes in base RefCounted.
-        // Any accesses to user objects (e.g. destruction if refc=0) would bind anyway.
-
-        match self.try_with_ref_counted(apply) {
-            Ok(result) => result,
-            Err(()) if self.is_null() => {
-                panic!(
-                    "RawGd::with_ref_counted(): expected to inherit RefCounted, encountered null pointer"
-                );
-            }
-            Err(()) => {
-                // SAFETY: this branch implies non-null.
-                let gd_ref = unsafe { self.as_non_null() };
-                let class = gd_ref.dynamic_class_string();
-
-                panic!(
-                    "Operation not permitted for object of class {class}:\n\
-                    class is either not RefCounted, or currently in construction/destruction phase"
-                );
-            }
-        }
-    }
-
-    /// Fallible version of [`with_ref_counted()`](Self::with_ref_counted), for situations during init/drop when downcast no longer works.
-    ///
-    /// Returns `Err(())` if `self` is null or does not inherit `RefCounted`.
-    #[expect(clippy::result_unit_err)]
-    pub fn try_with_ref_counted<R>(
-        &self,
-        apply: impl FnOnce(&mut classes::RefCounted) -> R,
-    ) -> Result<R, ()> {
-        // `InstanceId` carries a bit indicating ref-countedness — no FFI roundtrip needed.
-        let is_ref_counted = self
-            .cached_rtti
-            .as_ref()
-            .is_some_and(|rtti| rtti.instance_id().is_ref_counted());
-
-        if !is_ref_counted {
-            return Err(());
+    /// Infallible (no problematic virtual dispatch during C++ construction/destruction). Debug-printing an object being destroyed still works.
+    pub(crate) fn maybe_refcount(&self) -> Option<usize> {
+        let instance_id = self.instance_id_unchecked()?;
+        if !instance_id.is_ref_counted() || self.obj.is_null() {
+            return None;
         }
 
-        // Liveness check before invoking the user function; also validates type in Debug mode.
-        self.check_rtti("try_with_ref_counted");
+        // SAFETY: object is non-null and dynamically ref-counted, as checked above.
+        let ref_count = unsafe { self.as_ref_counted().get_reference_count() };
 
-        // SAFETY: instance ID confirms RefCounted base.
-        Ok(unsafe { self.with_ref_counted_unchecked(apply) })
+        Some(ref_count as usize)
     }
 
-    /// Executes a function directly on this object, assuming it is `RefCounted`.
+    /// Reinterprets this object as `RefCounted`, for the ref-count operations in this file.
     ///
-    /// Unlike [`try_with_ref_counted`](Self::try_with_ref_counted), this does **not** check the type at runtime.
-    ///
-    /// # Safety
-    /// Caller must guarantee that `T` inherits from `RefCounted`.
-    pub(crate) unsafe fn with_ref_counted_unchecked<R>(
-        &self,
-        apply: impl FnOnce(&mut classes::RefCounted) -> R,
-    ) -> R {
-        let cached_rtti = self
-            .cached_rtti
-            .as_ref()
-            .map(|rtti| ObjectRtti::of::<classes::RefCounted>(rtti.instance_id()));
-
-        // Note: caller guarantees T: Inherits<RefCounted>. `ManuallyDrop` keeps the refcount balanced when `borrow` goes out of scope.
-        let raw = RawGd::<classes::RefCounted> {
-            obj: self.obj.cast(),
-            cached_rtti,
-            cached_storage_ptr: InstanceCache::null(),
-        };
-
-        let mut borrow = std::mem::ManuallyDrop::new(raw);
-        apply(borrow.as_target_mut())
-    }
-
-    /// Reinterprets this object as `RefCounted`, for the `refc_*` operations below.
-    ///
-    /// Unlike [`as_upcast_ref()`][Self::as_upcast_ref], this runs no liveness check, and a method invoked on the result need not
-    /// run one either (see `special_cases::is_class_method_unvalidated()` in godot-codegen). Skipping liveness is sound, since
-    /// `refc_*` only runs on a `RawGd` that already holds a strong-ref.
+    /// Unlike [`as_upcast_ref()`][Self::as_upcast_ref], this runs no liveness or type check, and a method invoked on the result need
+    /// not run one either (see `special_cases::is_class_method_unvalidated()` in godot-codegen). Skipping those is sound, since the
+    /// callers only run on a `RawGd` that already holds a strong-ref. Also covers `T=Object` with a dynamically ref-counted object.
     ///
     /// # Safety
-    /// Caller must guarantee that `T` inherits from `RefCounted`, and that `self` is non-null and a strong reference.
+    /// Caller must guarantee that the dynamic object is ref-counted, and that `self` is non-null and a strong reference.
     unsafe fn as_ref_counted(&self) -> &classes::RefCounted {
         // SAFETY: layout reasoning as in as_upcast_ref(); RefCounted is an engine class.
         unsafe { std::mem::transmute::<&Self, &classes::RefCounted>(self) }
@@ -909,10 +842,7 @@ impl ValidatedObject {
         }
     }
 
-    /// Skips validation, for the ref-count methods of `RefCounted`.
-    ///
-    /// A liveness check is pointless there: `refc_inc()`/`refc_dec()` are only reachable through a `RawGd` that holds a share of the
-    /// reference count, so the object cannot be dead unless the count was already corrupted outside the safe API.
+    /// For ref-counted objects, liveness check is not needed; strong ref (RawGd) keeps Godot instance alive.
     #[doc(hidden)]
     #[inline]
     pub fn unvalidated(object_ptr: sys::GDExtensionObjectPtr) -> Self {

--- a/itest/rust/src/benchmarks/mod.rs
+++ b/itest/rust/src/benchmarks/mod.rs
@@ -76,7 +76,7 @@ fn class_engine_refc_clone_drop() -> BenchResult {
     bench_measure(100, || obj.clone())
 }
 
-/// Same as [`class_refc_engine_clone_drop()`], for a user class -- `RawGd` additionally carries the storage-pointer cache.
+/// Same as [`class_engine_refc_clone_drop()`], for a user class -- `RawGd` additionally carries the storage-pointer cache.
 #[bench(manual)]
 fn class_user_refc_clone_drop() -> BenchResult {
     let obj = MyBenchType::new_gd();

--- a/itest/rust/src/benchmarks/mod.rs
+++ b/itest/rust/src/benchmarks/mod.rs
@@ -15,7 +15,7 @@ use godot::classes::{Node3D, Os, RefCounted};
 use godot::obj::{Gd, InstanceId, NewAlloc, NewGd, Singleton};
 use godot::register::GodotClass;
 
-use crate::framework::bench;
+use crate::framework::{BenchResult, bench, bench_measure};
 
 mod callable;
 mod color;
@@ -59,13 +59,29 @@ fn class_node_life() -> InstanceId {
 }
 
 #[bench(repeat = 25)]
-fn class_refcounted_life() -> Gd<RefCounted> {
+fn class_engine_refc_life() -> Gd<RefCounted> {
     RefCounted::new_gd()
 }
 
 #[bench(repeat = 25)]
 fn class_user_refc_life() -> Gd<MyBenchType> {
     Gd::default()
+}
+
+/// Just measure `refc_inc` + `refc_dec` on already-existing object, without construction or destruction.
+#[bench(manual)]
+fn class_engine_refc_clone_drop() -> BenchResult {
+    let obj = RefCounted::new_gd();
+
+    bench_measure(100, || obj.clone())
+}
+
+/// Same as [`class_refc_engine_clone_drop()`], for a user class -- `RawGd` additionally carries the storage-pointer cache.
+#[bench(manual)]
+fn class_user_refc_clone_drop() -> BenchResult {
+    let obj = MyBenchType::new_gd();
+
+    bench_measure(100, || obj.clone())
 }
 
 #[bench]

--- a/itest/rust/src/object_tests/object_test.rs
+++ b/itest/rust/src/object_tests/object_test.rs
@@ -600,6 +600,14 @@ fn object_engine_convert_variant_nil() {
 }
 
 #[itest]
+fn object_dynamic_refcount() {
+    let obj = RefCounted::new_gd().upcast::<Object>();
+
+    assert_eq!(obj.test_refcount(), Some(1));
+    assert!(format!("{obj:?}").contains("refc: 1"), "{obj:?}");
+}
+
+#[itest]
 fn object_engine_convert_variant_error() {
     let refc = RefCounted::new_gd();
     let variant = refc.to_variant();


### PR DESCRIPTION
Optimizations:
* instance-ID lookup for `RefCounted` operations omitted (statically guaranteed by holding strong-ref)
* reinterpretation of `&RawGd<T>` as `&RefCounted` also without runtime check

Also small refactoring reducing `with_ref_counted*` functions.

## Benchmark

50-54% faster than `master` (min).
```
                                              min       median
master:
   -- class_engine_refc_clone_dr ...      0.072μs      0.080μs
   -- class_user_refc_clone_drop ...      0.098μs      0.106μs
   
branch:
   -- class_refc_engine_clone_dr ...      0.033μs      0.034μs
   -- class_user_refc_clone_drop ...      0.049μs      0.050μs
``` 