### PR TITLE
Add automatic conversion to/from HashMap and BTreeMap

### DIFF
--- a/godot-core/src/builtin/collections/dictionary.rs
+++ b/godot-core/src/builtin/collections/dictionary.rs
@@ -843,6 +843,31 @@ impl<K: Element, V: Element> FromIterator<(K, V)> for Dictionary<K, V> {
     }
 }
 
+/// Insert iterator of references into dictionary.
+///
+/// Inserts all key-value pairs from the iterator into the dictionary. Previous values for keys appearing
+/// in `iter` will be overwritten.
+impl<'k, 'v, K: Element, V: Element> Extend<(&'k K, &'v V)> for Dictionary<K, V> {
+    fn extend<I: IntoIterator<Item = (&'k K, &'v V)>>(&mut self, iter: I) {
+        for (k, v) in iter.into_iter() {
+            // Inline set logic to avoid generic owned_into_arg() (which can't resolve T::Pass).
+            self.balanced_ensure_mutable();
+
+            // SAFETY: K and V strongly typed.
+            unsafe { self.set_variant(k.to_variant(), v.to_variant()) };
+        }
+    }
+}
+
+/// Creates a `Dictionary` from an iterator over reference key-value pairs.
+impl<'k, 'v, K: Element, V: Element> FromIterator<(&'k K, &'v V)> for Dictionary<K, V> {
+    fn from_iter<I: IntoIterator<Item = (&'k K, &'v V)>>(iter: I) -> Self {
+        let mut dict = Dictionary::new();
+        dict.extend(iter);
+        dict
+    }
+}
+
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // GodotConvert/ToGodot/FromGodot for Dictionary<K, V>
 

--- a/godot-core/src/meta/godot_convert/impls.rs
+++ b/godot-core/src/meta/godot_convert/impls.rs
@@ -5,7 +5,10 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use crate::builtin::{Array, Variant};
+use std::collections::{BTreeMap, HashMap};
+use std::hash::Hash;
+
+use crate::builtin::{Array, Dictionary, Variant};
 use crate::meta;
 use crate::meta::error::{
     CallError, CallOutcome, ConvertError, ErrorKind, ErrorToGodot, FromFfiError,
@@ -456,6 +459,50 @@ impl<T: Element> ToGodot for &[T] {
 
     fn to_godot(&self) -> Self::Via {
         Array::from(*self)
+    }
+}
+
+impl<K: Element, V: Element> GodotConvert for HashMap<K, V> {
+    type Via = Dictionary<K, V>;
+
+    fn godot_shape() -> GodotShape {
+        <Dictionary<K, V> as GodotConvert>::godot_shape()
+    }
+}
+
+impl<K: Element, V: Element> ToGodot for HashMap<K, V> {
+    type Pass = meta::ByValue;
+
+    fn to_godot(&self) -> Self::Via {
+        self.iter().collect()
+    }
+}
+
+impl<K: Element + Eq + Hash, V: Element> FromGodot for HashMap<K, V> {
+    fn try_from_godot(via: Self::Via) -> Result<Self, ConvertError> {
+        Ok(via.iter_shared().collect())
+    }
+}
+
+impl<K: Element, V: Element> GodotConvert for BTreeMap<K, V> {
+    type Via = Dictionary<K, V>;
+
+    fn godot_shape() -> GodotShape {
+        <Dictionary<K, V> as GodotConvert>::godot_shape()
+    }
+}
+
+impl<K: Element, V: Element> ToGodot for BTreeMap<K, V> {
+    type Pass = meta::ByValue;
+
+    fn to_godot(&self) -> Self::Via {
+        self.iter().collect()
+    }
+}
+
+impl<K: Element + Ord, V: Element> FromGodot for BTreeMap<K, V> {
+    fn try_from_godot(via: Self::Via) -> Result<Self, ConvertError> {
+        Ok(via.iter_shared().collect())
     }
 }
 

--- a/itest/godot/ManualFfiTests.gd
+++ b/itest/godot/ManualFfiTests.gd
@@ -25,7 +25,7 @@ func test_init_defaults():
 
 func test_to_string():
 	var ffi = VirtualMethodTest.new()
-	
+
 	assert_eq(str(ffi), "VirtualMethodTest[integer=0]")
 
 func test_var_accessors():
@@ -183,6 +183,34 @@ func test_ffi_relaxed_conversions_in_varcall_ptrcall():
 
 	# If we reach this point, all conversions succeeded.
 	assert_eq(ConversionTest.successful_calls(), 4, "all calls should succeed with relaxed conversion")
+	mark_test_succeeded()
+
+
+func test_ffi_dictionary_conversion():
+	mark_test_pending()
+
+	var conv = ConversionTest.new()
+
+	# Test hash_to_btree: HashMap<u8, Vector2i> -> BTreeMap<u8, Vector2i>
+	var input_hash = {1: Vector2i(10, 20), 2: Vector2i(30, 40), 3: Vector2i(50, 60)}
+	var result_btree = conv.hash_to_btree(input_hash)
+	assert_eq(result_btree.size(), 3, "hash_to_btree should preserve size")
+	assert_eq(result_btree[1], Vector2i(10, 20), "hash_to_btree should preserve value for key 1")
+	assert_eq(result_btree[2], Vector2i(30, 40), "hash_to_btree should preserve value for key 2")
+	assert_eq(result_btree[3], Vector2i(50, 60), "hash_to_btree should preserve value for key 3")
+
+	# Test btree_to_hash: BTreeMap<GString, Gd<RefCounted>> -> HashMap<GString, Gd<RefCounted>>
+	var obj_a = RefCounted.new()
+	var obj_b = RefCounted.new()
+	var input_btree = {"alpha": obj_a, "beta": obj_b}
+	var result_hash = conv.btree_to_hash(input_btree)
+	assert_eq(result_hash.size(), 2, "btree_to_hash should preserve size")
+	assert_eq(result_hash["alpha"], obj_a, "btree_to_hash should preserve value for key 'alpha'")
+	assert_eq(result_hash["beta"], obj_b, "btree_to_hash should preserve value for key 'beta'")
+
+	# Test with empty dictionary
+	assert_eq(conv.hash_to_btree({}).size(), 0, "hash_to_btree should handle empty dictionary")
+	assert_eq(conv.btree_to_hash({}).size(), 0, "btree_to_hash should handle empty dictionary")
 	mark_test_succeeded()
 
 
@@ -477,7 +505,7 @@ func update_self_reference(value):
 #	# Create the gd_self_obj and connect its signal to a gdscript method that calls back into it.
 #	gd_self_obj = GdSelfObj.new()
 #	gd_self_obj.update_internal_signal.connect(update_self_reference)
-#	
+#
 #	# The returned value will still be 0 because update_internal can't be called in update_self_reference due to a borrowing issue.
 #	assert_eq(gd_self_obj.fail_to_update_internal_value_due_to_conflicting_borrow(10), 0)
 
@@ -535,11 +563,11 @@ func test_renamed_func_shape():
 	var node_props = base_node.get_property_list().map(func(p): return p.name)
 	var node_methods = base_node.get_method_list().map(func(m): return m.name)
 	base_node.free()
-	
+
 	# Get our object's properties and methods
 	var obj_props = obj.get_property_list().map(func(p): return p.name)
 	var obj_methods = obj.get_method_list().map(func(m): return m.name)
-	
+
 	# Get only the new properties and methods (not in Node)
 	var gdext_props = obj_props.filter(func(name): return not node_props.has(name))
 	var gdext_methods = obj_methods.filter(func(name): return not node_methods.has(name))
@@ -547,7 +575,7 @@ func test_renamed_func_shape():
 	# Assert counts
 	assert_eq(gdext_props.size(), 2, "number of properties should be 2")
 	assert_eq(gdext_methods.size(), 2, "number of methods should be 2")
-	
+
 	# Assert specific names
 	assert(gdext_props.has("int_val"), "should have a property named 'int_val'")
 	# Godot automatically adds a property of the class name (acts as the top-level category in the inspector UI).
@@ -567,12 +595,12 @@ func test_renamed_func_get_set():
 	assert_eq(obj.f1(), 0)
 
 	obj.int_val = 42;
-	
+
 	assert_eq(obj.int_val, 42)
 	assert_eq(obj.f1(), 42)
 
 	obj.f2(84)
-	
+
 	assert_eq(obj.int_val, 84)
 	assert_eq(obj.f1(), 84)
 

--- a/itest/rust/src/builtin_tests/containers/dictionary_test.rs
+++ b/itest/rust/src/builtin_tests/containers/dictionary_test.rs
@@ -958,6 +958,8 @@ fn dictionary_values_shared_typed() {
 
 #[cfg(since_api = "4.4")]
 mod typed_dictionary_tests {
+    use std::collections::BTreeMap;
+
     use godot::builtin::{array, dict};
     use godot::global::godot_str;
     use godot::meta;
@@ -1114,6 +1116,18 @@ mod typed_dictionary_tests {
             let new_value = value_map(&value);
             dict.set(meta::ref_to_arg(key), meta::owned_into_arg(new_value));
         }
+    }
+
+    #[itest]
+    fn dictionary_map_conversion() {
+        let dict = idict! { "one" => 1i16, "twelve" => 12i16 };
+        let hashmap = HashMap::from([(GString::from("one"), 1), (GString::from("twelve"), 12)]);
+        let btreemap = BTreeMap::from([(GString::from("one"), 1), (GString::from("twelve"), 12)]);
+
+        assert_eq!(HashMap::from_godot(dict.clone()), hashmap);
+        assert_eq!(hashmap.to_godot(), dict);
+        assert_eq!(BTreeMap::from_godot(dict.clone()), btreemap);
+        assert_eq!(btreemap.to_godot(), dict);
     }
 
     // ------------------------------------------------------------------------------------------------------------------------------------------

--- a/itest/rust/src/register_tests/conversion_test.rs
+++ b/itest/rust/src/register_tests/conversion_test.rs
@@ -5,9 +5,12 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+use std::collections::{BTreeMap, HashMap};
 use std::sync::atomic::{AtomicI32, Ordering};
 
 use godot::prelude::*;
+
+use crate::framework::itest;
 
 static SUCCESSFUL_CALLS: AtomicI32 = AtomicI32::new(0);
 
@@ -42,7 +45,32 @@ impl ConversionTest {
     }
 
     #[func]
+    fn hash_to_btree(map: HashMap<u8, Vector2i>) -> BTreeMap<u8, Vector2i> {
+        SUCCESSFUL_CALLS.fetch_add(1, Ordering::SeqCst);
+        map.into_iter().collect()
+    }
+
+    #[func]
+    fn btree_to_hash(map: BTreeMap<GString, Gd<RefCounted>>) -> HashMap<GString, Gd<RefCounted>> {
+        SUCCESSFUL_CALLS.fetch_add(1, Ordering::SeqCst);
+        map.into_iter().collect()
+    }
+
+    #[func]
     fn successful_calls() -> i32 {
         SUCCESSFUL_CALLS.load(Ordering::SeqCst)
     }
+}
+
+#[itest]
+fn test_convert_untyped_dict() {
+    let mut conv = ConversionTest::new_gd();
+
+    let dict = vdict! { 1u8 => Vector2i::new(2, 3), 4u8 => Vector2i::new(5, 6) };
+    let result = conv.call("hash_to_btree", vslice![dict]);
+    assert_eq!(result.to::<VarDictionary>(), dict);
+
+    let dict = vdict! { "one" => &RefCounted::new_gd(), "two" => &RefCounted::new_gd() };
+    let result = conv.call("btree_to_hash", vslice![dict]);
+    assert_eq!(result.to::<VarDictionary>(), dict);
 }


### PR DESCRIPTION
I think it'd be nice to be able to specify `HashMap<K, V>` at the API boundary, instead of having to use `Dictionary<K, V>`.

WDYT? And is this even the right approach?