### PR TITLE
Handle object destruction during Godot->Rust call 

### DIFF
--- a/godot-core/src/classes/class_runtime.rs
+++ b/godot-core/src/classes/class_runtime.rs
@@ -35,6 +35,7 @@ use strict::*;
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Debug/Display support for classes and enums
 
+// TODO(v0.7): print class and instance ID for freed objects, too -- ID is cached in the RTTI, static class known via `T::class_id()`.
 pub(crate) fn debug_string<T: GodotClass>(
     obj: &Gd<T>,
     f: &mut std::fmt::Formatter<'_>,

--- a/godot-core/src/obj/base.rs
+++ b/godot-core/src/obj/base.rs
@@ -171,10 +171,11 @@ impl<T: GodotClass> Base<T> {
         self.obj.obj_sys()
     }
 
-    // Internal use only, do not make public.
-    #[cfg(feature = "debug-log")]
-    pub(crate) fn debug_instance_id(&self) -> crate::obj::InstanceId {
-        self.obj.instance_id()
+    /// Last known instance ID; the object may already be destroyed.
+    ///
+    /// Unchecked, since callers run while the object is being destroyed: logging in `Storage::drop`, or reporting a destruction.
+    pub(crate) fn instance_id_unchecked(&self) -> crate::obj::InstanceId {
+        self.obj.instance_id_unchecked()
     }
 
     /// Returns a borrowed reference to the base object, for use in script contexts only.

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -391,8 +391,9 @@ impl<T: GodotClass> Gd<T> {
     /// # Safety
     /// Must be destroyed with [`drop_weak()`][Self::drop_weak]; regular `Drop` will cause use-after-free.
     pub(crate) unsafe fn clone_weak(&self) -> Self {
-        // SAFETY: delegated to caller.
-        unsafe { Gd::from_obj_sys_weak(self.obj_sys()) }
+        Self {
+            raw: self.raw.clone_weak(),
+        }
     }
 
     /// Drop without decrementing ref-counter.

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -615,21 +615,17 @@ impl<T: GodotClass> Gd<T> {
         if sys::is_editor_or_unknown().unwrap_or(false)
             && crate::registry::class::is_class_tool(class_id) == Some(false)
         {
-            use std::collections::HashSet;
+            // Dedup persists for the process lifetime, including across hot reloads -- one warning per class per process, not per reload.
+            let is_new = sys::defer_startup_warn!(
+                once_per: class_id;
+                id: "EditorPlaceholderV06",
+                "godot-rust v0.6 will change editor behavior for non-`#[class(tool)]` runtime classes.\n\
+                Class `{class_id}` creation in editor now returns real Rust instance; v0.6 will return a placeholder (details with RUST_BACKTRACE=1).\n\
+                Opt in early via the `upcoming-editor-placeholders` feature, or mark the class as `#[class(tool)]` if it runs in the editor.",
+            );
 
-            // Persists for the process lifetime, including across hot reloads -- one warning per class per process, not per reload.
-            static WARNED: sys::Global<HashSet<ClassId>> = sys::Global::default();
-
-            let is_new = WARNED.lock().insert(class_id);
+            // If RUST_BACKTRACE is set, print backtrace.
             if is_new {
-                sys::defer_startup_warn!(
-                    id: "EditorPlaceholderV06",
-                    "godot-rust v0.6 will change editor behavior for non-`#[class(tool)]` runtime classes.\n\
-                    Class `{class_id}` creation in editor now returns real Rust instance; v0.6 will return a placeholder (details with RUST_BACKTRACE=1).\n\
-                    Opt in early via the `upcoming-editor-placeholders` feature, or mark the class as `#[class(tool)]` if it runs in the editor.",
-                );
-
-                // If RUST_BACKTRACE is set, print backtrace.
                 let bt = std::backtrace::Backtrace::capture();
                 if bt.status() == std::backtrace::BacktraceStatus::Captured {
                     eprintln!(

--- a/godot-core/src/obj/raw_gd.rs
+++ b/godot-core/src/obj/raw_gd.rs
@@ -84,6 +84,15 @@ impl<T: GodotClass> RawGd<T> {
         unsafe { Self::from_obj_sys_weak(obj).with_inc_refcount() }
     }
 
+    /// Copy of `self` that leaves the reference count untouched, by adopting the cached fields (no FFI calls).
+    pub(super) fn clone_weak(&self) -> Self {
+        Self {
+            obj: self.obj,
+            cached_rtti: self.cached_rtti.clone(),
+            cached_storage_ptr: self.cached_storage_ptr.clone(),
+        }
+    }
+
     /// Returns `self` but with initialized ref-count.
     fn with_inc_refcount(mut self) -> Self {
         // Note: use refc_init() and not refc_inc(), since this might be the first reference increment.
@@ -792,14 +801,7 @@ impl<T: GodotClass> Clone for RawGd<T> {
             Self::null()
         } else {
             self.check_rtti("clone");
-
-            // Create new object, adopt cached fields.
-            let copy = Self {
-                obj: self.obj,
-                cached_rtti: self.cached_rtti.clone(),
-                cached_storage_ptr: self.cached_storage_ptr.clone(),
-            };
-            copy.with_inc_refcount()
+            self.clone_weak().with_inc_refcount()
         };
 
         out!("                  {self:?}  (after clone)");

--- a/godot-core/src/obj/raw_gd.rs
+++ b/godot-core/src/obj/raw_gd.rs
@@ -536,7 +536,9 @@ where
         // Potential issue is a concurrent free() in multi-threaded access; but that would need to be guarded against inside free().
         unsafe {
             let binding = self.resolve_instance_ptr();
-            sys::ptr_then(binding, |binding| crate::private::as_storage::<T>(binding))
+            sys::ptr_then(binding, |binding| {
+                crate::private::as_weak_storage::<T>(binding)
+            })
         }
     }
 

--- a/godot-core/src/obj/raw_gd.rs
+++ b/godot-core/src/obj/raw_gd.rs
@@ -528,13 +528,14 @@ where
     /// Returns `None` if self is null.
     ///
     /// # Safety
-    ///
     /// This method provides a reference to the storage with an arbitrarily long lifetime `'b`. The reference
     /// must actually be live for the duration of this lifetime.
     ///
     /// The only time when a `&mut` reference can be taken to a `InstanceStorage` is when it is constructed
     /// or destroyed. So it is sufficient to ensure that the storage is not created or destroyed during the
     /// lifetime `'b`.
+    // Prefer `storage()`, whose lifetime is tied to `&self`. This method exists for `WithBaseField::base_mut()`, whose guard must outlive the
+    // local `Gd` it is created from.
     pub(crate) unsafe fn storage_unbounded<'b>(&self) -> Option<&'b InstanceStorage<T>> {
         // SAFETY: instance pointer belongs to this instance. We only get a shared reference, no exclusive access, so even
         // calling this from multiple Gd pointers is safe.
@@ -545,7 +546,9 @@ where
         // Potential issue is a concurrent free() in multi-threaded access; but that would need to be guarded against inside free().
         unsafe {
             let binding = self.resolve_instance_ptr();
-            sys::ptr_then(binding, |binding| crate::private::as_storage::<T>(binding))
+            sys::ptr_then(binding, |binding| {
+                crate::private::as_weak_storage::<T>(binding)
+            })
         }
     }
 

--- a/godot-core/src/private.rs
+++ b/godot-core/src/private.rs
@@ -41,7 +41,7 @@ mod reexport_pub {
     pub use crate::signal::priv_re_export::*;
     pub use crate::storage::{
         IntoVirtualMethodReceiver, RecvGdSelf, RecvMut, RecvRef, Storage, VirtualMethodReceiver,
-        as_storage,
+        as_storage, as_weak_storage,
     };
     pub use crate::sys::out;
 }

--- a/godot-core/src/registry/callbacks.rs
+++ b/godot-core/src/registry/callbacks.rs
@@ -19,6 +19,7 @@ use sys::interface_fn;
 use crate::builder::ClassBuilder;
 use crate::builtin::{StringName, Variant};
 use crate::classes::Object;
+use crate::obj::bounds::Memory;
 use crate::obj::{AsDyn, Base, Bounds, Gd, GodotClass, Inherits, UserClass, bounds, cap};
 use crate::private::{IntoVirtualMethodReceiver, PanicPayload, handle_panic};
 use crate::registry::info::PropertyInfo;
@@ -223,6 +224,12 @@ pub unsafe extern "C" fn free<T: GodotClass>(
         {
             let storage = as_weak_storage::<T>(instance);
             storage.mark_destroyed_by_godot();
+
+            // Manually managed classes are excluded: `free()` during a call on the object is an established pattern, and the engine has not
+            // been observed to touch `this` afterwards on that path.
+            if <T::Memory as Memory>::IS_REF_COUNTED && storage.is_claimed_by_call() {
+                crate::storage::report_destruction_during_call(storage);
+            }
         } // Ref no longer valid once next statement is executed.
 
         crate::storage::release_storage::<T>(instance);

--- a/godot-core/src/registry/callbacks.rs
+++ b/godot-core/src/registry/callbacks.rs
@@ -23,7 +23,7 @@ use crate::obj::{AsDyn, Base, Bounds, Gd, GodotClass, Inherits, UserClass, bound
 use crate::private::{IntoVirtualMethodReceiver, PanicPayload, handle_panic};
 use crate::registry::info::PropertyInfo;
 use crate::registry::shard::ErasedDynGd;
-use crate::storage::{InstanceStorage, Storage, StorageRefCounted, as_storage};
+use crate::storage::{InstanceStorage, Storage, StorageRefCounted, as_storage, as_weak_storage};
 
 /// Invokes `code` -- a callback that calls into user code -- and catches any panic, so it does not unwind across the FFI boundary.
 ///
@@ -221,11 +221,11 @@ pub unsafe extern "C" fn free<T: GodotClass>(
     // SAFETY: Pointer valid for callback duration (Godot contract).
     unsafe {
         {
-            let storage = as_storage::<T>(instance);
+            let storage = as_weak_storage::<T>(instance);
             storage.mark_destroyed_by_godot();
         } // Ref no longer valid once next statement is executed.
 
-        crate::storage::destroy_storage::<T>(instance);
+        crate::storage::release_storage::<T>(instance);
     }
 }
 
@@ -291,7 +291,7 @@ pub unsafe extern "C" fn to_string<T: cap::GodotToString>(
 ) {
     let code = || {
         let storage = as_storage::<T>(instance);
-        let string = T::__godot_to_string(T::Recv::instance(storage));
+        let string = T::__godot_to_string(T::Recv::instance(&storage));
         string.move_into_string_ptr(out_string);
         true
     };
@@ -325,7 +325,7 @@ pub unsafe extern "C" fn get<T: cap::GodotGet>(
 ) -> sys::GDExtensionBool {
     let code = || {
         let storage = as_storage::<T>(instance);
-        let instance = T::Recv::instance(storage);
+        let instance = T::Recv::instance(&storage);
         let property = StringName::new_from_string_sys(name);
 
         match T::__godot_on_get(instance, property) {
@@ -348,7 +348,7 @@ pub unsafe extern "C" fn set<T: cap::GodotSet>(
 ) -> sys::GDExtensionBool {
     let code = || {
         let storage = as_storage::<T>(instance);
-        let instance = T::Recv::instance(storage);
+        let instance = T::Recv::instance(&storage);
 
         let property = StringName::new_from_string_sys(name);
         let value = Variant::new_from_var_sys(value);
@@ -360,12 +360,12 @@ pub unsafe extern "C" fn set<T: cap::GodotSet>(
 }
 
 pub unsafe extern "C" fn reference<T: GodotClass>(instance: sys::GDExtensionClassInstancePtr) {
-    let storage = unsafe { as_storage::<T>(instance) };
+    let storage = unsafe { as_weak_storage::<T>(instance) };
     storage.on_inc_ref();
 }
 
 pub unsafe extern "C" fn unreference<T: GodotClass>(instance: sys::GDExtensionClassInstancePtr) {
-    let storage = unsafe { as_storage::<T>(instance) };
+    let storage = unsafe { as_weak_storage::<T>(instance) };
     storage.on_dec_ref();
 }
 
@@ -379,7 +379,7 @@ pub unsafe extern "C" fn get_property_list<T: cap::GodotGetPropertyList>(
 ) -> *const sys::GDExtensionPropertyInfo {
     let code = || -> *const sys::GDExtensionPropertyInfo {
         let storage = as_storage::<T>(instance);
-        let instance = T::Recv::instance(storage);
+        let instance = T::Recv::instance(&storage);
 
         let property_list = T::__godot_on_get_property_list(instance);
         let property_list_sys: Box<[sys::GDExtensionPropertyInfo]> = property_list
@@ -450,7 +450,7 @@ unsafe fn raw_property_get_revert<T: cap::GodotPropertyGetRevert>(
     property_name: sys::GDExtensionConstStringNamePtr,
 ) -> Option<Variant> {
     let storage = as_storage::<T>(instance);
-    let instance = T::Recv::instance(storage);
+    let instance = T::Recv::instance(&storage);
 
     let property = StringName::borrow_string_sys(property_name);
     T::__godot_on_property_get_revert(instance, property.clone())
@@ -506,7 +506,7 @@ pub unsafe extern "C" fn validate_property<T: cap::GodotValidateProperty>(
 ) -> sys::GDExtensionBool {
     let code = || {
         let storage = as_storage::<T>(instance);
-        let instance = T::Recv::instance(storage);
+        let instance = T::Recv::instance(&storage);
 
         let mut property_info = PropertyInfo::new_from_sys(property_info_ptr);
         T::__godot_on_validate_property(instance, &mut property_info);

--- a/godot-core/src/registry/callbacks.rs
+++ b/godot-core/src/registry/callbacks.rs
@@ -23,7 +23,7 @@ use crate::obj::{AsDyn, Base, Bounds, Gd, GodotClass, Inherits, UserClass, bound
 use crate::private::{IntoVirtualMethodReceiver, PanicPayload, handle_panic};
 use crate::registry::info::PropertyInfo;
 use crate::registry::shard::ErasedDynGd;
-use crate::storage::{InstanceStorage, Storage, StorageRefCounted, as_storage};
+use crate::storage::{InstanceStorage, Storage, StorageRefCounted, as_storage, as_weak_storage};
 
 /// Invokes `code` -- a callback that calls into user code -- and catches any panic, so it does not unwind across the FFI boundary.
 ///
@@ -221,11 +221,11 @@ pub unsafe extern "C" fn free<T: GodotClass>(
     // SAFETY: Pointer valid for callback duration (Godot contract).
     unsafe {
         {
-            let storage = as_storage::<T>(instance);
+            let storage = as_weak_storage::<T>(instance);
             storage.mark_destroyed_by_godot();
         } // Ref no longer valid once next statement is executed.
 
-        crate::storage::destroy_storage::<T>(instance);
+        crate::storage::release_godot_claim::<T>(instance);
     }
 }
 
@@ -291,7 +291,7 @@ pub unsafe extern "C" fn to_string<T: cap::GodotToString>(
 ) {
     let code = || {
         let storage = as_storage::<T>(instance);
-        let string = T::__godot_to_string(T::Recv::instance(storage));
+        let string = T::__godot_to_string(T::Recv::instance(&storage));
         string.move_into_string_ptr(out_string);
         true
     };
@@ -325,7 +325,7 @@ pub unsafe extern "C" fn get<T: cap::GodotGet>(
 ) -> sys::GDExtensionBool {
     let code = || {
         let storage = as_storage::<T>(instance);
-        let instance = T::Recv::instance(storage);
+        let instance = T::Recv::instance(&storage);
         let property = StringName::new_from_string_sys(name);
 
         match T::__godot_on_get(instance, property) {
@@ -348,7 +348,7 @@ pub unsafe extern "C" fn set<T: cap::GodotSet>(
 ) -> sys::GDExtensionBool {
     let code = || {
         let storage = as_storage::<T>(instance);
-        let instance = T::Recv::instance(storage);
+        let instance = T::Recv::instance(&storage);
 
         let property = StringName::new_from_string_sys(name);
         let value = Variant::new_from_var_sys(value);
@@ -360,12 +360,12 @@ pub unsafe extern "C" fn set<T: cap::GodotSet>(
 }
 
 pub unsafe extern "C" fn reference<T: GodotClass>(instance: sys::GDExtensionClassInstancePtr) {
-    let storage = unsafe { as_storage::<T>(instance) };
+    let storage = unsafe { as_weak_storage::<T>(instance) };
     storage.on_inc_ref();
 }
 
 pub unsafe extern "C" fn unreference<T: GodotClass>(instance: sys::GDExtensionClassInstancePtr) {
-    let storage = unsafe { as_storage::<T>(instance) };
+    let storage = unsafe { as_weak_storage::<T>(instance) };
     storage.on_dec_ref();
 }
 
@@ -379,7 +379,7 @@ pub unsafe extern "C" fn get_property_list<T: cap::GodotGetPropertyList>(
 ) -> *const sys::GDExtensionPropertyInfo {
     let code = || -> *const sys::GDExtensionPropertyInfo {
         let storage = as_storage::<T>(instance);
-        let instance = T::Recv::instance(storage);
+        let instance = T::Recv::instance(&storage);
 
         let property_list = T::__godot_on_get_property_list(instance);
         let property_list_sys: Box<[sys::GDExtensionPropertyInfo]> = property_list
@@ -450,7 +450,7 @@ unsafe fn raw_property_get_revert<T: cap::GodotPropertyGetRevert>(
     property_name: sys::GDExtensionConstStringNamePtr,
 ) -> Option<Variant> {
     let storage = as_storage::<T>(instance);
-    let instance = T::Recv::instance(storage);
+    let instance = T::Recv::instance(&storage);
 
     let property = StringName::borrow_string_sys(property_name);
     T::__godot_on_property_get_revert(instance, property.clone())
@@ -506,7 +506,7 @@ pub unsafe extern "C" fn validate_property<T: cap::GodotValidateProperty>(
 ) -> sys::GDExtensionBool {
     let code = || {
         let storage = as_storage::<T>(instance);
-        let instance = T::Recv::instance(storage);
+        let instance = T::Recv::instance(&storage);
 
         let mut property_info = PropertyInfo::new_from_sys(property_info_ptr);
         T::__godot_on_validate_property(instance, &mut property_info);

--- a/godot-core/src/storage/instance_storage.rs
+++ b/godot-core/src/storage/instance_storage.rs
@@ -342,7 +342,28 @@ pub unsafe fn release_godot_claim<T: GodotClass>(instance_ptr: sys::GDExtensionC
     if was_last_claim {
         // SAFETY: no claim is left; each entry point running user code holds one for its duration.
         unsafe { deallocate_storage(storage) };
+        return;
     }
+
+    // Object died while a call still holds a claim, no matter if the last reference was dropped or `free()` was called. Both leave the engine
+    // with a dangling `this` for the rest of the call.
+    // SAFETY: the remaining claim keeps the storage alive.
+    unsafe { report_destruction_during_call(&*storage) };
+}
+
+/// Reports destruction during Godot->Rust call; see <https://github.com/godot-rust/gdext/pull/1671>.
+fn report_destruction_during_call<T: GodotClass>(storage: &InstanceStorage<T>) {
+    let class_id = T::class_id();
+    let instance_id = storage.base().instance_id_unchecked();
+
+    sys::defer_startup_error!(
+        once_per: class_id;
+        "Godot object destroyed during Godot->Rust call; Gd {{ id: {instance_id}, class: {class_id} }}.\n  \
+        Engine may access freed object afterwards, which is UB. Reported once per class.\n  \
+        Quick'n'dirty workarounds (prefer clean destruction order):\n  \
+        * Ref-counted objects: keep alive with self.to_gd().run_deferred_gd(|_| {{}})\n  \
+        * Manually managed objects: defer the free() to idle time, e.g. using queue_free()."
+    );
 }
 
 /// Reports that the storage is destroyed while the Rust object is still borrowed. May crash the process, depending on safeguard level.
@@ -364,7 +385,7 @@ fn report_destruction_while_bound<T: GodotClass>(storage: &InstanceStorage<T>) {
     //
     // For now we choose option 2 in strict+balanced levels, and 4 in disengaged level.
     let error = format!(
-        "Destroyed Godot object during active bind() or bind_mut() guard; object: {:?}.\n  \
+        "Godot object destroyed during active bind() or bind_mut() guard; {:?}.\n  \
         This is a bug in your code that may cause UB and logic errors. Make sure that objects are not\n  \
         destroyed while you still hold a Rust reference to them, or use Gd::free() which is safe.",
         storage.base()

--- a/godot-core/src/storage/instance_storage.rs
+++ b/godot-core/src/storage/instance_storage.rs
@@ -96,6 +96,10 @@ pub unsafe trait Storage {
     #[doc(hidden)]
     fn dec_claims(&self) -> bool;
 
+    /// Whether an ongoing Godot -> Rust call claims this storage, on top of Godot's own claim.
+    #[doc(hidden)]
+    fn is_claimed_by_call(&self) -> bool;
+
     /// Get a `Gd` referencing the Godot object.
     fn get_gd(&self) -> Gd<Self::Instance>
     where
@@ -364,6 +368,20 @@ pub unsafe fn release_storage<T: GodotClass>(instance_ptr: sys::GDExtensionClass
 
     // SAFETY: Godot's claim exists since construction, and the caller guarantees to release it only once.
     drop(unsafe { StorageClaim::assume_owned(storage) });
+}
+
+/// Reports that the Godot object died during a Godot -> Rust call on it, which leaves the engine with a dangling `this`.
+///
+/// Only the storage outlives the call, by claim; the object itself cannot be kept alive, since neither `free()` nor the last reference drop
+/// is vetoable. Godot dereferences `this` after the callback returns in at least `Object::_notification_forward()`.
+pub(crate) fn report_destruction_during_call<T: GodotClass>(storage: &InstanceStorage<T>) {
+    godot_error!(
+        "Destroyed the Godot object during a Godot -> Rust call on it.\n  \
+        The engine may access the object after the call returns, which is undefined behavior. Do not drop the last\n  \
+        reference to an object inside a call on that same object; defer it past the call instead.\n  \
+        object: {:?}",
+        storage.base()
+    );
 }
 
 /// Reports that the storage is destroyed while the Rust object is still borrowed. May crash the process, depending on safeguard level.

--- a/godot-core/src/storage/instance_storage.rs
+++ b/godot-core/src/storage/instance_storage.rs
@@ -88,7 +88,7 @@ pub unsafe trait Storage {
     /// expected.
     fn set_lifecycle(&self, lifecycle: Lifecycle);
 
-    /// Get a `Gd` referencing this storage's instance.
+    /// Get a `Gd` referencing the Godot object.
     fn get_gd(&self) -> Gd<Self::Instance>
     where
         Self::Instance: Inherits<<Self::Instance as GodotClass>::Base>,
@@ -98,7 +98,7 @@ pub unsafe trait Storage {
 
     /// Puts self onto the heap and returns a pointer to this new heap-allocation.
     ///
-    /// This will leak memory and so the caller is responsible for manually managing the memory.
+    /// The allocation is freed once the last claim on it is released; see `StorageClaim`.
     #[must_use]
     fn into_raw(self) -> *mut Self
     where
@@ -226,27 +226,127 @@ where
     }
 }
 
-/// Interprets the opaque pointer as pointing to `InstanceStorage<T>`.
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// Storage claims. The free functions sit at the FFI boundary: they turn Godot's opaque instance pointer into typed access.
+
+/// Keeps the Rust instance storage alive during a Godot -> Rust call.
 ///
-/// Note: returns reference with unbounded lifetime; intended for local usage
+/// User code can drop the last reference to the receiver mid-call (e.g. a signal handler nulling the emitter), or `free()` it. The Godot object
+/// then dies while a `GdRef`/`GdMut` guard is still active.
+///
+/// The storage counts claims: Godot holds one from construction to destruction, each ongoing call holds one. Removing the last claim frees the
+/// storage. Guards borrow the claim, so they drop first. A counter rather than a flag, to handle nested calls; atomic under
+/// `experimental-threads`.
+///
+/// Only the storage survives, not the Godot object -- godot-rust cannot prevent its destruction: `Ref::unref()` decides to `memdelete` before
+/// the extension's `unreference` callback runs, and `free()` is immediate. Holding a strong reference for the call's duration, like GDScript
+/// does, would not help either: it drops before the trampoline returns, fails at refcount 0, and costs ~40% per call. So for the rest of the
+/// call, field access works but base operations panic and `Drop` sees a dead base. To survive the call, an object needs a reference that
+/// outlives it: `self.to_gd().run_deferred_gd(|_| {})`.
+///
+/// Entry points which run no user code (`free`, `reference`, `unreference`) use [`as_weak_storage()`] instead.
+#[must_use = "dropping the claim immediately releases it, which may free the storage"]
+pub struct StorageClaim<T: GodotClass> {
+    // Raw pointer rather than reference: the claim owns no borrow (other claims may exist), and freeing needs write access to the whole
+    // allocation for drop(&mut). Using a &InstanceStorage shared-ref would be unsound as it would eventually be promoted to &mut.
+    storage: *mut InstanceStorage<T>,
+}
+
+impl<T: GodotClass> Deref for StorageClaim<T> {
+    type Target = InstanceStorage<T>;
+
+    fn deref(&self) -> &Self::Target {
+        // SAFETY: the claim keeps the storage alive.
+        unsafe { &*self.storage }
+    }
+}
+
+impl<T: GodotClass> Drop for StorageClaim<T> {
+    fn drop(&mut self) {
+        if self.dec_claims() {
+            // SAFETY: this was the last claim, and the guards borrowing it are already dropped.
+            unsafe { deallocate_storage(self.storage) };
+        }
+    }
+}
+
+/// Deallocates the storage, once no claim is left.
+///
+/// # Safety
+/// The last claim on `storage` must have been released, and no reference into it may be live.
+unsafe fn deallocate_storage<T: GodotClass>(storage: *mut InstanceStorage<T>) {
+    // SAFETY: delegated to caller.
+    let storage_ref = unsafe { &*storage };
+
+    // A guard still points into the storage -> leak instead of freeing, so its references stay valid.
+    // Only reachable for guards that hold no "claim", i.e. `Gd::bind()` outside a Godot->Rust call.
+    // Guards within such calls borrow the claim and thus drop before it.
+    if storage_ref.is_bound() {
+        report_destruction_while_bound(storage_ref); // May crash process, depending on safeguard level.
+        return;
+    }
+
+    // SAFETY: no claim is left, so no call is ongoing and no other reference into the storage exists -- guards borrow the claim, and
+    // `is_bound()` ruled out stray ones. Dropping is thus allowed by the safety contract of `Storage`, which `InstanceStorage<T>`
+    // implements (see `_INSTANCE_STORAGE_IMPLEMENTS_STORAGE`). The allocation stems from `Storage::into_raw()`.
+    let _drop = unsafe { Box::from_raw(storage) };
+}
+
+/// Interprets the opaque pointer as pointing to `InstanceStorage<T>`. Sole place deriving storage pointers from Godot's instance pointer.
+fn as_storage_ptr<T: GodotClass>(
+    instance_ptr: sys::GDExtensionClassInstancePtr,
+) -> *mut InstanceStorage<T> {
+    instance_ptr as *mut InstanceStorage<T>
+}
+
+/// Interprets the opaque pointer as pointing to `InstanceStorage<T>`, keeping the storage alive until the returned claim drops.
 ///
 /// # Safety
 /// `instance_ptr` is assumed to point to a valid instance.
-/// The returned reference must be live for the duration of `'u`.
-// Note: unbounded ref AND &mut out of thin air is not very beautiful, but it's  -- consider using with_storage(ptr, closure) and drop_storage(ptr)
-pub unsafe fn as_storage<'u, T: GodotClass>(
+///
+/// The claim keeps the storage (Rust object) alive, not the Godot object -- the latter may die mid-call.
+pub unsafe fn as_storage<T: GodotClass>(
     instance_ptr: sys::GDExtensionClassInstancePtr,
-) -> &'u InstanceStorage<T> {
-    unsafe { &*(instance_ptr as *mut InstanceStorage<T>) }
+) -> StorageClaim<T> {
+    let storage = as_storage_ptr::<T>(instance_ptr);
+
+    // SAFETY: delegated to caller.
+    unsafe { (*storage).inc_claims() };
+
+    StorageClaim { storage }
 }
 
+/// Like [`as_storage()`], but *weak*: the returned reference does not keep the storage alive. Only for entry points that run no user code.
+///
+/// # Safety
+/// Same as [`as_storage()`]. Additionally, the storage must not be destroyed while the returned reference is live.
+pub unsafe fn as_weak_storage<'u, T: GodotClass>(
+    instance_ptr: sys::GDExtensionClassInstancePtr,
+) -> &'u InstanceStorage<T> {
+    // SAFETY: delegated to caller.
+    unsafe { &*as_storage_ptr::<T>(instance_ptr) }
+}
+
+/// Releases the claim Godot took when the storage was constructed; see [`StorageClaim`].
+///
+/// Deallocates the storage, unless a Godot -> Rust call still holds a claim -- then the last of those calls deallocates it.
+///
 /// # Safety
 /// `instance_ptr` is assumed to point to a valid instance. This function must only be invoked once for a pointer.
-pub unsafe fn destroy_storage<T: GodotClass>(instance_ptr: sys::GDExtensionClassInstancePtr) {
-    let raw = instance_ptr as *mut InstanceStorage<T>;
-    // SAFETY: valid pointer, only invoked by one caller at a time.
-    let storage = unsafe { &mut *raw };
+pub unsafe fn release_godot_claim<T: GodotClass>(instance_ptr: sys::GDExtensionClassInstancePtr) {
+    let storage = as_storage_ptr::<T>(instance_ptr);
 
+    // SAFETY: Godot's claim exists since construction, and the caller guarantees to release it only once.
+    let was_last_claim = unsafe { (*storage).dec_claims() };
+
+    if was_last_claim {
+        // SAFETY: no claim is left; each entry point running user code holds one for its duration.
+        unsafe { deallocate_storage(storage) };
+    }
+}
+
+/// Reports that the storage is destroyed while the Rust object is still borrowed. May crash the process, depending on safeguard level.
+fn report_destruction_while_bound<T: GodotClass>(storage: &InstanceStorage<T>) {
     // We cannot panic here, since this code is invoked from a C callback. Panicking would mean unwinding into C code, which is UB.
     // We have the following options:
     // 1. Print an error as a best-effort, knowing that UB is likely to occur whenever the user will access &T or &mut T. (Technically, the
@@ -263,35 +363,20 @@ pub unsafe fn destroy_storage<T: GodotClass>(instance_ptr: sys::GDExtensionClass
     //      but we still can't control direct access to the T.
     //
     // For now we choose option 2 in strict+balanced levels, and 4 in disengaged level.
-    let mut leak_rust_object = false;
-    if storage.is_bound() {
-        let error = format!(
-            "Destroyed an object from Godot side, while a bind() or bind_mut() call was active.\n  \
-            This is a bug in your code that may cause UB and logic errors. Make sure that objects are not\n  \
-            destroyed while you still hold a Rust reference to them, or use Gd::free() which is safe.\n  \
-            object: {:?}",
-            storage.base()
-        );
+    let error = format!(
+        "Destroyed Godot object during active bind() or bind_mut() guard; object: {:?}.\n  \
+        This is a bug in your code that may cause UB and logic errors. Make sure that objects are not\n  \
+        destroyed while you still hold a Rust reference to them, or use Gd::free() which is safe.",
+        storage.base()
+    );
 
-        // In strict+balanced level, crash which may trigger breakpoint.
-        // In disengaged level, leak player object (Godot philosophy: don't crash if somehow avoidable). Likely leads to follow-up issues.
-        if cfg!(safeguards_balanced) {
-            let error = crate::builtin::GString::from(&error);
-            crate::classes::Os::singleton().crash(&error);
-        } else {
-            leak_rust_object = true;
-            godot_error!("{}", error);
-        }
-    }
-
-    if !leak_rust_object {
-        // SAFETY:
-        // `leak_rust_object` is false, meaning that `is_bound()` returned `false`. Because if it were `true`
-        // then the process would either be aborted, or we set `leak_rust_object = true`.
-        //
-        // Therefore, we can safely drop this storage as per the safety contract of `Storage`. Which we know
-        // `InstanceStorage<T>` implements because of `_INSTANCE_STORAGE_IMPLEMENTS_STORAGE`.
-        let _drop = unsafe { Box::from_raw(storage) };
+    // In strict+balanced level, crash which may trigger breakpoint.
+    // In disengaged level, leak Rust object (Godot philosophy: don't crash if somehow avoidable). Likely leads to follow-up issues.
+    if cfg!(safeguards_balanced) {
+        let error = crate::builtin::GString::from(&error);
+        crate::classes::Os::singleton().crash(&error);
+    } else {
+        godot_error!("{}", error);
     }
 }
 

--- a/godot-core/src/storage/instance_storage.rs
+++ b/godot-core/src/storage/instance_storage.rs
@@ -88,7 +88,15 @@ pub unsafe trait Storage {
     /// expected.
     fn set_lifecycle(&self, lifecycle: Lifecycle);
 
-    /// Get a `Gd` referencing this storage's instance.
+    /// Increments the claim counter; see [`StorageClaim`]. Raw counter access, use [`StorageClaim`] to manage claims.
+    #[doc(hidden)]
+    fn inc_claims(&self);
+
+    /// Decrements the claim counter; returns `true` if it was the last claim. Raw counter access, use [`StorageClaim`] to manage claims.
+    #[doc(hidden)]
+    fn dec_claims(&self) -> bool;
+
+    /// Get a `Gd` referencing the Godot object.
     fn get_gd(&self) -> Gd<Self::Instance>
     where
         Self::Instance: Inherits<<Self::Instance as GodotClass>::Base>,
@@ -98,7 +106,7 @@ pub unsafe trait Storage {
 
     /// Puts self onto the heap and returns a pointer to this new heap-allocation.
     ///
-    /// This will leak memory and so the caller is responsible for manually managing the memory.
+    /// The allocation is freed once the last claim on it is released; see `StorageClaim`.
     #[must_use]
     fn into_raw(self) -> *mut Self
     where
@@ -226,27 +234,140 @@ where
     }
 }
 
-/// Interprets the opaque pointer as pointing to `InstanceStorage<T>`.
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// Storage and "claim" mechanism
+//
+// Free functions = FFI boundary: turn Godot's opaque instance pointer into typed access (reference or owned claim).
+// StorageClaim inherent methods: claim lifetime only.
+
+/// Keeps the Rust instance storage alive for the duration of a Godot -> Rust call.
 ///
-/// Note: returns reference with unbounded lifetime; intended for local usage
+/// # Problem
+/// A Godot callback passes only the instance pointer, no reference (in case of `RefCounted`) to the Godot object. If user code drops the last
+/// reference mid-call -- e.g. a signal handler nulling the emitter -- Godot object and storage die while a `GdRef`/`GdMut` guard is active.
+/// Manually managed classes can also get into this situation with `free()`.
+///
+/// # Solution
+/// The storage counts "claims" to itself, expressing who needs it to be alive: Godot holds a claim between object construction and destruction,
+/// and each Godot -> Rust call holds one for as long as its `StorageClaim` lives. Removing the last claim frees the storage. Guards borrow the
+/// `StorageClaim`, so the compiler enforces that they drop first.
+///
+/// Trade-off: claims keep the *storage* (Rust object) alive, not the Godot object. The object dies with its last `RefCounted` reference, so for
+/// the rest of the call, `&self`/`&mut self` field access works but base operations panic (`ensure_object_alive()`, at default safeguard levels).
+/// The user instance's `Drop` also sees a dead base, unlike in ordinary destruction. A method that needs the object alive can explicitly
+/// request this: `let _keepalive = self.to_gd();`, or a `#[func(gd_self)]` receiver, which gets a `Gd<Self>` parameter acting as a strong-ref.
+///
+/// Claims are implemented as a counter rather than bool-flag, to recognize stacked call frames (re-entrancy). This also supports
+/// `experimental-threads` through atomic updates.
+///
+/// Cloning a `Gd` of the receiver instead, as GDScript does, would keep the Godot object alive too, but cannot cover callbacks that Godot runs
+/// during destruction: `RefCounted::init_ref()` fails at refcount 0.
+///
+/// Entry points which run no user code (`free`, `reference`, `unreference`) use [`as_weak_storage()`] instead.
+#[must_use = "dropping the claim immediately releases it, which may free the storage"]
+pub struct StorageClaim<T: GodotClass> {
+    // Raw pointer rather than reference: the claim owns no borrow (other claims may exist), and freeing needs write access to the whole
+    // allocation for drop(&mut). Using a &InstanceStorage shared-ref would be unsound as it would eventually be promoted to &mut.
+    storage: *mut InstanceStorage<T>,
+}
+
+impl<T: GodotClass> StorageClaim<T> {
+    /// Adds a claim on `storage`, released when the returned value drops.
+    ///
+    /// # Safety
+    /// `storage` must point to a valid storage, which stays valid until this claim is released.
+    unsafe fn take(storage: *mut InstanceStorage<T>) -> Self {
+        // SAFETY: delegated to caller.
+        unsafe { (*storage).inc_claims() };
+
+        Self { storage }
+    }
+
+    /// Adopts a claim that the caller already owns, without adding a new one.
+    ///
+    /// # Safety
+    /// Same as [`take()`][Self::take]. The caller must own a claim on `storage` and must not release it elsewhere.
+    unsafe fn assume_owned(storage: *mut InstanceStorage<T>) -> Self {
+        Self { storage }
+    }
+}
+
+impl<T: GodotClass> Deref for StorageClaim<T> {
+    type Target = InstanceStorage<T>;
+
+    fn deref(&self) -> &Self::Target {
+        // SAFETY: the claim keeps the storage alive.
+        unsafe { &*self.storage }
+    }
+}
+
+impl<T: GodotClass> Drop for StorageClaim<T> {
+    fn drop(&mut self) {
+        if !self.dec_claims() {
+            return;
+        }
+
+        // A guard still points into the storage; leak instead of freeing, so its references stay valid.
+        if self.is_bound() {
+            report_destruction_while_bound(self); // May crash process, depending on safeguard level.
+            return;
+        }
+
+        // SAFETY: the last claim is gone, so no call is ongoing and no other reference into the storage exists -- guards borrow `self`, and
+        // `is_bound()` ruled out stray ones. Dropping is thus allowed by the safety contract of `Storage`, which `InstanceStorage<T>`
+        // implements (see `_INSTANCE_STORAGE_IMPLEMENTS_STORAGE`). The allocation stems from `Storage::into_raw()`.
+        let _drop = unsafe { Box::from_raw(self.storage) };
+    }
+}
+
+/// Interprets the opaque pointer as pointing to `InstanceStorage<T>`. Sole place deriving storage pointers from Godot's instance pointer.
+fn as_storage_ptr<T: GodotClass>(
+    instance_ptr: sys::GDExtensionClassInstancePtr,
+) -> *mut InstanceStorage<T> {
+    instance_ptr as *mut InstanceStorage<T>
+}
+
+/// Interprets the opaque pointer as pointing to `InstanceStorage<T>`, keeping the storage alive until the returned claim drops.
 ///
 /// # Safety
 /// `instance_ptr` is assumed to point to a valid instance.
-/// The returned reference must be live for the duration of `'u`.
-// Note: unbounded ref AND &mut out of thin air is not very beautiful, but it's  -- consider using with_storage(ptr, closure) and drop_storage(ptr)
-pub unsafe fn as_storage<'u, T: GodotClass>(
+///
+/// The claim keeps the storage (Rust object) alive, not the Godot object -- the latter may die mid-call.
+pub unsafe fn as_storage<T: GodotClass>(
     instance_ptr: sys::GDExtensionClassInstancePtr,
-) -> &'u InstanceStorage<T> {
-    unsafe { &*(instance_ptr as *mut InstanceStorage<T>) }
+) -> StorageClaim<T> {
+    let storage = as_storage_ptr::<T>(instance_ptr);
+
+    // SAFETY: delegated to caller.
+    unsafe { StorageClaim::take(storage) }
 }
 
+/// Like [`as_storage()`], but *weak*: the returned reference does not keep the storage alive. Only for entry points that run no user code.
+///
+/// # Safety
+/// Same as [`as_storage()`]. Additionally, the storage must not be destroyed while the returned reference is live, for the duration of `'u`.
+pub unsafe fn as_weak_storage<'u, T: GodotClass>(
+    instance_ptr: sys::GDExtensionClassInstancePtr,
+) -> &'u InstanceStorage<T> {
+    // SAFETY: delegated to caller.
+    unsafe { &*as_storage_ptr::<T>(instance_ptr) }
+}
+
+/// Releases the claim Godot took when the storage was constructed; see [`StorageClaim`].
+///
+/// Frees the storage, unless a Godot -> Rust call still holds a claim -- then the last of those calls frees it.
+///
 /// # Safety
 /// `instance_ptr` is assumed to point to a valid instance. This function must only be invoked once for a pointer.
-pub unsafe fn destroy_storage<T: GodotClass>(instance_ptr: sys::GDExtensionClassInstancePtr) {
-    let raw = instance_ptr as *mut InstanceStorage<T>;
-    // SAFETY: valid pointer, only invoked by one caller at a time.
-    let storage = unsafe { &mut *raw };
+pub unsafe fn release_storage<T: GodotClass>(instance_ptr: sys::GDExtensionClassInstancePtr) {
+    let storage = as_storage_ptr::<T>(instance_ptr);
 
+    // SAFETY: Godot's claim exists since construction, and the caller guarantees to release it only once.
+    drop(unsafe { StorageClaim::assume_owned(storage) });
+}
+
+/// Reports that the storage is destroyed while the Rust object is still borrowed. May crash the process, depending on safeguard level.
+fn report_destruction_while_bound<T: GodotClass>(storage: &InstanceStorage<T>) {
     // We cannot panic here, since this code is invoked from a C callback. Panicking would mean unwinding into C code, which is UB.
     // We have the following options:
     // 1. Print an error as a best-effort, knowing that UB is likely to occur whenever the user will access &T or &mut T. (Technically, the
@@ -263,35 +384,21 @@ pub unsafe fn destroy_storage<T: GodotClass>(instance_ptr: sys::GDExtensionClass
     //      but we still can't control direct access to the T.
     //
     // For now we choose option 2 in strict+balanced levels, and 4 in disengaged level.
-    let mut leak_rust_object = false;
-    if storage.is_bound() {
-        let error = format!(
-            "Destroyed an object from Godot side, while a bind() or bind_mut() call was active.\n  \
-            This is a bug in your code that may cause UB and logic errors. Make sure that objects are not\n  \
-            destroyed while you still hold a Rust reference to them, or use Gd::free() which is safe.\n  \
-            object: {:?}",
-            storage.base()
-        );
+    let error = format!(
+        "Destroyed the Godot object, while a bind() or bind_mut() call was active.\n  \
+        This is a bug in your code that may cause UB and logic errors. Make sure that objects are not\n  \
+        destroyed while you still hold a Rust reference to them, or use Gd::free() which is safe.\n  \
+        object: {:?}",
+        storage.base()
+    );
 
-        // In strict+balanced level, crash which may trigger breakpoint.
-        // In disengaged level, leak player object (Godot philosophy: don't crash if somehow avoidable). Likely leads to follow-up issues.
-        if cfg!(safeguards_balanced) {
-            let error = crate::builtin::GString::from(&error);
-            crate::classes::Os::singleton().crash(&error);
-        } else {
-            leak_rust_object = true;
-            godot_error!("{}", error);
-        }
-    }
-
-    if !leak_rust_object {
-        // SAFETY:
-        // `leak_rust_object` is false, meaning that `is_bound()` returned `false`. Because if it were `true`
-        // then the process would either be aborted, or we set `leak_rust_object = true`.
-        //
-        // Therefore, we can safely drop this storage as per the safety contract of `Storage`. Which we know
-        // `InstanceStorage<T>` implements because of `_INSTANCE_STORAGE_IMPLEMENTS_STORAGE`.
-        let _drop = unsafe { Box::from_raw(storage) };
+    // In strict+balanced level, crash which may trigger breakpoint.
+    // In disengaged level, leak Rust object (Godot philosophy: don't crash if somehow avoidable). Likely leads to follow-up issues.
+    if cfg!(safeguards_balanced) {
+        let error = crate::builtin::GString::from(&error);
+        crate::classes::Os::singleton().crash(&error);
+    } else {
+        godot_error!("{}", error);
     }
 }
 

--- a/godot-core/src/storage/mod.rs
+++ b/godot-core/src/storage/mod.rs
@@ -93,7 +93,7 @@ mod log_active {
 
         out!(
             "    Storage::mark_destroyed_by_godot:  {base_id} (lcy={lifecycle:?})",
-            base_id = storage.base().debug_instance_id(),
+            base_id = storage.base().instance_id_unchecked(),
             lifecycle = storage.get_lifecycle(),
         );
     }
@@ -103,7 +103,7 @@ mod log_active {
 
         out!(
             "    Storage::drop:        {base_id}",
-            base_id = storage.base().debug_instance_id(),
+            base_id = storage.base().instance_id_unchecked(),
         );
     }
 }

--- a/godot-core/src/storage/multi_threaded.rs
+++ b/godot-core/src/storage/multi_threaded.rs
@@ -5,6 +5,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+use std::sync::atomic::{AtomicU32, Ordering};
+
 #[cfg(feature = "experimental-threads")]
 use godot_cell::blocking::{GdCell, InaccessibleGuard, MutGuard, RefGuard};
 #[cfg(not(feature = "experimental-threads"))]
@@ -12,6 +14,7 @@ use godot_cell::panicking::{GdCell, InaccessibleGuard, MutGuard, RefGuard};
 
 use crate::obj::{Base, GodotClass};
 use crate::storage::{AtomicLifecycle, DebugBorrowTracker, Lifecycle, Storage, StorageRefCounted};
+use crate::sys;
 
 pub struct InstanceStorage<T: GodotClass> {
     user_instance: GdCell<T>,
@@ -19,6 +22,9 @@ pub struct InstanceStorage<T: GodotClass> {
 
     // Declared after `user_instance`, is dropped last
     pub(super) lifecycle: AtomicLifecycle,
+
+    // Claims on this storage's lifetime: 1 from Godot, one from each ongoing Godot->Rust call. See `StorageClaim`.
+    claims: AtomicU32,
 
     // No-op in Release mode.
     borrow_tracker: DebugBorrowTracker,
@@ -45,6 +51,7 @@ unsafe impl<T: GodotClass> Storage for InstanceStorage<T> {
             user_instance: GdCell::new(user_instance),
             base,
             lifecycle: AtomicLifecycle::new(Lifecycle::Alive),
+            claims: AtomicU32::new(1),
             borrow_tracker: DebugBorrowTracker::new(),
         }
     }
@@ -95,6 +102,24 @@ unsafe impl<T: GodotClass> Storage for InstanceStorage<T> {
 
     fn set_lifecycle(&self, lifecycle: Lifecycle) {
         self.lifecycle.store(lifecycle)
+    }
+}
+
+impl<T: GodotClass> InstanceStorage<T> {
+    /// Adds a claim; see [`StorageClaim`][crate::storage::StorageClaim].
+    pub(super) fn inc_claims(&self) {
+        // Relaxed suffices: like `Arc::clone()`, the caller already holds a claim, so the storage cannot be freed concurrently.
+        self.claims.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Removes a claim; returns `true` if it was the last one.
+    pub(super) fn dec_claims(&self) -> bool {
+        // AcqRel: the freeing thread must observe every storage access of the claims removed before it. Acquire on each decrement, not just
+        // the last one as `Arc` does -- one ordering instead of a release/fence split, on a counter that is nowhere near hot.
+        let prev = self.claims.fetch_sub(1, Ordering::AcqRel);
+        sys::strict_assert_ne!(prev, 0, "claim released more often than taken");
+
+        prev == 1
     }
 }
 

--- a/godot-core/src/storage/multi_threaded.rs
+++ b/godot-core/src/storage/multi_threaded.rs
@@ -116,6 +116,11 @@ unsafe impl<T: GodotClass> Storage for InstanceStorage<T> {
 
         prev == 1
     }
+
+    fn is_claimed_by_call(&self) -> bool {
+        // Relaxed: purely informational. Under `experimental-threads`, a claim taken on another thread may not be observed yet.
+        self.claims.load(Ordering::Relaxed) > 1
+    }
 }
 
 impl<T: GodotClass> StorageRefCounted for InstanceStorage<T> {

--- a/godot-core/src/storage/multi_threaded.rs
+++ b/godot-core/src/storage/multi_threaded.rs
@@ -5,6 +5,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+use std::sync::atomic::{AtomicU32, Ordering};
+
 #[cfg(feature = "experimental-threads")]
 use godot_cell::blocking::{GdCell, InaccessibleGuard, MutGuard, RefGuard};
 #[cfg(not(feature = "experimental-threads"))]
@@ -12,6 +14,7 @@ use godot_cell::panicking::{GdCell, InaccessibleGuard, MutGuard, RefGuard};
 
 use crate::obj::{Base, GodotClass};
 use crate::storage::{AtomicLifecycle, DebugBorrowTracker, Lifecycle, Storage, StorageRefCounted};
+use crate::sys;
 
 pub struct InstanceStorage<T: GodotClass> {
     user_instance: GdCell<T>,
@@ -19,6 +22,9 @@ pub struct InstanceStorage<T: GodotClass> {
 
     // Declared after `user_instance`, is dropped last
     pub(super) lifecycle: AtomicLifecycle,
+
+    // Claims on this storage's lifetime: Godot's, plus one per ongoing Godot -> Rust call. See `StorageClaim`.
+    claims: AtomicU32,
 
     // No-op in Release mode.
     borrow_tracker: DebugBorrowTracker,
@@ -45,6 +51,7 @@ unsafe impl<T: GodotClass> Storage for InstanceStorage<T> {
             user_instance: GdCell::new(user_instance),
             base,
             lifecycle: AtomicLifecycle::new(Lifecycle::Alive),
+            claims: AtomicU32::new(1),
             borrow_tracker: DebugBorrowTracker::new(),
         }
     }
@@ -95,6 +102,19 @@ unsafe impl<T: GodotClass> Storage for InstanceStorage<T> {
 
     fn set_lifecycle(&self, lifecycle: Lifecycle) {
         self.lifecycle.store(lifecycle)
+    }
+
+    fn inc_claims(&self) {
+        // Relaxed suffices: like `Arc::clone()`, the caller already holds a claim, so the storage cannot be freed concurrently.
+        self.claims.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn dec_claims(&self) -> bool {
+        // AcqRel: the freeing thread must observe every storage access of the claims removed before it, like a reference count.
+        let prev = self.claims.fetch_sub(1, Ordering::AcqRel);
+        sys::strict_assert_ne!(prev, 0, "claim released more often than taken");
+
+        prev == 1
     }
 }
 

--- a/godot-core/src/storage/single_threaded.rs
+++ b/godot-core/src/storage/single_threaded.rs
@@ -14,6 +14,7 @@ use godot_cell::panicking::{GdCell, InaccessibleGuard, MutGuard, RefGuard};
 
 use crate::obj::{Base, GodotClass};
 use crate::storage::{DebugBorrowTracker, Lifecycle, Storage, StorageRefCounted};
+use crate::sys;
 
 pub struct InstanceStorage<T: GodotClass> {
     user_instance: GdCell<T>,
@@ -21,6 +22,9 @@ pub struct InstanceStorage<T: GodotClass> {
 
     // Declared after `user_instance`, is dropped last.
     pub(super) lifecycle: cell::Cell<Lifecycle>,
+
+    // Claims on this storage's lifetime: Godot's, plus one per ongoing Godot -> Rust call. See `StorageClaim`.
+    claims: cell::Cell<u32>,
 
     // No-op in Release mode.
     borrow_tracker: DebugBorrowTracker,
@@ -47,6 +51,7 @@ unsafe impl<T: GodotClass> Storage for InstanceStorage<T> {
             user_instance: GdCell::new(user_instance),
             base,
             lifecycle: cell::Cell::new(Lifecycle::Alive),
+            claims: cell::Cell::new(1),
             borrow_tracker: DebugBorrowTracker::new(),
         }
     }
@@ -94,6 +99,18 @@ unsafe impl<T: GodotClass> Storage for InstanceStorage<T> {
 
     fn set_lifecycle(&self, lifecycle: Lifecycle) {
         self.lifecycle.set(lifecycle)
+    }
+
+    fn inc_claims(&self) {
+        self.claims.set(self.claims.get() + 1);
+    }
+
+    fn dec_claims(&self) -> bool {
+        let prev = self.claims.get();
+        sys::strict_assert_ne!(prev, 0, "claim released more often than taken");
+
+        self.claims.set(prev - 1);
+        prev == 1
     }
 }
 

--- a/godot-core/src/storage/single_threaded.rs
+++ b/godot-core/src/storage/single_threaded.rs
@@ -14,6 +14,7 @@ use godot_cell::panicking::{GdCell, InaccessibleGuard, MutGuard, RefGuard};
 
 use crate::obj::{Base, GodotClass};
 use crate::storage::{DebugBorrowTracker, Lifecycle, Storage, StorageRefCounted};
+use crate::sys;
 
 pub struct InstanceStorage<T: GodotClass> {
     user_instance: GdCell<T>,
@@ -21,6 +22,9 @@ pub struct InstanceStorage<T: GodotClass> {
 
     // Declared after `user_instance`, is dropped last.
     pub(super) lifecycle: cell::Cell<Lifecycle>,
+
+    // Claims on this storage's lifetime: 1 from Godot, one from each ongoing Godot->Rust call. See `StorageClaim`.
+    claims: cell::Cell<u32>,
 
     // No-op in Release mode.
     borrow_tracker: DebugBorrowTracker,
@@ -47,6 +51,7 @@ unsafe impl<T: GodotClass> Storage for InstanceStorage<T> {
             user_instance: GdCell::new(user_instance),
             base,
             lifecycle: cell::Cell::new(Lifecycle::Alive),
+            claims: cell::Cell::new(1),
             borrow_tracker: DebugBorrowTracker::new(),
         }
     }
@@ -94,6 +99,22 @@ unsafe impl<T: GodotClass> Storage for InstanceStorage<T> {
 
     fn set_lifecycle(&self, lifecycle: Lifecycle) {
         self.lifecycle.set(lifecycle)
+    }
+}
+
+impl<T: GodotClass> InstanceStorage<T> {
+    /// Adds a claim; see [`StorageClaim`][crate::storage::StorageClaim].
+    pub(super) fn inc_claims(&self) {
+        self.claims.set(self.claims.get() + 1);
+    }
+
+    /// Removes a claim; returns `true` if it was the last one.
+    pub(super) fn dec_claims(&self) -> bool {
+        let prev = self.claims.get();
+        sys::strict_assert_ne!(prev, 0, "claim released more often than taken");
+
+        self.claims.set(prev - 1);
+        prev == 1
     }
 }
 

--- a/godot-core/src/storage/single_threaded.rs
+++ b/godot-core/src/storage/single_threaded.rs
@@ -112,6 +112,10 @@ unsafe impl<T: GodotClass> Storage for InstanceStorage<T> {
         self.claims.set(prev - 1);
         prev == 1
     }
+
+    fn is_claimed_by_call(&self) -> bool {
+        self.claims.get() > 1
+    }
 }
 
 impl<T: GodotClass> StorageRefCounted for InstanceStorage<T> {

--- a/godot-ffi/src/lib.rs
+++ b/godot-ffi/src/lib.rs
@@ -139,9 +139,9 @@ struct StartupMessages {
     /// Set once a fatal message is collected (see `defer_startup_fatal!`); consumed by [`take_startup_fatal`] at the terminal init point.
     has_fatal: bool,
 
-    /// Message keys already emitted via the `once` flag, so each is shown only once. Keys are namespaced per level (`w`/`e`/`f`), with `:`
-    /// for an explicit ID and `@` for an implicit call site, to avoid collisions.
-    once_emitted: std::collections::HashSet<&'static str>,
+    /// Message keys already emitted via the `once`/`once_per` flags, so each is shown only once. Keys are namespaced per level (`w`/`e`/`f`),
+    /// with `:` for an explicit ID and `@` for an implicit call site, to avoid collisions. `once_per` appends `#` and the runtime key.
+    once_emitted: std::collections::HashSet<std::borrow::Cow<'static, str>>,
 }
 
 /// A message to be displayed in the Godot editor once UI is ready.
@@ -346,6 +346,8 @@ fn safeguards_level_string() -> &'static str {
 }
 
 /// Internal function to collect a message for deferred display in Godot editor UI. Called by macros.
+///
+/// Returns whether the message was accepted, i.e. neither suppressed nor already emitted under its `once` key.
 #[doc(hidden)]
 pub fn collect_startup_message(
     mut message: String,
@@ -354,12 +356,14 @@ pub fn collect_startup_message(
     line: u32,
     module_path: &str,
     id: Option<&'static str>,
-    once_id: Option<&'static str>,
-) {
+    // Dedup key: `site_id` identifies the message (explicit ID or call site), the optional `per_id` narrows it to one occurrence per runtime
+    // value, e.g. per class.
+    once: Option<(&'static str, Option<&dyn std::fmt::Display>)>,
+) -> bool {
     // Check if this warning should be suppressed (only warnings can be suppressed, not errors).
     if let (StartupMessageLevel::Warn, Some(id)) = (level, id) {
         if is_message_suppressed(id) {
-            return;
+            return false;
         } else {
             message = format!(
                 "{message}\n(Suppress this warning with env-var `GDRUST_SUPPRESSED_WARNINGS={id},...`)",
@@ -383,10 +387,15 @@ pub fn collect_startup_message(
     }
 
     // After the suppression check above, so a suppressed warning does not consume the once-slot.
-    if let Some(id) = once_id
-        && !state.once_emitted.insert(id)
-    {
-        return;
+    if let Some((site_id, per_id)) = once {
+        let key = match per_id {
+            Some(per_id) => std::borrow::Cow::Owned(format!("{site_id}#{per_id}")),
+            None => std::borrow::Cow::Borrowed(site_id),
+        };
+
+        if !state.once_emitted.insert(key) {
+            return false;
+        }
     }
 
     if state.flushed {
@@ -395,6 +404,8 @@ pub fn collect_startup_message(
     } else {
         state.deferred.push(msg);
     }
+
+    true
 }
 
 /// Print a single message to the editor UI via the FFI interface.
@@ -823,11 +834,19 @@ macro_rules! interface_fn {
 #[macro_export]
 #[doc(hidden)]
 macro_rules! __defer_startup_message {
+    ($level:ident, $ns:literal, once_per: $per_id:expr; id: $id:literal, $($fmt:tt)+) => {
+        $crate::__defer_startup_message!(@emit $level, Some($id),
+            Some((concat!($ns, ":", $id), Some(&$per_id as &dyn std::fmt::Display))), $($fmt)+)
+    };
+    ($level:ident, $ns:literal, once_per: $per_id:expr; $($fmt:tt)+) => {
+        $crate::__defer_startup_message!(@emit $level, None,
+            Some((concat!($ns, "@", file!(), ":", line!()), Some(&$per_id as &dyn std::fmt::Display))), $($fmt)+)
+    };
     ($level:ident, $ns:literal, once; id: $id:literal, $($fmt:tt)+) => {
-        $crate::__defer_startup_message!(@emit $level, Some($id), Some(concat!($ns, ":", $id)), $($fmt)+)
+        $crate::__defer_startup_message!(@emit $level, Some($id), Some((concat!($ns, ":", $id), None)), $($fmt)+)
     };
     ($level:ident, $ns:literal, once; $($fmt:tt)+) => {
-        $crate::__defer_startup_message!(@emit $level, None, Some(concat!($ns, "@", file!(), ":", line!())), $($fmt)+)
+        $crate::__defer_startup_message!(@emit $level, None, Some((concat!($ns, "@", file!(), ":", line!()), None)), $($fmt)+)
     };
     ($level:ident, $ns:literal, id: $id:literal, $($fmt:tt)+) => {
         $crate::__defer_startup_message!(@emit $level, Some($id), None, $($fmt)+)
@@ -836,7 +855,7 @@ macro_rules! __defer_startup_message {
         $crate::__defer_startup_message!(@emit $level, None, None, $($fmt)+)
     };
 
-    (@emit $level:ident, $id:expr, $once_id:expr, $fmt:literal $(, $args:expr)* $(,)?) => {
+    (@emit $level:ident, $id:expr, $once:expr, $fmt:literal $(, $args:expr)* $(,)?) => {
         $crate::collect_startup_message(
             format!($fmt $(, $args)*),
             $crate::StartupMessageLevel::$level,
@@ -844,7 +863,7 @@ macro_rules! __defer_startup_message {
             line!(),
             module_path!(),
             $id,
-            $once_id,
+            $once,
         )
     };
 }
@@ -862,11 +881,19 @@ macro_rules! __defer_startup_message {
 /// defer_startup_warn!(id: "FeatureDeprecated", "Feature X is deprecated");
 /// // One-time warning only:
 /// defer_startup_warn!(once; id: "BadCond", "A runtime condition is bad");
+/// // One-time warning per runtime key, e.g. per class:
+/// # let class_id = "MyClass";
+/// defer_startup_warn!(once_per: class_id; id: "BadCond", "Class {class_id} is bad");
 /// # }
 /// ```
+///
+/// Evaluates to `bool`: whether the warning was accepted, i.e. neither suppressed nor already emitted. Useful to gate extra diagnostics.
 #[macro_export]
 macro_rules! defer_startup_warn {
     // Only the `id:` forms; warnings need an ID for suppression.
+    (once_per: $per_id:expr; id: $($tt:tt)+) => {
+        $crate::__defer_startup_message!(Warn, "w", once_per: $per_id; id: $($tt)+)
+    };
     (once; id: $($tt:tt)+) => {
         $crate::__defer_startup_message!(Warn, "w", once; id: $($tt)+)
     };
@@ -890,8 +917,13 @@ macro_rules! defer_startup_warn {
 /// defer_startup_error!(once; "A runtime condition is bad");
 /// // One-time error, deduplicated by explicit ID (shared across call sites):
 /// defer_startup_error!(once; id: "InitFail", "Failed to initialize: {reason}");
+/// // One-time error per runtime key, e.g. per class; the key must implement `Display`:
+/// # let class_id = "MyClass";
+/// defer_startup_error!(once_per: class_id; "Class {class_id} failed: {reason}");
 /// # }
 /// ```
+///
+/// Evaluates to `bool`: whether the error was accepted, i.e. not already emitted under its `once` key.
 #[macro_export]
 macro_rules! defer_startup_error {
     ($($tt:tt)+) => {

--- a/godot-macros/src/class/data_models/func.rs
+++ b/godot-macros/src/class/data_models/func.rs
@@ -344,10 +344,10 @@ fn make_forwarding_closure(
 
     let instance_decl = match &signature_info.receiver_type {
         ReceiverType::Ref => quote! {
-            let __gdext_self = ::godot::private::Storage::get(storage);
+            let __gdext_self = ::godot::private::Storage::get(&*storage);
         },
         ReceiverType::Mut => quote! {
-            let mut __gdext_self = ::godot::private::Storage::get_mut(storage);
+            let mut __gdext_self = ::godot::private::Storage::get_mut(&*storage);
         },
         _ => quote! {},
     };
@@ -357,7 +357,7 @@ fn make_forwarding_closure(
             let before_method = format_ident!("__before_{method_name}", span = method_name.span());
             if let ReceiverType::GdSelf = signature_info.receiver_type {
                 // In case of GdSelf receiver use instance only to call the before_method.
-                quote! { ::godot::private::Storage::get_mut(storage).#before_method(); }
+                quote! { ::godot::private::Storage::get_mut(&*storage).#before_method(); }
             } else {
                 quote! { __gdext_self.#before_method(); }
             }
@@ -438,7 +438,7 @@ fn make_forwarding_closure(
                         unsafe { ::godot::private::as_storage::<#class_name>(instance_ptr) };
 
                     #before_method_call
-                    #class_name::#method_name(::godot::private::Storage::get_gd(storage), #(#params),*)
+                    #class_name::#method_name(::godot::private::Storage::get_gd(&*storage), #(#params),*)
                 }
             }
         }

--- a/itest/rust/src/benchmarks/mod.rs
+++ b/itest/rust/src/benchmarks/mod.rs
@@ -10,10 +10,10 @@
 use std::hint::black_box;
 
 use godot::builtin::inner::InnerRect2i;
-use godot::builtin::{GString, PackedInt32Array, Rect2i, StringName, Vector2i};
+use godot::builtin::{GString, PackedInt32Array, Rect2i, StringName, Vector2i, varray};
 use godot::classes::{Node3D, Os, RefCounted};
 use godot::obj::{Gd, InstanceId, NewAlloc, NewGd, Singleton};
-use godot::register::GodotClass;
+use godot::register::{GodotClass, godot_api};
 
 use crate::framework::{BenchResult, bench, bench_measure};
 
@@ -84,6 +84,26 @@ fn class_user_refc_clone_drop() -> BenchResult {
     bench_measure(100, || obj.clone())
 }
 
+/// Godot -> Rust call into a `#[func]` method, through the trampoline that keeps the storage alive for the call's duration.
+#[bench(manual)]
+fn class_user_refc_call_ref() -> BenchResult {
+    let obj = MyBenchType::new_gd();
+    let callable = obj.callable("noop_ref");
+    let args = varray![];
+
+    bench_measure(100, || callable.callv(&args))
+}
+
+/// Same as [`class_user_refc_call_ref()`], but the receiver additionally requires an exclusive bind.
+#[bench(manual)]
+fn class_user_refc_call_mut() -> BenchResult {
+    let obj = MyBenchType::new_gd();
+    let callable = obj.callable("noop_mut");
+    let args = varray![];
+
+    bench_measure(100, || callable.callv(&args))
+}
+
 #[bench]
 fn class_singleton_access() -> Gd<Os> {
     Os::singleton()
@@ -132,3 +152,16 @@ fn packed_array_from_iter_unknown_size() -> PackedInt32Array {
 #[derive(GodotClass)]
 #[class(init)]
 struct MyBenchType {}
+
+#[godot_api]
+impl MyBenchType {
+    #[func]
+    fn noop_ref(&self) -> i64 {
+        42
+    }
+
+    #[func]
+    fn noop_mut(&mut self) -> i64 {
+        42
+    }
+}

--- a/itest/rust/src/benchmarks/mod.rs
+++ b/itest/rust/src/benchmarks/mod.rs
@@ -13,7 +13,7 @@ use godot::builtin::inner::InnerRect2i;
 use godot::builtin::{GString, PackedInt32Array, Rect2i, StringName, Vector2i};
 use godot::classes::{Node3D, Os, RefCounted};
 use godot::obj::{Gd, InstanceId, NewAlloc, NewGd, Singleton};
-use godot::register::GodotClass;
+use godot::register::{GodotClass, godot_api};
 
 use crate::framework::{BenchResult, bench, bench_measure};
 
@@ -84,6 +84,24 @@ fn class_user_refc_clone_drop() -> BenchResult {
     bench_measure(100, || obj.clone())
 }
 
+/// Godot -> Rust call into a `#[func]` method, through the trampoline that keeps the storage alive for the call's duration.
+#[bench(manual)]
+fn class_user_refc_call_ref() -> BenchResult {
+    let obj = MyBenchType::new_gd();
+    let callable = obj.callable("noop_ref");
+
+    bench_measure(100, || callable.call(&[]))
+}
+
+/// Same as [`class_user_refc_call_ref()`], but the receiver additionally requires an exclusive bind.
+#[bench(manual)]
+fn class_user_refc_call_mut() -> BenchResult {
+    let obj = MyBenchType::new_gd();
+    let callable = obj.callable("noop_mut");
+
+    bench_measure(100, || callable.call(&[]))
+}
+
 #[bench]
 fn class_singleton_access() -> Gd<Os> {
     Os::singleton()
@@ -132,3 +150,12 @@ fn packed_array_from_iter_unknown_size() -> PackedInt32Array {
 #[derive(GodotClass)]
 #[class(init)]
 struct MyBenchType {}
+
+#[godot_api]
+impl MyBenchType {
+    #[func]
+    fn noop_ref(&self) {}
+
+    #[func]
+    fn noop_mut(&mut self) {}
+}

--- a/itest/rust/src/object_tests/mod.rs
+++ b/itest/rust/src/object_tests/mod.rs
@@ -27,6 +27,7 @@ mod phantom_var_test;
 mod property_template_test;
 mod property_test;
 mod reentrant_test;
+mod self_destruct_test;
 mod singleton_test;
 // `validate_property` is only supported in Godot 4.2+.
 mod base_init_test;

--- a/itest/rust/src/object_tests/mod.rs
+++ b/itest/rust/src/object_tests/mod.rs
@@ -27,6 +27,9 @@ mod phantom_var_test;
 mod property_template_test;
 mod property_test;
 mod reentrant_test;
+// Before Godot 4.4, an object destroyed inside its own call is an engine-side use-after-free: `Object::callp()`'s debug lock keeps a raw
+// `this` and unrefs it after the call. Fixed by https://github.com/godotengine/godot/pull/96856.
+#[cfg(since_api = "4.4")]
 mod self_destruct_test;
 mod singleton_test;
 // `validate_property` is only supported in Godot 4.2+.

--- a/itest/rust/src/object_tests/object_test.rs
+++ b/itest/rust/src/object_tests/object_test.rs
@@ -400,7 +400,7 @@ fn object_user_dynamic_free_during_bind() {
     let mut copy = obj.clone(); // TODO clone allowed while bound?
 
     // This technically triggers UB, but in practice no one accesses the references.
-    // There is no alternative to test this, see destroy_storage() comments.
+    // There is no alternative to test this, see report_destruction_while_bound() comments.
     copy.call("free", &[]);
 
     drop(guard);

--- a/itest/rust/src/object_tests/self_destruct_test.rs
+++ b/itest/rust/src/object_tests/self_destruct_test.rs
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+//! Objects that are destroyed while a Godot -> Rust call on them is still running.
+//!
+//! The storage must outlive such a call, since the trampoline and any instance guard keep using it after the method returns.
+
+use std::cell::{Cell, RefCell};
+use std::rc::Rc;
+
+use godot::builtin::vslice;
+use godot::classes::notify::ObjectNotification;
+use godot::classes::{IRefCounted, Object, RefCounted};
+use godot::meta::ToGodot;
+use godot::obj::{Base, Gd, InstanceId, NewAlloc, NewGd, WithBaseField, WithUserSignals};
+use godot::register::{GodotClass, godot_api};
+
+use crate::framework::itest;
+
+// A signal handler may drop the last reference to the emitter, mid-call. The object must survive until the method returns, otherwise the
+// active instance guard would dangle. Regression test for https://github.com/godot-rust/gdext/issues/1666.
+#[itest]
+fn signal_emitter_destroyed_during_own_call() {
+    let instance_id = call_self_destroyer("emit_and_die");
+
+    assert!(!instance_id.lookup_validity(), "object must be destroyed");
+    assert_eq!(SELF_DESTROYER_DROPS.get(), 1, "storage must not leak");
+}
+
+// Same, but the destruction happens one call deeper, so two claims are outstanding and only the outermost may free.
+#[itest]
+fn signal_emitter_destroyed_during_nested_call() {
+    let instance_id = call_self_destroyer("nested_emit_and_die");
+
+    assert!(!instance_id.lookup_validity());
+    assert_eq!(SELF_DESTROYER_DROPS.get(), 1);
+}
+
+// `gd_self` holds no instance guard, so free() succeeds and destroys the object mid-call. The storage must outlive the call, whose trampoline
+// still uses it after the method returns. `&mut self` receivers cannot reach this: free() panics on an active bind.
+#[itest]
+fn object_free_during_own_gd_self_call() {
+    SELF_FREER_DROPS.set(0);
+
+    let mut object = SelfFreer::new_alloc();
+    let id = object.instance_id();
+
+    assert_eq!(object.call("free_self", &[]), 1.to_variant());
+    assert!(!id.lookup_validity());
+    assert_eq!(SELF_FREER_DROPS.get(), 1, "storage must not leak");
+}
+
+// Like `signal_emitter_destroyed_during_own_call`, but through the notification callback. The reference dropped mid-call is not the last one:
+// Godot reads `this` after the callback returns, so the object must outlive it -- see the keepalive below.
+#[itest]
+fn notification_drops_own_reference() {
+    DESTROYER_DROPS.set(0);
+
+    let object = NotificationSelfDestroyer::new_gd();
+    let instance_id = object.instance_id();
+
+    // Callable holds no strong reference, so the handler's reference and this one are the only two.
+    let callable = object.callable("notification");
+    DESTROYER_REF.with(|cell| *cell.borrow_mut() = Some(object.clone()));
+
+    // Keepalive: Godot reads `this` after the callback returns (Object::_notification_forward()), so the last reference must not drop here.
+    let keepalive = object;
+
+    // Arbitrary user notification ID; the handler ignores it.
+    callable.call(vslice![9999]);
+
+    assert!(DESTROYER_REF.with(|cell| cell.borrow().is_none()));
+    assert!(instance_id.lookup_validity(), "keepalive outlives the call");
+
+    drop(keepalive);
+    assert!(!instance_id.lookup_validity());
+    assert_eq!(DESTROYER_DROPS.get(), 1, "storage must not leak");
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// Helper types
+
+thread_local! {
+    // The `*_DROPS` counters are incremented per destroyed storage, to detect a claimed storage that is never freed.
+    static SELF_DESTROYER_DROPS: Cell<u32> = const { Cell::new(0) };
+    static SELF_FREER_DROPS: Cell<u32> = const { Cell::new(0) };
+    static DESTROYER_DROPS: Cell<u32> = const { Cell::new(0) };
+
+    /// Lets the notification handler drop a reference to its own object, without access to the test's local variables.
+    static DESTROYER_REF: RefCell<Option<Gd<NotificationSelfDestroyer>>> = const { RefCell::new(None) };
+}
+
+/// Invokes `method` on a fresh [`SelfDestroyer`], whose signal handler drops the last reference to it mid-call.
+fn call_self_destroyer(method: &str) -> InstanceId {
+    SELF_DESTROYER_DROPS.set(0);
+
+    let object = SelfDestroyer::new_gd();
+    let instance_id = object.instance_id();
+
+    // Callable holds no strong reference, so the only one remains inside `last_ref`.
+    let callable = object.callable(method);
+    let last_ref = Rc::new(RefCell::new(None));
+
+    let cell = last_ref.clone();
+    object.signals().about_to_die().connect(move || {
+        *cell.borrow_mut() = None; // Drops the last reference to the emitter, mid-call.
+    });
+
+    *last_ref.borrow_mut() = Some(object);
+
+    // Goes through the Godot -> Rust method trampoline, which must keep the receiver alive for the duration of the call.
+    callable.call(&[]);
+    assert!(last_ref.borrow().is_none(), "handler must have run");
+
+    instance_id
+}
+
+/// Emits a signal whose handler drops the last reference to this very object.
+#[derive(GodotClass)]
+#[class(base = RefCounted, init)]
+struct SelfDestroyer {
+    base: Base<RefCounted>,
+}
+
+impl Drop for SelfDestroyer {
+    fn drop(&mut self) {
+        SELF_DESTROYER_DROPS.set(SELF_DESTROYER_DROPS.get() + 1);
+    }
+}
+
+#[godot_api]
+impl SelfDestroyer {
+    #[signal]
+    fn about_to_die();
+
+    #[func]
+    fn emit_and_die(&mut self) {
+        self.signals().about_to_die().emit();
+    }
+
+    /// Re-enters through Godot, so two calls are ongoing. Uses `&self` receivers, since a nested `&mut self` bind would conflict.
+    #[func]
+    fn nested_emit_and_die(&self) {
+        // Callable holds no strong reference, so the object can die inside the inner frame.
+        let callable = self.to_gd().callable("emit_shared");
+        callable.call(&[]);
+    }
+
+    #[func]
+    fn emit_shared(&self) {
+        // Engine-side emit, which needs no bind of the user instance.
+        self.to_gd().emit_signal("about_to_die", &[]);
+    }
+}
+
+/// Frees itself from within a call on it, which its `gd_self` receiver permits.
+#[derive(GodotClass)]
+#[class(base = Object, init)]
+struct SelfFreer {
+    base: Base<Object>,
+}
+
+impl Drop for SelfFreer {
+    fn drop(&mut self) {
+        SELF_FREER_DROPS.set(SELF_FREER_DROPS.get() + 1);
+    }
+}
+
+#[godot_api]
+impl SelfFreer {
+    #[func(gd_self)]
+    fn free_self(this: Gd<Self>) -> i32 {
+        this.free();
+        1
+    }
+}
+
+/// Drops a reference to itself when notified.
+#[derive(GodotClass)]
+#[class(base = RefCounted, init)]
+struct NotificationSelfDestroyer {}
+
+impl Drop for NotificationSelfDestroyer {
+    fn drop(&mut self) {
+        DESTROYER_DROPS.set(DESTROYER_DROPS.get() + 1);
+    }
+}
+
+#[godot_api]
+impl IRefCounted for NotificationSelfDestroyer {
+    fn on_notification(&mut self, _what: ObjectNotification) {
+        // Drops a reference to this object, mid-call. Still empty during POSTINITIALIZE.
+        DESTROYER_REF.with(|cell| *cell.borrow_mut() = None);
+    }
+}

--- a/itest/rust/src/object_tests/self_destruct_test.rs
+++ b/itest/rust/src/object_tests/self_destruct_test.rs
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+//! Objects that are destroyed while a Godot -> Rust call on them is still running.
+//!
+//! The storage must outlive such a call, since the trampoline and any instance guard keep using it after the method returns.
+
+use std::cell::{Cell, RefCell};
+use std::rc::Rc;
+
+use godot::builtin::vslice;
+use godot::classes::notify::ObjectNotification;
+use godot::classes::{IRefCounted, Object, RefCounted};
+use godot::meta::ToGodot;
+use godot::obj::{Base, Gd, InstanceId, NewAlloc, NewGd, WithBaseField, WithUserSignals};
+use godot::register::{GodotClass, godot_api};
+
+use crate::framework::itest;
+
+// A signal handler may drop the last reference to the emitter, mid-call. The object must survive until the method returns, otherwise the
+// active instance guard would dangle. Regression test for https://github.com/godot-rust/gdext/issues/1666.
+#[itest]
+fn signal_emitter_destroyed_during_own_call() {
+    let instance_id = call_self_destroyer("emit_and_die");
+
+    assert!(!instance_id.lookup_validity(), "object must be destroyed");
+    assert_eq!(SELF_DESTROYER_DROPS.get(), 1, "storage must not leak");
+}
+
+// Same, but the destruction happens one call deeper, so two claims are outstanding and only the outermost may free.
+#[itest]
+fn signal_emitter_destroyed_during_nested_call() {
+    let instance_id = call_self_destroyer("nested_emit_and_die");
+
+    assert!(!instance_id.lookup_validity());
+    assert_eq!(SELF_DESTROYER_DROPS.get(), 1);
+}
+
+// `gd_self` holds no instance guard, so free() succeeds and destroys the object mid-call. The storage must outlive the call, whose trampoline
+// still uses it after the method returns. `&mut self` receivers cannot reach this: free() panics on an active bind.
+#[itest]
+fn object_free_during_own_gd_self_call() {
+    #[derive(GodotClass)]
+    #[class(base = Object, init)]
+    struct SelfFreer {
+        base: Base<Object>,
+    }
+
+    impl Drop for SelfFreer {
+        fn drop(&mut self) {
+            SELF_FREER_DROPS.set(SELF_FREER_DROPS.get() + 1);
+        }
+    }
+
+    #[godot_api]
+    impl SelfFreer {
+        #[func(gd_self)]
+        fn free_self(this: Gd<Self>) -> i32 {
+            this.free();
+            1
+        }
+    }
+
+    SELF_FREER_DROPS.set(0);
+
+    let mut object = SelfFreer::new_alloc();
+    let id = object.instance_id();
+
+    assert_eq!(object.call("free_self", &[]), 1.to_variant());
+    assert!(!id.lookup_validity());
+    assert_eq!(SELF_FREER_DROPS.get(), 1, "storage must not leak");
+}
+
+// Like `signal_emitter_destroyed_during_own_call`, but through the notification callback. The reference dropped mid-call is not the last one:
+// Godot reads `this` after the callback returns, so the object must outlive it -- see the keepalive below.
+#[itest]
+fn notification_drops_own_reference() {
+    DESTROYER_DROPS.set(0);
+
+    let object = NotificationSelfDestroyer::new_gd();
+    let instance_id = object.instance_id();
+
+    // Callable holds no strong reference, so the handler's reference and this one are the only two.
+    let callable = object.callable("notification");
+    DESTROYER_REF.with(|cell| *cell.borrow_mut() = Some(object.clone()));
+
+    // TODO(v0.7): drop this keepalive once Godot stops reading `this` after the callback, see Object::_notification_forward().
+    let keepalive = object;
+
+    // Arbitrary user notification ID; the handler ignores it.
+    callable.call(vslice![9999]);
+
+    assert!(DESTROYER_REF.with(|cell| cell.borrow().is_none()));
+    assert!(instance_id.lookup_validity(), "keepalive outlives the call");
+
+    drop(keepalive);
+    assert!(!instance_id.lookup_validity());
+    assert_eq!(DESTROYER_DROPS.get(), 1, "storage must not leak");
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// Helper types
+
+thread_local! {
+    // The `*_DROPS` counters are incremented per destroyed storage, to detect a claimed storage that is never freed.
+    static SELF_DESTROYER_DROPS: Cell<u32> = const { Cell::new(0) };
+    static SELF_FREER_DROPS: Cell<u32> = const { Cell::new(0) };
+    static DESTROYER_DROPS: Cell<u32> = const { Cell::new(0) };
+
+    /// Lets the notification handler drop a reference to its own object, without access to the test's local variables.
+    static DESTROYER_REF: RefCell<Option<Gd<NotificationSelfDestroyer>>> = const { RefCell::new(None) };
+}
+
+/// Invokes `method` on a fresh [`SelfDestroyer`], whose signal handler drops the last reference to it mid-call.
+fn call_self_destroyer(method: &str) -> InstanceId {
+    SELF_DESTROYER_DROPS.set(0);
+
+    let object = SelfDestroyer::new_gd();
+    let instance_id = object.instance_id();
+
+    // Callable holds no strong reference, so the only one remains inside `last_ref`.
+    let callable = object.callable(method);
+    let last_ref = Rc::new(RefCell::new(None));
+
+    let cell = last_ref.clone();
+    object.signals().about_to_die().connect(move || {
+        *cell.borrow_mut() = None; // Drops the last reference to the emitter, mid-call.
+    });
+
+    *last_ref.borrow_mut() = Some(object);
+
+    // Goes through the Godot -> Rust method trampoline, which must keep the receiver alive for the duration of the call.
+    callable.call(&[]);
+    assert!(last_ref.borrow().is_none(), "handler must have run");
+
+    instance_id
+}
+
+/// Emits a signal whose handler drops the last reference to this very object.
+#[derive(GodotClass)]
+#[class(base = RefCounted, init)]
+struct SelfDestroyer {
+    base: Base<RefCounted>,
+}
+
+impl Drop for SelfDestroyer {
+    fn drop(&mut self) {
+        SELF_DESTROYER_DROPS.set(SELF_DESTROYER_DROPS.get() + 1);
+    }
+}
+
+#[godot_api]
+impl SelfDestroyer {
+    #[signal]
+    fn about_to_die();
+
+    #[func]
+    fn emit_and_die(&mut self) {
+        self.signals().about_to_die().emit();
+    }
+
+    /// Re-enters through Godot, so two calls are ongoing. Uses `&self` receivers, since a nested `&mut self` bind would conflict.
+    #[func]
+    fn nested_emit_and_die(&self) {
+        // Callable holds no strong reference, so the object can die inside the inner frame.
+        let callable = self.to_gd().callable("emit_shared");
+        callable.call(&[]);
+    }
+
+    #[func]
+    fn emit_shared(&self) {
+        // Engine-side emit, which needs no bind of the user instance.
+        self.to_gd().emit_signal("about_to_die", &[]);
+    }
+}
+
+/// Drops a reference to itself when notified.
+#[derive(GodotClass)]
+#[class(base = RefCounted, init)]
+struct NotificationSelfDestroyer {}
+
+impl Drop for NotificationSelfDestroyer {
+    fn drop(&mut self) {
+        DESTROYER_DROPS.set(DESTROYER_DROPS.get() + 1);
+    }
+}
+
+#[godot_api]
+impl IRefCounted for NotificationSelfDestroyer {
+    fn on_notification(&mut self, _what: ObjectNotification) {
+        // Drops a reference to this object, mid-call. Still empty during POSTINITIALIZE.
+        DESTROYER_REF.with(|cell| *cell.borrow_mut() = None);
+    }
+}

--- a/itest/rust/src/object_tests/self_destruct_test.rs
+++ b/itest/rust/src/object_tests/self_destruct_test.rs
@@ -19,7 +19,7 @@ use godot::meta::ToGodot;
 use godot::obj::{Base, Gd, InstanceId, NewAlloc, NewGd, WithBaseField, WithUserSignals};
 use godot::register::{GodotClass, godot_api};
 
-use crate::framework::itest;
+use crate::framework::{itest, suppress_godot_print};
 
 // A signal handler may drop the last reference to the emitter, mid-call. The object must survive until the method returns, otherwise the
 // active instance guard would dangle. Regression test for https://github.com/godot-rust/gdext/issues/1666.
@@ -42,6 +42,7 @@ fn signal_emitter_destroyed_during_nested_call() {
 
 // `gd_self` holds no instance guard, so free() succeeds and destroys the object mid-call. The storage must outlive the call, whose trampoline
 // still uses it after the method returns. `&mut self` receivers cannot reach this: free() panics on an active bind.
+// Manually managed classes are excluded from the destruction report, so no error is expected here.
 #[itest]
 fn object_free_during_own_gd_self_call() {
     #[derive(GodotClass)]
@@ -134,7 +135,8 @@ fn call_self_destroyer(method: &str) -> InstanceId {
     *last_ref.borrow_mut() = Some(object);
 
     // Goes through the Godot -> Rust method trampoline, which must keep the receiver alive for the duration of the call.
-    callable.call(&[]);
+    // The destruction is reported as an error, which is expected here.
+    suppress_godot_print(|| callable.call(&[]));
     assert!(last_ref.borrow().is_none(), "handler must have run");
 
     instance_id

--- a/itest/rust/src/object_tests/self_destruct_test.rs
+++ b/itest/rust/src/object_tests/self_destruct_test.rs
@@ -19,7 +19,7 @@ use godot::meta::ToGodot;
 use godot::obj::{Base, Gd, InstanceId, NewAlloc, NewGd, WithBaseField, WithUserSignals};
 use godot::register::{GodotClass, godot_api};
 
-use crate::framework::itest;
+use crate::framework::{itest, suppress_godot_print};
 
 // A signal handler may drop the last reference to the emitter, mid-call. The object must survive until the method returns, otherwise the
 // active instance guard would dangle. Regression test for https://github.com/godot-rust/gdext/issues/1666.
@@ -40,8 +40,20 @@ fn signal_emitter_destroyed_during_nested_call() {
     assert_eq!(SELF_DESTROYER_DROPS.get(), 1);
 }
 
+// The workaround named in the destruction report: a deferred callable holds a reference past the call.
+#[itest]
+fn signal_emitter_kept_alive_by_deferred_call() {
+    let instance_id = call_self_destroyer("emit_and_survive");
+
+    assert!(
+        instance_id.lookup_validity(),
+        "object must survive the call"
+    );
+}
+
 // `gd_self` holds no instance guard, so free() succeeds and destroys the object mid-call. The storage must outlive the call, whose trampoline
 // still uses it after the method returns. `&mut self` receivers cannot reach this: free() panics on an active bind.
+// The destruction is reported as an error, which is expected here.
 #[itest]
 fn object_free_during_own_gd_self_call() {
     SELF_FREER_DROPS.set(0);
@@ -49,7 +61,8 @@ fn object_free_during_own_gd_self_call() {
     let mut object = SelfFreer::new_alloc();
     let id = object.instance_id();
 
-    assert_eq!(object.call("free_self", &[]), 1.to_variant());
+    let result = suppress_godot_print(|| object.call("free_self", &[]));
+    assert_eq!(result, 1.to_variant());
     assert!(!id.lookup_validity());
     assert_eq!(SELF_FREER_DROPS.get(), 1, "storage must not leak");
 }
@@ -113,7 +126,8 @@ fn call_self_destroyer(method: &str) -> InstanceId {
     *last_ref.borrow_mut() = Some(object);
 
     // Goes through the Godot -> Rust method trampoline, which must keep the receiver alive for the duration of the call.
-    callable.call(&[]);
+    // The destruction is reported as an error, which is expected here.
+    suppress_godot_print(|| callable.call(&[]));
     assert!(last_ref.borrow().is_none(), "handler must have run");
 
     instance_id
@@ -139,6 +153,12 @@ impl SelfDestroyer {
 
     #[func]
     fn emit_and_die(&mut self) {
+        self.signals().about_to_die().emit();
+    }
+
+    #[func]
+    fn emit_and_survive(&mut self) {
+        self.to_gd().run_deferred_gd(|_| {}); // Keeps a reference until idle time.
         self.signals().about_to_die().emit();
     }
 


### PR DESCRIPTION

For `RefCounted` objects, user code can drop the last ref to itself mid-call (e.g. a signal handler nulling the emitter), which previously freed the storage under the active instance. 

I did **not** go the route of GDScript to add a strong-ref to every Godot->Rust call, for multiple reasons:
- The problem of rugpulling the own instance still exists for manually managed objects. A panic makes it clear.
- The extra refcounts cost around ~40% overhead of an empty function call. This is a lot, considering that most Godot->Rust calls never face the rugpulling problem.
- There are still some edge cases that aren't even covered with the strong-ref approach (e.g. when refcount is already 0 during `NOTIFICATION_PREDELETE`)

Instead, the storage now counts "claims" on itself (Godot's + 1 per call on the stack), and is freed by whoever releases the last one. This is a bit more complex but retains the benefits of the old version.

Fixes #1666, now covered via itest `signal_emitter_destroyed_during_own_call`.