### PR TITLE
Adapt `#[var(no_get)]` test to GDScript 4.8 abort-on-error

### DIFF
--- a/godot-core/src/global/print.rs
+++ b/godot-core/src/global/print.rs
@@ -317,7 +317,7 @@ pub fn __threadsafe_print(message: String, rich: bool) {
 #[macro_export]
 macro_rules! godot_warn {
     ($fmt:literal $(, $args:expr_2021)* $(,)?) => {
-        $crate::inner_godot_msg!($crate::global::PrintLevel::Warn; $fmt $(, $args)*);
+        $crate::inner_godot_msg!($crate::global::PrintLevel::Warn; $fmt $(, $args)*)
     };
 }
 
@@ -333,7 +333,7 @@ macro_rules! godot_warn {
 #[macro_export]
 macro_rules! godot_error {
     ($fmt:literal $(, $args:expr_2021)* $(,)?) => {
-        $crate::inner_godot_msg!($crate::global::PrintLevel::Error; $fmt $(, $args)*);
+        $crate::inner_godot_msg!($crate::global::PrintLevel::Error; $fmt $(, $args)*)
     };
 }
 
@@ -348,7 +348,7 @@ macro_rules! godot_error {
 #[macro_export]
 macro_rules! godot_script_error {
     ($fmt:literal $(, $args:expr_2021)* $(,)?) => {
-        $crate::inner_godot_msg!($crate::global::PrintLevel::ScriptError; $fmt $(, $args)*);
+        $crate::inner_godot_msg!($crate::global::PrintLevel::ScriptError; $fmt $(, $args)*)
     };
 }
 

--- a/godot-core/src/obj/dyn_gd.rs
+++ b/godot-core/src/obj/dyn_gd.rs
@@ -163,9 +163,7 @@ use crate::{meta, sys};
 /// # let some_node = Node::new_alloc();
 /// match some_node.try_dynify::<dyn Pushable>() {
 ///     Ok(dyn_gd) => (),
-///     Err(some_node) => {
-///         godot_warn!("Failed to convert {some_node} into dyn Pushable!");
-///     }
+///     Err(some_node) => godot_warn!("Failed to convert {some_node} into dyn Pushable!"),
 /// }
 /// ```
 ///

--- a/godot-macros/src/class/data_models/field_var.rs
+++ b/godot-macros/src/class/data_models/field_var.rs
@@ -565,12 +565,10 @@ impl GetterSetterImpl {
             Callable::from_fn(#callable_name, move |_args| {
                 match ::godot::obj::Gd::<Self>::try_from_instance_id(instance_id) {
                     Ok(mut obj) => (#tool_button_fn)(&mut *obj.bind_mut()),
-                    Err(_) => {
-                        ::godot::global::godot_error!(
-                            "tool button `{}` invoked on freed instance {:?}",
-                            #callable_name, instance_id,
-                        );
-                    }
+                    Err(_) => ::godot::global::godot_error!(
+                        "tool button `{}` invoked on freed instance {:?}",
+                        #callable_name, instance_id,
+                    ),
                 }
             })
         };

--- a/itest/godot/ManualFfiTests.gd
+++ b/itest/godot/ManualFfiTests.gd
@@ -73,25 +73,29 @@ func test_var_accessors():
 
 	obj.free()
 
+# Reading a #[var(no_get)] property panics in Rust -> test GDScript response.
 func test_var_no_get_panics_on_read():
-	mark_test_pending()
-
 	var obj = VarAccessors.new()
-	# Getter is registered (panicking), unlike old behavior where no getter existed.
-	assert_that(obj.has_method("__disabled_get_g_noget"), "panicking getter should be registered")
-
 	obj.g_noget = 7
+
+	# Read in a lambda: an abort unwinds only the innermost GDScript frame, so the test can still clean up.
+	var trace := []
+	var read := func():
+		trace.append(obj.g_noget)
+		trace.append("end")
+
 	Engine.print_error_messages = false
-	var val = obj.g_noget # Getter panics in Rust; returns default, execution continues.
+	read.call()
 	Engine.print_error_messages = true
 
-	# Panic was caught: returned default Variant (null) instead of actual field value (7).
-	assert_eq(val, null, "no_get getter should return default after panic")
-	# The field itself is intact.
-	assert_eq(obj.gdscript_get("g"), 7, "actual field value should be preserved")
+	# Godot 4.8 propagates the getter's call error to the property access, which aborts the GDScript function. New in 4.8; before it returned
+	# null -- see https://github.com/godotengine/godot/pull/122596. Also, release builds don't abort functions on call errors.
+	if Engine.get_version_info().minor < 8 || runs_release():
+		assert_eq(trace, [null, "end"], "property read should return null and continue")
+	else:
+		assert_eq(trace, [], "property read should abort the reading function")
 
 	obj.free()
-	mark_test_succeeded()
 
 func test_export():
 	var obj = HasProperty.new()

--- a/itest/godot/SpecialTests.gd
+++ b/itest/godot/SpecialTests.gd
@@ -38,7 +38,7 @@ func test_collision_object_2d_input_event():
 	root.add_child(window)
 
 	assert_that(not collision_object.input_event_called(), "Input event should not be propagated")
-	assert_eq(collision_object.get_viewport(), null, "Collision viewport should be null")
+	assert_eq(collision_object.get_captured_viewport(), null, "Collision viewport should be null")
 
 	var event := InputEventMouseMotion.new()
 	event.global_position = Vector2.ZERO
@@ -53,7 +53,7 @@ func test_collision_object_2d_input_event():
 	await root.get_tree().physics_frame
 
 	assert_that(collision_object.input_event_called(), "Input event should be propagated")
-	assert_eq(collision_object.get_viewport(), window, "Collision viewport should be the (non-null) window")
+	assert_eq(collision_object.get_captured_viewport(), window, "Collision viewport should be the (non-null) window")
 
 	window.queue_free()
 

--- a/itest/rust/src/builtin_tests/containers/variant_test.rs
+++ b/itest/rust/src/builtin_tests/containers/variant_test.rs
@@ -844,23 +844,11 @@ where
         VariantOperator::GREATER_EQUAL,
     ));
 
-    let true_rels;
-    let false_rels;
-
-    match expected_order {
-        Ordering::Less => {
-            true_rels = [ne, lt, le];
-            false_rels = [eq, gt, ge];
-        }
-        Ordering::Equal => {
-            true_rels = [eq, le, ge];
-            false_rels = [ne, lt, gt];
-        }
-        Ordering::Greater => {
-            true_rels = [ne, gt, ge];
-            false_rels = [eq, lt, le];
-        }
-    }
+    let (true_rels, false_rels) = match expected_order {
+        Ordering::Less => ([ne, lt, le], [eq, gt, ge]),
+        Ordering::Equal => ([eq, le, ge], [ne, lt, gt]),
+        Ordering::Greater => ([ne, gt, ge], [eq, lt, le]),
+    };
 
     for rel in true_rels {
         assert!(

--- a/itest/rust/src/object_tests/virtual_methods_niche_test.rs
+++ b/itest/rust/src/object_tests/virtual_methods_niche_test.rs
@@ -85,7 +85,7 @@ impl CollisionObject2DTest {
     }
 
     #[func]
-    fn get_viewport(&self) -> Variant {
+    fn get_captured_viewport(&self) -> Variant {
         self.viewport
             .as_ref()
             .map(ToGodot::to_variant)

--- a/itest/rust/src/register_tests/var_test.rs
+++ b/itest/rust/src/register_tests/var_test.rs
@@ -7,7 +7,7 @@
 use godot::global::godot_str;
 use godot::prelude::*;
 
-use crate::framework::{expect_panic, itest};
+use crate::framework::{expect_panic, itest, suppress_godot_print};
 
 #[derive(GodotClass)]
 #[class(init)]
@@ -192,6 +192,18 @@ fn var_orthogonal_getters_setters() {
     assert_eq!(obj.bind().my_custom_get(), 4 + 8 + 9); // d+h+j.
     assert!(obj.has_method("my_custom_get"));
     assert!(obj.has_method("my_custom_set"));
+
+    obj.free();
+}
+
+#[itest]
+fn var_no_get_panics_on_read() {
+    let mut obj = VarAccessors::new_alloc();
+    obj.set("g_noget", &7.to_variant());
+
+    // Getter is registered but panics, so the read yields nil. The field itself is intact.
+    assert_eq!(suppress_godot_print(|| obj.get("g_noget")), Variant::nil());
+    assert_eq!(obj.bind().g_noget, 7);
 
     obj.free();
 }


### PR DESCRIPTION
Godot 4.8 propagates a getter's call error to the property access, which aborts the reading function. Before, the read returned `null` and execution continued. A panicking Rust getter -- as registered for `#[var(no_get)]` -- is now observable in GDScript.

Also fixes a clippy lint, a method naming collision closes #1674.