### PR TITLE
Benchmarks: run separately from itest, reduce noise

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,13 @@
 # Skips type/variable debug metadata while keeping file:line info for backtraces. Saves 1-4% build time on clean dev builds.
 debug = "line-tables-only"
 
+# Build for `check.sh bench`. A single codegen unit + fat LTO prevents unrelated code from being compiled differently in two builds,
+# which otherwise moves benchmarks by several percent. See the module docs of itest/rust/src/framework/bencher.rs.
+[profile.itest-bench]
+inherits = "release"
+lto = "fat"
+codegen-units = 1
+
 [workspace]
 resolver = "2"
 members = [

--- a/check.sh
+++ b/check.sh
@@ -26,10 +26,11 @@ If no commands are specified, the following commands will be run:
 
 Commands:
     fmt           format code, fail if bad
-    test          run unit tests (no Godot needed)
     itest         run integration tests (from within Godot)
+    test          run unit tests (no Godot needed)
     test-web-t    run unit tests on web, threaded (requires node.js and emcc)
     test-web-nt   run unit tests on web, nothreads (requires node.js and emcc)
+    bench         run benchmarks (from within Godot)
     clippy        validate clippy lints
     klippy        validate + fix clippy
     doc           generate docs for 'godot' crate
@@ -38,8 +39,8 @@ Commands:
 Options:
     -h, --help               print this help text
     --double                 run check with double-precision (implies 'api-custom' feature)
-    -f, --filter <arg>       only run integration tests which contain any of the
-                             args (comma-separated). requires itest.
+    -f, --filter <arg>       only run integration tests or benchmarks which contain
+                             any of the args (comma-separated). requires itest or bench.
         --editor             run integration tests in editor mode (passes -e to Godot). requires itest.
     -a, --api-version <ver>  specify the Godot API version to use (e.g. 4.3, 4.3.1).
     --full                   run check with full codegen (all classes)
@@ -195,9 +196,19 @@ function cmd_test() {
 }
 
 function cmd_itest() {
+    # Prefix for the Godot invocation, empty here; see cmd_bench(). Visible to run_itest_in_godot() through dynamic scoping.
+    local godotLauncher=()
+
     findGodot && \
         run cargo build -p itest "${extraCargoArgs[@]}" || return 1
 
+    run_itest_in_godot
+}
+
+# Runs the already-built library in Godot, checking the log for errors that are not reflected in the exit code.
+# Arguments are passed to the Godot project, before the test filter.
+function run_itest_in_godot() {
+    local projectArgs=("$@")
     # Keep in sync with: .github/composite/godot-itest/action.yml (steps "Run Godot integration tests" and "Check for memory leaks").
 
     local logFile
@@ -209,7 +220,7 @@ function cmd_itest() {
     fi
 
     cd itest/godot || return 1
-    "$godotBin" "${editorArgs[@]}" --headless -- "[${extraArgs[@]}]" 2>&1 \
+    "${godotLauncher[@]}" "$godotBin" "${editorArgs[@]}" --headless -- "${projectArgs[@]}" "[${extraArgs[@]}]" 2>&1 \
     | tee "$logFile"
 
     # PIPESTATUS[0] is Godot's exit code; $? would only give tee's exit code (masking crashes).
@@ -270,6 +281,78 @@ function cmd_dok() {
 }
 
 ################################################################################
+# Benchmarks
+################################################################################
+
+# The only platform-specific part of `bench`. All optional, on outside Linux the reads will be empty and `setarch` is absent, so benchmarks
+# still run, just noisier. Both CPU knobs need root, hence warnings only. User could additionally pin cores (e.g. `taskset -c 0-7 check.sh bench`,
+# depending on CPU topology). Sets $godotLauncher for the caller.
+function prepare_bench_env() {
+    # Address space randomization moves heap and stack between runs, changing cache conflicts and thus timings.
+    command -v setarch > /dev/null && godotLauncher=(setarch --addr-no-randomize)
+
+    local governor boost noTurbo
+    read -r governor < /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor 2>/dev/null
+    read -r boost < /sys/devices/system/cpu/cpufreq/boost 2>/dev/null      # amd-pstate, acpi-cpufreq.
+    read -r noTurbo < /sys/devices/system/cpu/intel_pstate/no_turbo 2>/dev/null
+
+    if [[ -n "$governor" && "$governor" != "performance" ]]; then
+        logf "${YELLOW}Warning: CPU governor is '$governor', not 'performance'; clock speed varies with load.${END}\n"
+    fi
+    if [[ "$boost" == "1" || "$noTurbo" == "0" ]]; then
+        logf "${YELLOW}Warning: CPU boost is enabled; clock speed drops as the CPU heats up over the run.${END}\n"
+    fi
+}
+
+# On top of the `itest-bench` profile (see Cargo.toml). Alignment pins code placement across builds -- without it, untouched benchmarks move
+# by several percent. It pads every function, spreading code over more cache lines, so numbers compare across builds but are not absolute.
+BENCH_RUSTFLAGS="-C llvm-args=-align-all-functions=6 -C llvm-args=-align-all-nofallthru-blocks=5"
+
+# Library copied to target/debug by cmd_bench(), as an absolute path since the traps can fire with cwd inside the Godot project.
+benchLib=
+
+function cmd_bench() {
+    # Prefix for the Godot invocation, filled in by prepare_bench_env(). Visible to run_itest_in_godot() through dynamic scoping.
+    local godotLauncher=()
+
+    findGodot || return 1
+    prepare_bench_env
+
+    log "Building with RUSTFLAGS=\"$BENCH_RUSTFLAGS\" (replaces RUSTFLAGS from the environment)."
+    RUSTFLAGS="$BENCH_RUSTFLAGS" run cargo build -p itest --profile itest-bench "${extraCargoArgs[@]}" || return 1
+
+    # Exactly one of these exists, depending on the platform.
+    local lib
+    for lib in target/itest-bench/libitest.{so,dylib} target/itest-bench/itest.dll; do
+        [[ -f "$lib" ]] && break
+        lib=
+    done
+
+    # Else Godot silently loads a stale debug lib.
+    if [[ -z "$lib" ]]; then
+        log "No itest library in target/itest-bench; 'bench' does not support a custom CARGO_TARGET_DIR or --target."
+        return 1
+    fi
+
+    mkdir -p target/debug || return 1
+    benchLib="$PWD/target/debug/${lib##*/}"
+
+    # If a copy is left over, later `itest` runs load the Release lib, because cargo re-creates its hardlink only if that path is absent.
+    # So: remove it on return (disarming the handlers there) and on interrupt (where they must exit) -- otherwise the shell resumes and
+    # evaluates the log of the aborted run.
+    trap 'trap - INT TERM; rm -f "$benchLib"' RETURN
+    trap 'rm -f "$benchLib"; exit 130' INT
+    trap 'rm -f "$benchLib"; exit 143' TERM
+
+    # itest.gdextension points to target/debug, so copy there (like CI). Cargo hardlinks its artifact to that path, so copying onto it
+    # would write through into the artifact itself; unlinking first gives the copy its own inode.
+    rm -f "$benchLib" && cp "$lib" "$benchLib" || return 1
+
+    # `--bench-only` skips the test suite, which the benchmarks don't depend on.
+    run_itest_in_godot --bench-only
+}
+
+################################################################################
 # Argument parsing
 ################################################################################
 
@@ -300,11 +383,11 @@ while [[ $# -gt 0 ]]; do
             extraCargoArgs+=("--features" "godot/__codegen-full,itest/codegen-full")
             docCargoArgs+=("--features" "godot/__codegen-full")
             ;;
-        fmt | test | itest | test-web-t | test-web-nt | clippy | klippy | doc | dok)
+        fmt | test | itest | bench | test-web-t | test-web-nt | clippy | klippy | doc | dok)
             cmds+=("$arg")
             ;;
         -f | --filter)
-            if [[ "${cmds[*]}" =~ itest ]]; then
+            if [[ "${cmds[*]}" =~ itest || "${cmds[*]}" =~ bench ]]; then
                 if [[ -z "$2" ]]; then
                     log "-f/--filter requires an argument."
                     exit 2
@@ -313,7 +396,7 @@ while [[ $# -gt 0 ]]; do
                 extraArgs+=("$2")
                 shift
             else
-                log "-f/--filter requires 'itest' to be specified as a command."
+                log "-f/--filter requires 'itest' or 'bench' to be specified as a command."
                 exit 2
             fi
             ;;

--- a/godot-bindings/src/lib.rs
+++ b/godot-bindings/src/lib.rs
@@ -133,7 +133,6 @@ pub use depend_on_custom_json::*;
 // Prebuilt mode: Reuse existing files
 
 #[cfg(not(any(feature = "api-custom", feature = "api-custom-json")))]
-#[path = ""]
 mod depend_on_prebuilt {
     use super::*;
     use crate::import::prebuilt;

--- a/itest/godot/TestRunner.gd
+++ b/itest/godot/TestRunner.gd
@@ -24,18 +24,24 @@ func _ready():
 	await get_tree().physics_frame
 
 	var allow_focus := true
+	var bench_only := false
 	var filters: Array = []
 	var unrecognized_args: Array = []
 	for arg in OS.get_cmdline_user_args():
 		match arg:
 			"--disallow-focus":
 				allow_focus = false
+			"--bench-only":
+				bench_only = true
 			_:
 				if not arg.begins_with("[") or not arg.ends_with("]"):
 					unrecognized_args.push_back(arg)
 
-				var args = arg.lstrip("[").rstrip("]").split(",")
-				filters.append_array(args)
+				# Empty entries are dropped, so that an unfiltered run has no filters at all: "[]" would otherwise split into one empty
+				# string, which matches everything but is not an empty filter list.
+				for filter in arg.lstrip("[").rstrip("]").split(","):
+					if not filter.is_empty():
+						filters.push_back(filter)
 
 	if unrecognized_args:
 		push_error("Unrecognized arguments: ", unrecognized_args)
@@ -43,6 +49,12 @@ func _ready():
 		return
 
 	var rust_runner = IntegrationTests.new()
+
+	# Benchmarks don't depend on the test run; skip it, so their output isn't buried under hundreds of test lines.
+	if bench_only:
+		var bench_success: bool = rust_runner.run_all_benchmarks(self, filters)
+		get_tree().quit(0 if bench_success else 1)
+		return
 
 	var gdscript_suites: Array = [] if editor_only_run else [
 		load("res://ManualFfiTests.gd").new(),
@@ -65,10 +77,11 @@ func _ready():
 	var property_tests = load("res://gen/GenPropertyTests.gd").new()
 
 	# Run benchmarks after all synchronous and asynchronous tests have completed.
-	# Skipped in editor-only mode -- benchmarks are not editor-specific.
+	# Skipped in editor-only mode (benchmarks are not editor-specific) and in filtered runs.
 	var run_benchmarks = func (success: bool):
-		if success and not editor_only_run:
-			rust_runner.run_all_benchmarks(self)
+		# A filtered run targets specific tests; the `bench` command is the way to run benchmarks.
+		if success and not editor_only_run and filters.is_empty():
+			success = rust_runner.run_all_benchmarks(self, filters)
 
 		var exit_code: int = 0 if success else 1
 		get_tree().quit(exit_code)

--- a/itest/rust/src/benchmarks/anchor_bench.rs
+++ b/itest/rust/src/benchmarks/anchor_bench.rs
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) godot-rust; Bromeon and contributors.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+//! Benchmarks over pure Rust code, ranging from sub-nanosecond (integer multiply) to 100s-of-nanoseconds (hashmap build), covering similar
+//! range to Godot benchmarks. Their duration cannot change between commits, so whatever they move by is measurement error. The runner finds them
+//! through the `anchor_` prefix and reports their spread as _noise floor_.
+//!
+//! Such a floor covers one run. Two builds may also differ in code layout, which shifts anchors' absolute times -- comparing those is manual.
+
+use std::collections::HashMap;
+use std::hash::{BuildHasherDefault, DefaultHasher};
+use std::hint::black_box;
+
+use crate::framework::bench;
+
+#[bench]
+fn anchor_int_mul() -> u64 {
+    black_box(0x9e3779b97f4a7c15u64).wrapping_mul(black_box(6364136223846793005))
+}
+
+#[bench]
+fn anchor_vec_push() -> Vec<u32> {
+    let mut vec = Vec::with_capacity(16);
+    for i in 0..16u32 {
+        vec.push(black_box(i));
+    }
+    vec
+}
+
+#[bench]
+fn anchor_hashmap_build() -> Option<u32> {
+    // Rebuilt per operation on purpose: a lookup alone is too fast to separate from the timer, so construction dominates.
+    // The hasher is fixed, as the per-process seed of `RandomState` would move this anchor for reasons other than the machine.
+    let map: HashMap<u32, u32, BuildHasherDefault<DefaultHasher>> =
+        (0..32u32).map(|i| (i, i * 2)).collect();
+
+    map.get(&black_box(17)).copied()
+}
+
+#[bench]
+fn anchor_string_format() -> String {
+    format!("{}-{}", black_box(42), black_box("anchor"))
+}

--- a/itest/rust/src/benchmarks/mod.rs
+++ b/itest/rust/src/benchmarks/mod.rs
@@ -5,8 +5,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-//! Benchmarks are grouped by what they measure: `builtin` (values), `call` (method calls in both directions), `object` (instance access
-//! and lifetime), `variant` (conversions). Each one tests a single thing, so a slowdown points to a specific place.
+//! Benchmarks are grouped by what they measure: `anchor` (plain Rust, as reference), `builtin` (values), `call` (method calls in both
+//! directions), `callable` (`Callable` invocation), `color` (color conversions), `object` (instance access and lifetime), `variant`
+//! (conversions). Each one tests a single thing, so a slowdown points to a specific place.
 
 use godot::builtin::{GString, GodotStringExt};
 use godot::classes::notify::ObjectNotification;
@@ -14,6 +15,7 @@ use godot::classes::{IRefCounted, RefCounted};
 use godot::obj::Base;
 use godot::register::{GodotClass, godot_api};
 
+mod anchor_bench;
 mod builtin_bench;
 mod call_bench;
 mod callable_bench;

--- a/itest/rust/src/framework/bencher.rs
+++ b/itest/rust/src/framework/bencher.rs
@@ -21,6 +21,14 @@
 // Instead, we focus on min (fastest run) and median -- even median may vary quite a bit between runs; but it gives an idea of the distribution.
 // See also https://easyperf.net/blog/2019/12/30/Comparing-performance-measurements#average-median-minimum.
 // We also measure noise as IQR/mean and flag benchmarks that exceed a threshold; see below.
+//
+// Comparing two commits is coarser than the sample statistics suggest. Repeated runs of one binary differ by a few percent, two builds by
+// more: `itest` instantiates godot-core's generics, so a changed function set moves inlining and code placement for untouched code.
+// `check.sh bench` limits this, but differences of a few percent stay unattributable; count instructions instead (`objdump`, `iai-callgrind`).
+//
+// Above ~10ns per operation, that spread stems from clock drift, code/data layout and allocator state, so it does not shrink with more
+// samples. Benchmarks are therefore measured in PASSES interleaved passes. Spreading a transient over all passes dampens it a little,
+// but the point is detection: passes that disagree get flagged, which a single long run cannot do. See anchor_bench.rs.
 
 use std::any::TypeId;
 use std::time::{Duration, Instant};
@@ -31,16 +39,21 @@ const MIN_SAMPLE_TIME: Duration = Duration::from_micros(5);
 /// Time spent warming up caches and estimating the cost of one operation.
 const WARMUP_TIME: Duration = Duration::from_millis(5);
 
-/// Time budget for one benchmark, including warmup. No hard cap: the sample count is derived from it up front, and `MIN_SAMPLES` are always run.
+/// Time budget for one benchmark across all passes, including warmup. No hard cap: the sample count is derived from it up front, and
+/// `MIN_SAMPLES` are always run.
 const TOTAL_BUDGET: Duration = Duration::from_millis(50);
 
-/// Lower bound on the sample count, even if that exceeds the budget. Uneven, so the median needs no interpolation.
-/// Only reached above ~1.5ms per operation; no benchmark is currently that slow.
+/// Lower bound on the sample count per pass, even if that exceeds the budget. Uneven, so the median needs no interpolation.
+/// Only reached above ~0.4ms per operation; no benchmark is currently that slow.
 const MIN_SAMPLES: usize = 31;
 
 /// Ceiling, to bound the suite runtime. More samples give the `min` metric more chances to catch an uninterrupted run, but cost time
 /// (e.g. raising 501 -> 2001 reduced the run-to-run spread by ~2.5x, for +0.7s runtime over the whole suite.)
 const MAX_SAMPLES: usize = 2001;
+
+/// Number of interleaved passes over the whole suite, spreading a benchmark's samples over the entire run.
+/// Costs one warmup per pass; the sample count is divided, so the timed work stays the same.
+pub const PASSES: usize = 3;
 
 /// Upper bound for repetitions per sample. Even a 0.05ns operation needs far fewer. Also limits the inputs held by bench_measure_batched().
 const MAX_REPETITIONS: usize = 100_000;
@@ -53,6 +66,15 @@ const MAX_REPETITIONS: usize = 100_000;
 /// percentages would invite comparing those values over time, which may not contain useful information. The flag means "look further into this".
 const NOISY_IQR_RATIO: f64 = 0.05;
 
+/// How far the `min` of the individual passes may disagree before the benchmark is considered noisy.
+///
+/// Higher than [`NOISY_IQR_RATIO`]: passes span the whole run and thus also pick up drift, which is a few percent even when nothing
+/// is wrong.
+const NOISY_PASS_SPREAD: f64 = 0.10;
+
+/// Upper bound on the samples of one pass, so that all passes together stay at [`MAX_SAMPLES`]. Uneven, like [`MIN_SAMPLES`].
+const MAX_SAMPLES_PER_PASS: usize = (MAX_SAMPLES / PASSES) | 1;
+
 const METRIC_COUNT: usize = 2;
 
 pub type BenchResult = Result<BenchMeasurement, String>;
@@ -63,6 +85,11 @@ pub struct BenchMeasurement {
 
     /// Whether the samples were too spread out to be trusted.
     pub noisy: bool,
+
+    /// How far the `min` of the individual passes moved, relative to the smallest one. Zero for a single pass.
+    ///
+    /// Covers only what varies within a run; code layout is fixed per binary, so this says nothing about how far two builds may differ.
+    pub pass_spread: f64,
 }
 
 pub fn metrics() -> [&'static str; METRIC_COUNT] {
@@ -190,9 +217,12 @@ fn sample_within_budget(
     inner: usize,
     mut take_sample: impl FnMut(&mut Vec<Duration>),
 ) -> BenchResult {
-    let remaining = TOTAL_BUDGET.saturating_sub(start.elapsed()).as_nanos() as f64;
+    // Each pass may spend its share of the budget; without the division, a benchmark slow enough for the budget to bind would take
+    // PASSES times as long.
+    let budget = TOTAL_BUDGET / PASSES as u32;
+    let remaining = budget.saturating_sub(start.elapsed()).as_nanos() as f64;
     let affordable = (remaining / sample_cost) as usize;
-    let samples = affordable.clamp(MIN_SAMPLES, MAX_SAMPLES) | 1;
+    let samples = affordable.clamp(MIN_SAMPLES, MAX_SAMPLES_PER_PASS) | 1;
 
     let mut times = Vec::with_capacity(samples);
     for _ in 0..samples {
@@ -217,6 +247,36 @@ fn calculate_stats(times: Vec<Duration>, inner: usize) -> BenchMeasurement {
     BenchMeasurement {
         stats: [min, median],
         noisy,
+        pass_spread: 0.0,
+    }
+}
+
+/// Combines the passes of one benchmark into a single measurement.
+///
+/// `min` is the smallest sample of all passes, `median` the median of the per-pass medians (close enough at this resolution). Noisy if the
+/// majority of passes were -- so a single transient doesn't flag it -- or if the passes' minima differ by more than [`NOISY_PASS_SPREAD`].
+pub fn merge_passes(passes: Vec<BenchMeasurement>) -> BenchMeasurement {
+    let noisy_count = passes.iter().filter(|pass| pass.noisy).count();
+
+    let mut medians: Vec<f64> = passes.iter().map(|pass| pass.stats[1]).collect();
+    medians.sort_by(f64::total_cmp);
+    let median = medians[medians.len() / 2];
+
+    let mins = passes.iter().map(|pass| pass.stats[0]);
+    let min = mins.clone().fold(f64::INFINITY, f64::min);
+    let max = mins.fold(0.0, f64::max);
+
+    // A zero minimum means the sample window stayed below clock granularity, so the passes cannot be said to agree on anything.
+    let pass_spread = if min > 0.0 {
+        (max - min) / min
+    } else {
+        f64::INFINITY
+    };
+
+    BenchMeasurement {
+        stats: [min, median],
+        noisy: noisy_count * 2 > passes.len() || pass_spread > NOISY_PASS_SPREAD,
+        pass_spread,
     }
 }
 
@@ -238,6 +298,62 @@ fn bench_used<T: Sized>(value: T) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn measurement(min: f64, median: f64, noisy: bool) -> BenchMeasurement {
+        BenchMeasurement {
+            stats: [min, median],
+            noisy,
+            pass_spread: 0.0,
+        }
+    }
+
+    #[test]
+    fn merged_passes_combine_stats() {
+        let merged = merge_passes(vec![
+            measurement(12.0, 22.0, false),
+            measurement(10.0, 20.0, false),
+            measurement(11.0, 21.0, false),
+        ]);
+
+        assert_eq!(merged.stats[0], 10.0); // Smallest sample of all passes, which is also the smallest overall.
+        assert_eq!(merged.stats[1], 21.0); // Median of the per-pass medians.
+        assert_eq!(merged.pass_spread, 0.2);
+        assert!(merged.noisy); // 20% apart, well above NOISY_PASS_SPREAD.
+    }
+
+    #[test]
+    fn merged_passes_need_a_majority_to_flag_noise() {
+        let agreeing = [10.0, 10.2, 10.4]; // Below NOISY_PASS_SPREAD, so only the per-pass flags decide.
+
+        let single = merge_passes(
+            agreeing
+                .iter()
+                .enumerate()
+                .map(|(i, min)| measurement(*min, 20.0, i == 0))
+                .collect(),
+        );
+        assert!(!single.noisy);
+
+        let majority = merge_passes(
+            agreeing
+                .iter()
+                .enumerate()
+                .map(|(i, min)| measurement(*min, 20.0, i < 2))
+                .collect(),
+        );
+        assert!(majority.noisy);
+    }
+
+    #[test]
+    fn merged_passes_below_clock_granularity_are_noisy() {
+        let merged = merge_passes(vec![
+            measurement(0.0, 0.0, false),
+            measurement(0.0, 1.0, false),
+        ]);
+
+        assert_eq!(merged.pass_spread, f64::INFINITY);
+        assert!(merged.noisy);
+    }
 
     #[test]
     fn repetitions_fill_sample_window() {

--- a/itest/rust/src/framework/mod.rs
+++ b/itest/rust/src/framework/mod.rs
@@ -97,13 +97,19 @@ fn collect_async_rust_tests(
     (tests, all_files, is_focused_run)
 }
 
+/// Whether a benchmark is an anchor, i.e. measures plain Rust code; see `benchmarks/anchor_bench.rs`.
+pub fn is_anchor(bench_name: &str) -> bool {
+    bench_name.starts_with("anchor_")
+}
+
 /// Finds all `#[bench]` benchmarks.
 fn collect_rust_benchmarks(filters: &[String]) -> (Vec<RustBenchmark>, usize) {
     let mut all_files = HashSet::new();
     let mut benchmarks: Vec<RustBenchmark> = vec![];
 
     sys::shard_foreach!(__GODOT_BENCH; |bench: &RustBenchmark| {
-        if !passes_filter(filters, bench.name) {
+        // Anchors always run, so that a filtered run still has a noise floor to interpret its numbers against.
+        if !is_anchor(bench.name) && !passes_filter(filters, bench.name) {
             return;
         }
 

--- a/itest/rust/src/framework/mod.rs
+++ b/itest/rust/src/framework/mod.rs
@@ -98,11 +98,15 @@ fn collect_async_rust_tests(
 }
 
 /// Finds all `#[bench]` benchmarks.
-fn collect_rust_benchmarks() -> (Vec<RustBenchmark>, usize) {
+fn collect_rust_benchmarks(filters: &[String]) -> (Vec<RustBenchmark>, usize) {
     let mut all_files = HashSet::new();
     let mut benchmarks: Vec<RustBenchmark> = vec![];
 
     sys::shard_foreach!(__GODOT_BENCH; |bench: &RustBenchmark| {
+        if !passes_filter(filters, bench.name) {
+            return;
+        }
+
         benchmarks.push(*bench);
         all_files.insert(bench.file);
     });

--- a/itest/rust/src/framework/runner.rs
+++ b/itest/rust/src/framework/runner.rs
@@ -15,7 +15,7 @@ use godot::register::{GodotClass, godot_api};
 
 use super::AsyncRustTestCase;
 use crate::framework::{
-    BenchResult, RustBenchmark, RustTestCase, TestContext, bencher, passes_filter,
+    BenchResult, RustBenchmark, RustTestCase, TestContext, bencher, is_anchor, passes_filter,
 };
 
 #[derive(Debug, Clone, Default)]
@@ -173,10 +173,11 @@ impl IntegrationTests {
         );
 
         let clock = Instant::now();
-        let failed_count = self.run_rust_benchmarks(benchmarks, scene_tree);
+        let results = self.run_rust_benchmarks(&benchmarks, scene_tree);
         let total_time = clock.elapsed();
 
-        self.conclude_benchmarks(failed_count, total_time)
+        self.print_rust_benchmarks(&benchmarks, &results);
+        self.conclude_benchmarks(&benchmarks, &results, total_time)
     }
 
     fn warn_if_debug(&self) {
@@ -384,39 +385,74 @@ impl IntegrationTests {
         }
     }
 
-    /// Returns how many benchmarks failed.
+    /// Returns the merged result of each benchmark, in the order they were passed in.
     fn run_rust_benchmarks(
         &mut self,
-        benchmarks: Vec<RustBenchmark>,
+        benchmarks: &[RustBenchmark],
         _scene_tree: Gd<Node>,
-    ) -> usize {
+    ) -> Vec<BenchResult> {
         // let ctx = TestContext { scene_tree };
 
+        // Passes are interleaved rather than run back-to-back per benchmark, so that a transient hits all benchmarks alike.
+        // Nothing is printed during measurement, as the output is grouped per benchmark, not per pass.
+        let mut passes: Vec<Vec<BenchResult>> = (0..benchmarks.len()).map(|_| vec![]).collect();
+        for _ in 0..bencher::PASSES {
+            for (bench, results) in benchmarks.iter().zip(passes.iter_mut()) {
+                results.push(run_rust_benchmark(bench));
+            }
+        }
+
+        passes.into_iter().map(merge_bench_passes).collect()
+    }
+
+    fn print_rust_benchmarks(&self, benchmarks: &[RustBenchmark], results: &[BenchResult]) {
         print!("\n{FMT_CYAN}{space}", space = " ".repeat(36));
         for metrics in bencher::metrics() {
             print!(" {:>11}   ", format!("{metrics} [ns]"));
         }
         print!("{FMT_END}");
 
-        let mut failed_count = 0;
         let mut last_file = None;
-        for bench in benchmarks {
+        for (bench, result) in benchmarks.iter().zip(results) {
             print_bench_pre(bench.name, bench.file, last_file.as_deref());
             last_file = Some(bench.file.to_string());
 
-            let result = run_rust_benchmark(&bench);
-            failed_count += usize::from(result.is_err());
             print_bench_post(result);
         }
-
-        failed_count
     }
 
     /// Returns whether all benchmarks succeeded.
-    fn conclude_benchmarks(&self, failed_count: usize, total_time: Duration) -> bool {
+    fn conclude_benchmarks(
+        &self,
+        benchmarks: &[RustBenchmark],
+        results: &[BenchResult],
+        total_time: Duration,
+    ) -> bool {
         let secs = total_time.as_secs_f32();
         println!("\nBenchmarks completed in {secs:.2}s.");
 
+        // Anchors measure plain Rust code, so their spread is what this machine adds to every other number in the table.
+        // Only within one run: code layout is fixed per binary, so a build-to-build comparison needs the anchors' absolute times.
+        let mut floor: Option<f64> = None;
+        for (bench, result) in benchmarks.iter().zip(results) {
+            let Ok(measured) = result else { continue };
+
+            if is_anchor(bench.name) && measured.pass_spread.is_finite() {
+                floor = Some(floor.unwrap_or(0.0).max(measured.pass_spread));
+            }
+        }
+
+        if let Some(floor) = floor {
+            let percent = floor * 100.0;
+            println!(
+                "  Run-to-run floor (anchors): {percent:.1}%; smaller differences within this run mean nothing."
+            );
+            println!(
+                "  Comparing two builds: diff the anchor rows between the runs, that floor is the higher one."
+            );
+        }
+
+        let failed_count = results.iter().filter(|result| result.is_err()).count();
         if failed_count > 0 {
             println!("  {FMT_RED}{failed_count} benchmark(s) failed.{FMT_END}");
         }
@@ -469,6 +505,14 @@ fn run_rust_test(test: &RustTestCase, ctx: &TestContext) -> TestOutcome {
         godot::private::handle_panic(&err_context, || (test.function)(ctx));
 
     TestOutcome::from_bool(success.is_ok())
+}
+
+/// Merges the passes of one benchmark, propagating the first error if any pass failed.
+fn merge_bench_passes(passes: Vec<BenchResult>) -> BenchResult {
+    passes
+        .into_iter()
+        .collect::<Result<Vec<_>, _>>()
+        .map(bencher::merge_passes)
 }
 
 /// A panicking benchmark is turned into an `Err`, so it fails the run instead of unwinding into Godot.
@@ -619,7 +663,7 @@ fn format_time(nanos: f64) -> String {
     format!("{grouped:>11}{fraction:<3}")
 }
 
-fn print_bench_post(result: BenchResult) {
+fn print_bench_post(result: &BenchResult) {
     match result {
         Ok(measured) => {
             for stat in measured.stats.iter() {

--- a/itest/rust/src/framework/runner.rs
+++ b/itest/rust/src/framework/runner.rs
@@ -151,19 +151,21 @@ impl IntegrationTests {
         cfg!(feature = "codegen-full")
     }
 
+    /// Returns whether all benchmarks completed without error.
     #[allow(clippy::uninlined_format_args)]
     #[func]
-    fn run_all_benchmarks(&mut self, scene_tree: Gd<Node>) {
+    fn run_all_benchmarks(&mut self, scene_tree: Gd<Node>, filters: VarArray) -> bool {
         if self.focused_run {
             println!("  Benchmarks skipped (focused run).");
-            return;
+            return true;
         }
 
         println!("\n\n{}Run{} Godot benchmarks...", FMT_CYAN_BOLD, FMT_END);
 
         self.warn_if_debug();
 
-        let (benchmarks, rust_file_count) = super::collect_rust_benchmarks();
+        let filters: Vec<String> = filters.iter_shared().map(|v| v.to::<String>()).collect();
+        let (benchmarks, rust_file_count) = super::collect_rust_benchmarks(filters.as_slice());
         println!(
             "  Rust: found {} benchmarks in {} files.",
             benchmarks.len(),
@@ -171,9 +173,10 @@ impl IntegrationTests {
         );
 
         let clock = Instant::now();
-        self.run_rust_benchmarks(benchmarks, scene_tree);
+        let failed_count = self.run_rust_benchmarks(benchmarks, scene_tree);
         let total_time = clock.elapsed();
-        self.conclude_benchmarks(total_time);
+
+        self.conclude_benchmarks(failed_count, total_time)
     }
 
     fn warn_if_debug(&self) {
@@ -381,7 +384,12 @@ impl IntegrationTests {
         }
     }
 
-    fn run_rust_benchmarks(&mut self, benchmarks: Vec<RustBenchmark>, _scene_tree: Gd<Node>) {
+    /// Returns how many benchmarks failed.
+    fn run_rust_benchmarks(
+        &mut self,
+        benchmarks: Vec<RustBenchmark>,
+        _scene_tree: Gd<Node>,
+    ) -> usize {
         // let ctx = TestContext { scene_tree };
 
         print!("\n{FMT_CYAN}{space}", space = " ".repeat(36));
@@ -390,19 +398,30 @@ impl IntegrationTests {
         }
         print!("{FMT_END}");
 
+        let mut failed_count = 0;
         let mut last_file = None;
         for bench in benchmarks {
             print_bench_pre(bench.name, bench.file, last_file.as_deref());
             last_file = Some(bench.file.to_string());
 
-            let result = (bench.function)();
+            let result = run_rust_benchmark(&bench);
+            failed_count += usize::from(result.is_err());
             print_bench_post(result);
         }
+
+        failed_count
     }
 
-    fn conclude_benchmarks(&self, total_time: Duration) {
+    /// Returns whether all benchmarks succeeded.
+    fn conclude_benchmarks(&self, failed_count: usize, total_time: Duration) -> bool {
         let secs = total_time.as_secs_f32();
         println!("\nBenchmarks completed in {secs:.2}s.");
+
+        if failed_count > 0 {
+            println!("  {FMT_RED}{failed_count} benchmark(s) failed.{FMT_END}");
+        }
+
+        failed_count == 0
     }
 
     fn update_stats(
@@ -450,6 +469,16 @@ fn run_rust_test(test: &RustTestCase, ctx: &TestContext) -> TestOutcome {
         godot::private::handle_panic(&err_context, || (test.function)(ctx));
 
     TestOutcome::from_bool(success.is_ok())
+}
+
+/// A panicking benchmark is turned into an `Err`, so it fails the run instead of unwinding into Godot.
+fn run_rust_benchmark(bench: &RustBenchmark) -> BenchResult {
+    let err_context = format!("benchmark `{}` failed", bench.name);
+
+    match godot::private::handle_panic(&err_context, bench.function) {
+        Ok(result) => result,
+        Err(_) => Err("panicked".to_string()),
+    }
 }
 
 fn run_async_rust_test(


### PR DESCRIPTION
Another benchmark methodology improvement, following #1683.

Benchmarks are noisy in two dimensions:
1. Multiple runs of the same binary can vary 2-6%, due to machine load, dynamic CPU clock rate, thermal throttling, etc. Depending on CPU core pinning, individual benchmarks move by >5%.
2. Even on stable machine, runs of similar binaries vary ~1% (worst case up to ~14%), due to difference in inlining, code placement, codegen units layout.

This PR tries to mitigate both effects through a new `check.sh bench` subcommand, with a variety of measures:
- Sample each benchmark multiple times, interleaved.
- Build with fat LTO, single codegen unit, fixed function alignment.
- Disable address-space randomization (Linux-only).
- Check CPU governor/boost configurations and warn (Linux-only, AMD/Intel CPUs).
- Detect noise in known-independent Rust-only benchmarks ("anchors").

Benchmarks no longer run at the end of every `itest`. The Godot project takes `--bench-only` to run benchmarks alone; it also supports `-f` filters.