### PR TITLE
Reduce `#[func]` codegen, and with it 10-25% user compile time 

### DIFF
--- a/godot-core/src/builtin/callable.rs
+++ b/godot-core/src/builtin/callable.rs
@@ -711,15 +711,17 @@ mod custom_callable {
         };
         let ctx = meta::CallContext::custom_callable(name.as_ref());
 
-        let err = unsafe { &mut *r_error };
-        crate::private::handle_fallible_varcall(&ctx, err, || {
+        let code = || {
             // Re-borrow inside closure so C doesn't have to be UnwindSafe.
             let c: &mut C = unsafe { CallableUserdata::inner_from_raw(callable_userdata) };
             let result = c.invoke(arg_refs);
 
             unsafe { meta::varcall_return_checked(Ok(result), r_return, r_error, &ctx)? };
             Ok(())
-        });
+        };
+
+        // SAFETY: `r_error` points to a live call error, as guaranteed by the caller.
+        unsafe { crate::private::handle_fallible_varcall(&ctx, r_error, code) };
     }
 
     pub unsafe extern "C" fn rust_callable_call_fn<F, R>(
@@ -741,8 +743,7 @@ mod custom_callable {
         let w: &FnWrapper<F> = unsafe { CallableUserdata::inner_from_raw(callable_userdata) };
         let ctx = meta::CallContext::custom_callable(&w.meta.name);
 
-        let err = unsafe { &mut *r_error };
-        crate::private::handle_fallible_varcall(&ctx, err, || {
+        let code = || {
             // Re-borrow inside closure so FnMut doesn't have to be UnwindSafe.
             let w: &mut FnWrapper<F> =
                 unsafe { CallableUserdata::inner_from_raw(callable_userdata) };
@@ -759,7 +760,10 @@ mod custom_callable {
             let result = (w.rust_function)(arg_refs).to_variant();
             unsafe { meta::varcall_return_checked(Ok(result), r_return, r_error, &ctx)? };
             Ok(())
-        });
+        };
+
+        // SAFETY: `r_error` points to a live call error, as guaranteed by the caller.
+        unsafe { crate::private::handle_fallible_varcall(&ctx, r_error, code) };
     }
 
     /// `T` here is entire object stored in [`CallableUserdata`], not just the actual [`RustCallable`] or closure instance.

--- a/godot-core/src/private.rs
+++ b/godot-core/src/private.rs
@@ -477,9 +477,12 @@ where
 const CALL_FAILED_STATUS: sys::GDExtensionCallErrorType = 1337;
 
 /// Invokes a function with the _varcall_ calling convention, handling both expected errors and user panics.
-pub fn handle_fallible_varcall<F, R>(
+///
+/// # Safety
+/// `out_err` must point to a live `GDExtensionCallError`. Pointer instead of `&mut` ref, to avoid potential aliasing by `code` function.
+pub unsafe fn handle_fallible_varcall<F, R>(
     call_ctx: &CallContext,
-    out_err: &mut sys::GDExtensionCallError,
+    out_err: *mut sys::GDExtensionCallError,
     code: F,
 ) where
     F: FnOnce() -> CallResult<R> + std::panic::UnwindSafe,
@@ -487,11 +490,15 @@ pub fn handle_fallible_varcall<F, R>(
     if handle_fallible_call(call_ctx, code) {
         // Use CALL_FAILED_STATUS so the GDScript VM recognizes the failure and aborts the calling function.
         // The Rust-side CallError has been stored in the thread-local, so that try_call() can retrieve it later.
-        *out_err = sys::GDExtensionCallError {
-            error: CALL_FAILED_STATUS,
-            argument: 0,
-            expected: 0,
-        };
+        //
+        // SAFETY: `out_err` is live per caller guarantee, and `code` has returned, so no other access to it is in flight.
+        unsafe {
+            *out_err = sys::GDExtensionCallError {
+                error: CALL_FAILED_STATUS,
+                argument: 0,
+                expected: 0,
+            };
+        }
     };
 }
 
@@ -548,6 +555,7 @@ unsafe fn handle_erased_call(
     code: unsafe fn(*mut ()) -> CallResult<()>,
     data: *mut (),
 ) -> bool {
+    // SAFETY: `data` is a valid argument for `code` (caller guarantee), and `handle_panic` invokes the closure exactly once.
     let outcome = handle_panic(call_ctx, || unsafe { code(data) });
 
     let call_error = match outcome {

--- a/godot-core/src/registry/class.rs
+++ b/godot-core/src/registry/class.rs
@@ -16,6 +16,7 @@ use crate::meta::ClassId;
 use crate::meta::error::FromGodotError;
 use crate::obj::{DynGd, Gd, GodotClass, Singleton, cap};
 use crate::private::{ClassShard, ShardItem};
+use crate::registry::method::ErasedMethodUserdata;
 use crate::registry::shard::{DynTraitImpl, ErasedRegisterFn, ITraitImpl, InherentImpl, Struct};
 use crate::registry::{callbacks, reg_validation};
 use crate::{godot_error, godot_warn, sys};
@@ -50,6 +51,25 @@ pub struct ClassMetadata {
     // Only read on the legacy (feature-off) path via `is_class_tool`; under `upcoming-editor-placeholders` the field is set but unused.
     #[cfg_attr(feature = "upcoming-editor-placeholders", allow(dead_code))]
     pub is_tool: bool,
+}
+
+/// Returns a lock to a global map of per-method userdata, by class ID.
+///
+/// GDExtension has no free callback for method userdata, so godot-rust keeps ownership here and releases it when the class is unregistered.
+fn global_method_userdata_by_class()
+-> GlobalGuard<'static, HashMap<ClassId, Vec<ErasedMethodUserdata>>> {
+    static METHOD_USERDATA_BY_CLASS: Global<HashMap<ClassId, Vec<ErasedMethodUserdata>>> =
+        Global::default();
+
+    lock_or_panic(&METHOD_USERDATA_BY_CLASS, "method userdata")
+}
+
+/// Hands the userdata of one registered method to `class_id`, which frees it once the class is unregistered.
+pub(crate) fn store_method_userdata(class_id: ClassId, method_userdata: ErasedMethodUserdata) {
+    global_method_userdata_by_class()
+        .entry(class_id)
+        .or_default()
+        .push(method_userdata);
 }
 
 fn global_dyn_traits_by_typeid() -> GlobalGuard<'static, HashMap<any::TypeId, Vec<DynTraitImpl>>> {
@@ -691,6 +711,12 @@ fn unregister_class_raw(class: LoadedClass) {
     let _: () = unsafe {
         interface_fn!(classdb_unregister_extension_class)(sys::get_library(), class_id.string_sys())
     };
+
+    // Now that Godot has dropped its method binds, no further call reaches the method callbacks, so we can unregister our cache.
+    // Keep the two statements separate: the userdata must be dropped *after* the lock is released, since `lock_or_panic()` tolerates no
+    // re-entrancy from the Variant destructors.
+    let userdata = global_method_userdata_by_class().remove(&class_id);
+    drop(userdata);
 
     out!("Class {class_id} unloaded");
 }

--- a/godot-core/src/registry/method.rs
+++ b/godot-core/src/registry/method.rs
@@ -5,11 +5,14 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+use std::ffi::c_void;
+
 use godot_ffi as sys;
 use sys::interface_fn;
 
 use crate::builtin::{StringName, Variant};
-use crate::meta::{ClassId, GodotConvert, ParamTuple, sig_params};
+use crate::meta::private_reexport::{CallContext, Signature};
+use crate::meta::{ClassId, EngineToGodot, GodotConvert, InParamTuple, sig_params};
 use crate::obj::GodotClass;
 use crate::registry::info::{MethodFlags, PropertyInfo};
 
@@ -49,51 +52,67 @@ pub struct ClassMethodInfo {
     method_name: StringName,
     call_func: sys::GDExtensionClassMethodCall,
     ptrcall_func: sys::GDExtensionClassMethodPtrCall,
+    method_userdata: *mut c_void,
     method_flags: MethodFlags,
     return_value: Option<MethodParamOrReturnInfo>,
     arguments: Vec<MethodParamOrReturnInfo>,
     /// Whether default arguments are real "arguments" is controversial. From the function PoV they are, but for the caller,
     /// they are just pre-set values to fill in for missing arguments.
-    default_arguments: Vec<Variant>,
+    ///
+    /// Points into the [`MethodUserdata`] stored for this class, which outlives the registration.
+    default_arguments: Vec<sys::GDExtensionVariantPtr>,
 }
 
 impl ClassMethodInfo {
+    /// Builds the method info from `method_data`, whose allocation is owned by `C`'s registry entry and passed to Godot as `method_userdata`.
+    ///
     /// # Safety
-    ///
-    /// `ptrcall_func`, if provided, must:
-    ///
-    /// - Interpret its parameters according to the types specified in `S`.
-    /// - Return the value that is specified in `S`, or return nothing if the return value is `()`.
-    ///
-    /// `call_func`, if provided, must:
-    ///
-    /// - Interpret its parameters as a list of `S::PARAM_COUNT` `Variant`s.
-    /// - Return a `Variant`.
-    ///
-    /// `call_func` and `ptrcall_func`, if provided, must:
-    ///
-    /// - Follow the behavior expected from the `method_flags`.
-    pub unsafe fn from_signature<C: GodotClass, Params: ParamTuple, Ret: GodotConvert>(
+    /// `method_data`'s function must interpret its instance pointer as an instance of `C`, and `method_flags` must match the receiver
+    /// (e.g. [`MethodFlags::STATIC`] only for functions ignoring the instance pointer).
+    pub unsafe fn from_signature<
+        C: GodotClass,
+        Params: InParamTuple + 'static,
+        Ret: EngineToGodot + 'static,
+    >(
         method_name: StringName,
-        call_func: sys::GDExtensionClassMethodCall,
-        ptrcall_func: sys::GDExtensionClassMethodPtrCall,
         method_flags: MethodFlags,
         param_names: &[&str],
-        default_arguments: Vec<Variant>,
+        method_data: MethodUserdata<Params, Ret>,
     ) -> Self {
+        use crate::obj::EngineBitfield as _;
+
         let return_value = MethodParamOrReturnInfo::for_return::<Ret>();
         let arguments = sig_params::<Params>(param_names);
 
         assert!(
-            default_arguments.len() <= arguments.len(),
+            method_data.default_arguments.len() <= arguments.len(),
             "cannot have more default arguments than arguments"
         );
 
+        let class_id = C::class_id();
+
+        // Virtual methods are registered through `classdb_register_extension_class_virtual_method()`, which takes neither callbacks nor
+        // userdata, nor default arguments -- so we don't allocate anything for those.
+        let mut call_func: sys::GDExtensionClassMethodCall = None;
+        let mut ptrcall_func: sys::GDExtensionClassMethodPtrCall = None;
+        let mut method_userdata = std::ptr::null_mut();
+        let mut default_arguments = Vec::new();
+
+        if !method_flags.is_set(MethodFlags::VIRTUAL) {
+            call_func = Some(varcall_callback::<Params, Ret>);
+            ptrcall_func = Some(ptrcall_callback::<Params, Ret>);
+
+            // default_arguments points into Vec, which is kept in-place by store_in_registry() below.
+            default_arguments = default_argument_ptrs(&method_data.default_arguments);
+            method_userdata = method_data.store_in_registry(class_id);
+        }
+
         Self {
-            class_id: C::class_id(),
+            class_id,
             method_name,
             call_func,
             ptrcall_func,
+            method_userdata,
             method_flags,
             return_value,
             arguments,
@@ -123,15 +142,9 @@ impl ClassMethodInfo {
         let mut arguments_metadata: Vec<sys::GDExtensionClassMethodArgumentMetadata> =
             self.arguments.iter().map(|info| info.metadata).collect();
 
-        let mut default_arguments_sys: Vec<sys::GDExtensionVariantPtr> = self
-            .default_arguments
-            .iter()
-            .map(|v| sys::SysPtr::force_mut(v.var_sys()))
-            .collect();
-
         let method_info_sys = sys::GDExtensionClassMethodInfo {
             name: sys::SysPtr::force_mut(self.method_name.string_sys()),
-            method_userdata: std::ptr::null_mut(),
+            method_userdata: self.method_userdata,
             call_func: self.call_func,
             ptrcall_func: self.ptrcall_func,
             method_flags: self.method_flags.ord() as u32,
@@ -142,7 +155,8 @@ impl ClassMethodInfo {
             arguments_info: arguments_info_sys.as_mut_ptr(),
             arguments_metadata: arguments_metadata.as_mut_ptr(),
             default_argument_count: self.default_argument_count(),
-            default_arguments: default_arguments_sys.as_mut_ptr(),
+            // Godot copies the default arguments during registration -- the array itself is only read.
+            default_arguments: self.default_arguments.as_ptr().cast_mut(),
         };
 
         if self.method_flags.is_set(MethodFlags::VIRTUAL) {
@@ -218,4 +232,187 @@ impl ClassMethodInfo {
             .try_into()
             .expect("arguments length should fit in u32")
     }
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+// Shared #[func] callbacks
+
+/// Everything the FFI callbacks need to invoke one `#[func]`, passed to Godot as its `method_userdata`.
+///
+/// Erasure for per-method code: `varcall_callback()` and `ptrcall_callback()` are instantiated once per `(Params, Ret)` pair, instead of once
+/// per registered function.
+pub struct MethodUserdata<Params, Ret> {
+    class_name: &'static str,
+    method_name: &'static str,
+    func: fn(sys::GDExtensionClassInstancePtr, Params) -> Ret,
+    default_arguments: MethodDefaults,
+}
+
+impl<Params, Ret> MethodUserdata<Params, Ret> {
+    /// # Safety
+    /// `func` must treat its instance pointer as an instance of the class the method is registered for.
+    pub unsafe fn new(
+        class_name: &'static str,
+        method_name: &'static str,
+        func: fn(sys::GDExtensionClassInstancePtr, Params) -> Ret,
+        default_arguments: Vec<Variant>,
+    ) -> Self {
+        Self {
+            class_name,
+            method_name,
+            func,
+            default_arguments: MethodDefaults(default_arguments),
+        }
+    }
+
+    /// Moves `self` to the heap and registers the allocation with the class registry under `class_id`.
+    ///
+    /// Dropped when class is unregistered (hot reload or library shutdown). GDExtension has no `free` callback for method userdata, so
+    /// godot-rust owns it rather than Godot.
+    ///
+    /// Returns the raw pointer, passed to Godot as `method_userdata`.
+    fn store_in_registry(self, class_id: ClassId) -> *mut c_void {
+        let ptr = Box::into_raw(Box::new(self)).cast::<c_void>();
+        let erased = ErasedMethodUserdata {
+            ptr,
+            drop_fn: Self::drop_raw,
+        };
+
+        crate::registry::class::store_method_userdata(class_id, erased);
+        ptr
+    }
+
+    /// Reconstructs [`ErasedMethodUserdata`] box and drops it. Instantiated once per `(Params, Ret)` pair, not per `#[func]`.
+    ///
+    /// # Safety
+    /// `ptr` must come from `Box::into_raw()` of a `MethodUserdata<Params, Ret>` that is no longer aliased.
+    unsafe fn drop_raw(ptr: *mut c_void) {
+        let method_userdata_ptr = ptr.cast::<Self>();
+
+        // SAFETY: guaranteed by the caller.
+        drop(unsafe { Box::from_raw(method_userdata_ptr) });
+    }
+}
+
+/// Non-generic part of [`ClassMethodInfo::from_signature()`]: avoid monomorphizing iterator chain once per `#[func]` signature.
+fn default_argument_ptrs(defaults: &[Variant]) -> Vec<sys::GDExtensionVariantPtr> {
+    defaults
+        .iter()
+        .map(|v| sys::SysPtr::force_mut(v.var_sys()))
+        .collect()
+}
+
+/// Owns one [`MethodUserdata`] without naming its `Params`/`Ret`, so that the class registry can hold methods of all signatures.
+///
+/// Raw pointer + drop fn instead of `Box<dyn Any>`: in a `cdylib`, a vtable per signature costs ~100kB more stripped than a `fn` pointer,
+/// in `.data.rel.ro` and relocations.
+pub(crate) struct ErasedMethodUserdata {
+    ptr: *mut c_void,
+    drop_fn: unsafe fn(*mut c_void),
+}
+
+impl Drop for ErasedMethodUserdata {
+    fn drop(&mut self) {
+        // SAFETY: `ptr` and `drop_fn` match by construction, and run once -- `ErasedMethodUserdata` is neither `Copy` nor cloneable.
+        unsafe { (self.drop_fn)(self.ptr) }
+    }
+}
+
+// SAFETY: the pointee is only read through `&MethodUserdata`, which is `Sync`. Godot registers and unregisters classes on the main thread,
+// so the allocation is created and dropped there.
+unsafe impl Send for ErasedMethodUserdata {}
+
+/// Default arguments of one `#[func]`, evaluated once at registration and reused by every call.
+///
+/// [`GodotImmutable`]: crate::meta::GodotImmutable
+/// [`opt_default_value()`]: crate::private::opt_default_value
+struct MethodDefaults(Vec<Variant>);
+
+// SAFETY: Variants stored inside are never mutated after registration: #[opt] requires GodotImmutable types and runs them through
+// opt_default_value(), which makes engine containers read-only. Concurrent readers can thus only clone them (through atomic Godot refcounts).
+unsafe impl Sync for MethodDefaults {}
+
+impl std::ops::Deref for MethodDefaults {
+    type Target = [Variant];
+
+    fn deref(&self) -> &[Variant] {
+        &self.0
+    }
+}
+
+/// Varcall FFI entry point shared by all `#[func]`s with signature `(Params, Ret)`.
+///
+/// Applies default arguments when the caller provides fewer than the method declares. Registered for every `#[func]` alongside
+/// [`ptrcall_callback()`]. Godot picks the convention per call, based on the type information available at the call site.
+///
+/// # Safety
+/// `method_data` must point to a `MethodUserdata<Params, Ret>` stored by [`MethodUserdata::store_in_registry()`]; the remaining parameters must
+/// follow the varcall convention for that signature.
+unsafe extern "C" fn varcall_callback<Params: InParamTuple, Ret: EngineToGodot>(
+    method_data: *mut c_void,
+    instance_ptr: sys::GDExtensionClassInstancePtr,
+    args_ptr: *const sys::GDExtensionConstVariantPtr,
+    arg_count: sys::GDExtensionInt,
+    ret: sys::GDExtensionVariantPtr,
+    err: *mut sys::GDExtensionCallError,
+) {
+    // SAFETY: `method_data` is the pointer registered together with this function, and the data behind it is never mutated, nor freed while
+    // the method stays registered.
+    let data = unsafe { &*method_data.cast::<MethodUserdata<Params, Ret>>() };
+    let call_ctx = CallContext::func(data.class_name, data.method_name);
+
+    let code = || {
+        // SAFETY: guaranteed by this function's caller.
+        unsafe {
+            Signature::<Params, Ret>::in_varcall(
+                instance_ptr,
+                &call_ctx,
+                args_ptr,
+                arg_count,
+                &data.default_arguments,
+                ret,
+                err,
+                data.func,
+            )
+        }
+    };
+
+    // SAFETY: `err` points to a live call error, as guaranteed by the caller.
+    unsafe { crate::private::handle_fallible_varcall(&call_ctx, err, code) };
+}
+
+/// Ptrcall FFI entry point shared by all `#[func]`s with signature `(Params, Ret)`.
+///
+/// Faster path without default-argument handling, usable once the caller provides all arguments. Registered for every `#[func]`, also for
+/// those declaring `#[opt]` defaults; see [`varcall_callback()`].
+///
+/// # Safety
+/// `method_data` must point to a `MethodUserdata<Params, Ret>` stored by [`MethodUserdata::store_in_registry()`]; the remaining parameters must
+/// follow the ptrcall convention for that signature.
+unsafe extern "C" fn ptrcall_callback<Params: InParamTuple, Ret: EngineToGodot>(
+    method_data: *mut c_void,
+    instance_ptr: sys::GDExtensionClassInstancePtr,
+    args_ptr: *const sys::GDExtensionConstTypePtr,
+    ret: sys::GDExtensionTypePtr,
+) {
+    // SAFETY: `method_data` is the pointer registered together with this function, and the data behind it is never mutated, nor freed while
+    // the method stays registered.
+    let data = unsafe { &*method_data.cast::<MethodUserdata<Params, Ret>>() };
+    let call_ctx = CallContext::func(data.class_name, data.method_name);
+
+    let code = || {
+        // SAFETY: guaranteed by this function's caller.
+        unsafe {
+            Signature::<Params, Ret>::in_ptrcall(
+                instance_ptr,
+                &call_ctx,
+                args_ptr,
+                ret,
+                data.func,
+                sys::PtrcallType::Standard,
+            )
+        }
+    };
+
+    crate::private::handle_fallible_ptrcall(&call_ctx, code);
 }

--- a/godot-macros/src/class/data_models/func.rs
+++ b/godot-macros/src/class/data_models/func.rs
@@ -141,17 +141,6 @@ pub fn make_method_registration(
     let class_name_str = class_name.to_string();
     let method_name_str = func_definition.godot_name();
 
-    let call_ctx = make_call_context(&class_name_str, &method_name_str);
-
-    // Both varcall and ptrcall functions are always generated and registered, even when default parameters are present via #[opt].
-    // Key differences are:
-    // - varcall: handles default parameters, applying them when caller provides fewer arguments.
-    // - ptrcall: optimized path without default handling, can be used when caller provides all arguments.
-    //
-    // Godot decides at call-time which calling convention to use based on available type information.
-    let varcall_fn_decl = make_varcall_fn(&call_ctx, &forwarding_closure, &default_parameters);
-    let ptrcall_fn_decl = make_ptrcall_fn(&call_ctx, &forwarding_closure);
-
     // String literals II
     let param_ident_strs = signature_info
         .param_idents
@@ -180,7 +169,7 @@ pub fn make_method_registration(
         #(#cfg_attrs)*
         {
             use ::godot::obj::GodotClass;
-            use ::godot::register::private::method::ClassMethodInfo;
+            use ::godot::register::private::method::{ClassMethodInfo, MethodUserdata};
             use ::godot::builtin::{StringName, Variant};
             use ::godot::sys;
 
@@ -191,20 +180,26 @@ pub fn make_method_registration(
 
             let method_name = StringName::from(#method_name_str);
 
-            #varcall_fn_decl;
-            #ptrcall_fn_decl;
-
-            // SAFETY: varcall_fn + ptrcall_fn interpret their in/out parameters correctly.
+            // The varcall and ptrcall callbacks live in godot-core, shared by all #[func]s with this signature; everything method-specific
+            // is passed to Godot as method userdata. See `varcall_callback()` for how Godot picks between the two conventions.
+            //
+            // SAFETY: the forwarding closure interprets its instance pointer as an instance of #class_name, matching the class the method
+            // is registered for; #method_flags matches its receiver.
             let method_info = unsafe {
+                let method_data = MethodUserdata::<CallParams, CallRet>::new(
+                    #class_name_str,
+                    #method_name_str,
+                    #forwarding_closure,
+                    #default_parameters,
+                );
+
                 ClassMethodInfo::from_signature::<#class_name, CallParams, CallRet>(
                     method_name,
-                    Some(varcall_fn),
-                    Some(ptrcall_fn),
                     #method_flags,
                     &[
                         #( #param_ident_strs ),*
                     ],
-                    #default_parameters,
+                    method_data,
                 )
             };
 
@@ -222,7 +217,7 @@ pub fn make_method_registration(
     Ok(registration)
 }
 
-/// Generates code to create a `Vec<Variant>` containing default argument values for varcall. Allocates on every call.
+/// Generates code to create a `Vec<Variant>` containing default argument values for varcall, evaluated once at registration.
 fn make_default_argument_vec(
     optional_param_default_exprs: &[TokenStream],
     all_params: &[venial::TypeExpr],
@@ -247,16 +242,9 @@ fn make_default_argument_vec(
             }
         });
 
-    // Performance: This generates `vec![...]` in the varcall FFI function, which allocates on *every* call when default parameters
-    // are present. This is a performance cost we accept for now.
-    //
-    // If no #[opt] attributes are used, this generates `vec![]` which does *not* allocate, so most #[func] functions are unaffected.
-    //
-    // Potential future improvements:
-    // - Use `Global<Vec<Variant>>` (or LazyLock/thread_local) to allocate once per function instead of per call.
-    // - Store defaults in MethodInfo during registration and retrieve via method_data pointer.
-    //
-    // Note also that there may be a semantic difference on reusing the same object vs. recreating it, see Python's default-param issue.
+    // The vector is built once during registration and stored in the method's `MethodUserdata`, so calls with missing arguments reuse the
+    // same values rather than re-evaluating the expressions. Unlike Python's mutable default arguments, this is not observable: `#[opt]`
+    // accepts only `GodotImmutable` types, so no caller can change a default.
     Ok(quote! {
         vec![ #(#default_parameters),* ]
     })
@@ -631,54 +619,6 @@ fn make_method_flags(
     Ok(flags)
 }
 
-/// Generate code for a C FFI function that performs a varcall.
-fn make_varcall_fn(
-    call_ctx: &TokenStream,
-    wrapped_method: &TokenStream,
-    default_parameters: &TokenStream,
-) -> TokenStream {
-    let invocation = make_varcall_invocation(wrapped_method, default_parameters);
-
-    // TODO reduce amount of code generated, by delegating work to a library function. Could even be one that produces this function pointer.
-    quote! {
-        unsafe extern "C" fn varcall_fn(
-            _method_data: *mut std::ffi::c_void,
-            instance_ptr: sys::GDExtensionClassInstancePtr,
-            args_ptr: *const sys::GDExtensionConstVariantPtr,
-            arg_count: sys::GDExtensionInt,
-            ret: sys::GDExtensionVariantPtr,
-            err: *mut sys::GDExtensionCallError,
-        ) {
-            let call_ctx = #call_ctx;
-            ::godot::private::handle_fallible_varcall(
-                &call_ctx,
-                &mut *err,
-                || #invocation
-            );
-        }
-    }
-}
-
-/// Generate code for a C FFI function that performs a ptrcall.
-fn make_ptrcall_fn(call_ctx: &TokenStream, wrapped_method: &TokenStream) -> TokenStream {
-    let invocation = make_ptrcall_invocation(wrapped_method, false);
-
-    quote! {
-        unsafe extern "C" fn ptrcall_fn(
-            _method_data: *mut std::ffi::c_void,
-            instance_ptr: sys::GDExtensionClassInstancePtr,
-            args_ptr: *const sys::GDExtensionConstTypePtr,
-            ret: sys::GDExtensionTypePtr,
-        ) {
-            let call_ctx = #call_ctx;
-            ::godot::private::handle_fallible_ptrcall(
-                &call_ctx,
-                || #invocation
-            );
-        }
-    }
-}
-
 /// Generate code for a `ptrcall` call expression.
 fn make_ptrcall_invocation(wrapped_method: &TokenStream, is_virtual: bool) -> TokenStream {
     let ptrcall_type = if is_virtual {
@@ -696,28 +636,6 @@ fn make_ptrcall_invocation(wrapped_method: &TokenStream, is_virtual: bool) -> To
             #wrapped_method,
             #ptrcall_type,
         )
-    }
-}
-
-/// Generate code for a `varcall()` call expression.
-fn make_varcall_invocation(
-    wrapped_method: &TokenStream,
-    default_parameters: &TokenStream,
-) -> TokenStream {
-    quote! {
-        {
-            let defaults = #default_parameters;
-            ::godot::private::Signature::<CallParams, CallRet>::in_varcall(
-                instance_ptr,
-                &call_ctx,
-                args_ptr,
-                arg_count,
-                &defaults,
-                ret,
-                err,
-                #wrapped_method,
-            )
-        }
     }
 }
 

--- a/itest/rust/src/benchmarks/call_bench.rs
+++ b/itest/rust/src/benchmarks/call_bench.rs
@@ -42,6 +42,15 @@ fn class_user_refc_call_args() -> BenchResult {
     bench_measure(|| callable.call(&args))
 }
 
+/// Same as [`class_user_refc_call_args()`], but the argument is omitted and filled in from its `#[opt(default = ...)]`.
+#[bench(manual)]
+fn class_user_refc_call_default_arg() -> BenchResult {
+    let obj = BenchObj::new_gd();
+    let callable = obj.callable("echo_default");
+
+    bench_measure(|| callable.call(&[]))
+}
+
 /// Godot -> Rust call into a virtual method, through the panic-handling chain. `Object::to_string()` is not public, so this also
 /// includes the `GString` -> `String` conversion measured by `builtin_string_to_rust`.
 #[bench(manual)]

--- a/itest/rust/src/benchmarks/mod.rs
+++ b/itest/rust/src/benchmarks/mod.rs
@@ -42,6 +42,11 @@ impl BenchObj {
     fn echo(&self, text: GString) -> GString {
         text
     }
+
+    #[func]
+    fn echo_default(&self, #[opt(default = "some test string")] text: GString) -> GString {
+        text
+    }
 }
 
 /// Separate class, so that the base field and signal registration don't affect the benchmarks using [`BenchObj`].


### PR DESCRIPTION
Every `#[func]` generates two small C functions -- one for each of the two calling conventions _ptrcall_ and _varcall_ (2 ways how Godot can call into Rust). Those two functions were identical for every method except for: the class name, the method name, the Rust user function to forward to, and the default argument values.

So a project with 500 registered methods got 1000 near-identical duplicates of the same code compiled into the binary.

With the changes in this PR, those two functions are now generated **once per method signature** instead of once per method. The values that actually differ per method are collected into a small record that Godot stores alongside the method and hands back on every call.

Nothing changes for users of the library: `#[func]`, `#[opt]` and virtual methods behave the same.

## Compile time

I used the `itest` crate as a case study. It registers a lot of methods; projects with fewer methods will likely encounter smaller improvements.

Since this is already the third compile-time optimization PR after #1677 and #1684, I wondered how the total savings look now compared to last release 0.5.5:

| measurement                     | vs. master | vs. 0.5.5 |
|---------------------------------|-----------:|----------:|
| generated code (LLVM lines)     |      -6.5% |    -44.0% |
| generated code (instantiations) |     -15.1% |    -35.3% |
| binary size, debug              |      -3.9% |    -40.6% |
| binary size, release + stripped |      -8.9% |    -16.3% |
| build itest, debug              |     -18.1% |    -35.3% |
| build itest, release            |     -29.4% |    -51.8% |
| clean rebuild, debug            |     -10.8% |    -20.4% |
| clean rebuild, release          |     -19.6% |    -40.2% |

"build itest" is basically `cargo clean -p itest && cargo build -p itest` when it was hot.
"clean rebuild" is `cargo clean && cargo build -p itest`.


<details>
<summary>Absolute numbers</summary>

| measurement                     |    this PR |     master |       0.5.5 |
|---------------------------------|-----------:|-----------:|------------:|
| generated code (LLVM lines)     |  1,663,209 |  1,787,739 |   2,971,866 |
| generated code (instantiations) |     81,106 |     95,964 |     125,434 |
| binary size, debug              | 61,746,344 | 64,573,152 | 104,010,272 |
| binary size, release            | 13,969,192 | 15,540,760 |  16,418,632 |
| binary size, release + stripped |  9,174,856 | 10,080,664 |  10,961,864 |
| build itest, debug              |     7.98 s |     9.85 s |     12.34 s |
| build itest, release            |    11.06 s |    15.73 s |     22.96 s |
| clean rebuild, debug            |    14.69 s |    16.56 s |     18.45 s |
| clean rebuild, release          |    18.37 s |    23.99 s |     30.73 s |

Sizes in bytes, times are median wall-clock in interleaved rounds (5 for "build itest", 3 for "clean rebuild"). Measured with default features.

</details>


## Runtime

`itest-bench` profile, `min` column. Builds are measured in alternating passes (to eliminate machine drift). The table is the median over 14 passes from two sessions. All builds run the same benchmark code; 0.5.5 uses the backported benchmarking suite from this commit.

First row: I originally used Godot 4.8-dev (893cf5cbf, scons `dev_build=yes`) and realized that 4.7.1-stable was compiled with `production=yes` instead, which makes quite a difference at runtime. For comparison I also included 4.8-dev `template_release`.

| benchmark (ns)                     | this PR | master | 0.5.5 | vs. master | vs. 0.5.5 |
|------------------------------------|--------:|-------:|------:|-----------:|----------:|
| `class_user_refc_call_default_arg` |     383 |    550 |   554 |     -30.6% (editor, dev)<br>-15.5% (editor, prod)<br>-20.5% (release) |    -30.6% |
| `class_user_refc_call_ref`         |     228 |    226 |   228 |      +1.3% |     +0.2% |
| `class_user_refc_call_mut`         |     227 |    225 |   228 |      +0.2% |     -0.7% |
| `class_user_refc_call_args`        |     491 |    491 |   482 |      +0.2% |     +2.0% |
| `class_user_refc_ptrcall`          |    9327 |   9212 |  9288 |      +0.9% |     +0.9% |
| `class_user_script_virtual`        |     536 |    549 |   531 |      -2.5% |     +1.4% |
| `class_engine_out_varcall`         |     250 |    248 |   255 |      +0.0% |     -2.4% |
| `anchor_int_mul` (reference)       |    0.55 |   0.55 |  0.55 |      +0.0% |     +0.0% |
| `anchor_vec_push` (reference)      |    7.61 |   7.61 |  7.83 |      +0.0% |     -2.9% |
| `anchor_hashmap_build` (reference) |     184 |    184 |   186 |      +0.0% |     -0.3% |


The anchors are a plain-Rust reference bench (see #1687), to get a baseline for noise on the machine. Only the first row exceeds them; everything else stays within the -2% to +1.5% noise spread.

So this PR also comes with an _at least_ 15% runtime win for the default-param benchmark: default argument values from `#[opt(default = ...)]` used to be constructed on every single call that omitted an argument. They are now built once, when the method is registered. Since we explicitly require immutability (#1406), this has no observable impact -- we avoid Python's "mutable default argument" trap.