### PR TITLE
Add `Array::resize_default()`

### DIFF
--- a/godot-core/src/builtin/collections/any_array.rs
+++ b/godot-core/src/builtin/collections/any_array.rs
@@ -516,7 +516,9 @@ impl Clone for AnyArray {
 // Only implement for untyped arrays; typed arrays cannot be nested in Godot.
 impl meta::sealed::Sealed for AnyArray {}
 
-impl Element for AnyArray {}
+impl Element for AnyArray {
+    const USE_GODOT_DEFAULT: bool = true;
+}
 
 impl GodotConvert for AnyArray {
     type Via = Self;

--- a/godot-core/src/builtin/collections/any_dictionary.rs
+++ b/godot-core/src/builtin/collections/any_dictionary.rs
@@ -469,7 +469,9 @@ impl Clone for AnyDictionary {
 
 impl meta::sealed::Sealed for AnyDictionary {}
 
-impl Element for AnyDictionary {}
+impl Element for AnyDictionary {
+    const USE_GODOT_DEFAULT: bool = true;
+}
 
 impl GodotConvert for AnyDictionary {
     type Via = Self;

--- a/godot-core/src/builtin/collections/array.rs
+++ b/godot-core/src/builtin/collections/array.rs
@@ -466,13 +466,7 @@ impl<T: Element> Array<T> {
     ///
     /// If you know that the new size is smaller, then consider using [`shrink`][AnyArray::shrink] instead.
     pub fn resize(&mut self, new_size: usize, value: impl AsArg<T>) {
-        self.balanced_ensure_mutable();
-
-        let original_size = self.len();
-
-        // SAFETY: While we do insert `Variant::nil()` if the new size is larger, we then fill it with `value` ensuring that all values in the
-        // array are of type `T` still.
-        unsafe { self.as_inner_mut() }.resize(to_i64(new_size));
+        let original_size = self.resize_inner(new_size);
 
         meta::arg_into_ref!(value: T);
 
@@ -489,6 +483,37 @@ impl<T: Element> Array<T> {
             // ptr_mut() lookup could be optimized if we know the internal layout.
             unsafe { variant.move_into_var_ptr(ptr_mut) };
         }
+    }
+
+    /// Resizes the array, filling new elements with `T`'s default value.
+    ///
+    /// `resize_default(n)` behaves like `array.resize(n, T::default())`, but can bypass the `Default` trait for some `T` and directly use Godot's
+    /// [`Array.resize()`](https://docs.godotengine.org/en/stable/classes/class_array.html#class-array-method-resize). Unlike the latter, this
+    /// method maintains type safety for element types like `Gd<T>`, not allowing nils.
+    ///
+    /// Use [`resize()`][Self::resize] if you need more flexibility.
+    // noinspection RsConstantConditionIf -- Jetbrains IDE false positive.
+    pub fn resize_default(&mut self, new_size: usize)
+    where
+        T: Default,
+    {
+        // If type opts in to Godot's default-initialization, use that to avoid element-wise construction. Private API only for godot-rust types.
+        if T::USE_GODOT_DEFAULT {
+            self.resize_inner(new_size);
+        } else {
+            self.resize(new_size, meta::owned_into_arg(T::default()));
+        }
+    }
+
+    fn resize_inner(&mut self, new_size: usize) -> usize {
+        self.balanced_ensure_mutable();
+
+        let original_size = self.len();
+
+        // SAFETY: Godot's `resize()` fills new slots with type-appropriate defaults for typed arrays (e.g. 0 for int, nil for Variant).
+        // Callers that need non-default values (like `resize()`) must overwrite the new slots afterward.
+        unsafe { self.as_inner_mut() }.resize(to_i64(new_size));
+        original_size
     }
 
     /// Appends another array at the end of this array. Equivalent of `append_array` in GDScript.
@@ -1139,7 +1164,9 @@ unsafe impl<T: Element> GodotFfi for Array<T> {
 }
 
 // Only implement for untyped arrays; typed arrays cannot be nested in Godot.
-impl Element for VarArray {}
+impl Element for VarArray {
+    const USE_GODOT_DEFAULT: bool = true;
+}
 
 impl<T: Element> GodotConvert for Array<T> {
     type Via = Self;

--- a/godot-core/src/builtin/collections/dictionary.rs
+++ b/godot-core/src/builtin/collections/dictionary.rs
@@ -930,7 +930,9 @@ impl<K: Element, V: Element> meta::GodotType for Dictionary<K, V> {
 
 // Only implement for untyped dictionaries; typed dictionaries cannot be nested in typed containers.
 // Analogous to how only `VarArray` (not `Array<T>`) implements `Element`.
-impl Element for VarDictionary {}
+impl Element for VarDictionary {
+    const USE_GODOT_DEFAULT: bool = true;
+}
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Var/Export implementations for Dictionary<K, V>

--- a/godot-core/src/builtin/variant/impls.rs
+++ b/godot-core/src/builtin/variant/impls.rs
@@ -103,7 +103,9 @@ macro_rules! impl_ffi_variant {
             }
         }
 
-        impl Element for $T {}
+        impl Element for $T {
+            const USE_GODOT_DEFAULT: bool = true;
+        }
     };
 
     (@assoc_to_ffi by_ref) => {

--- a/godot-core/src/builtin/variant/mod.rs
+++ b/godot-core/src/builtin/variant/mod.rs
@@ -537,7 +537,9 @@ impl Variant {
     }
 }
 
-impl Element for Variant {}
+impl Element for Variant {
+    const USE_GODOT_DEFAULT: bool = true;
+}
 
 // SAFETY:
 // `from_opaque` properly initializes a dereferenced pointer to an `OpaqueVariant`.

--- a/godot-core/src/meta/godot_convert/impls.rs
+++ b/godot-core/src/meta/godot_convert/impls.rs
@@ -237,6 +237,8 @@ macro_rules! impl_godot_scalar {
 
         // For integer types, we can validate the conversion.
         impl Element for $T {
+            const USE_GODOT_DEFAULT: bool = true;
+
             fn debug_validate_elements(array: &Array<Self>) -> Result<(), ConvertError> {
                 array.debug_validate_int_elements()
             }
@@ -266,7 +268,9 @@ macro_rules! impl_godot_scalar {
         }
 
         // For f32, conversion from f64 is lossy but will always succeed. Thus no debug validation needed.
-        impl Element for $T {}
+        impl Element for $T {
+            const USE_GODOT_DEFAULT: bool = true;
+        }
 
         impl_godot_scalar!(@shared_traits; $T);
     };

--- a/godot-core/src/meta/traits.rs
+++ b/godot-core/src/meta/traits.rs
@@ -179,6 +179,11 @@ pub trait Element: ToGodot + FromGodot + 'static {
     // Note: several indirections in `Element` and the global `element_*` functions go through `GodotConvert::Via`,
     // to not require Self: `GodotType`. What matters is how array elements map to Godot on the FFI level (`GodotType` trait).
 
+    /// Whether this element type can bypass `T`'s `Default` impl and use Godot's default-initialization instead.
+    /// Optimizes APIs like [`Array::resize_default()`][crate::builtin::Array::resize_default].
+    #[doc(hidden)]
+    const USE_GODOT_DEFAULT: bool = false;
+
     #[doc(hidden)]
     fn debug_validate_elements(_array: &builtin::Array<Self>) -> Result<(), ConvertError> {
         // No-op for most element types.

--- a/itest/rust/src/builtin_tests/containers/array_test.rs
+++ b/itest/rust/src/builtin_tests/containers/array_test.rs
@@ -687,6 +687,76 @@ fn array_shrink() {
 }
 
 #[itest]
+fn array_resize_default() {
+    // Integers.
+    let mut a: Array<i64> = Array::new();
+    a.resize_default(4);
+    assert_eq!(a.len(), 4);
+    assert_eq!(a, array![0, 0, 0, 0]);
+
+    a.resize_default(1);
+    assert_eq!(a, array![0]);
+
+    // Non-i64 integers (test separately because their Element impl is defined in separate place).
+    let mut a: Array<u16> = Array::new();
+    a.resize_default(4);
+    assert_eq!(a.len(), 4);
+    assert_eq!(a, array![0, 0, 0, 0]);
+
+    // Floats.
+    let mut a: Array<f64> = Array::new();
+    a.resize_default(3);
+    assert_eq!(a.len(), 3);
+    assert_eq!(a, array![0.0, 0.0, 0.0]);
+
+    // Copy builtins.
+    let mut a: Array<Color> = Array::new();
+    a.resize_default(2);
+    assert_eq!(a.len(), 2);
+    assert_eq!(a, array![Color::default(), Color::default()]);
+
+    // Non-Copy builtins.
+    let mut a: Array<GString> = Array::new();
+    a.resize_default(3);
+    assert_eq!(a.len(), 3);
+    assert_eq!(a, array!["", "", ""]);
+
+    a.resize_default(1);
+    assert_eq!(a, array![""]);
+
+    // Objects
+    let mut a: Array<Gd<RefCounted>> = Array::new();
+    a.resize_default(2);
+    assert_eq!(a.len(), 2);
+    let a0 = a.at(0);
+    let a1 = a.at(1);
+    assert!(a0.is_instance_valid(), "null type-hole for [0]");
+    assert!(a1.is_instance_valid(), "null type-hole for [1]");
+    assert_eq!(a, array![&a0, &a1]);
+
+    a.resize_default(1);
+    assert_eq!(a, array![&a0]);
+
+    // Variants.
+    let mut a = varray![1, "two", Vector2i::new(2, 3)];
+    a.resize_default(5);
+    assert_eq!(a.len(), 5);
+    assert_eq!(
+        a,
+        varray![
+            1,
+            "two",
+            Vector2i::new(2, 3),
+            &Variant::nil(),
+            &Variant::nil(),
+        ]
+    );
+
+    a.resize_default(2);
+    assert_eq!(a, varray![1, "two"]);
+}
+
+#[itest]
 fn array_resize() {
     let mut a = iarray!["hello", "bar", "mixed", "baz", "meow"];
 


### PR DESCRIPTION
Addition to `Array` API:

`array.resize_default(3)` is basically `array.resize(3, T::default())` but can bypass the `Default` trait and directly use Godot's element initialization, effectively behaving like [`Array.resize()` in GDScript](https://docs.godotengine.org/en/stable/classes/class_array.html#class-array-method-resize).

The reason why this can't be done for all types is that Godot would initialize `Array<Gd<...>>` with nil elements, violating our type safety. So this PR internally dispatches, with `T::default()` as the safe default, and an optimized version for builtin types.

<details>
<summary>This is much better than my original idea (2 methods)...</summary>

1. `resize_default()` 
   - bounded on `Default + Copy`, to exclude types like `Gd<T>` which would end up as `nil`
   - limited to `Array<T>` (without `VarArray`)

1. `resize_nil()`
   - the same, but for `VarArray`

The `Copy` now admittedly does a bit of heavy lifting (and restricts some elements like `Variant`). We _could_ technically make a new trait that is "`Default` but not `Gd`", but it would complicate the type system to have yet another trait that's only needed for one method. Maybe we find a better way in the future...
</details>