### PR TITLE
Cheaper main-thread checks

### DIFF
--- a/check.sh
+++ b/check.sh
@@ -57,6 +57,7 @@ EOF
 RED='\033[1;31m'
 CYAN='\033[1;36m'
 YELLOW='\033[1;33m'
+YELLOW_DIM='\033[33m' # Non-bold; for informational asides that shouldn't shout as loud as the bold warnings above.
 END='\033[0m'
 
 ################################################################################
@@ -286,21 +287,24 @@ function cmd_dok() {
 
 # The only platform-specific part of `bench`. All optional, on outside Linux the reads will be empty and `setarch` is absent, so benchmarks
 # still run, just noisier. Both CPU knobs need root, hence warnings only. User could additionally pin cores (e.g. `taskset -c 0-7 check.sh bench`,
-# depending on CPU topology). Sets $godotLauncher for the caller.
+# depending on CPU topology). Sets $godotLauncher and $benchWarnings for the caller.
 function prepare_bench_env() {
     # Address space randomization moves heap and stack between runs, changing cache conflicts and thus timings.
     command -v setarch > /dev/null && godotLauncher=(setarch --addr-no-randomize)
 
+    # 2>/dev/null must precede the input redirect, else a missing path's error prints before it's suppressed.
     local governor boost noTurbo
-    read -r governor < /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor 2>/dev/null
-    read -r boost < /sys/devices/system/cpu/cpufreq/boost 2>/dev/null      # amd-pstate, acpi-cpufreq.
-    read -r noTurbo < /sys/devices/system/cpu/intel_pstate/no_turbo 2>/dev/null
+    read -r governor 2>/dev/null < /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
+    read -r boost 2>/dev/null < /sys/devices/system/cpu/cpufreq/boost      # amd-pstate, acpi-cpufreq.
+    read -r noTurbo 2>/dev/null < /sys/devices/system/cpu/intel_pstate/no_turbo
 
+    # cmd_bench() prints these warnings after the run.
+    benchWarnings=""
     if [[ -n "$governor" && "$governor" != "performance" ]]; then
-        logf "${YELLOW}Warning: CPU governor is '$governor', not 'performance'; clock speed varies with load.${END}\n"
+        benchWarnings+="${YELLOW_DIM}Warning: CPU governor is '$governor', not 'performance'; clock speed varies with load.${END}\n"
     fi
     if [[ "$boost" == "1" || "$noTurbo" == "0" ]]; then
-        logf "${YELLOW}Warning: CPU boost is enabled; clock speed drops as the CPU heats up over the run.${END}\n"
+        benchWarnings+="${YELLOW_DIM}Warning: CPU boost is enabled; clock speed drops as the CPU heats up over the run.${END}\n"
     fi
 }
 
@@ -314,11 +318,14 @@ benchLib=
 function cmd_bench() {
     # Prefix for the Godot invocation, filled in by prepare_bench_env(). Visible to run_itest_in_godot() through dynamic scoping.
     local godotLauncher=()
+    # Warning text collected by prepare_bench_env(), printed below only after the run -- see the comment there.
+    local benchWarnings=""
 
     findGodot || return 1
     prepare_bench_env
 
-    log "Building with RUSTFLAGS=\"$BENCH_RUSTFLAGS\" (replaces RUSTFLAGS from the environment)."
+    log
+    log "> RUSTFLAGS=\"$BENCH_RUSTFLAGS\""
     RUSTFLAGS="$BENCH_RUSTFLAGS" run cargo build -p itest --profile itest-bench "${extraCargoArgs[@]}" || return 1
 
     # Exactly one of these exists, depending on the platform.
@@ -350,6 +357,12 @@ function cmd_bench() {
 
     # `--bench-only` skips the test suite, which the benchmarks don't depend on.
     run_itest_in_godot --bench-only
+    local exitCode=$?
+
+    # Printed straight after rust-emitted warnings (e.g. Godot debug build).
+    [[ -n "$benchWarnings" ]] && logf "$benchWarnings"
+
+    return $exitCode
 }
 
 ################################################################################

--- a/godot-cell/src/blocking_cell.rs
+++ b/godot-cell/src/blocking_cell.rs
@@ -5,7 +5,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::collections::HashMap;
 use std::error::Error;
 use std::pin::Pin;
 use std::sync::{Arc, Condvar, Mutex, MutexGuard};
@@ -184,15 +183,17 @@ pub(crate) struct ThreadTracker {
     /// the field to an acceptable value and avoid the overhead.
     mut_thread: thread::ThreadId,
 
-    /// Shared reference count per thread.
-    shared_counts: HashMap<thread::ThreadId, usize>,
+    /// Shared-reference count per thread.
+    ///
+    /// `Vec` instead of `HashMap`: #threads concurrently holding a shared borrow on a cell is almost always 0 or 1, so linear search is cheaper.
+    shared_counts: Vec<(thread::ThreadId, usize)>,
 }
 
 impl Default for ThreadTracker {
     fn default() -> Self {
         Self {
             mut_thread: current_thread_id(),
-            shared_counts: HashMap::new(),
+            shared_counts: Vec::new(),
         }
     }
 }
@@ -208,22 +209,25 @@ fn current_thread_id() -> thread::ThreadId {
 
 impl ThreadTracker {
     /// Number of shared references in the current thread.
-    pub fn current_thread_shared_count(&self) -> usize {
-        *self.shared_counts.get(&current_thread_id()).unwrap_or(&0)
+    // Could be &self, but not needed and this allows to reuse find_shared_count().
+    pub fn current_thread_shared_count(&mut self) -> usize {
+        self.find_shared_count(current_thread_id())
+            .map_or(0, |count| *count)
     }
 
     /// Increments the shared reference count in the current thread.
     pub fn increment_current_thread_shared_count(&mut self) {
-        self.shared_counts
-            .entry(current_thread_id())
-            .and_modify(|count| *count += 1)
-            .or_insert(1);
+        let thread_id = current_thread_id();
+        match self.find_shared_count(thread_id) {
+            Some(count) => *count += 1,
+            None => self.shared_counts.push((thread_id, 1)),
+        }
     }
 
     /// Decrements the shared reference count in the current thread.
     pub fn decrement_current_thread_shared_count(&mut self) {
         let thread_id = current_thread_id();
-        let entry = self.shared_counts.get_mut(&thread_id);
+        let entry = self.find_shared_count(thread_id);
 
         debug_assert!(
             entry.is_some(),
@@ -240,6 +244,13 @@ impl ThreadTracker {
     /// Returns if the current thread can hold the mutable reference.
     pub fn current_thread_has_mut_ref(&self) -> bool {
         self.mut_thread == current_thread_id()
+    }
+
+    fn find_shared_count(&mut self, thread_id: thread::ThreadId) -> Option<&mut usize> {
+        self.shared_counts
+            .iter_mut()
+            .find(|(id, _)| *id == thread_id)
+            .map(|(_, count)| count)
     }
 
     /// Claims the mutable reference for the current thread.

--- a/godot-cell/src/blocking_cell.rs
+++ b/godot-cell/src/blocking_cell.rs
@@ -191,32 +191,38 @@ pub(crate) struct ThreadTracker {
 impl Default for ThreadTracker {
     fn default() -> Self {
         Self {
-            mut_thread: thread::current().id(),
+            mut_thread: current_thread_id(),
             shared_counts: HashMap::new(),
         }
     }
 }
 
+/// Same as `godot_ffi::current_thread_id()`, duplicated to keep this crate dependency-free.
+fn current_thread_id() -> thread::ThreadId {
+    thread_local! {
+        static CURRENT_THREAD_ID: thread::ThreadId = thread::current().id();
+    }
+
+    CURRENT_THREAD_ID.with(|id| *id)
+}
+
 impl ThreadTracker {
     /// Number of shared references in the current thread.
     pub fn current_thread_shared_count(&self) -> usize {
-        *self
-            .shared_counts
-            .get(&thread::current().id())
-            .unwrap_or(&0)
+        *self.shared_counts.get(&current_thread_id()).unwrap_or(&0)
     }
 
     /// Increments the shared reference count in the current thread.
     pub fn increment_current_thread_shared_count(&mut self) {
         self.shared_counts
-            .entry(thread::current().id())
+            .entry(current_thread_id())
             .and_modify(|count| *count += 1)
             .or_insert(1);
     }
 
     /// Decrements the shared reference count in the current thread.
     pub fn decrement_current_thread_shared_count(&mut self) {
-        let thread_id = thread::current().id();
+        let thread_id = current_thread_id();
         let entry = self.shared_counts.get_mut(&thread_id);
 
         debug_assert!(
@@ -233,11 +239,11 @@ impl ThreadTracker {
 
     /// Returns if the current thread can hold the mutable reference.
     pub fn current_thread_has_mut_ref(&self) -> bool {
-        self.mut_thread == thread::current().id()
+        self.mut_thread == current_thread_id()
     }
 
     /// Claims the mutable reference for the current thread.
     fn claim_mut_ref(&mut self) {
-        self.mut_thread = thread::current().id();
+        self.mut_thread = current_thread_id();
     }
 }

--- a/godot-core/src/builtin/callable.rs
+++ b/godot-core/src/builtin/callable.rs
@@ -287,7 +287,7 @@ impl Callable {
         S: Into<CowStr>,
     {
         let thread_id = if cfg!(safeguards_balanced) {
-            Some(std::thread::current().id())
+            Some(sys::current_thread_id())
         } else {
             None // Thread not checked.
         };
@@ -751,7 +751,7 @@ mod custom_callable {
             // NOTE: this panic is currently not propagated to the caller, but results in an error message and Nil return.
             // See comments in itest callable_call() for details.
             sys::balanced_assert!(
-                w.meta.thread_id.is_none() || w.meta.thread_id == Some(std::thread::current().id()),
+                w.meta.thread_id.is_none() || w.meta.thread_id == Some(sys::current_thread_id()),
                 "Callable '{}' created with from_fn() must be called from the same thread it was created in.\n\
                 If you need to call it from any thread, use from_sync_fn() instead (requires `experimental-threads` feature).",
                 w.meta.name

--- a/godot-core/src/meta/signature.rs
+++ b/godot-core/src/meta/signature.rs
@@ -777,7 +777,7 @@ pub mod trace {
 
     pub fn pop() -> CallReport {
         let lock = TRACE.take();
-        // let th = std::thread::current().id();
+        // let th = sys::current_thread_id();
         // println!("trace::pop [{th:?}]...");
 
         lock.expect("trace::pop() had no prior call stored.")
@@ -787,7 +787,7 @@ pub mod trace {
         if call_ctx.function_name.contains("notrace") {
             return;
         }
-        // let th = std::thread::current().id();
+        // let th = sys::current_thread_id();
         // println!("trace::push [{th:?}] - inbound: {inbound}, ptrcall: {ptrcall}, ctx: {call_ctx}");
 
         let report = CallReport {

--- a/godot-core/src/task/async_runtime.rs
+++ b/godot-core/src/task/async_runtime.rs
@@ -14,10 +14,11 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::task::{Context, Poll, Wake, Waker};
-use std::thread::{self, LocalKey, ThreadId};
+use std::thread::{LocalKey, ThreadId};
 
 use crate::builtin::{Callable, Variant};
 use crate::private::handle_panic;
+use crate::sys;
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Public interface
@@ -164,7 +165,7 @@ pub fn spawn(future: impl Future<Output = ()> + 'static) -> TaskHandle {
         let godot_waker = Arc::new(GodotWaker::new(
             task_handle.index,
             task_handle.id,
-            thread::current().id(),
+            sys::current_thread_id(),
         ));
 
         (task_handle, godot_waker)
@@ -525,7 +526,7 @@ impl WithRuntime for LocalKey<RefCell<Option<AsyncRuntime>>> {
 /// # Panics
 /// - If called from a thread other than the main-thread.
 fn poll_future(godot_waker: Arc<GodotWaker>) {
-    let current_thread = thread::current().id();
+    let current_thread = sys::current_thread_id();
 
     assert_eq!(
         godot_waker.thread_id, current_thread,

--- a/godot-core/src/task/futures.rs
+++ b/godot-core/src/task/futures.rs
@@ -437,7 +437,7 @@ impl<T> ThreadConfined<T> {
     pub(crate) fn new(value: T) -> Self {
         Self {
             value: Some(value),
-            thread_id: std::thread::current().id(),
+            thread_id: sys::current_thread_id(),
         }
     }
 
@@ -453,7 +453,7 @@ impl<T> ThreadConfined<T> {
     }
 
     fn is_original_thread(&self) -> bool {
-        self.thread_id == std::thread::current().id()
+        self.thread_id == sys::current_thread_id()
     }
 }
 

--- a/godot-ffi/src/binding/single_threaded.rs
+++ b/godot-ffi/src/binding/single_threaded.rs
@@ -122,26 +122,31 @@ impl BindingStorage {
 
     /// Asserts that the caller is on the main thread. Used by the restricted accessor (`sys::on_main()`) for FFI functions that touch
     /// engine/scene state; thread-safe functions skip this.
+    ///
+    /// Only enabled with balanced+ safeguards and for threaded Wasm. In `wasm_nothreads` there's only one thread -> no check needed.
+    #[inline(always)] // Runs on every FFI call. Failure path now outlined -> remaining body = load + predicted branch.
     pub(super) fn ensure_main_thread() {
-        // Check that we're on the main thread. Only enabled with balanced+ safeguards and, for Wasm, in threaded builds.
-        // In wasm_nothreads, there's only one thread, so no check is needed.
         #[cfg(all(safeguards_balanced, not(wasm_nothreads)))]
         if !crate::is_main_thread() {
-            // If a binding is accessed the first time, this will panic and start unwinding. It can then happen that during unwinding,
-            // another FFI call happens (e.g. Godot destructor), which would cause immediate abort, swallowing the error message.
-            // Thus check if a panic is already in progress.
+            #[cold]
+            #[inline(never)] // Outlined error path.
+            fn report_wrong_thread() {
+                // If a binding is accessed for 1st time, this will panic and start unwinding. During unwinding, another FFI call may happen
+                // (e.g. Godot destructor), which aborts and swallows the message -- so if a panic is already in progress, only print.
+                if std::thread::panicking() {
+                    eprintln!(
+                        "ERROR: Attempted to access binding from different thread than main thread; this is UB.\n\
+                        Cannot panic because panic unwind is already in progress. Please check surrounding messages to fix the bug."
+                    );
+                } else {
+                    panic!(
+                        "attempted to access binding from different thread than main thread; \
+                        this is UB - use the \"experimental-threads\" feature."
+                    )
+                }
+            }
 
-            if std::thread::panicking() {
-                eprintln!(
-                    "ERROR: Attempted to access binding from different thread than main thread; this is UB.\n\
-                    Cannot panic because panic unwind is already in progress. Please check surrounding messages to fix the bug."
-                );
-            } else {
-                panic!(
-                    "attempted to access binding from different thread than main thread; \
-                    this is UB - use the \"experimental-threads\" feature."
-                )
-            };
+            report_wrong_thread();
         }
     }
 }

--- a/godot-ffi/src/lib.rs
+++ b/godot-ffi/src/lib.rs
@@ -117,9 +117,35 @@ use binding::{
     initialize_class_editor_method_table, initialize_class_scene_method_table,
     initialize_class_servers_method_table, runtime_metadata,
 };
-
 #[cfg(not(wasm_nothreads))]
-static MAIN_THREAD_ID: ManualInitCell<std::thread::ThreadId> = ManualInitCell::new();
+use thread_ids::MAIN_THREAD_ID;
+pub use thread_ids::current_thread_id;
+
+mod thread_ids {
+    use std::thread::{self, ThreadId};
+
+    #[cfg(not(wasm_nothreads))]
+    use crate::ManualInitCell;
+
+    #[cfg(not(wasm_nothreads))]
+    pub(super) static MAIN_THREAD_ID: ManualInitCell<ThreadId> = ManualInitCell::new();
+
+    // Cache thread ID for perf reasons, comparison:
+    // * direct, Arc refcount      -- thread::current().id()                                               2.250 ns/call
+    // * lazy (this one)           -- thread_local! { static X: ThreadId = thread::current().id(); })      0.246 ns/call
+    // * const + access-site check -- thread_local! { static X: Cell<Option<ThreadId>> = const {None} })   0.185 ns/call
+    //
+    // The const one is only faster in executables (local-exec TLS). In a cdylib, both variants go through a `__tls_get_addr` call that dominates,
+    // so const-init would just add manual init code for no measurable gain. See also https://github.com/rust-lang/rust/issues/147194.
+    thread_local! {
+        static CURRENT_THREAD_ID: ThreadId = thread::current().id();
+    }
+
+    #[inline(always)] // Ensure no overhead -> only thread-local load.
+    pub fn current_thread_id() -> ThreadId {
+        CURRENT_THREAD_ID.with(|id| *id)
+    }
+}
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Deferred editor messages
@@ -227,7 +253,7 @@ pub unsafe fn initialize(
     // SAFETY: We set the main thread ID exactly once here and never again.
     #[cfg(not(wasm_nothreads))]
     unsafe {
-        MAIN_THREAD_ID.set(std::thread::current().id())
+        MAIN_THREAD_ID.set(current_thread_id())
     };
 
     // Before anything else: if we run into a Godot binary that's compiled differently from gdext, proceeding would be UB -> panic.
@@ -630,6 +656,7 @@ pub unsafe fn godot_has_feature(
 /// # Panics
 /// - If it is called before the engine bindings have been initialized.
 #[cfg(not(wasm_nothreads))]
+#[inline(always)] // Called on every FFI call through is_main_thread(). The assert's panic path stays outlined.
 pub fn main_thread_id() -> std::thread::ThreadId {
     assert!(
         MAIN_THREAD_ID.is_initialized(),
@@ -646,10 +673,11 @@ pub fn main_thread_id() -> std::thread::ThreadId {
 ///
 /// # Panics
 /// - If it is called before the engine bindings have been initialized.
+#[inline(always)] // Trivial forwarder, cheap to inline at call-site.
 pub fn is_main_thread() -> bool {
     #[cfg(not(wasm_nothreads))]
     {
-        std::thread::current().id() == main_thread_id()
+        current_thread_id() == main_thread_id()
     }
 
     #[cfg(wasm_nothreads)]
@@ -760,7 +788,7 @@ pub unsafe fn discover_main_thread() {
             return;
         }
 
-        let thread_id = std::thread::current().id();
+        let thread_id = current_thread_id();
 
         // SAFETY: initialize must have already been called before this function is called. By clearing and setting the cell again we can reinitialize it.
         unsafe {

--- a/itest/godot/TestRunner.gd
+++ b/itest/godot/TestRunner.gd
@@ -10,7 +10,7 @@ class_name GDScriptTestRunner
 
 func _ready():
 	# Don't run tests when opened in the editor, unless it's headless mode (-e --headless).
-	# When editor tests are run, we skip GDScript suites and benchmarks -- they aren't editor-specific.
+	# When editor tests are run, we skip GDScript suites -- they aren't editor-specific.
 	var editor_only_run := false
 	if Engine.is_editor_hint():
 		if DisplayServer.get_name() == 'headless':
@@ -76,13 +76,8 @@ func _ready():
 
 	var property_tests = load("res://gen/GenPropertyTests.gd").new()
 
-	# Run benchmarks after all synchronous and asynchronous tests have completed.
-	# Skipped in editor-only mode (benchmarks are not editor-specific) and in filtered runs.
-	var run_benchmarks = func (success: bool):
-		# A filtered run targets specific tests; the `bench` command is the way to run benchmarks.
-		if success and not editor_only_run and filters.is_empty():
-			success = rust_runner.run_all_benchmarks(self, filters)
-
+	# Benchmarks are not part of itest, they can be run with `./check.sh bench` command (forwards `--bench-only` to Godot).
+	var on_tests_finished = func (success: bool):
 		var exit_code: int = 0 if success else 1
 		get_tree().quit(exit_code)
 
@@ -94,7 +89,7 @@ func _ready():
 		self,
 		filters,
 		property_tests,
-		run_benchmarks
+		on_tests_finished
 	)
 
 

--- a/itest/rust/src/framework/runner.rs
+++ b/itest/rust/src/framework/runner.rs
@@ -30,7 +30,6 @@ struct TestStats {
 #[class(init)]
 pub struct IntegrationTests {
     stats: TestStats,
-    focused_run: bool,
 }
 
 #[godot_api]
@@ -63,7 +62,6 @@ impl IntegrationTests {
 
         let rust_focused = rust_test_cases.focused_run;
         let focused = rust_focused || gdscript_focused;
-        self.focused_run = focused;
 
         // If the other side is focused (and this side is not), skip this side entirely.
         let run_rust = !gdscript_focused || rust_focused;
@@ -155,14 +153,7 @@ impl IntegrationTests {
     #[allow(clippy::uninlined_format_args)]
     #[func]
     fn run_all_benchmarks(&mut self, scene_tree: Gd<Node>, filters: VarArray) -> bool {
-        if self.focused_run {
-            println!("  Benchmarks skipped (focused run).");
-            return true;
-        }
-
-        println!("\n\n{}Run{} Godot benchmarks...", FMT_CYAN_BOLD, FMT_END);
-
-        self.warn_if_debug();
+        println!("\n{}Run{} Godot benchmarks...", FMT_CYAN_BOLD, FMT_END);
 
         let filters: Vec<String> = filters.iter_shared().map(|v| v.to::<String>()).collect();
         let (benchmarks, rust_file_count) = super::collect_rust_benchmarks(filters.as_slice());
@@ -192,7 +183,7 @@ impl IntegrationTests {
         };
 
         if let Some(what) = what {
-            println!("{FMT_YELLOW}  Warning: {what}, benchmarks may not be expressive.{FMT_END}");
+            println!("{FMT_YELLOW}Warning: {what}, benchmarks may not be expressive.{FMT_END}");
         }
     }
 
@@ -406,9 +397,12 @@ impl IntegrationTests {
     }
 
     fn print_rust_benchmarks(&self, benchmarks: &[RustBenchmark], results: &[BenchResult]) {
-        print!("\n{FMT_CYAN}{space}", space = " ".repeat(36));
+        // Padding must match print_bench_pre()'s prefix: "   -- " + name + " ...".
+        let prefix_width = 6 + COL_W_NAME + 4;
+        print!("\n{FMT_CYAN}{space}", space = " ".repeat(prefix_width));
         for metrics in bencher::metrics() {
-            print!(" {:>11}   ", format!("{metrics} [ns]"));
+            let header = format!("{metrics} [ns]");
+            print!(" {header:>width$}", width = COL_W_TIME + COL_W_DECIMAL);
         }
         print!("{FMT_END}");
 
@@ -448,14 +442,17 @@ impl IntegrationTests {
                 "  Run-to-run floor (anchors): {percent:.1}%; smaller differences within this run mean nothing."
             );
             println!(
-                "  Comparing two builds: diff the anchor rows between the runs, that floor is the higher one."
+                "  Comparing two builds: benchmark diff < anchor diff means noise, not a real change."
             );
+            println!();
         }
 
         let failed_count = results.iter().filter(|result| result.is_err()).count();
         if failed_count > 0 {
             println!("  {FMT_RED}{failed_count} benchmark(s) failed.{FMT_END}");
         }
+
+        self.warn_if_debug(); // Printed last, before check.sh warnings.
 
         failed_count == 0
     }
@@ -479,6 +476,11 @@ impl IntegrationTests {
     }
 }
 
+// Column widths for benchmark table.
+const COL_W_NAME: usize = 30;
+const COL_W_TIME: usize = 11;
+const COL_W_DECIMAL: usize = 3;
+
 // For more colors, see https://stackoverflow.com/a/54062826
 // To experiment with colors, add `rand` dependency and add following code above.
 //     use rand::seq::SliceRandom;
@@ -487,7 +489,8 @@ impl IntegrationTests {
 const FMT_CYAN_BOLD: &str = "\x1b[36;1;1m";
 const FMT_CYAN: &str = "\x1b[36m";
 const FMT_GREEN: &str = "\x1b[32m";
-const FMT_YELLOW: &str = "\x1b[33m";
+const FMT_YELLOW: &str = "\x1b[33m"; // sometimes orange.
+const FMT_YELLOW_BRIGHT: &str = "\x1b[93m";
 const FMT_RED: &str = "\x1b[31m";
 const FMT_END: &str = "\x1b[0m";
 
@@ -626,16 +629,15 @@ fn print_test_post(test_case: &str, outcome: TestOutcome) {
 }
 
 fn print_bench_pre(benchmark: &str, bench_file: &str, last_file: Option<&str>) {
-    let max_width: usize = 30;
     print_file_header(bench_file, last_file);
 
-    let benchmark = if benchmark.len() > max_width {
-        &benchmark[..max_width]
+    let benchmark = if benchmark.len() > COL_W_NAME {
+        &benchmark[..COL_W_NAME]
     } else {
         benchmark
     };
 
-    print!("   -- {benchmark:<max_width$} ...");
+    print!("   -- {benchmark:<COL_W_NAME$} ...");
 }
 
 /// Formats nanoseconds, grouping digits by thousands. Decimals only below 100ns, where they still carry information.
@@ -660,7 +662,7 @@ fn format_time(nanos: f64) -> String {
         grouped.push(digit);
     }
 
-    format!("{grouped:>11}{fraction:<3}")
+    format!("{grouped:>COL_W_TIME$}{fraction:<COL_W_DECIMAL$}")
 }
 
 fn print_bench_post(result: &BenchResult) {
@@ -670,7 +672,7 @@ fn print_bench_post(result: &BenchResult) {
                 print!(" {}", format_time(*stat));
             }
             if measured.noisy {
-                print!("  {FMT_YELLOW}~noisy{FMT_END}");
+                print!("    {FMT_YELLOW_BRIGHT}~noisy{FMT_END}");
             }
         }
         Err(msg) => {


### PR DESCRIPTION
`sys::on_main()` asserts main thread on every FFI call, and `std::thread::current()` uses ref-counts -> now cached in thread-local.

Also, panic path had code inline in function, exceeding inliner budget and causing `ensure_main_thread()` to be outlined -> now split and marked.