### PR TITLE
Harden `godot-ffi` crate

### DIFF
--- a/godot-codegen/src/context.rs
+++ b/godot-codegen/src/context.rs
@@ -239,7 +239,7 @@ impl Context {
     }
 
     // Private, because initialized in constructor. Ensures deterministic assignment.
-    fn register_table_index(&mut self, key: MethodTableKey) -> usize {
+    fn register_table_index(&mut self, key: MethodTableKey) {
         let key_category = key.category();
 
         let next_index = self
@@ -251,7 +251,6 @@ impl Context {
         assert!(prev.is_none(), "table index already registered");
 
         *next_index += 1;
-        *next_index
     }
 
     pub fn get_table_index(&self, key: &MethodTableKey) -> usize {
@@ -259,15 +258,6 @@ impl Context {
             .method_table_indices
             .get(key)
             .unwrap_or_else(|| panic!("did not register table index for key {key:?}"))
-    }
-
-    /// Yields cached sys pointer types – various pointer types declared in `gdextension_interface`
-    /// and used as parameters in exposed Godot APIs.
-    #[allow(dead_code)] // Currently unused, as RawPtr<P> covers all raw pointers.
-    pub fn cached_sys_pointer_types(&self) -> impl Iterator<Item = &RustTy> {
-        self.cached_rust_types
-            .values()
-            .filter(|rust_ty| rust_ty.is_sys_pointer())
     }
 
     /// Whether an interface trait is generated for a class.

--- a/godot-codegen/src/conv/type_conversions.rs
+++ b/godot-codegen/src/conv/type_conversions.rs
@@ -78,10 +78,7 @@ fn to_hardcoded_rust_ident(full_ty: &GodotTy) -> Option<Ident> {
         }
 
         // Fixed-width types needed for native structures mapping; shared with header_codegen.rs map_c_base_type().
-        (ty, None) => match conv::fixed_width_c_int_ident(ty) {
-            Some(rust) => rust,
-            None => return None,
-        },
+        (ty, None) => conv::fixed_width_c_int_ident(ty)?,
 
         _ => return None,
     };

--- a/godot-codegen/src/conv/type_conversions.rs
+++ b/godot-codegen/src/conv/type_conversions.rs
@@ -15,7 +15,7 @@ use quote::{ToTokens, quote};
 use crate::context::Context;
 use crate::conv;
 use crate::models::domain::{ArgPassing, FlowDirection, GodotTy, ModName, RustTy, TyName};
-use crate::special_cases::{get_global_enum_rust_path, is_builtin_type_scalar};
+use crate::special_cases::{get_global_enum_module_path, is_builtin_type_scalar};
 use crate::util::ident;
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
@@ -67,15 +67,7 @@ fn to_hardcoded_rust_ident(full_ty: &GodotTy) -> Option<Ident> {
             None => "_unused__Dictionary_must_not_appear_in_idents",
         },
 
-        // Types needed for native structures mapping; duplicated in header_codegen.rs map_c_type().
-        ("uint8_t", None) => "u8",
-        ("uint16_t", None) => "u16",
-        ("uint32_t", None) => "u32",
-        ("uint64_t", None) => "u64",
-        ("int8_t", None) => "i8",
-        ("int16_t", None) => "i16",
-        ("int32_t", None) => "i32",
-        ("int64_t", None) => "i64",
+        // Types needed for native structures mapping.
         ("real_t", None) => "real",
         ("void", None) => "c_void",
 
@@ -85,10 +77,34 @@ fn to_hardcoded_rust_ident(full_ty: &GodotTy) -> Option<Ident> {
             panic!("unhandled type {ty:?} with meta {meta:?}")
         }
 
+        // Fixed-width types needed for native structures mapping; shared with header_codegen.rs map_c_base_type().
+        (ty, None) => match conv::fixed_width_c_int_ident(ty) {
+            Some(rust) => rust,
+            None => return None,
+        },
+
         _ => return None,
     };
 
     Some(ident(result))
+}
+
+/// Maps a fixed-width C integer type name (e.g. `"uint32_t"`) to its Rust equivalent (e.g. `"u32"`).
+///
+/// Returns `None` for anything else, including `void`/`char`/`int`/`float`/`double`/`size_t`, which
+/// each caller handles according to its own context. Shared between this module and `header_codegen::map_c_base_type()`.
+pub(crate) fn fixed_width_c_int_ident(c_type: &str) -> Option<&'static str> {
+    match c_type {
+        "int8_t" => Some("i8"),
+        "int16_t" => Some("i16"),
+        "int32_t" => Some("i32"),
+        "int64_t" => Some("i64"),
+        "uint8_t" => Some("u8"),
+        "uint16_t" => Some("u16"),
+        "uint32_t" => Some("u32"),
+        "uint64_t" => Some("u64"),
+        _ => None,
+    }
 }
 
 fn to_hardcoded_rust_enum(ty: &str) -> Option<Ident> {
@@ -348,7 +364,9 @@ pub(crate) fn to_enum_type_uncached(enum_or_bitfield: &str, is_bitfield: bool) -
         to_class_enum_uncached("Resource", enum_or_bitfield, is_bitfield)
     } else {
         // Global enum or bitfield.
-        let path = get_global_enum_rust_path(enum_or_bitfield);
+        let path: TokenStream = get_global_enum_module_path(enum_or_bitfield)
+            .parse()
+            .expect("valid module path");
         let enum_or_bitfield_name = conv::make_enum_name(enum_or_bitfield);
 
         RustTy::EngineEnum {

--- a/godot-codegen/src/formatter/mod.rs
+++ b/godot-codegen/src/formatter/mod.rs
@@ -61,24 +61,12 @@ pub(crate) fn format_tokens(tokens: TokenStream) -> String {
 }
 
 fn indent(n: usize) -> &'static str {
-    // This looks strange, but it means we don't need to actually allocate anything.
-    // The downside is there's a limit to how deep we can nest.
-    // The code that's generated doesn't seem like it's any deeper than this.
-
+    // Trick to avoid allocations. n too big panics -> fix the bug.
     //           |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
     let idents = "                                                        ";
 
     let end = n * 4;
     &idents[0..end]
-
-    // If at some point this approach doesn't work anymore, a `Cow<'static, str>`
-    // could be returned.
-
-    // if let Some(s) = idents.get(0..end) {
-    //     Cow::Borrowed(s)
-    // } else {
-    //     Cow::Owned("    ".repeat(n))
-    // }
 }
 
 //

--- a/godot-codegen/src/generator/default_parameters.rs
+++ b/godot-codegen/src/generator/default_parameters.rs
@@ -68,8 +68,7 @@ pub fn make_function_definition_with_defaults(
     let return_decl = &sig.return_value().decl;
     let (maybe_deprecated, maybe_expect_deprecated) = fns::make_deprecation_attribute(sig);
 
-    // If either the builder has a lifetime (non-static/global method), or one of its parameters is a reference,
-    // then we need to annotate the _ex() function with an explicit lifetime. Also adjust &self -> &'ex self.
+    // The _ex() function and builder always get an explicit lifetime (see make_extender()); adjust &self -> &'ex self.
     let receiver_self = &code.receiver.self_prefix;
     let simple_receiver_param = &code.receiver.param;
     let extended_receiver_param = &code.receiver.param_lifetime_ex;
@@ -138,8 +137,7 @@ pub fn make_function_definition_with_defaults(
             ).done()
         }
 
-        // _ex() function:
-        // Lifetime is set if any parameter is a reference OR if the method is not static/global (and thus can refer to self).
+        // _ex() function: always has an explicit lifetime -- see make_extender().
         #maybe_deprecated
         #maybe_specific_docs
         #maybe_godot_doc
@@ -280,8 +278,8 @@ fn make_extender(
         .chain(required_params.iter().cloned())
         .chain(default_params.iter().cloned());
 
-    // If builder is a method with a receiver OR any *required* parameter is by-ref, use lifetime.
-    // Default parameters cannot be by-ref, since they need to store a default value. Potential optimization later.
+    // Always use a lifetime, for simplicity -- even if the builder has no receiver and no by-ref required parameter.
+    // Default parameters cannot be by-ref, since they need to store a default value. Potential optimization: only add lifetime when needed.
     let param_decl = FnParamDecl::FnPublicLifetime;
     let ctor_decl = FnKind::ExBuilderConstructorLifetimed;
     let default_len = default_params.len();

--- a/godot-codegen/src/generator/functions_common.rs
+++ b/godot-codegen/src/generator/functions_common.rs
@@ -694,6 +694,7 @@ pub(crate) fn make_params_exprs_virtual<'a>(
     method_args: impl Iterator<Item = &'a FnParam>,
     function_sig: &dyn Function,
 ) -> FnParamTokens {
+    // Virtual branch uses only `param_decls`; leave the rest empty.
     let mut ret = FnParamTokens::default();
 
     for param in method_args {
@@ -705,8 +706,6 @@ pub(crate) fn make_params_exprs_virtual<'a>(
 
         ret.param_decls
             .push(quote! { #param_name: #param_ty_tokens });
-        ret.arg_exprs.push(quote! { #param_name });
-        ret.callsig_param_types.push(quote! { #param_ty });
     }
 
     ret

--- a/godot-codegen/src/generator/gdext_build_struct.rs
+++ b/godot-codegen/src/generator/gdext_build_struct.rs
@@ -37,14 +37,22 @@ pub fn make_gdext_build_struct(header: &GodotApiVersion) -> TokenStream {
             }
 
             /// Version of the Godot engine which loaded godot-rust via GDExtension binding.
+            ///
+            /// # Panics (safeguards-balanced)
+            /// If called before the GDExtension binding has been initialized. UB in disengaged.
             pub fn godot_runtime_version_string() -> String {
+                // SAFETY: binding must be initialized before this is called; see # Panics.
                 let rt = unsafe { crate::runtime_metadata() };
                 rt.version_string().to_string()
             }
 
             /// Version of the Godot engine which loaded godot-rust via GDExtension binding, as
             /// `(major, minor, patch)` triple.
+            ///
+            /// # Panics (safeguards-balanced)
+            /// If called before the GDExtension binding has been initialized. UB in disengaged.
             pub fn godot_runtime_version_triple() -> (u8, u8, u8) {
+                // SAFETY: see godot_runtime_version_string().
                 let rt = unsafe { crate::runtime_metadata() };
                 rt.version_triple()
             }

--- a/godot-codegen/src/generator/header_codegen.rs
+++ b/godot-codegen/src/generator/header_codegen.rs
@@ -427,29 +427,26 @@ fn map_c_type(c_type: &str) -> TokenStream {
         (false, c_type)
     };
 
-    // Handle pointer types
-    if c_type.ends_with('*') {
-        let base_type = c_type.trim_end_matches('*').trim();
-        let inner = map_c_type_as_pointee(base_type);
-
-        return if is_const {
-            quote! { *const #inner }
-        } else {
-            quote! { *mut #inner }
-        };
+    let pointer_levels = c_type.chars().rev().filter(|c| *c == '*').count();
+    if pointer_levels == 0 {
+        return map_c_base_type(c_type);
     }
 
-    // Base types
-    map_c_base_type(c_type)
-}
+    let base_type = c_type.trim_end_matches(['*', ' ']);
 
-/// Map a C type that appears as the pointee of a pointer.
-/// `void` maps to `std::ffi::c_void` (not `()`) so that `void*` becomes `*mut c_void`.
-fn map_c_type_as_pointee(c_type: &str) -> TokenStream {
-    if c_type == "void" {
+    let pointee = if base_type == "void" {
         quote! { std::ffi::c_void }
     } else {
-        map_c_type(c_type)
+        map_c_base_type(base_type)
+    };
+
+    // Right now, at most 2 levels of indirection occur in the JSON (e.g. "void**"); hardcode the cases instead of fancy algorithm.
+    match (pointer_levels, is_const) {
+        (1, false) => quote! { *mut #pointee },
+        (1, true) => quote! { *const #pointee },
+        (2, false) => quote! { *mut *mut #pointee },
+        (2, true) => quote! { *mut *const #pointee },
+        (n, _) => panic!("unsupported pointer type with {n} levels of indirection: {c_type:?}"),
     }
 }
 
@@ -459,21 +456,18 @@ fn map_c_base_type(c_type: &str) -> TokenStream {
         "void" => quote! { () },
         "char" => quote! { std::ffi::c_char },
         "int" => quote! { std::ffi::c_int }, // Only appears once in current JSON (worker_thread_pool_add_native_group_task).
-        "int8_t" => quote! { i8 },
-        "int16_t" => quote! { i16 },
-        "int32_t" => quote! { i32 },
-        "int64_t" => quote! { i64 },
-        "uint8_t" => quote! { u8 },
-        "uint16_t" => quote! { u16 },
-        "uint32_t" => quote! { u32 },
-        "uint64_t" => quote! { u64 },
         "size_t" => quote! { usize },
         "float" => quote! { f32 },
         "double" => quote! { f64 },
         _ => {
-            // Fallback: use the type as-is (should be a GDExtension type)
-            let type_ident = ident(c_type);
-            quote! { #type_ident }
+            if let Some(rust_ty) = crate::conv::fixed_width_c_int_ident(c_type) {
+                let type_ident = ident(rust_ty);
+                quote! { #type_ident }
+            } else {
+                // Fallback: use the type as-is (should be a GDExtension type).
+                let type_ident = ident(c_type);
+                quote! { #type_ident }
+            }
         }
     }
 }
@@ -501,6 +495,33 @@ mod tests {
         let mut watch = godot_bindings::StopWatch::start();
         let json_str = godot_bindings::load_gdextension_interface_json(&mut watch);
         DeJson::deserialize_json(json_str.as_ref()).expect("failed to deserialize JSON")
+    }
+
+    #[test]
+    fn test_map_c_type() {
+        #[rustfmt::skip]
+        let cases = [
+            ("void",                  "()"),
+            ("uint32_t",              "u32"),
+            ("size_t",                "usize"),
+            ("GDExtensionVariantPtr", "GDExtensionVariantPtr"),
+            ("void*",                 "* mut std :: ffi :: c_void"),
+            ("const void*",           "* const std :: ffi :: c_void"),
+            ("const uint8_t *",       "* const u8"),
+            ("void **",               "* mut * mut std :: ffi :: c_void"),
+            ("const void **",         "* mut * const std :: ffi :: c_void"),
+        ];
+
+        for (c_type, expected_rust_type) in cases {
+            let rust_type = map_c_type(c_type).to_string();
+            assert_eq!(rust_type, expected_rust_type, "C type {c_type:?}");
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "unsupported pointer type with 3 levels of indirection")]
+    fn test_map_c_type_triple_pointer_unsupported() {
+        map_c_type("const char ***");
     }
 
     #[test]

--- a/godot-codegen/src/generator/lifecycle_builtins.rs
+++ b/godot-codegen/src/generator/lifecycle_builtins.rs
@@ -162,6 +162,7 @@ fn make_extra_constructors(
     builtin: &BuiltinVariant,
     constructors: &[Constructor],
 ) -> (Vec<TokenStream>, Vec<TokenStream>) {
+    // First two constructors (default and copy) always present, thus >= 2 guaranteed.
     let mut extra_decls = Vec::with_capacity(constructors.len() - 2);
     let mut extra_inits = Vec::with_capacity(constructors.len() - 2);
     let variant_type = builtin.sys_variant_type();

--- a/godot-codegen/src/generator/method_tables.rs
+++ b/godot-codegen/src/generator/method_tables.rs
@@ -44,11 +44,8 @@ pub fn make_builtin_lifecycle_table(api: &ExtensionApi) -> TokenStream {
         },
         method_decls: Vec::with_capacity(len),
         method_inits: Vec::with_capacity(len),
-        class_count: len,
-        method_count: 0,
     };
 
-    // Note: NIL is not part of this iteration, it will be added manually.
     for variant in builtins.iter() {
         let (decls, inits) = lifecycle_builtins::make_variant_fns(api, variant);
 
@@ -71,7 +68,9 @@ pub fn make_class_method_table(
             interface: &crate::GDExtensionInterface,
             string_names: &mut crate::StringCache,
         },
-        pre_init_code: TokenStream::new(), // late-init, depends on class string names
+        pre_init_code: quote! {
+            let fetch_fptr = interface.classdb_get_method_bind;
+        },
         fptr_type: quote! { crate::ClassMethodBind },
         fetch_fptr_type: quote! { crate::GDExtensionInterfaceClassdbGetMethodBind },
         method_init_groups: vec![],
@@ -96,10 +95,6 @@ pub fn make_class_method_table(
         .iter()
         .filter(|c| c.api_level == api_level)
         .for_each(|c| populate_class_methods(&mut table, c, ctx));
-
-    table.pre_init_code = quote! {
-        let fetch_fptr = interface.classdb_get_method_bind;
-    };
 
     make_method_table(table)
 }
@@ -155,8 +150,6 @@ pub fn make_utility_function_table(api: &ExtensionApi) -> TokenStream {
         },
         method_decls: vec![],
         method_inits: vec![],
-        class_count: 0,
-        method_count: 0,
     };
 
     for function in api.utility_functions.iter() {
@@ -171,8 +164,6 @@ pub fn make_utility_function_table(api: &ExtensionApi) -> TokenStream {
         table.method_inits.push(quote! {
             #field: crate::load_utility_function(get_utility_fn, string_names, #fn_name_str, #hash),
         });
-
-        table.method_count += 1;
     }
 
     make_named_method_table(table)
@@ -188,8 +179,6 @@ struct NamedMethodTable {
     pre_init_code: TokenStream,
     method_decls: Vec<TokenStream>,
     method_inits: Vec<TokenStream>,
-    class_count: usize,
-    method_count: usize,
 }
 
 #[allow(dead_code)] // Individual fields would need to be cfg'ed with: feature = "codegen-lazy-fptrs".
@@ -269,8 +258,6 @@ fn make_named_method_table(info: NamedMethodTable) -> TokenStream {
         pre_init_code,
         method_decls,
         method_inits,
-        class_count,
-        method_count,
     } = info;
 
     // Assumes that both decls and inits already have a trailing comma.
@@ -285,9 +272,6 @@ fn make_named_method_table(info: NamedMethodTable) -> TokenStream {
         }
 
         impl #table_name {
-            pub const CLASS_COUNT: usize = #class_count;
-            pub const METHOD_COUNT: usize = #method_count;
-
             #safety_doc
             pub unsafe fn load(
                 #ctor_parameters
@@ -590,7 +574,7 @@ fn populate_builtin_methods(
     for method in builtin_class.methods.iter() {
         let index = ctx.get_table_index(&MethodTableKey::from_builtin(builtin_class, method));
 
-        let method_init = make_builtin_method_init(builtin, method, index);
+        let method_init = make_builtin_method_init(builtin, method);
         method_inits.push(MethodInit { method_init, index });
         table.method_count += 1;
 
@@ -616,6 +600,7 @@ fn populate_builtin_methods(
         }
     }
 
+    // Assumes that every group has at least 1 method; presently the case.
     table.method_init_groups.push(MethodInitGroup::new(
         &builtin_class.name().godot_ty,
         None, // load_builtin_method() doesn't need a StringName for the class, as it accepts the VariantType enum.
@@ -646,11 +631,7 @@ fn make_class_method_init(
     }
 }
 
-fn make_builtin_method_init(
-    builtin: &BuiltinVariant,
-    method: &BuiltinMethod,
-    index: usize,
-) -> TokenStream {
+fn make_builtin_method_init(builtin: &BuiltinVariant, method: &BuiltinMethod) -> TokenStream {
     let method_name_str = method.name();
 
     let variant_type = builtin.sys_variant_type();
@@ -660,17 +641,14 @@ fn make_builtin_method_init(
 
     // Could reuse lazy key, but less code like this -> faster parsing.
     quote! {
-        {
-            let _ = #index;
-            crate::load_builtin_method(
-                fetch_fptr,
-                string_names,
-                crate::#variant_type,
-                #variant_type_str,
-                #method_name_str,
-                #hash
-            )
-        },
+        crate::load_builtin_method(
+            fetch_fptr,
+            string_names,
+            crate::#variant_type,
+            #variant_type_str,
+            #method_name_str,
+            #hash
+        ),
     }
 }
 

--- a/godot-codegen/src/generator/native_structures.rs
+++ b/godot-codegen/src/generator/native_structures.rs
@@ -170,7 +170,7 @@ fn make_native_structure_field_and_accessor(
         // Having node also avoids the lifetime issue with reference-counted objects (unclear if gdext should increment refcount or not).
         // If other fields use different classes in the future, we'll need to update this.
         accessor = Some(quote! {
-            /// Returns the object as a `Gd<Node>`, or `None` if it no longer exists.
+            /// Returns the object as a `Gd<Object>`, or `None` if it no longer exists.
             pub fn #getter_name(&self) -> Option<Gd<Object>> {
                 crate::obj::InstanceId::try_from_u64(self.#id_field_name.id)
                     .and_then(|id| Gd::try_from_instance_id(id).ok())
@@ -180,7 +180,7 @@ fn make_native_structure_field_and_accessor(
                 // unsafe { Gd::from_obj_sys(ptr) }
             }
 
-            /// Sets the object from a `Gd` pointer holding `Node` or a derived class.
+            /// Sets the object from a `Gd` pointer.
             ///
             /// # Safety
             /// You must ensure that the provided object remains alive while Godot accesses it.

--- a/godot-codegen/src/generator/signals.rs
+++ b/godot-codegen/src/generator/signals.rs
@@ -18,7 +18,7 @@ use quote::{format_ident, quote};
 use crate::context::Context;
 use crate::conv;
 use crate::models::domain::{Class, ClassLike, ClassSignal, FnParam, ModName, RustTy, TyName};
-use crate::util::{ident, safe_ident};
+use crate::util::ident;
 
 pub struct SignalCodegen {
     pub signal_code: TokenStream,
@@ -291,7 +291,7 @@ impl SignalParams {
         let mut first = true;
 
         for param in params.iter() {
-            let param_name = safe_ident(&param.name.to_string());
+            let param_name = &param.name;
             let param_ty = &param.type_;
             let param_ty_tokens = param_ty.tokens_non_null();
 

--- a/godot-codegen/src/models/domain.rs
+++ b/godot-codegen/src/models/domain.rs
@@ -639,40 +639,18 @@ impl FnParam {
 /// Builder for constructing `FnParam` instances with configurable enum replacements and default value handling.
 pub(crate) struct FnParamBuilder {
     replacements: EnumReplacements,
-    no_defaults: bool,
 }
 
 impl FnParamBuilder {
     /// Creates a new parameter builder with default settings (no replacements, defaults enabled).
     pub fn new() -> Self {
-        Self {
-            replacements: &[],
-            no_defaults: false,
-        }
+        Self { replacements: &[] }
     }
 
     /// Configures the builder to use specific enum replacements.
     pub fn enum_replacements(mut self, replacements: EnumReplacements) -> Self {
         self.replacements = replacements;
         self
-    }
-
-    /// Configures the builder to exclude default values from generated parameters.
-    #[expect(dead_code)] // May be useful in future.
-    pub fn no_defaults(mut self) -> Self {
-        self.no_defaults = true;
-        self
-    }
-
-    /// Builds a single function parameter from the provided JSON method argument.
-    #[expect(dead_code)] // May be useful in future.
-    pub fn build_single(
-        self,
-        method_arg: &JsonMethodArg,
-        flow: FlowDirection,
-        ctx: &mut Context,
-    ) -> FnParam {
-        self.build_single_impl(method_arg, flow, ctx)
     }
 
     /// Builds a vector of function parameters from the provided JSON method arguments.
@@ -719,14 +697,10 @@ impl FnParamBuilder {
             type_
         };
 
-        let default_value = if self.no_defaults {
-            None
-        } else {
-            method_arg
-                .default_value
-                .as_ref()
-                .map(|v| conv::to_rust_expr(v, &type_))
-        };
+        let default_value = method_arg
+            .default_value
+            .as_ref()
+            .map(|v| conv::to_rust_expr(v, &type_));
 
         FnParam {
             name,

--- a/godot-codegen/src/models/domain_mapping.rs
+++ b/godot-codegen/src/models/domain_mapping.rs
@@ -301,7 +301,10 @@ impl BuiltinVariant {
             godot_original_name = json_builtin.name.clone();
             builtin_class = BuiltinClass::from_json(json_builtin, ctx);
         } else {
-            assert_eq!(json_variant_enumerator_name, "OBJECT");
+            assert_eq!(
+                json_variant_enumerator_name, "OBJECT",
+                "variant type {json_variant_enumerator_name:?} has no builtin class entry in the JSON"
+            );
 
             builtin_class = None;
             godot_original_name = "Object".to_string();
@@ -566,8 +569,8 @@ impl ClassMethod {
 
         // Since Godot 4.4, GDExtension advertises whether virtual methods have a default implementation or are required to be overridden.
         #[cfg(before_api = "4.4")]
-        let is_virtual_required =
-            special_cases::is_virtual_method_required(&class_name, &method.name);
+        let is_virtual_required = method.is_virtual
+            && special_cases::is_virtual_method_required(&class_name, &method.name);
 
         #[cfg(since_api = "4.4")]
         #[allow(clippy::let_and_return)]
@@ -659,7 +662,7 @@ impl ClassMethod {
             return rust_name;
         }
 
-        // In general, just rlemove leading underscore from virtual method names.
+        // In general, just remove leading underscore from virtual method names.
         godot_method_name
             .strip_prefix('_')
             .unwrap_or(godot_method_name)

--- a/godot-codegen/src/special_cases/special_cases.rs
+++ b/godot-codegen/src/special_cases/special_cases.rs
@@ -29,8 +29,7 @@
 
 use std::borrow::Cow;
 
-use proc_macro2::{Ident, TokenStream};
-use quote::quote;
+use proc_macro2::Ident;
 
 use crate::Context;
 use crate::conv::to_enum_type_uncached;
@@ -859,7 +858,7 @@ pub fn is_builtin_type_deleted(class_name: &TyName) -> bool {
 
 /// True if `int`, `float`, `bool`, ...
 pub fn is_builtin_type_scalar(name: &str) -> bool {
-    name.chars().next().unwrap().is_ascii_lowercase()
+    name.starts_with(|c: char| c.is_ascii_lowercase())
 }
 
 #[rustfmt::skip]
@@ -1341,15 +1340,6 @@ pub fn get_global_enum_module_path(enum_name: &str) -> &'static str {
         // Godot's JSON spells `VariantType` as `Variant.Type`; accept both since callers may pass either form.
         "Corner" | "EulerOrder" | "Side" | "VariantType" | "Variant.Type" => "crate::builtin",
         _ => "crate::global",
-    }
-}
-
-/// Returns the Rust module path of a global Godot enum (instead of `crate::global::EnumName`).
-pub fn get_global_enum_rust_path(enum_name: &str) -> TokenStream {
-    match get_global_enum_module_path(enum_name) {
-        "crate::registry::info" => quote! { crate::registry::info },
-        "crate::builtin" => quote! { crate::builtin },
-        _ => quote! { crate::global },
     }
 }
 

--- a/godot-ffi/src/binding/mod.rs
+++ b/godot-ffi/src/binding/mod.rs
@@ -20,14 +20,61 @@ mod single_threaded;
 
 #[cfg(feature = "experimental-threads")]
 use multi_threaded::BindingStorage;
-// ----------------------------------------------------------------------------------------------------------------------------------------------
-// Public re-exports
-#[cfg(feature = "experimental-threads")]
-pub use multi_threaded::GdextConfig;
 #[cfg(not(feature = "experimental-threads"))]
 use single_threaded::BindingStorage;
-#[cfg(not(feature = "experimental-threads"))]
-pub use single_threaded::GdextConfig;
+
+pub struct GdextConfig {
+    /// True if only `#[class(tool)]` classes are active in editor; false if all classes are.
+    pub tool_only_in_editor: bool,
+}
+
+impl GdextConfig {
+    pub fn new(tool_only_in_editor: bool) -> Self {
+        Self {
+            tool_only_in_editor,
+        }
+    }
+}
+
+/// Panics if the binding is not currently live. Shared by both binding storages for a consistent live check.
+#[cfg(safeguards_balanced)]
+#[inline(always)]
+pub(super) fn assert_binding_live(initialized: &std::sync::atomic::AtomicBool) {
+    if !initialized.load(std::sync::atomic::Ordering::Acquire) {
+        not_live_panic();
+    }
+}
+
+/// Cold failure path, so the hot check stays a predicted-not-taken branch.
+#[cfg(safeguards_balanced)]
+#[cold]
+#[inline(never)]
+fn not_live_panic() -> ! {
+    panic!(
+        "Godot binding accessed before initialization or after deinitialization. \
+        This typically means a `#[ctor]`/`#[dtor]` constructor, a library destructor, or a leftover user thread touched the Godot API \
+        outside the engine's load/unload window."
+    )
+}
+
+#[cfg(all(test, safeguards_balanced))]
+mod tests {
+    use std::sync::atomic::AtomicBool;
+
+    use super::assert_binding_live;
+
+    #[test]
+    fn live_check_passes_when_initialized() {
+        // Must not panic.
+        assert_binding_live(&AtomicBool::new(true));
+    }
+
+    #[test]
+    #[should_panic(expected = "accessed before initialization or after deinitialization")]
+    fn live_check_panics_when_not_initialized() {
+        assert_binding_live(&AtomicBool::new(false));
+    }
+}
 
 // Note, this is `Sync` and `Send` when "experimental-threads" is enabled because all its fields are. We have avoided implementing `Sync`
 // and `Send` for `GodotBinding` as that could hide issues if any of the field types are changed to no longer be sync/send, but the manual
@@ -38,7 +85,7 @@ pub(crate) struct GodotBinding {
     library: ClassLibraryPtr,
     global_method_table: BuiltinLifecycleTable,
     class_core_method_table: ManualInitCell<ClassCoreMethodTable>,
-    class_server_method_table: ManualInitCell<ClassServersMethodTable>,
+    class_servers_method_table: ManualInitCell<ClassServersMethodTable>,
     class_scene_method_table: ManualInitCell<ClassSceneMethodTable>,
     class_editor_method_table: ManualInitCell<ClassEditorMethodTable>,
     builtin_method_table: ManualInitCell<BuiltinMethodTable>,
@@ -105,7 +152,7 @@ impl GodotBinding {
             global_method_table,
             thread_safe_lifecycle,
             class_core_method_table: ManualInitCell::new(),
-            class_server_method_table: ManualInitCell::new(),
+            class_servers_method_table: ManualInitCell::new(),
             class_scene_method_table: ManualInitCell::new(),
             class_editor_method_table: ManualInitCell::new(),
             builtin_method_table: ManualInitCell::new(),
@@ -259,7 +306,7 @@ pub unsafe fn thread_safe_lifecycle() -> &'static ThreadSafeLifecycle {
 #[allow(unsafe_op_in_unsafe_fn)] // Safety preconditions forwarded 1:1.
 pub unsafe fn class_servers_api() -> &'static ClassServersMethodTable {
     get_table(
-        &get_binding().class_server_method_table,
+        &get_binding().class_servers_method_table,
         "cannot fetch classes; init level 'Servers' not yet loaded",
     )
 }
@@ -444,9 +491,9 @@ pub(crate) unsafe fn initialize_class_core_method_table(table: ClassCoreMethodTa
 ///
 /// If "experimental-threads" is not enabled, then this must be called from the same thread that the bindings were initialized from.
 #[allow(unsafe_op_in_unsafe_fn)] // Safety preconditions forwarded 1:1.
-pub(crate) unsafe fn initialize_class_server_method_table(table: ClassServersMethodTable) {
+pub(crate) unsafe fn initialize_class_servers_method_table(table: ClassServersMethodTable) {
     initialize_table(
-        &get_binding().class_server_method_table,
+        &get_binding().class_servers_method_table,
         table,
         "classes (Server level)",
     )

--- a/godot-ffi/src/binding/multi_threaded.rs
+++ b/godot-ffi/src/binding/multi_threaded.rs
@@ -11,10 +11,17 @@
 //!
 //! The user of these structs and functions must still ensure that multithreaded usage of the various pointers is safe.
 
+use std::sync::atomic::{AtomicBool, Ordering};
+
 use super::GodotBinding;
 use crate::ManualInitCell;
 
 pub(super) struct BindingStorage {
+    /// Tracks the binding-live window (true between init and deinit) so it can be checked atomically from any thread.
+    ///
+    /// Needed because `ManualInitCell::is_initialized()` is a non-atomic read (per its SAFETY, not callable concurrently with `set`).
+    /// Otherwise, another thread's `initialize`/`deinitialize` would cause race-conditions under experimental-threads.
+    initialized: AtomicBool,
     binding: ManualInitCell<GodotBinding>,
 }
 
@@ -23,9 +30,14 @@ impl BindingStorage {
     #[inline(always)]
     fn storage() -> &'static Self {
         static BINDING: BindingStorage = BindingStorage {
+            initialized: AtomicBool::new(false),
             binding: ManualInitCell::new(),
         };
         &BINDING
+    }
+
+    fn is_initialized_atomic(&self) -> bool {
+        self.initialized.load(Ordering::Acquire)
     }
 
     /// Initialize the binding storage, this must be called before any other public functions.
@@ -37,12 +49,15 @@ impl BindingStorage {
         let storage = Self::storage();
 
         assert!(
-            !storage.binding.is_initialized(),
+            !storage.is_initialized_atomic(),
             "initialize must only be called at startup or after deinitialize"
         );
 
         // SAFETY: per declared invariants.
         unsafe { storage.binding.set(binding) }
+
+        // Publish the binding *before* marking it live, see single-threaded storage for rationale.
+        storage.initialized.store(true, Ordering::Release);
     }
 
     /// Deinitialize the binding storage.
@@ -53,9 +68,12 @@ impl BindingStorage {
         let storage = Self::storage();
 
         assert!(
-            storage.binding.is_initialized(),
+            storage.is_initialized_atomic(),
             "deinitialize must only be called after initialize"
         );
+
+        // Mark the binding not-live *before* clearing it, see single-threaded storage for rationale.
+        storage.initialized.store(false, Ordering::Release);
 
         // SAFETY: per declared invariants.
         unsafe { storage.binding.clear() };
@@ -70,10 +88,9 @@ impl BindingStorage {
     pub unsafe fn get_binding_unchecked() -> &'static GodotBinding {
         let storage = Self::storage();
 
-        crate::strict_assert!(
-            storage.binding.is_initialized(),
-            "Godot engine not available; make sure you are not calling it from unit/doc tests"
-        );
+        // Live check: see single-threaded storage for rationale.
+        #[cfg(safeguards_balanced)]
+        super::assert_binding_live(&storage.initialized);
 
         // SAFETY: The binding has been initialized before calling this method.
         unsafe { storage.binding.get_unchecked() }
@@ -81,24 +98,11 @@ impl BindingStorage {
 
     pub fn is_initialized() -> bool {
         let storage = Self::storage();
-        storage.binding.is_initialized()
+        storage.is_initialized_atomic()
     }
 
     /// No-op in multi-threaded builds: with "experimental-threads", FFI access from any thread is permitted, so there is no main-thread
     /// assertion to make. Exists for API parity with the single-threaded storage, which the shared `get_binding()` relies on.
     #[inline(always)]
     pub(super) fn ensure_main_thread() {}
-}
-
-pub struct GdextConfig {
-    /// True if only `#[class(tool)]` classes are active in editor; false if all classes are.
-    pub tool_only_in_editor: bool,
-}
-
-impl GdextConfig {
-    pub fn new(tool_only_in_editor: bool) -> Self {
-        Self {
-            tool_only_in_editor,
-        }
-    }
 }

--- a/godot-ffi/src/binding/single_threaded.rs
+++ b/godot-ffi/src/binding/single_threaded.rs
@@ -41,7 +41,7 @@ impl BindingStorage {
     /// Returns whether the binding storage has already been initialized.
     ///
     /// It is recommended to use this function for that purpose as the field to check varies depending on the compilation target.
-    fn initialized(&self) -> bool {
+    fn is_initialized_atomic(&self) -> bool {
         self.initialized.load(Ordering::Acquire)
     }
 
@@ -57,7 +57,7 @@ impl BindingStorage {
         // in which case we can tell that the storage has been initialized, and we don't access `binding`.
         let storage = unsafe { Self::storage() };
 
-        assert!(!storage.initialized(), "already initialized");
+        assert!(!storage.is_initialized_atomic(), "already initialized");
 
         // SAFETY: We are the first thread to set this binding (possibly after deinitialize), as otherwise the above assert would fail. We also
         // know initialize() is not called concurrently with anything else that can call another method on the binding, since this method is
@@ -81,7 +81,7 @@ impl BindingStorage {
         let storage = unsafe { Self::storage() };
 
         assert!(
-            storage.initialized(),
+            storage.is_initialized_atomic(),
             "deinitialize without prior initialize"
         );
 
@@ -107,7 +107,7 @@ impl BindingStorage {
         // Live check: passes in ~100% of real calls. Compiled out under the disengaged safety profile, recovering unchecked speed for users who
         // promise the invariant. The actual check lives in a standalone function so it can be unit-tested without a real binding.
         #[cfg(safeguards_balanced)]
-        assert_binding_live(&storage.initialized);
+        super::assert_binding_live(&storage.initialized);
 
         // SAFETY: Per the safety contract the binding is initialized, so the cell holds a value.
         unsafe { storage.binding.get_unchecked() }
@@ -117,7 +117,7 @@ impl BindingStorage {
         // SAFETY: We don't access the binding.
         let storage = unsafe { Self::storage() };
 
-        storage.initialized()
+        storage.is_initialized_atomic()
     }
 
     /// Asserts that the caller is on the main thread. Used by the restricted accessor (`sys::on_main()`) for FFI functions that touch
@@ -150,57 +150,3 @@ impl BindingStorage {
 unsafe impl Sync for BindingStorage {}
 // SAFETY: We ensure that `binding` is only ever accessed from the same thread that initialized it.
 unsafe impl Send for BindingStorage {}
-
-/// Panics if the binding is not currently live, turning before-init / after-deinit access into a clean error instead of UB.
-///
-/// Standalone (not a method) so it can be unit-tested against a hand-made `AtomicBool` without a real binding behind it.
-#[cfg(safeguards_balanced)]
-#[inline(always)]
-fn assert_binding_live(initialized: &AtomicBool) {
-    if !initialized.load(Ordering::Acquire) {
-        not_live_panic();
-    }
-}
-
-/// Failure path for the live check; separated out and marked cold so the hot path stays a predicted-not-taken branch.
-#[cfg(safeguards_balanced)]
-#[cold]
-#[inline(never)]
-fn not_live_panic() -> ! {
-    panic!(
-        "Godot binding accessed before initialization or after deinitialization. \
-        This typically means a `#[ctor]`/`#[dtor]` constructor, a library destructor, or a leftover user thread touched the Godot API \
-        outside the engine's load/unload window."
-    )
-}
-
-#[cfg(all(test, safeguards_balanced))]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn live_check_passes_when_initialized() {
-        // Must not panic.
-        assert_binding_live(&AtomicBool::new(true));
-    }
-
-    #[test]
-    #[should_panic(expected = "accessed before initialization or after deinitialization")]
-    fn live_check_panics_when_not_initialized() {
-        assert_binding_live(&AtomicBool::new(false));
-    }
-}
-
-// ----------------------------------------------------------------------------------------------------------------------------------------------
-
-pub struct GdextConfig {
-    pub tool_only_in_editor: bool,
-}
-
-impl GdextConfig {
-    pub fn new(tool_only_in_editor: bool) -> Self {
-        Self {
-            tool_only_in_editor,
-        }
-    }
-}

--- a/godot-ffi/src/extras.rs
+++ b/godot-ffi/src/extras.rs
@@ -126,11 +126,16 @@ pub fn panic_call_error(
     let reason = match error {
         GDEXTENSION_CALL_ERROR_INVALID_METHOD => "method not found".to_string(),
         GDEXTENSION_CALL_ERROR_INVALID_ARGUMENT => {
-            let from = vararg_types[argument as usize];
-            let to = VariantType::from_sys(expected as GDExtensionVariantType);
             let i = argument + 1;
+            let idx = argument as usize;
 
-            format!("cannot convert argument #{i} from {from:?} to {to:?}")
+            if idx < vararg_types.len() {
+                let from = vararg_types[idx];
+                let to = VariantType::from_sys(expected as GDExtensionVariantType);
+                format!("cannot convert argument #{i} from {from:?} to {to:?}")
+            } else {
+                format!("invalid argument #{i} (type unknown)")
+            }
         }
         GDEXTENSION_CALL_ERROR_TOO_MANY_ARGUMENTS => {
             format!("too many arguments; expected {argument}, but called with {argc}")

--- a/godot-ffi/src/godot_ffi.rs
+++ b/godot-ffi/src/godot_ffi.rs
@@ -5,8 +5,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::marker::PhantomData;
-
 use crate as sys;
 use crate::VariantType;
 
@@ -172,7 +170,8 @@ macro_rules! ffi_methods_one {
         $( #[$attr] )? $vis
         unsafe fn $new_from_sys(ptr: <$Ptr as $crate::SysPtr>::Const) -> Self {
             // TODO: Directly use copy constructors here?
-            let opaque = std::ptr::read(ptr.cast());
+            // SAFETY: `ptr` points to a valid, initialized opaque value.
+            let opaque = unsafe { std::ptr::read(ptr.cast()) };
             let new = Self::from_opaque(opaque);
             std::mem::forget(new.clone());
             new
@@ -184,7 +183,8 @@ macro_rules! ffi_methods_one {
             let mut raw = std::mem::MaybeUninit::uninit();
             init(raw.as_mut_ptr() as *mut _);
 
-            Self::from_opaque(raw.assume_init())
+            // SAFETY: `init` fully initializes `raw`.
+            Self::from_opaque(unsafe { raw.assume_init() })
         }
     };
     (OpaquePtr $Ptr:ty; $( #[$attr:meta] )? $vis:vis $new_with_init:ident = new_with_init) => {
@@ -210,13 +210,15 @@ macro_rules! ffi_methods_one {
     (OpaquePtr $Ptr:ty; $( #[$attr:meta] )? $vis:vis $from_arg_ptr:ident = from_arg_ptr) => {
         $( #[$attr] )? $vis
         unsafe fn $from_arg_ptr(ptr: $Ptr, _call_type: $crate::PtrcallType) -> Self {
-            Self::new_from_sys(ptr.cast())
+            // SAFETY: forwarded from this fn's own contract.
+            unsafe { Self::new_from_sys($crate::SysPtr::as_const(ptr)) }
         }
     };
     (OpaquePtr $Ptr:ty; $( #[$attr:meta] )? $vis:vis $move_return_ptr:ident = move_return_ptr) => {
         $( #[$attr] )? $vis
         unsafe fn $move_return_ptr(mut self, dst: $Ptr, _call_type: $crate::PtrcallType) {
-            std::ptr::swap(dst.cast(), std::ptr::addr_of_mut!(self.opaque))
+            // SAFETY: `dst` is valid for a write of `Self`.
+            unsafe { std::ptr::swap(dst.cast(), std::ptr::addr_of_mut!(self.opaque)) }
         }
     };
 
@@ -259,9 +261,10 @@ macro_rules! ffi_methods_one {
     };
     (SelfPtr $Ptr:ty; $( #[$attr:meta] )? $vis:vis $from_arg_ptr:ident = from_arg_ptr) => {
         $( #[$attr] )? $vis
-        unsafe fn $from_arg_ptr(ptr: $Ptr, _call_type: $crate::PtrcallType) -> Self { unsafe {
-            Self::new_from_sys(ptr.cast())
-        }}
+        unsafe fn $from_arg_ptr(ptr: $Ptr, _call_type: $crate::PtrcallType) -> Self {
+            // SAFETY: forwarded from this fn's own contract.
+            unsafe { Self::new_from_sys($crate::SysPtr::as_const(ptr)) }
+        }
     };
     (SelfPtr $Ptr:ty; $( #[$attr:meta] )? $vis:vis $move_return_ptr:ident = move_return_ptr) => {
         $( #[$attr] )? $vis
@@ -343,101 +346,12 @@ macro_rules! ffi_methods {
     };
 }
 
-/// An error representing a failure to convert some value of type `From` into the type `Into`.
-#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-pub struct PrimitiveConversionError<From, Into> {
-    from: From,
-    into_ty: PhantomData<Into>,
-}
-
-impl<From, Into> PrimitiveConversionError<From, Into> {
-    pub fn new(from: From) -> Self {
-        Self {
-            from,
-            into_ty: PhantomData,
-        }
-    }
-}
-
-impl<From, Into> std::fmt::Display for PrimitiveConversionError<From, Into>
-where
-    From: std::fmt::Display,
-    Into: std::fmt::Display,
-{
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "could not convert {} to type {}",
-            self.from,
-            std::any::type_name::<Into>()
-        )
-    }
-}
-
-impl<From, Into> std::error::Error for PrimitiveConversionError<From, Into>
-where
-    From: std::fmt::Display + std::fmt::Debug,
-    Into: std::fmt::Display + std::fmt::Debug,
-{
-}
-
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Implementation for common types (needs to be this crate due to orphan rule)
 mod scalars {
     use super::{ExtVariantType, GodotFfi};
     use crate as sys;
 
-    /*
-    macro_rules! impl_godot_marshalling {
-        ($T:ty) => {
-            // SAFETY:
-            // This type is represented as `Self` in Godot, so `*mut Self` is sound.
-            unsafe impl GodotFfi for $T {
-                ffi_methods! { type sys::GDExtensionTypePtr = *mut Self; .. }
-            }
-        };
-
-        ($T:ty as $Via:ty) => {
-            // implicit bounds:
-            //    T: TryFrom<Via>, Copy
-            //    Via: TryFrom<T>, GodotFfi
-            impl GodotFuncMarshal for $T {
-                type Via = $Via;
-                type FromViaError = PrimitiveConversionError<$Via, Self>;
-                type IntoViaError = PrimitiveConversionError<Self, $Via>;
-
-                fn try_from_via(via: Self::Via) -> Result<Self, Self::FromViaError> {
-                    Self::try_from(via).map_err(|_| PrimitiveConversionError::new(via))
-                }
-
-                fn try_into_via(self) -> Result<Self::Via, Self::IntoViaError> {
-                    <$Via>::try_from(self).map_err(|_| PrimitiveConversionError::new(self))
-                }
-            }
-        };
-
-        ($T:ty as $Via:ty; lossy) => {
-            // implicit bounds:
-            //    T: TryFrom<Via>, Copy
-            //    Via: TryFrom<T>, GodotFfi
-            impl GodotFuncMarshal for $T {
-                type Via = $Via;
-                type FromViaError = Infallible;
-                type IntoViaError = Infallible;
-
-                #[inline]
-                fn try_from_via(via: Self::Via) -> Result<Self, Self::FromViaError> {
-                    Ok(via as Self)
-                }
-
-                #[inline]
-                fn try_into_via(self) -> Result<Self::Via, Self::IntoViaError> {
-                    Ok(self as $Via)
-                }
-            }
-        };
-    }
-    */
     unsafe impl GodotFfi for bool {
         const VARIANT_TYPE: ExtVariantType = ExtVariantType::Concrete(sys::VariantType::BOOL);
 

--- a/godot-ffi/src/interface_init.rs
+++ b/godot-ffi/src/interface_init.rs
@@ -157,7 +157,7 @@ unsafe fn fetch_version<V>(
 pub(crate) unsafe fn runtime_version(
     get_proc_address: GetProcAddress,
 ) -> (sys::GDExtensionGodotVersion, bool) {
-    // Try get_godot_version first (available in all versions, unless Godot built with deprecated features).
+    // Try get_godot_version first (absent only if Godot was built with `deprecated=no`).
 
     // SAFETY: `get_proc_address` is valid, function has signature fn(*mut GDExtensionGodotVersion).
     let version1: Option<sys::GDExtensionGodotVersion> =

--- a/godot-ffi/src/lib.rs
+++ b/godot-ffi/src/lib.rs
@@ -103,7 +103,7 @@ pub use init_level::*;
 pub use string_cache::StringCache;
 pub use toolbox::*;
 
-pub use crate::godot_ffi::{ExtVariantType, GodotFfi, PrimitiveConversionError, PtrcallType};
+pub use crate::godot_ffi::{ExtVariantType, GodotFfi, PtrcallType};
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // API to access Godot via FFI
@@ -115,7 +115,7 @@ pub use binding::*;
 use binding::{
     initialize_binding, initialize_builtin_method_table, initialize_class_core_method_table,
     initialize_class_editor_method_table, initialize_class_scene_method_table,
-    initialize_class_server_method_table, runtime_metadata,
+    initialize_class_servers_method_table, runtime_metadata,
 };
 
 #[cfg(not(wasm_nothreads))]
@@ -201,11 +201,6 @@ impl GdextRuntimeMetadata {
         self.supports_deprecated_apis
     }
 }
-
-// SAFETY: The `string` pointer in `godot_version` is only ever read from while the struct exists, so we cannot have any race conditions.
-unsafe impl Sync for GdextRuntimeMetadata {}
-// SAFETY: See `Sync` impl safety doc.
-unsafe impl Send for GdextRuntimeMetadata {}
 
 /// Initializes the library.
 ///
@@ -333,6 +328,10 @@ pub unsafe fn deinitialize() {
             unsafe { MAIN_THREAD_ID.clear() };
         }
     }
+
+    // TODO: reset process-lifetime startup statics here. Hot-reload on Linux/macOS re-enters initialize() in the same process, but
+    // STARTUP_MESSAGES_FLUSHED, ONCE_EMITTED_MESSAGES, IS_EDITOR_HINT and IS_EDITOR_BINARY survive, so `once` messages never fire again
+    // and the editor-state getters report the previous session until re-populated.
 }
 
 fn safeguards_level_string() -> &'static str {
@@ -519,9 +518,9 @@ pub unsafe fn load_class_method_table(api_level: InitLevel) {
             // SAFETY: The interface has been initialized and this function hasn't been called before.
             unsafe {
                 #[cfg(feature = "codegen-lazy-fptrs")]
-                initialize_class_server_method_table(ClassServersMethodTable::load());
+                initialize_class_servers_method_table(ClassServersMethodTable::load());
                 #[cfg(not(feature = "codegen-lazy-fptrs"))]
-                initialize_class_server_method_table(ClassServersMethodTable::load(
+                initialize_class_servers_method_table(ClassServersMethodTable::load(
                     interface,
                     &mut string_names,
                 ));

--- a/godot-ffi/src/string_cache.rs
+++ b/godot-ffi/src/string_cache.rs
@@ -33,7 +33,8 @@ impl<'a> StringCache<'a> {
 
     /// Get a pointer to a `StringName`. Reuses cached instances, only deallocates on destruction of this cache.
     pub fn fetch(&mut self, key: &'static str) -> sys::GDExtensionStringNamePtr {
-        assert!(key.is_ascii(), "string is not ASCII: {key}");
+        // Codegen invariant: keys are always ASCII.
+        crate::strict_assert!(key.is_ascii(), "string is not ASCII: {key}");
 
         // Already cached.
         if let Some(opaque_box) = self.instances_by_str.get_mut(key) {
@@ -94,12 +95,12 @@ fn box_to_sname_ptr(
     opaque_ptr as sys::GDExtensionStringNamePtr
 }
 
-unsafe fn sname_uninit_ptr(
+fn sname_uninit_ptr(
     opaque_ptr: *mut sys::types::OpaqueStringName,
 ) -> sys::GDExtensionUninitializedStringNamePtr {
     opaque_ptr as sys::GDExtensionUninitializedStringNamePtr
 }
 
-unsafe fn sname_type_ptr(opaque_ptr: *mut sys::types::OpaqueStringName) -> sys::GDExtensionTypePtr {
+fn sname_type_ptr(opaque_ptr: *mut sys::types::OpaqueStringName) -> sys::GDExtensionTypePtr {
     opaque_ptr as sys::GDExtensionTypePtr
 }

--- a/godot-ffi/src/toolbox.rs
+++ b/godot-ffi/src/toolbox.rs
@@ -37,37 +37,8 @@ macro_rules! out {
     }}
 }
 
-/// Extract a function pointer from its `Option` and convert it to the (dereferenced) target type.
-///
-/// ```ignore
-///  let get_godot_version = get_proc_address(sys::c_str(b"get_godot_version\0"));
-///  let get_godot_version = sys::unsafe_cast_fn_ptr!(get_godot_version as sys::GDExtensionInterfaceGetGodotVersion);
-/// ```
-///
-/// # Safety
-///
-/// `$ToType` must be an option of an `unsafe extern "C"` function pointer.
-#[allow(unused)]
-#[macro_export]
-macro_rules! unsafe_cast_fn_ptr {
-    ($option:ident as $ToType:ty) => {{
-        // SAFETY: `$ToType` is an `unsafe extern "C"` function pointer and is thus compatible with `unsafe extern "C" fn()`.
-        // And `Option<T>` is compatible with `Option<U>` when both `T` and `U` are compatible function pointers.
-        #[allow(unused_unsafe)]
-        let ptr: Option<_> = unsafe { std::mem::transmute::<Option<unsafe extern "C" fn()>, $ToType>($option) };
-        ptr.expect("null function pointer")
-    }};
-}
-
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Utility functions
-
-/// Extract value from box before `into_inner()` is stable
-#[allow(clippy::boxed_local)] // false positive
-pub fn unbox<T>(value: Box<T>) -> T {
-    // Deref-move is a Box magic feature; see https://stackoverflow.com/a/42264074
-    *value
-}
 
 /// Explicitly cast away `const` from a pointer, similar to C++ `const_cast`.
 ///
@@ -184,13 +155,6 @@ pub fn found_to_option(index: i64) -> Option<usize> {
     }
 }
 
-/*
-pub fn unqualified_type_name<T>() -> &'static str {
-    let type_name = std::any::type_name::<T>();
-    type_name.split("::").last().unwrap()
-}
-*/
-
 /// Like [`std::any::type_name`], but returns a short type name without module paths.
 pub fn short_type_name<T: ?Sized>() -> String {
     let full_name = std::any::type_name::<T>();
@@ -256,7 +220,6 @@ fn strip_module_paths(full_name: &str) -> String {
 // Private helpers
 
 /// Metafunction to extract inner function pointer types from all the bindgen `Option<F>` type names.
-/// Needed for `unsafe_cast_fn_ptr` macro.
 pub trait Inner: Sized {
     type FnPtr: Sized;
 }


### PR DESCRIPTION
Several cleanups in `godot-ffi`: gets rid of dead and pointless code, addresses safety conditions and code duplication, but also fixes a few things (race conditions + potential out-of-bounds that's hard to reach in practice though...)