### PR TITLE
Reduce code size of often-monomorphized functions, 27% compile time win for user crates

### DIFF
--- a/godot-core/src/init/mod.rs
+++ b/godot-core/src/init/mod.rs
@@ -5,6 +5,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+use std::fmt::Display;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 use godot_ffi as sys;
@@ -117,9 +118,9 @@ struct InitUserData {
 
 #[cfg(since_api = "4.5")]
 unsafe extern "C" fn startup_func<E: ExtensionLibrary>() {
-    let ctx = || "ExtensionLibrary::on_stage_init(MainLoop)".to_string();
+    let ctx = "ExtensionLibrary::on_stage_init(MainLoop)";
 
-    swallow_panics(ctx, || {
+    swallow_panics(&ctx, || {
         E::on_stage_init(InitStage::MainLoop);
     });
 
@@ -132,9 +133,9 @@ unsafe extern "C" fn startup_func<E: ExtensionLibrary>() {
 
 #[cfg(since_api = "4.5")]
 unsafe extern "C" fn frame_func<E: ExtensionLibrary>() {
-    let ctx = || "ExtensionLibrary::on_main_loop_frame()".to_string();
+    let ctx = "ExtensionLibrary::on_main_loop_frame()";
 
-    swallow_panics(ctx, || {
+    swallow_panics(&ctx, || {
         E::on_main_loop_frame();
     });
 }
@@ -145,9 +146,9 @@ unsafe extern "C" fn shutdown_func<E: ExtensionLibrary>() {
     // is left suspended (and dropped in cleanup()) instead of being woken into a spurious panic. See `async_runtime::is_engine_exiting()`.
     crate::task::mark_engine_exiting();
 
-    let ctx = || "ExtensionLibrary::on_stage_deinit(MainLoop)".to_string();
+    let ctx = "ExtensionLibrary::on_stage_deinit(MainLoop)";
 
-    swallow_panics(ctx, || {
+    swallow_panics(&ctx, || {
         E::on_stage_deinit(InitStage::MainLoop);
     });
 }
@@ -226,7 +227,7 @@ unsafe extern "C" fn ffi_initialize_layer<E: ExtensionLibrary>(
     unsafe {
         let userdata = userdata.cast::<InitUserData>().as_ref().unwrap();
         let level = InitLevel::from_sys(init_level);
-        let ctx = || format!("ExtensionLibrary::on_stage_init({level:?})");
+        let ctx = format!("ExtensionLibrary::on_stage_init({level:?})");
 
         fn try_load<E: ExtensionLibrary>(level: InitLevel, userdata: &InitUserData) {
             // Workaround for https://github.com/godot-rust/gdext/issues/629:
@@ -251,7 +252,7 @@ unsafe extern "C" fn ffi_initialize_layer<E: ExtensionLibrary>(
         }
 
         // TODO consider crashing if gdext init fails.
-        swallow_panics(ctx, || {
+        swallow_panics(&ctx, || {
             try_load::<E>(level, userdata);
         });
     }
@@ -263,9 +264,9 @@ unsafe extern "C" fn ffi_deinitialize_layer<E: ExtensionLibrary>(
 ) {
     unsafe {
         let level = InitLevel::from_sys(init_level);
-        let ctx = || format!("ExtensionLibrary::on_stage_deinit({level:?})");
+        let ctx = format!("ExtensionLibrary::on_stage_deinit({level:?})");
 
-        swallow_panics(ctx, || {
+        swallow_panics(&ctx, || {
             if level == InitLevel::Core {
                 // Once the CORE api is unloaded, reset the flag to initial state.
                 LEVEL_SERVERS_CORE_LOADED.store(false, Ordering::Relaxed);
@@ -434,9 +435,8 @@ const fn previous_init_level(level: InitLevel) -> Option<InitLevel> {
 }
 
 /// Catches panics without propagating them further. Prints error messages.
-fn swallow_panics<E, F>(error_context: E, code: F)
+fn swallow_panics<F>(error_context: &dyn Display, code: F)
 where
-    E: Fn() -> String,
     F: FnOnce() + std::panic::UnwindSafe,
 {
     let _ = crate::private::handle_panic(error_context, code);

--- a/godot-core/src/obj/script.rs
+++ b/godot-core/src/obj/script.rs
@@ -661,6 +661,7 @@ use self::bounded_ptr_list::BoundedPtrList;
 mod script_instance_info {
     use std::any::type_name;
     use std::ffi::c_void;
+    use std::fmt;
 
     use sys::conv::{SYS_FALSE, SYS_TRUE, bool_from_sys, bool_to_sys};
     #[cfg(since_api = "4.3")]
@@ -1345,16 +1346,14 @@ mod script_instance_info {
         }
     }
 
-    fn error_ctx<T: ScriptInstance>(method: &'static str) -> impl Fn() -> String {
-        move || format!("{}::{method}(), script instance method", type_name::<T>())
-    }
-
     fn with_instance<T: ScriptInstance, R>(
         instance: &ScriptInstanceData<T>,
         method: &'static str,
         f: impl FnOnce(&T) -> R + std::panic::UnwindSafe,
     ) -> Result<R, PanicPayload> {
-        handle_panic(error_ctx::<T>(method), || f(&instance.borrow()))
+        handle_panic(&ScriptInstanceMethodContext::new::<T>(method), || {
+            f(&instance.borrow())
+        })
     }
 
     fn with_instance_mut<T: ScriptInstance, R>(
@@ -1362,10 +1361,34 @@ mod script_instance_info {
         method: &'static str,
         f: impl FnOnce(SiMut<T>) -> R + std::panic::UnwindSafe,
     ) -> Result<R, PanicPayload> {
-        handle_panic(error_ctx::<T>(method), || {
+        handle_panic(&ScriptInstanceMethodContext::new::<T>(method), || {
             let mut guard = instance.borrow_mut();
             let instance_guard = SiMut::new(instance.cell_ref(), &mut guard, &instance.base);
             f(instance_guard)
         })
+    }
+
+    struct ScriptInstanceMethodContext {
+        class_name: &'static str,
+        method_name: &'static str,
+    }
+
+    impl ScriptInstanceMethodContext {
+        fn new<T>(method_name: &'static str) -> Self {
+            Self {
+                class_name: type_name::<T>(),
+                method_name,
+            }
+        }
+    }
+
+    impl fmt::Display for ScriptInstanceMethodContext {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            write!(
+                f,
+                "{}::{}(), script instance method",
+                self.class_name, self.method_name,
+            )
+        }
     }
 }

--- a/godot-core/src/private.rs
+++ b/godot-core/src/private.rs
@@ -391,6 +391,27 @@ thread_local! {
     }
 }
 
+/// Pushes the given context function to the current thread's error context stack.
+/// # Safety
+/// Function must be removed (using [`pop_panic_context()`]) before its lifetime `'b` is invalidated.
+unsafe fn push_panic_context<'b>(error_context: &'b (dyn Fn() -> String + 'b)) {
+    #[cfg(not(safeguards_strict))]
+    let _ = error_context; // Unused in Release.
+
+    #[cfg(safeguards_strict)]
+    ERROR_CONTEXT_STACK.with(|cell| {
+        let mut stack = cell.borrow_mut();
+        // SAFETY: caller promises to pop error_context before its lifetime is invalidated.
+        unsafe { stack.push_function(error_context) }
+    });
+}
+
+/// Pops a function from the current thread's error context stack.
+fn pop_panic_context() {
+    #[cfg(safeguards_strict)]
+    ERROR_CONTEXT_STACK.with(|cell| cell.borrow_mut().pop_function());
+}
+
 // Value may return `None`, even from panic hook, if called from a non-Godot thread.
 pub fn fetch_last_panic_context() -> Option<String> {
     #[cfg(safeguards_strict)]
@@ -433,19 +454,13 @@ where
     E: Fn() -> String,
     F: FnOnce() -> R + std::panic::UnwindSafe,
 {
-    #[cfg(not(safeguards_strict))]
-    let _ = error_context; // Unused in Release.
-
-    #[cfg(safeguards_strict)]
-    ERROR_CONTEXT_STACK.with(|cell| unsafe {
-        // SAFETY: &error_context is valid for lifetime of function, and is removed from LAST_ERROR_CONTEXT before end of function.
-        cell.borrow_mut().push_function(&error_context)
-    });
+    // SAFETY: &error_context is valid for lifetime of function, and is removed from LAST_ERROR_CONTEXT before end of function.
+    unsafe { push_panic_context(&error_context) };
 
     let result = std::panic::catch_unwind(code).map_err(PanicPayload::new);
 
-    #[cfg(safeguards_strict)]
-    ERROR_CONTEXT_STACK.with(|cell| cell.borrow_mut().pop_function());
+    pop_panic_context();
+
     result
 }
 

--- a/godot-core/src/private.rs
+++ b/godot-core/src/private.rs
@@ -511,6 +511,14 @@ where
         Err(panic_msg) => CallError::failed_by_user_panic(call_ctx, panic_msg),
     };
 
+    handle_call_error(call_error)
+}
+
+/// Helper for `handle_fallible_call` that does not depend on generic arguments.
+///
+/// This is a separate non-generic function to improve compilation time of `handle_fallible_call`, which may be monomorphized thousands of
+/// times while compiling the user's crate.
+fn handle_call_error(call_error: CallError) -> bool {
     // Print failed calls to Godot's console.
     //
     // OUT_CALL_DEPTH > 0 means this failure is observed during a Rust-initiated out-call (e.g. `try_call`); the caller already sees

--- a/godot-core/src/private.rs
+++ b/godot-core/src/private.rs
@@ -346,7 +346,7 @@ pub(crate) fn has_error_print_level(level: ErrorPrintLevel) -> bool {
 
 /// Internal type used to store context information for debug purposes. Debug context is stored on the thread-local
 /// ERROR_CONTEXT_STACK, which can later be used to retrieve the current context in the event of a panic. This value
-/// probably shouldn't be used directly; use ['get_gdext_panic_context()'](fetch_last_panic_context) instead.
+/// probably shouldn't be used directly; use [`fetch_last_panic_context()`] instead.
 #[cfg(safeguards_strict)]
 struct ScopedFunctionStack {
     functions: Vec<*const dyn Fn() -> String>,

--- a/godot-core/src/private.rs
+++ b/godot-core/src/private.rs
@@ -8,6 +8,7 @@
 use std::cell::Cell;
 #[cfg(safeguards_strict)]
 use std::cell::RefCell;
+use std::fmt::Display;
 use std::io::Write;
 use std::sync::atomic;
 
@@ -348,53 +349,52 @@ pub(crate) fn has_error_print_level(level: ErrorPrintLevel) -> bool {
 /// ERROR_CONTEXT_STACK, which can later be used to retrieve the current context in the event of a panic. This value
 /// probably shouldn't be used directly; use [`fetch_last_panic_context()`] instead.
 #[cfg(safeguards_strict)]
-struct ScopedFunctionStack {
-    functions: Vec<*const dyn Fn() -> String>,
+struct ScopedContextStack {
+    contexts: Vec<*const dyn Display>,
 }
 
 #[cfg(safeguards_strict)]
-impl ScopedFunctionStack {
+impl ScopedContextStack {
     /// # Safety
-    /// Function must be removed (using [`pop_function()`](Self::pop_function)) before lifetime is invalidated.
-    unsafe fn push_function<'a, 'b>(&'a mut self, function: &'b (dyn Fn() -> String + 'b)) {
-        // SAFETY: Function has its lifetime `'b` extended to `'static` to satisfy the signature
-        // of `functions` which has an implied `'static` bound.
-        // Given function must be removed before lifetime `'b` is invalidated.
-        let function = unsafe {
-            std::mem::transmute::<
-                *const (dyn Fn() -> String + 'b),
-                *const (dyn Fn() -> String + 'static),
-            >(function)
+    /// Context must be removed (using [`Self::pop_context()`]) before lifetime is invalidated.
+    unsafe fn push_context<'a, 'b>(&'a mut self, context: &'b dyn Display) {
+        // SAFETY: Context has its lifetime `'b` extended to `'static` to satisfy the signature
+        // of `self.contexts` which has an implied `'static` bound.
+        // Given context must be removed before lifetime `'b` is invalidated.
+        let context = unsafe {
+            std::mem::transmute::<*const (dyn Display + 'b), *const (dyn Display + 'static)>(
+                context,
+            )
         };
 
-        self.functions.push(function);
+        self.contexts.push(context);
     }
 
-    fn pop_function(&mut self) {
-        self.functions.pop().expect("function stack is empty!");
+    fn pop_context(&mut self) {
+        self.contexts.pop().expect("context stack is empty!");
     }
 
     fn get_last(&self) -> Option<String> {
-        self.functions.last().cloned().map(|pointer| {
+        self.contexts.last().cloned().map(|pointer| {
             // SAFETY:
-            // Invariants provided by push_function assert that any and all functions held by ScopedFunctionStack
-            // are removed before they are invalidated; functions must always be valid.
-            unsafe { (*pointer)() }
+            // Invariants provided by push_context assert that any and all contexts held by ScopedContextStack
+            // are removed before they are invalidated; contexts must always be valid.
+            unsafe { (*pointer).to_string() }
         })
     }
 }
 
 #[cfg(safeguards_strict)]
 thread_local! {
-    static ERROR_CONTEXT_STACK: RefCell<ScopedFunctionStack> = const {
-        RefCell::new(ScopedFunctionStack { functions: Vec::new() })
+    static ERROR_CONTEXT_STACK: RefCell<ScopedContextStack> = const {
+        RefCell::new(ScopedContextStack { contexts: Vec::new() })
     }
 }
 
-/// Pushes the given context function to the current thread's error context stack.
+/// Pushes the given context to the current thread's error context stack.
 /// # Safety
-/// Function must be removed (using [`pop_panic_context()`]) before its lifetime `'b` is invalidated.
-unsafe fn push_panic_context<'b>(error_context: &'b (dyn Fn() -> String + 'b)) {
+/// Context must be removed (using [`pop_panic_context()`]) before its lifetime is invalidated.
+unsafe fn push_panic_context(error_context: &dyn Display) {
     #[cfg(not(safeguards_strict))]
     let _ = error_context; // Unused in Release.
 
@@ -402,14 +402,14 @@ unsafe fn push_panic_context<'b>(error_context: &'b (dyn Fn() -> String + 'b)) {
     ERROR_CONTEXT_STACK.with(|cell| {
         let mut stack = cell.borrow_mut();
         // SAFETY: caller promises to pop error_context before its lifetime is invalidated.
-        unsafe { stack.push_function(error_context) }
+        unsafe { stack.push_context(error_context) }
     });
 }
 
-/// Pops a function from the current thread's error context stack.
+/// Pops a context from the current thread's error context stack.
 fn pop_panic_context() {
     #[cfg(safeguards_strict)]
-    ERROR_CONTEXT_STACK.with(|cell| cell.borrow_mut().pop_function());
+    ERROR_CONTEXT_STACK.with(|cell| cell.borrow_mut().pop_context());
 }
 
 // Value may return `None`, even from panic hook, if called from a non-Godot thread.
@@ -449,13 +449,12 @@ impl PanicPayload {
 ///
 /// In contrast to [`handle_fallible_varcall`] and [`handle_fallible_ptrcall`], this function is not intended for use in `try_` functions,
 /// where the error is propagated as a `CallError` in a global variable.
-pub fn handle_panic<E, F, R>(error_context: E, code: F) -> Result<R, PanicPayload>
+pub fn handle_panic<F, R>(error_context: &dyn Display, code: F) -> Result<R, PanicPayload>
 where
-    E: Fn() -> String,
     F: FnOnce() -> R + std::panic::UnwindSafe,
 {
-    // SAFETY: &error_context is valid for lifetime of function, and is removed from LAST_ERROR_CONTEXT before end of function.
-    unsafe { push_panic_context(&error_context) };
+    // SAFETY: &error_context is valid for lifetime of function, and is popped again before end of function.
+    unsafe { push_panic_context(error_context) };
 
     let result = std::panic::catch_unwind(code).map_err(PanicPayload::new);
 
@@ -512,8 +511,7 @@ fn handle_fallible_call<F, R>(call_ctx: &CallContext, code: F) -> bool
 where
     F: FnOnce() -> CallResult<R> + std::panic::UnwindSafe,
 {
-    let outcome: Result<CallResult<R>, PanicPayload> =
-        handle_panic(|| format!("{call_ctx}()"), code);
+    let outcome: Result<CallResult<R>, PanicPayload> = handle_panic(call_ctx, code);
 
     let call_error = match outcome {
         // All good.

--- a/godot-core/src/registry/callbacks.rs
+++ b/godot-core/src/registry/callbacks.rs
@@ -10,6 +10,7 @@
 //! Re-exported to `crate::private`.
 #![allow(clippy::missing_safety_doc)]
 
+use core::fmt;
 use std::any::Any;
 
 use godot_ffi as sys;
@@ -19,11 +20,32 @@ use sys::interface_fn;
 use crate::builder::ClassBuilder;
 use crate::builtin::{StringName, Variant};
 use crate::classes::Object;
+use crate::meta::ClassId;
 use crate::obj::{AsDyn, Base, Bounds, Gd, GodotClass, Inherits, UserClass, bounds, cap};
 use crate::private::{IntoVirtualMethodReceiver, PanicPayload, handle_panic};
 use crate::registry::info::PropertyInfo;
 use crate::registry::shard::ErasedDynGd;
 use crate::storage::{InstanceStorage, Storage, StorageRefCounted, as_storage, as_weak_storage};
+
+struct MethodCallContext<'a> {
+    class_id: ClassId,
+    method_name: &'a str,
+}
+
+impl<'a> MethodCallContext<'a> {
+    fn new<T: GodotClass>(method_name: &'a str) -> Self {
+        Self {
+            class_id: T::class_id(),
+            method_name,
+        }
+    }
+}
+
+impl<'a> fmt::Display for MethodCallContext<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}::{}()", self.class_id, self.method_name)
+    }
+}
 
 /// Invokes `code` -- a callback that calls into user code -- and catches any panic, so it does not unwind across the FFI boundary.
 ///
@@ -33,8 +55,7 @@ fn handle_method_panic<T: GodotClass, R>(
     method: &str,
     code: impl FnOnce() -> R + std::panic::UnwindSafe,
 ) -> Result<R, PanicPayload> {
-    let context = || format!("{}::{method}()", T::class_id());
-    handle_panic(context, code)
+    handle_panic(&MethodCallContext::new::<T>(method), code)
 }
 
 /// Same as [`handle_method_panic()`], for the many callbacks that report success as a Godot bool. A panic counts as failure.
@@ -174,9 +195,9 @@ where
     let base = unsafe { Base::from_sys(base_ptr) };
 
     // User constructor init() can panic, which crashes the engine if unhandled.
-    let context = || format!("{class_id}::init()");
+    let context = MethodCallContext::new::<T>("init");
     let code = || make_user_instance(unsafe { Base::from_base(&base) });
-    let user_instance = handle_panic(context, std::panic::AssertUnwindSafe(code))?;
+    let user_instance = handle_panic(&context, std::panic::AssertUnwindSafe(code))?;
 
     // Print shouldn't be necessary as panic itself is printed. If this changes, re-enable in error case:
     // godot_error!("failed to create instance of {class_id}; Rust init() panicked");

--- a/godot-core/src/task/async_runtime.rs
+++ b/godot-core/src/task/async_runtime.rs
@@ -6,6 +6,7 @@
  */
 
 use std::cell::RefCell;
+use std::fmt;
 use std::future::Future;
 use std::marker::PhantomData;
 use std::panic::AssertUnwindSafe;
@@ -557,7 +558,9 @@ fn poll_future(godot_waker: Arc<GodotWaker>) {
         return;
     };
 
-    let error_context = || format!("async task #{}", godot_waker.task_id);
+    let error_context = AsyncTaskErrorContext {
+        task_id: godot_waker.task_id,
+    };
 
     // If Future::poll() panics, the future is immediately dropped and cannot be accessed again,
     // thus any state that may not have been unwind-safe cannot be observed later.
@@ -568,7 +571,7 @@ fn poll_future(godot_waker: Arc<GodotWaker>) {
     #[cfg(safeguards_strict)]
     let bind_guard_baseline = await_point_read();
 
-    let panic_result = handle_panic(error_context, move || {
+    let panic_result = handle_panic(&error_context, move || {
         (future.as_mut().poll(&mut ctx), future)
     });
 
@@ -606,6 +609,16 @@ fn poll_future(godot_waker: Arc<GodotWaker>) {
         // Future has resolved, so we remove it from the runtime.
         Poll::Ready(()) => rt.clear_task(godot_waker.runtime_index),
     });
+}
+
+struct AsyncTaskErrorContext {
+    task_id: u64,
+}
+
+impl fmt::Display for AsyncTaskErrorContext {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "async task #{}", self.task_id)
+    }
 }
 
 /// Implementation of a [`Waker`] to poll futures with the engine.

--- a/godot-core/src/task/futures.rs
+++ b/godot-core/src/task/futures.rs
@@ -340,8 +340,8 @@ impl<R: InParamTuple + IntoDynamicSend> Drop for FallibleSignalFuture<R> {
             }
         };
 
-        let context = || "FallibleSignalFuture::drop: object freed concurrently".to_string();
-        let _ = crate::private::handle_panic(context, cleanup);
+        let context = "FallibleSignalFuture::drop: object freed concurrently";
+        let _ = crate::private::handle_panic(&context, cleanup);
     }
 }
 

--- a/itest/rust/src/framework/runner.rs
+++ b/itest/rust/src/framework/runner.rs
@@ -443,10 +443,11 @@ fn run_rust_test(test: &RustTestCase, ctx: &TestContext) -> TestOutcome {
 
     // This will appear in all panics, but those inside expect_panic() are suppressed.
     // So the "itest failed" message will only appear for unexpected panics, where tests indeed fail.
-    let err_context = || format!("itest `{}` failed", test.name);
+    let err_context = format!("itest `{}` failed", test.name);
 
     // Explicit type to prevent tests from returning a value.
-    let success: Result<(), _> = godot::private::handle_panic(err_context, || (test.function)(ctx));
+    let success: Result<(), _> =
+        godot::private::handle_panic(&err_context, || (test.function)(ctx));
 
     TestOutcome::from_bool(success.is_ok())
 }
@@ -461,9 +462,9 @@ fn run_async_rust_test(
     }
 
     // Explicit type to prevent tests from returning a value
-    let err_context = || format!("itest `{}` failed", test.name);
+    let err_context = format!("itest `{}` failed", test.name);
     let success: Result<godot::task::TaskHandle, _> =
-        godot::private::handle_panic(err_context, || (test.function)(ctx));
+        godot::private::handle_panic(&err_context, || (test.function)(ctx));
 
     let Ok(task_handle) = success else {
         return on_test_finished(TestOutcome::Failed);


### PR DESCRIPTION
[cargo-llvm-lines](https://github.com/dtolnay/cargo-llvm-lines) reports on my extension crate that `godot_core::private::handle_panic` and `godot_core::private::handle_fallible_call` are being monomorphized over 1000 times in my extension. This turns out to be a major cause of long compile times.

N.B. I'm measuring compile time in debug mode but I'm still using `opt-level = 2`, so my compile times are probably longer than usual.

This PR extracts some code into separate functions insofar as it doesn't depend on the generic arguments. With these three changes, compilation time for my extension goes from 19.2 s to 14.0 s, a reduction of 27%.

My `.so`'s size in `--release` mode goes down from 42.5 MiB to 41.9 MiB, a reduction of 574 kiB.

~~I've found another 5% compile time reduction by making the panic context stack contain structs, rather than `Fn() -> String` implementations. This helps `handle_fallible_call`, because it no longer needs to instantiate a closure (which is also monomorphized). But this change is more invasive and makes `handle_panic` less flexible, so I judged it to be not worthwhile.~~ This is added in a nicer way and included in the above numbers.