### PR TITLE
Cut down monomorphizations -> reduce compile time of user crates

### DIFF
--- a/godot-core/src/meta/error/call_error.rs
+++ b/godot-core/src/meta/error/call_error.rs
@@ -11,8 +11,8 @@ use std::fmt;
 use godot_ffi::join_debug;
 
 use crate::builtin::{Variant, VariantType};
+use crate::meta::CallContext;
 use crate::meta::error::{ConvertError, ErasedConvertError};
-use crate::meta::{CallContext, ToGodot};
 use crate::private::PanicPayload;
 use crate::sys;
 
@@ -139,10 +139,10 @@ impl CallError {
     }
 
     /// Checks the Godot side of a varcall (low-level `sys::GDExtensionCallError`).
-    pub(crate) fn check_out_varcall<T: ToGodot>(
+    pub(crate) fn check_out_varcall(
         call_ctx: &CallContext,
         err: sys::GDExtensionCallError,
-        explicit_args: &[T],
+        explicit_args: &[Variant],
         varargs: &[Variant],
     ) -> Result<(), Self> {
         // Always drain stale thread-local errors (even on success), so that entries left over from previous `#[func]` failures
@@ -153,11 +153,11 @@ impl CallError {
             return Ok(());
         }
 
-        let explicit_args_str = join_args(explicit_args.iter().map(|arg| arg.to_variant()));
+        let explicit_args_str = join_args(explicit_args);
         let vararg_str = if varargs.is_empty() {
             String::new()
         } else {
-            format!(", [va] {}", join_args(varargs.iter().cloned()))
+            format!(", [va] {}", join_args(varargs))
         };
         let call_expr = format!("{call_ctx}({explicit_args_str}{vararg_str})");
 
@@ -171,7 +171,7 @@ impl CallError {
         }
 
         let mut arg_types = Vec::with_capacity(explicit_args.len() + varargs.len());
-        arg_types.extend(explicit_args.iter().map(|arg| arg.to_variant().get_type()));
+        arg_types.extend(explicit_args.iter().map(Variant::get_type));
         arg_types.extend(varargs.iter().map(Variant::get_type));
 
         Err(Self::failed_varcall_inner(
@@ -457,8 +457,8 @@ where
     Some(t)
 }
 
-fn join_args(args: impl Iterator<Item = Variant>) -> String {
-    join_debug(args)
+fn join_args(args: &[Variant]) -> String {
+    join_debug(args.iter())
 }
 
 fn plural(count: usize) -> &'static str {

--- a/godot-core/src/meta/mod.rs
+++ b/godot-core/src/meta/mod.rs
@@ -90,7 +90,7 @@ pub use crate::arg_into_ref;
 // Crate-local re-exports. Done like this to prevent rustfmt from mixing with public export.
 mod reexport_crate {
     pub(crate) use super::param_tuple::TupleFromGodot;
-    pub(crate) use super::signature::{CallContext, Signature, varcall_return_checked};
+    pub(crate) use super::signature::{CallContext, sig_params, varcall_return_checked};
     pub(crate) use super::traits::{
         ExtVariantType, GodotFfiVariant, GodotNullableType, ffi_variant_type,
     };

--- a/godot-core/src/meta/signature.rs
+++ b/godot-core/src/meta/signature.rs
@@ -16,8 +16,8 @@ use crate::builtin::Variant;
 use crate::meta::error::{CallError, CallResult, ConvertError, ErrorToGodot};
 use crate::meta::param_tuple::TupleFromGodot;
 use crate::meta::{
-    EngineFromGodot, EngineToGodot, FromGodot, GodotConvert, GodotType, InParamTuple,
-    MethodParamOrReturnInfo, OutParamTuple, ParamTuple, ToGodot,
+    EngineFromGodot, EngineToGodot, FromGodot, GodotType, InParamTuple, MethodParamOrReturnInfo,
+    OutParamTuple, ParamTuple, ToGodot,
 };
 use crate::obj::{GodotClass, ValidatedObject};
 
@@ -60,20 +60,18 @@ pub struct Signature<Params, Ret> {
     _r: PhantomData<Ret>,
 }
 
-impl<Params: ParamTuple, Ret: GodotConvert> Signature<Params, Ret> {
-    pub fn param_names(param_names: &[&str]) -> Vec<MethodParamOrReturnInfo> {
-        assert_eq!(
-            param_names.len(),
-            Params::LEN,
-            "`param_names` should contain one name for each parameter"
-        );
+/// Builds parameter info for `Params`.
+///
+/// Free function rather than a `Signature` method, which would also be generic over `Ret` and thus instantiate the iterator chain once per
+/// `(Params, Ret)` pair.
+pub(crate) fn sig_params<Params: ParamTuple>(param_names: &[&str]) -> Vec<MethodParamOrReturnInfo> {
+    sys::strict_assert_eq!(param_names.len(), Params::LEN);
 
-        param_names
-            .iter()
-            .enumerate()
-            .map(|(index, param_name)| Params::param_info(index, param_name).unwrap())
-            .collect()
-    }
+    param_names
+        .iter()
+        .enumerate()
+        .map(|(index, param_name)| Params::param_info(index, param_name).unwrap())
+        .collect()
 }
 
 /// In-calls (varcall):

--- a/godot-core/src/meta/signature.rs
+++ b/godot-core/src/meta/signature.rs
@@ -167,31 +167,17 @@ impl<Params: OutParamTuple, Ret: EngineFromGodot> Signature<Params, Ret> {
         let call_ctx = CallContext::outbound(class_name, method_name);
         //$crate::out!("out_class_varcall: {call_ctx}");
 
-        let class_fn = sys::interface_fn!(object_method_bind_call);
+        let target = OutVarcall::ClassMethod {
+            method_bind,
+            object_ptr: ValidatedObject::object_ptr(validated_obj.as_ref()),
+        };
 
         // Silence inbound `#[func]` failure prints during this out-call; caller observes the error via the returned `CallError`.
         let _guard = crate::private::OutCallGuard::new();
 
-        let variant = args.with_variants(|explicit_args| {
-            let mut variant_ptrs = Vec::with_capacity(explicit_args.len() + varargs.len());
-            variant_ptrs.extend(explicit_args.iter().map(Variant::var_sys));
-            variant_ptrs.extend(varargs.iter().map(Variant::var_sys));
-
-            unsafe {
-                Variant::new_with_var_uninit_result(|return_ptr| {
-                    let mut err = sys::default_call_error();
-                    class_fn(
-                        method_bind.0,
-                        ValidatedObject::object_ptr(validated_obj.as_ref()),
-                        variant_ptrs.as_ptr(),
-                        variant_ptrs.len() as i64,
-                        return_ptr,
-                        &raw mut err,
-                    );
-
-                    CallError::check_out_varcall(&call_ctx, err, explicit_args, varargs)
-                })
-            }
+        // SAFETY: caller guarantees that `method_bind` matches the object and expects these arguments.
+        let variant = args.with_variants(|explicit_args| unsafe {
+            out_varcall(&call_ctx, target, explicit_args, varargs)
         });
 
         variant.and_then(|v| {
@@ -575,6 +561,98 @@ unsafe fn ptrcall_return<R: EngineToGodot>(
     Ok(())
 }
 
+/// Call target for [`out_varcall`].
+enum OutVarcall {
+    /// `object_ptr` is null for static methods.
+    ClassMethod {
+        method_bind: sys::ClassMethodBind,
+        object_ptr: sys::GDExtensionObjectPtr,
+    },
+    /// Script-virtual override.
+    #[cfg(since_api = "4.3")]
+    ScriptMethod {
+        object_ptr: sys::GDExtensionObjectPtr,
+        method_sname_ptr: sys::GDExtensionConstStringNamePtr,
+    },
+}
+
+impl OutVarcall {
+    /// Dispatches to the engine, writing the result to `return_ptr` and the status to `err`.
+    ///
+    /// # Safety
+    /// The pointers in `self` must be valid, `args` must match the called method's parameters, and `return_ptr` must be uninitialized
+    /// `Variant` storage.
+    #[inline]
+    unsafe fn invoke(
+        self,
+        args: &[sys::GDExtensionConstVariantPtr],
+        return_ptr: sys::GDExtensionUninitializedVariantPtr,
+        err: &mut sys::GDExtensionCallError,
+    ) {
+        let arg_ptr = args.as_ptr();
+        let arg_count = args.len() as i64;
+
+        // SAFETY: guaranteed by the caller.
+        unsafe {
+            match self {
+                Self::ClassMethod {
+                    method_bind,
+                    object_ptr,
+                } => sys::interface_fn!(object_method_bind_call)(
+                    method_bind.0,
+                    object_ptr,
+                    arg_ptr,
+                    arg_count,
+                    return_ptr,
+                    err,
+                ),
+
+                #[cfg(since_api = "4.3")]
+                Self::ScriptMethod {
+                    object_ptr,
+                    method_sname_ptr,
+                } => sys::interface_fn!(object_call_script_method)(
+                    object_ptr,
+                    method_sname_ptr,
+                    arg_ptr,
+                    arg_count,
+                    return_ptr,
+                    err,
+                ),
+            }
+        }
+    }
+}
+
+/// Performs an outbound varcall. Free of `Params`/`Ret`, thus compiled once instead of once per generic instantiation.
+///
+/// # Safety
+/// The pointers in `target` must be valid, and the arguments must match the called method's parameters.
+unsafe fn out_varcall(
+    call_ctx: &CallContext,
+    target: OutVarcall,
+    explicit_args: &[Variant],
+    varargs: &[Variant],
+) -> CallResult<Variant> {
+    // Currently needs allocation in each call. A SmallVec-style stack buffer had almost no effect: malloc/free = few ns, vs. ~540ns engine call.
+    // Might however be worth revisiting in case of allocator pressure under contention (single-threaded #[bench] doesn't show).
+    let mut variant_ptrs = Vec::with_capacity(explicit_args.len() + varargs.len());
+    variant_ptrs.extend(explicit_args.iter().map(Variant::var_sys));
+    variant_ptrs.extend(varargs.iter().map(Variant::var_sys));
+
+    let call = |return_ptr| {
+        let mut err = sys::default_call_error();
+
+        // SAFETY: guaranteed by this function's caller.
+        unsafe { target.invoke(&variant_ptrs, return_ptr, &mut err) };
+
+        CallError::check_out_varcall(call_ctx, err, explicit_args, varargs)
+    };
+
+    // SAFETY: `call` initializes the return pointer whenever it succeeds.
+    unsafe { Variant::new_with_var_uninit_result(call) }
+}
+
 #[cold]
 #[inline(never)]
 fn return_error_dyn(call_ctx: &CallContext, return_ty: &'static str, err: ConvertError) -> ! {
@@ -593,29 +671,14 @@ unsafe fn out_script_virtual_call_inner<Params: OutParamTuple>(
     object_ptr: sys::GDExtensionObjectPtr,
     args: Params,
 ) -> Variant {
-    let object_call_script_method = sys::interface_fn!(object_call_script_method);
+    let target = OutVarcall::ScriptMethod {
+        object_ptr,
+        method_sname_ptr,
+    };
 
-    let variant = args.with_variants(|call_args| {
-        let variant_ptrs: Vec<_> = call_args.iter().map(Variant::var_sys).collect();
-
-        // SAFETY: `object_ptr`/`method_sname_ptr` and the argument pointers are valid per the caller's guarantee; `return_ptr` is uninitialized
-        // result storage that the engine writes on success.
-        unsafe {
-            Variant::new_with_var_uninit_result(|return_ptr| {
-                let mut err = sys::default_call_error();
-                object_call_script_method(
-                    object_ptr,
-                    method_sname_ptr,
-                    variant_ptrs.as_ptr(),
-                    variant_ptrs.len() as i64,
-                    return_ptr,
-                    &raw mut err,
-                );
-
-                CallError::check_out_varcall(call_ctx, err, call_args, &[] as &[Variant])
-            })
-        }
-    });
+    // SAFETY: `object_ptr`/`method_sname_ptr` and the arguments are valid per the caller's guarantee.
+    let variant =
+        args.with_variants(|call_args| unsafe { out_varcall(call_ctx, target, call_args, &[]) });
 
     variant.unwrap_or_else(|err| panic!("{err}"))
 }

--- a/godot-core/src/private.rs
+++ b/godot-core/src/private.rs
@@ -10,6 +10,7 @@ use std::cell::Cell;
 use std::cell::RefCell;
 use std::fmt::Display;
 use std::io::Write;
+use std::mem;
 use std::sync::atomic;
 
 use crate::global::godot_error;
@@ -502,16 +503,52 @@ where
     handle_fallible_call(call_ctx, code);
 }
 
+/// Type-erases `code` and forwards to [`handle_erased_call`], so that the panic chain is compiled once instead of once per `#[func]`.
+///
+/// Returns `true` if the call failed.
+#[inline]
+fn handle_fallible_call<F, R>(call_ctx: &CallContext, code: F) -> bool
+where
+    F: FnOnce() -> CallResult<R> + std::panic::UnwindSafe,
+{
+    let mut code = mem::ManuallyDrop::new(code);
+    let code_ptr = (&raw mut code).cast::<()>();
+
+    // SAFETY: `code` outlives the call, and `invoke_erased` reads it exactly once.
+    unsafe { handle_erased_call(call_ctx, invoke_erased::<F, R>, code_ptr) }
+}
+
+/// Invokes the fallible call stored at `data`, discarding its return value.
+///
+/// Instantiated per `#[func]`, but only as a plain `fn` pointer -- unlike `&mut dyn FnMut`, this needs neither a vtable nor drop glue, which
+/// together made up most of the binary-size cost of erasing the call.
+///
+/// # Safety
+/// `data` must point to a live `ManuallyDrop<F>` that is read exactly once.
+unsafe fn invoke_erased<F, R>(data: *mut ()) -> CallResult<()>
+where
+    F: FnOnce() -> CallResult<R>,
+{
+    // SAFETY: `data` points to a live, not-yet-read `ManuallyDrop<F>`, which has the same layout as `F`.
+    let code = unsafe { data.cast::<F>().read() };
+
+    code().map(|_| ())
+}
+
 /// Common error handling for fallible calls, handling detectable errors and user panics.
 ///
 /// Returns `true` if the call failed, `false` if it succeeded.
 ///
 /// On failure, the [`CallError`] is stored in thread-local storage for later retrieval via [`call_error_take`].
-fn handle_fallible_call<F, R>(call_ctx: &CallContext, code: F) -> bool
-where
-    F: FnOnce() -> CallResult<R> + std::panic::UnwindSafe,
-{
-    let outcome: Result<CallResult<R>, PanicPayload> = handle_panic(call_ctx, code);
+///
+/// # Safety
+/// `data` must be a valid argument for `code`, which is invoked exactly once.
+unsafe fn handle_erased_call(
+    call_ctx: &CallContext,
+    code: unsafe fn(*mut ()) -> CallResult<()>,
+    data: *mut (),
+) -> bool {
+    let outcome = handle_panic(call_ctx, || unsafe { code(data) });
 
     let call_error = match outcome {
         // All good.

--- a/godot-core/src/private.rs
+++ b/godot-core/src/private.rs
@@ -630,8 +630,7 @@ mod tests {
             argument: 0,
             expected: 0,
         };
-        let result =
-            CallError::check_out_varcall(&call_ctx, ok_err, &[] as &[crate::builtin::Variant], &[]);
+        let result = CallError::check_out_varcall(&call_ctx, ok_err, &[], &[]);
         assert!(result.is_ok(), "successful call must return Ok");
 
         // TLS must now be empty.
@@ -658,12 +657,7 @@ mod tests {
             argument: 2,
             expected: 3,
         };
-        let result = CallError::check_out_varcall(
-            &call_ctx,
-            godot_err,
-            &[] as &[crate::builtin::Variant],
-            &[],
-        );
+        let result = CallError::check_out_varcall(&call_ctx, godot_err, &[], &[]);
         let err = result.expect_err("must fail");
 
         // Must be a direct Godot error, not a wrapped source error.

--- a/godot-core/src/registry/callbacks.rs
+++ b/godot-core/src/registry/callbacks.rs
@@ -117,7 +117,7 @@ pub unsafe extern "C" fn recreate<T: cap::GodotDefault>(
     _class_userdata: *mut std::ffi::c_void,
     object: sys::GDExtensionObjectPtr,
 ) -> sys::GDExtensionClassInstancePtr {
-    create_rust_part_for_existing_godot_part(T::__godot_user_init, object, |_| {})
+    create_rust_part_for_existing_godot_part(T::__godot_user_init, object, false)
         .unwrap_or(std::ptr::null_mut())
 }
 
@@ -143,24 +143,11 @@ where
     let base_class_id = T::Base::class_id();
     let base_ptr = unsafe { sys::classdb_construct_object(base_class_id.string_sys()) };
 
-    let postinit = |base_ptr| {
-        #[cfg(since_api = "4.4")]
-        if notify_postinitialize {
-            // Should notify it with a weak pointer, during `NOTIFICATION_POSTINITIALIZE`, ref-counted object is not yet fully-initialized.
-            #[cfg(before_api = "4.7")]
-            let mut obj = unsafe { Gd::<Object>::from_obj_sys_weak(base_ptr) };
-
-            // Since 4.7 base comes in fully initialized.
-            #[cfg(since_api = "4.7")]
-            let mut obj = unsafe { Gd::<Object>::from_obj_sys(base_ptr) };
-
-            obj.notify(crate::classes::notify::ObjectNotification::POSTINITIALIZE);
-            #[cfg(before_api = "4.7")]
-            obj.drop_weak();
-        }
-    };
-
-    match create_rust_part_for_existing_godot_part(make_user_instance, base_ptr, postinit) {
+    match create_rust_part_for_existing_godot_part(
+        make_user_instance,
+        base_ptr,
+        notify_postinitialize,
+    ) {
         Ok(_extension_ptr) => Ok(base_ptr),
         Err(payload) => {
             // Creation of extension object failed; we must now also destroy the base object to avoid leak.
@@ -179,15 +166,16 @@ where
 /// With godot-rust, custom objects consist of two parts: the Godot object and the Rust object. This method takes the Godot part by pointer,
 /// creates the Rust part with the supplied state, and links them together. This is used for both brand-new object creation and hot reload.
 /// During hot reload, Rust objects are disposed of and then created again with updated code, so it's necessary to re-link them to Godot objects.
-fn create_rust_part_for_existing_godot_part<T, F, P>(
+///
+/// `notify_postinitialize` is a `bool` rather than a callback, so that this function is not instantiated twice per class.
+fn create_rust_part_for_existing_godot_part<T, F>(
     make_user_instance: F,
     base_ptr: sys::GDExtensionObjectPtr,
-    postinit: P,
+    notify_postinitialize: bool,
 ) -> Result<sys::GDExtensionClassInstancePtr, PanicPayload>
 where
     T: GodotClass,
     F: FnOnce(Base<T::Base>) -> T,
-    P: Fn(sys::GDExtensionObjectPtr),
 {
     let class_id = T::class_id();
     //out!("create callback: {}", class_id.backing);
@@ -225,7 +213,24 @@ where
         );
     }
 
-    postinit(base_ptr);
+    // Before Godot 4.4, the engine sends this notification itself.
+    #[cfg(before_api = "4.4")]
+    let _ = notify_postinitialize;
+
+    #[cfg(since_api = "4.4")]
+    if notify_postinitialize {
+        // Notify through a weak pointer: during `NOTIFICATION_POSTINITIALIZE`, a ref-counted object is not yet fully initialized.
+        #[cfg(before_api = "4.7")]
+        let mut obj = unsafe { Gd::<Object>::from_obj_sys_weak(base_ptr) };
+
+        // Since 4.7 base comes in fully initialized.
+        #[cfg(since_api = "4.7")]
+        let mut obj = unsafe { Gd::<Object>::from_obj_sys(base_ptr) };
+
+        obj.notify(crate::classes::notify::ObjectNotification::POSTINITIALIZE);
+        #[cfg(before_api = "4.7")]
+        obj.drop_weak();
+    }
 
     // Mark initialization as complete, now that user constructor has finished.
     #[cfg(before_api = "4.7")]

--- a/godot-core/src/registry/method.rs
+++ b/godot-core/src/registry/method.rs
@@ -9,7 +9,7 @@ use godot_ffi as sys;
 use sys::interface_fn;
 
 use crate::builtin::{StringName, Variant};
-use crate::meta::{ClassId, GodotConvert, ParamTuple, Signature};
+use crate::meta::{ClassId, GodotConvert, ParamTuple, sig_params};
 use crate::obj::GodotClass;
 use crate::registry::info::{MethodFlags, PropertyInfo};
 
@@ -82,7 +82,7 @@ impl ClassMethodInfo {
         default_arguments: Vec<Variant>,
     ) -> Self {
         let return_value = MethodParamOrReturnInfo::for_return::<Ret>();
-        let arguments = Signature::<Params, Ret>::param_names(param_names);
+        let arguments = sig_params::<Params>(param_names);
 
         assert!(
             default_arguments.len() <= arguments.len(),


### PR DESCRIPTION
Follow-up work to:
- #1587
- #1677

Several functions in the registration and call paths were generic over parameters they never read, so the compiler emitted the same machine code once per `(Params, Ret)` pair. This PR removes those parameters and type-erases the panic handling below `#[func]` calls. 


## Results

### Compile time and size
| metric                                  | master     | this PR    | Δ                             |
|-----------------------------------------|------------|------------|-------------------------------|
| `itest`, LLVM lines                     | 2,240,976  | 1,846,572  | **-17.6%**                    |
| `itest`, generic instantiations [^inst] | 93,083     | 94,668     | +1.7%                         |
| `libitest.so`, debug                    | 77,983,648 | 65,383,496 | **-16.2%**                    |
| `libitest.so`, release + stripped       | 10,229,976 | 9,955,744  | -2.7%                         |
| `itest` rebuild, CPU time (median)      | 16.65 s    | 15.11 s    | **-9%**                       |
| `itest` rebuild, wall time [^wall]      | 10.19 s    | 9.43 s     | -5 to -8%                     |
| `godot-core`, LLVM lines                | 366,923    | 366,202    | -0.2%                         |
| `godot-core`, instantiations            | 22,817     | 22,797     | -0.1%                         |
| `godot-core` rebuild, CPU time          | 6.50 s     | 6.38 s     | -1.8% <sub>(-2.9..+0.9)</sub> |
| `godot-core` rebuild, wall time         | 5.83 s     | 5.85 s     | -1.3% <sub>(-1.4..+1.5)</sub> |
| `godot-core` codegen-full build, CPU    | 32.19 s    | 32.35 s    | +0.5% <sub>(-1.0..+0.7)</sub> |
| `godot-core` codegen-full build, wall   | 29.33 s    | 29.41 s    | +0.1% <sub>(-1.5..+0.9)</sub> |

### Runtime
| benchmark                             | master   | this PR  | Δ 1st run [^runs] | Δ 2nd run |
|---------------------------------------|----------|----------|-------------------|-----------|
| `class_engine_out_varcall` [^abs]     | 316 ns   | 327 ns   | +3.3%             | +1.0%     |
| `class_engine_out_varcall_arg` [^abs] | 537 ns   | 563 ns   | +5.3%             | -0.7%     |
| `class_user_script_virtual` [^abs]    | 532 ns   | 539 ns   | +1.7%             | +0.3%     |
| `class_user_refc_call_mut` [^abs]     | 328 ns   | 329 ns   | +0.4%             | -2.3%     |
| `class_user_refc_ptrcall` [^abs]      | 9,763 ns | 9,803 ns | +0.6%             | +0.5%     |
| `class_user_refc_life` [^abs]         | 766 ns   | 766 ns   | -0.1%             | +0.6%     |
| `class_user_bind_mut` [^ctrl]         | 23 ns    | 27 ns    | +16.7%            | -0.2%     |

[^runs]: For runtime, I made two runs on the same `.so` file. The first shows regressions on both out-varcall benchmarks, the second shows nothing. I used a control row (last), which **also** had +16.7% in every round of the first session, -0.2% in the second -- on code unchanged by the PR. That one only ever lands on ~22.4 ns or ~26.2 ns depending on binary and session, and small numbers make it dramatic. The 4ns difference seems to recur as a discrete step (e.g. code placement relative to a cache line). Harness, arm ordering and the file swap were ruled out (each within ±1.7%).

[^inst]: Instantiation count goes slightly up while emitted code goes down: a few large instantiations are replaced by more, much smaller ones.

[^abs]: These two columns give scale only and are from the 1st run (the 2nd run's own absolutes, 1-2% off, are not shown). Neither Δ follows from them arithmetically -- see below how a Δ is computed.

[^wall]: Wall time depends on how well the build parallelizes and on machine state; two sessions measured -7.5% and -5.4%, with the master baseline itself differing by 19% between them. CPU time is the stable figure -- -9.3% and -8.9% in the same two sessions.

[^ctrl]: Control benchmark -- it tests code not changed here, so both Δ columns _should_ read 0%.


## Conclusion

For user crates, compile times improve by up to 9%, and binary sizes up to 16% (or 2.7% in release). Note that `itest` isn't a typical user crate, e.g. one class has 491 `#[func]`s, which benefits from changes in this PR. So users might see smaller gains.

Runtime performance is unchanged. (I originally introduced a regression, which could be fixed by making `OutVarcall` #[inline]` -- important to have benchmarks).

`godot-core` compile times aren't affected by changes here, as those specific monomorphizations aren't used much internally. Engine methods use mostly ptrcall, while this PR focuses on varcall and panic paths, which are exercised more in user code.

## How this was measured

Linux, default features, API version 4.7, runtime version `4.8.dev.custom_build.23d42bdf6`.
cargo 1.98.0-nightly (`0b1123a48 2026-06-01`)

Compile time, per arm: `cargo clean -p itest` then `cargo build -p itest`, arms interleaved over 5 rounds, median reported, dependencies pre-built so only `itest` is timed. LLVM lines from `cargo llvm-lines -p itest --lib`, sizes from the resulting `.so` (release figure after `strip -s`).

Runtime: `cargo build -p itest --release`, the release library copied over `target/debug/libitest.so` (a debug Godot binary always loads the `.debug` entry of `itest.gdextension`), then `godot --headless -- "[]"` from `itest/godot`. A round runs both arms back to back with the order mirrored between rounds (8 rounds in the 1st session, 4 in the 2nd), and each round yields one paired delta per benchmark from the `min` column -- 540 ns against 567 ns in that round is +5.0%. The reported Δ is the median over those per-round deltas, which is why it does not equal the ratio of the two absolute columns.

