### PR TITLE
Set lower bounds of dependencies down to specific patch versions.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,28 +31,28 @@ rust-version = "1.94"
 gdextension-api = { version = "0.5.0", git = "https://github.com/godot-rust/godot4-prebuilt", branch = "release-v0.5" }
 
 # Main library features.
-glam = { version = "0.32", features = ["debug-glam-assert"] }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+glam = { version = "<=0.32.1", features = ["debug-glam-assert"] }
+serde = { version = "<=1.0.229", features = ["derive"] }
+serde_json = "<=1.0.151"
 
 # Related to tooling/build setup.
 # * regex: not used for unicode parsing -> features unicode-bool + unicode-gencat are enabled instead of unicode-perl.
 #          'unicode-gencat' needed for \d, see https://docs.rs/regex/latest/regex/#unicode-features.
-libc = "0.2.183"
-regex = { version = "1.12", default-features = false, features = ["std", "unicode-bool", "unicode-gencat"] }
-which = "8"
+libc = "<=0.2.183"
+regex = { version = "<=1.12.4", default-features = false, features = ["std", "unicode-bool", "unicode-gencat"] }
+which = "<=8.0.5"
 
 # Macros and codegen. Minimal versions compatible with -Zminimal-versions.
 # * proc_macro2: Literal::c_string() added in 1.0.80.
 # * quote: 1.0.37 allows tokenizing CStr.
 # * venial: 0.6.1 contains some bugfixes.
-heck = "0.5"
-litrs = { version = "1.0", features = ["proc-macro2"] }
-markdown = "1.0.0"
-nanoserde = "0.2"
-proc-macro2 = "1.0.106"
-quote = "1.0.45"
-venial = "0.6.1"
+heck = "<=0.5.0"
+litrs = { version = "<=1.0.0", features = ["proc-macro2"] }
+markdown = "<=1.0.0"
+nanoserde = "<=0.2.1"
+proc-macro2 = "<=1.0.106"
+quote = "<=1.0.45"
+venial = "<=0.6.1"
 
 # Testing (godot-cell, itest).
 proptest = "1.10.0"


### PR DESCRIPTION
For time travellers - recently we have seen supply chain attack on popular rust package; attackers published new patch version of the crate in question with malicious dependency attached (which was executing malicious script in `build.rs` yada yada, you know the rest).

Pinning upper bounds of given crates will make sure that gdext won't install newest version by itself.


Upper bounds has been picked by checking latest version of dependencies (manually).

Glam is at 0.33 now (I should check if it is worth to bother with update tho) - we are at 0.32
regex it as 0.13 now - we are at 0.12

serde && serde json are tricky and might result in treadmill work.
which was updated last month

markdown was updated to 1.0.0 last year and haven't seen any activity since then.
litrs was updated to 1.0.0 10 months ago (its maintainer even made PR to update it in gdext!)

heck is at 0.5.0 and has been for over 2 years