### PR TITLE
feat(QoL): Renames some functions to a more stadard rust naming

### DIFF
--- a/godot-codegen/src/context.rs
+++ b/godot-codegen/src/context.rs
@@ -404,7 +404,7 @@ impl NotificationEnum {
     }
 
     /// Returns the name of the enum if it is declared by the current class, or `None` if it is inherited.
-    pub fn try_to_own_name(&self) -> Option<Ident> {
+    pub fn to_own_name(&self) -> Option<Ident> {
         if self.declared_by_own_class {
             Some(self.name.clone())
         } else {

--- a/godot-codegen/src/generator/classes.rs
+++ b/godot-codegen/src/generator/classes.rs
@@ -45,7 +45,7 @@ pub fn generate_class_files(
         modules.push(GeneratedClassModule {
             class_name: class.name().clone(),
             module_name: class.mod_name().clone(),
-            own_notification_enum_name: generated_class.notification_enum.try_to_own_name(),
+            own_notification_enum_name: generated_class.notification_enum.to_own_name(),
             inherits_macro_ident: generated_class.inherits_macro_ident,
             is_pub_sidecar: generated_class.has_sidecar_module,
             has_interface_trait: generated_class.has_interface_trait,

--- a/godot-core/src/classes/manual_extensions.rs
+++ b/godot-core/src/classes/manual_extensions.rs
@@ -24,13 +24,13 @@ impl Node {
     ///
     /// # Panics
     /// If the node is not found, or if it does not have type `T` or inherited.
-    pub fn get_node_as<T>(&self, path: impl AsArg<NodePath>) -> Gd<T>
+    pub fn node_as<T>(&self, path: impl AsArg<NodePath>) -> Gd<T>
     where
         T: Inherits<Node>,
     {
         arg_into_ref!(path);
 
-        self.try_get_node_as(path).unwrap_or_else(|| {
+        self.get_node_as(path).unwrap_or_else(|| {
             panic!(
                 "There is no node of type {ty} at path `{path}`",
                 ty = T::class_id()
@@ -42,7 +42,7 @@ impl Node {
     ///
     /// If the node is not found, or if it does not have type `T` or inherited,
     /// `None` will be returned.
-    pub fn try_get_node_as<T>(&self, path: impl AsArg<NodePath>) -> Option<Gd<T>>
+    pub fn get_node_as<T>(&self, path: impl AsArg<NodePath>) -> Option<Gd<T>>
     where
         T: Inherits<Node>,
     {
@@ -66,14 +66,14 @@ impl PackedScene {
     where
         T: Inherits<Node>,
     {
-        self.try_instantiate_as::<T>()
+        self.checked_instantiate_as::<T>()
             .unwrap_or_else(|| panic!("Failed to instantiate {to}", to = T::class_id()))
     }
 
-    /// Instantiates the scene as type `T` (fallible).
+    /// Instantiates the scene as type `T`.
     ///
-    /// If the scene is not type `T` or inherited.
-    pub fn try_instantiate_as<T>(&self) -> Option<Gd<T>>
+    /// Returns `None` if the instantiated scene is not of type `T` or inherited.
+    pub fn checked_instantiate_as<T>(&self) -> Option<Gd<T>>
     where
         T: Inherits<Node>,
     {

--- a/godot-core/src/obj/on_ready.rs
+++ b/godot-core/src/obj/on_ready.rs
@@ -146,7 +146,7 @@ impl<T: Inherits<Node>> OnReady<Gd<T>> {
     pub fn from_node(path: impl AsArg<NodePath>) -> Self {
         arg_into_owned!(path);
 
-        Self::from_base_fn(move |base| base.get_node_as(&path))
+        Self::from_base_fn(move |base| base.node_as(&path))
     }
 }
 

--- a/godot-core/src/tools/autoload.rs
+++ b/godot-core/src/tools/autoload.rs
@@ -115,7 +115,7 @@ where
     let root = scene_tree.get_root();
 
     let autoload_node = root
-        .try_get_node_as::<Node>(&autoload_path)
+        .get_node_as::<Node>(&autoload_path)
         .ok_or_else(|| ConvertError::new(format!("autoload `{autoload_name}` not found")))?;
 
     // Store in cache as Gd<Node>.

--- a/itest/rust/src/engine_tests/node_test.rs
+++ b/itest/rust/src/engine_tests/node_test.rs
@@ -28,11 +28,11 @@ fn node_get_node() {
     grandparent.add_child(&parent);
 
     // Directly on Gd<T>
-    let found = grandparent.get_node_as::<Node3D>("parent/child");
+    let found = grandparent.node_as::<Node3D>("parent/child");
     assert_eq!(found.instance_id(), child_id);
 
     // Deref via &T
-    let found = grandparent.try_get_node_as::<Node3D>(&NodePath::from("parent/child"));
+    let found = grandparent.get_node_as::<Node3D>(&NodePath::from("parent/child"));
     let found = found.expect("try_get_node_as() returned Some(..)");
     assert_eq!(found.instance_id(), child_id);
 
@@ -44,7 +44,7 @@ fn node_get_node_fail() {
     let mut child = Node3D::new_alloc();
     child.set_name("child");
 
-    let found = child.try_get_node_as::<Node3D>("non-existent");
+    let found = child.get_node_as::<Node3D>("non-existent");
     assert!(found.is_none());
 
     child.free();


### PR DESCRIPTION
As per https://github.com/godot-rust/gdext/issues/1672

## What

Renames a set of accessor/constructor methods across gdext to follow standard
Rust naming conventions for fallibility:

- `get_*` : returns `Option<T>` when the operation is a genuine *lookup* that
  may not find anything (mirrors an existing Godot `get_*_or_null`-style method).
- `checked_*`: returns `Option<T>` when the operation is a *construction or
  conversion* that validates before returning (not a lookup).
- `try_*` : reserved for methods returning `Result<T, E>`, distinguishing *why*
  an operation failed.
- Plain method name: panicking variant.

## Changes

- `Node::get_node_as` / `Node::try_node_as` 
- `PackedScene::instantiate_as` / `try_instantiate_as` 

## Why

Rust conventions establish `get` as Option-returning (`HashMap::get`,
`slice::get`) and `try_` as Result-returning (`TryFrom`, etc.), the previous
naming had this inverted, which is surprising for anyone coming from std.
